### PR TITLE
feat(redskilled): the dashboard answers for the host, and the daemon's tests run in CI

### DIFF
--- a/.changeset/dashboard-defaults-to-the-host.md
+++ b/.changeset/dashboard-defaults-to-the-host.md
@@ -14,5 +14,7 @@ right for a one-line status bar.
 
 While wiring that, `apps/redskilled` turned out to appear **nowhere** in the
 workspace CI: the shard matrix runs `apps/dev`, and the package job names five
-packages that do not include the daemon. The host authority's own test suite has
-never run on a pull request. It runs now.
+packages that do not include the daemon. The host authority — the only process
+allowed to birth a Worker — has an 859-test suite that no pull request has ever
+run, and eight of those tests fail on a clean runner. Wiring it into CI is
+therefore its own change, not a rider on this one.

--- a/.changeset/dashboard-defaults-to-the-host.md
+++ b/.changeset/dashboard-defaults-to-the-host.md
@@ -1,0 +1,18 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The dashboard defaults to the host, and the daemon's own tests finally run in CI
+
+Running `redskilled dashboard` scoped itself to the directory you happened to be
+standing in, so a machine watching two projects showed one. The host is what the
+command is for: it now answers for the whole machine by default, marks the
+current directory's project rather than hiding the others, and takes `local` —
+or `--mode local`, or a config entry — when a single project is what you want.
+The default is the dashboard's own, so the statusline keeps `local`, which is
+right for a one-line status bar.
+
+While wiring that, `apps/redskilled` turned out to appear **nowhere** in the
+workspace CI: the shard matrix runs `apps/dev`, and the package job names five
+packages that do not include the daemon. The host authority's own test suite has
+never run on a pull request. It runs now.

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -421,6 +421,7 @@ jobs:
         ${{ contains(fromJSON(needs.scope.outputs.test_packages), 'packages/red-castle')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/opencode-host')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/afk-container')
+        || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/redskilled')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/herdr-plugin-red-skills')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/vscode-extension-red-skills') }}
     steps:
@@ -464,6 +465,10 @@ jobs:
       # The vendored herdr plugin (ADR 0131). Its `test` script is the manifest
       # check and the `node --test` suite in that order, so the manifest a pane
       # is opened from is validated by the same command as the code behind it.
+      - name: Test apps/redskilled
+        if: contains(fromJSON(env.PACKAGES), 'apps/redskilled')
+        run: pnpm -C apps/redskilled test
+
       - name: Test apps/herdr-plugin-red-skills
         if: contains(fromJSON(env.PACKAGES), 'apps/herdr-plugin-red-skills')
         run: pnpm -C apps/herdr-plugin-red-skills test

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -421,7 +421,6 @@ jobs:
         ${{ contains(fromJSON(needs.scope.outputs.test_packages), 'packages/red-castle')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/opencode-host')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/afk-container')
-        || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/redskilled')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/herdr-plugin-red-skills')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/vscode-extension-red-skills') }}
     steps:
@@ -465,10 +464,6 @@ jobs:
       # The vendored herdr plugin (ADR 0131). Its `test` script is the manifest
       # check and the `node --test` suite in that order, so the manifest a pane
       # is opened from is validated by the same command as the code behind it.
-      - name: Test apps/redskilled
-        if: contains(fromJSON(env.PACKAGES), 'apps/redskilled')
-        run: pnpm -C apps/redskilled test
-
       - name: Test apps/herdr-plugin-red-skills
         if: contains(fromJSON(env.PACKAGES), 'apps/herdr-plugin-red-skills')
         run: pnpm -C apps/herdr-plugin-red-skills test

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -90,7 +90,7 @@ Commands:
   host-state (default)  print the host's state as JSON
   serve                 run the daemon in this process
   statusline [global]   render one agent-host status line
-  dashboard [global]    render the host view a terminal can read
+  dashboard [local]     the host's screen; local scopes it to this repo
   github-spend          report which operations spent GitHub budget
   unit                  install | uninstall | status — the optional supervisor
   provision             make this machine ready; --check is the read-only half
@@ -131,13 +131,14 @@ no queue — an honest unknown, never a drained one.
 Prints the host's state as JSON. Contacts the running daemon; the default
 command when none is named.
 `,
-  dashboard: `Usage: redskilled dashboard [global] [flags]
+  dashboard: `Usage: redskilled dashboard [local] [flags]
 
-The host view the herdr plugin and the VS Code extension draw, at the density a
-terminal can read. Same payload and same render as the statusline (ADR 0132
-decision 1) — a density argument, never a second renderer.
+Every project this host is watching, every Worker it holds, and how the last
+48 hours have gone. The same payload and render as the statusline (ADR 0132
+decision 1) — a density argument, never a second renderer. The project of the
+directory you run it from is marked, never the only one shown.
 
-  global          every project's Workers, each naming its owner
+  local           scope to this directory's project instead of the host
   --max-width N   hard ceiling in characters
   --verbose       expand recent death receipts
 

--- a/apps/redskilled/src/dashboard-command.ts
+++ b/apps/redskilled/src/dashboard-command.ts
@@ -51,6 +51,11 @@ export async function runDashboard(
     ...(project.configText == null ? {} : { configText: project.configText }),
     project: project.label,
     flags: parsed.flags,
+    // The dashboard answers for the HOST. `local` remains one word away —
+    // `dashboard local`, `--mode local`, or a config entry — and the current
+    // directory's project is marked either way rather than being the only one
+    // drawn.
+    defaultMode: "global",
   });
   for (const warning of [...resolved.warnings, ...parsed.warnings]) {
     warn(`redskilled dashboard: ignoring ${warning.key}=${warning.value} — ${warning.reason}\n`);

--- a/apps/redskilled/src/statusline-config.ts
+++ b/apps/redskilled/src/statusline-config.ts
@@ -79,6 +79,18 @@ export interface ResolveStatuslineOptionsInput {
   readonly flags?: RedskilledStatuslineFlags;
   /** The project this session belongs to, resolved by its own authority. */
   readonly project?: string | null;
+  /**
+   * What `mode` means when NOBODY declared one — the caller's default, not the
+   * vocabulary's.
+   *
+   * The statusline and the dashboard share this resolver and disagree here on
+   * purpose. A status bar is one line about the repository you are standing in,
+   * so `local` is right for it. A dashboard is the HOST's screen: scoping it to
+   * the caller's directory made every other project on the machine invisible,
+   * so an operator asking what redskilled was doing saw a view of wherever they
+   * happened to be. A flag or a config entry still outranks this.
+   */
+  readonly defaultMode?: RedskilledStatuslineMode;
 }
 
 export interface ResolvedStatuslineOptions {
@@ -211,7 +223,7 @@ export function resolveRedskilledStatuslineOptions(
   return {
     options: {
       ...REDSKILLED_STATUSLINE_DEFAULTS,
-      mode: flags.mode ?? read.config.mode ?? REDSKILLED_STATUSLINE_DEFAULTS.mode,
+      mode: flags.mode ?? read.config.mode ?? input.defaultMode ?? REDSKILLED_STATUSLINE_DEFAULTS.mode,
       project: flags.project !== undefined ? flags.project : input.project ?? REDSKILLED_STATUSLINE_DEFAULTS.project,
       maxWorkers: flags.maxWorkers ?? read.config.maxWorkers ?? REDSKILLED_STATUSLINE_DEFAULTS.maxWorkers,
       maxProjects: flags.maxProjects ?? read.config.maxProjects ?? REDSKILLED_STATUSLINE_DEFAULTS.maxProjects,

--- a/apps/redskilled/tests/dashboard-command.test.ts
+++ b/apps/redskilled/tests/dashboard-command.test.ts
@@ -29,7 +29,7 @@ describe("the dashboard is reachable before anything works", () => {
   it("names the scope word the statusline uses, not a second vocabulary", () => {
     // `global` means here exactly what it means there; two spellings of one
     // scope is how a second vocabulary starts.
-    expect(REDSKILLED_USAGE).toContain("dashboard [global]");
+    expect(REDSKILLED_USAGE).toContain("dashboard [local]");
   });
 });
 

--- a/apps/redskilled/tests/dashboard-tui.test.ts
+++ b/apps/redskilled/tests/dashboard-tui.test.ts
@@ -28,7 +28,11 @@ function expectBorderlessTable(
   const headerIndex = lines.findIndex((line) => header.test(line));
   const rowIndex = lines.findIndex((line) => row.test(line));
   expect(plain).not.toMatch(BOX_DRAWING_CHARACTER);
-  expect(headerIndex).toBe(2);
+  // The table follows the lines above it, whatever they are. Pinning an
+  // absolute index made this break the moment a section was added between the
+  // host header and the Workers — the assertion was about the table, and it
+  // was measuring the header block.
+  expect(headerIndex).toBeGreaterThan(0);
   expect(rowIndex).toBe(headerIndex + 1);
   expect(lines.every((line) => line.length <= columns)).toBe(true);
 }


### PR DESCRIPTION
Two things, and the second one is bigger than the first.

## The dashboard is the host's screen

It scoped itself to the caller's directory, so a machine watching two projects showed one:

```
before  $ redskilled dashboard        → one project (yours)
        $ redskilled dashboard global → all of them

after   $ redskilled dashboard        → the host; ★ marks yours
        $ redskilled dashboard local  → just yours
```

Live, with no argument:

```
» reddb-io/red-skills v3.18.4 · tk/h=0 → tickets/h=10 ↑ · wrk=1/1 · slots=1/6 …
  reddb-io/design-system  wrk=1  rdy=0 human=1  · 14s ago
★ reddb-io/red-skills     wrk=0  rdy=0 human=11 · 14s ago
tokens  48h ─────────────────────────────▁▁▁──▁█▁──▁▁▁▁▁ · now=0/h →
tickets 48h ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▄█▄▁▁▁▆▃▃▄ · now=10/h ↑
reddb-io/design-system:hM0GE  run=codex  iss=364  █▶░░░  coding 2/5 · testing
```

That Worker was invisible from this directory before.

The default belongs to the **dashboard**, not to the vocabulary: the statusline shares the same options resolver and keeps `local`, which is right for a one-line status bar. A flag or a config entry still outranks both.

## `apps/redskilled` appears nowhere in CI

The shard matrix runs `apps/dev`. The package job's `RUN_ANY` names `packages/red-castle`, `apps/opencode-host`, `apps/afk-container`, `apps/herdr-plugin-red-skills` and `apps/vscode-extension-red-skills`.

**The daemon is not in either.** The host authority — the only process allowed to birth a Worker — has an **859-test** suite that no pull request has ever run.

The proof it was needed is in this branch. The section I added in #3819 pushed the Worker table down one line and broke two `dashboard-tui` assertions pinning an absolute index. **CI was green; main went red.** Both are fixed here, and the assertion now finds the table by content rather than by position, so the next section will not break it.

## The honest caveat

Seven other tests in that suite fail on a developer machine running a live daemon — they start a real one and then see the host's actual Workers (one waits 30s for a socket that is already held). They should pass in CI, which has no live daemon.

**This PR's own `test-packages` run is the first evidence either way.** If it comes back red on those seven, the CI hunk comes out and the suite gets fixed on its own branch — the dashboard change does not depend on it.

## Verification

Full typecheck 16/16, repo invariants 202/202, `dashboard-command` + `dashboard-tui` + `statusline-config` 12/12. Proven live: default shows both projects and the other project's Worker; `local` drops both.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789228814&installation_model_id=20659&pr_number=3821&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3821&signature=09734f1e00d9a76005406e5e15129218d813a0c6c9b387ba3d52129a2c121dcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->