### PR TITLE
The daemon's 859-test suite is green, and CI runs it

### DIFF
--- a/.changeset/the-daemon-suite-is-green.md
+++ b/.changeset/the-daemon-suite-is-green.md
@@ -1,0 +1,34 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The daemon's own test suite runs in CI, and passes
+
+`apps/redskilled` appeared nowhere in the workspace CI: the shard matrix runs
+`apps/dev` and the package job named five packages that did not include the
+daemon. The host authority — the only process allowed to birth a Worker — had an
+859-test suite no pull request had ever run. Wiring it in was refused once
+already, on evidence: eight tests failed on a clean runner, and a *different*
+seventy-seven failed on a developer machine. A gate is not a gate until it is
+green, so the suite was fixed first and the wiring follows it here.
+
+The 77 were one bug wearing many faces. The sandbox pinned four PATHS — HOME,
+the runtime dir, the machine dir, its own root — and unit discovery is not a
+path: a booting daemon asks the user's systemd for `red-worker-*` units, and
+systemd has never heard of HOME. So every sandboxed daemon adopted the
+operator's live Workers and counted them against budgets the test had just
+declared. The sandbox no longer sweeps by default, and the three suites whose
+SUBJECT is the sweep ask for it back explicitly.
+
+The rest were tests outliving the designs they described: POSIX placement
+stopped being macOS-only when it became the fallback for a systemd-less Linux
+host; a malformed lane row stopped being fatal when #3651 showed what fatal
+costs (one row an older daemon wrote took every `worker_dispatch` on the machine
+down, reported as "the daemon did not answer"); a held daemon became retryable,
+so a test that declared no patience inherited the 30s product default and raced
+its own 30s timeout; and the successor is now staged while the incumbent still
+holds the socket, so the spawn is no longer the moment the socket goes quiet.
+
+One was a teardown that removed a directory out from under a live process — the
+successor is spawned by the daemon under test, so it is the one child the suite
+never holds a handle to.

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -465,6 +465,26 @@ jobs:
       # The vendored herdr plugin (ADR 0131). Its `test` script is the manifest
       # check and the `node --test` suite in that order, so the manifest a pane
       # is opened from is validated by the same command as the code behind it.
+      # `tq` is the query surface the /redskilled skill documents an operator
+      # into, and one test runs those exact recipes against a fixture lane — so
+      # the doc and the tool are checked by the same command. It is an external
+      # Rust binary, not a workspace dependency, so CI installs it: the
+      # PREBUILT static binary against its published checksum, never
+      # `cargo install`, which would spend minutes compiling on every run.
+      - name: Install tq (event-lane query recipes)
+        if: contains(fromJSON(env.PACKAGES), 'apps/redskilled')
+        env:
+          TQ_VERSION: v0.28.2
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release download "$TQ_VERSION" -R reddb-io/toon \
+            -p 'tq-linux-x86_64-static*' -D "$RUNNER_TEMP/tq"
+          cd "$RUNNER_TEMP/tq"
+          awk '{print $1"  tq-linux-x86_64-static"}' tq-linux-x86_64-static.sha256 | sha256sum -c -
+          install -m 0755 tq-linux-x86_64-static "$RUNNER_TEMP/tq/tq"
+          echo "$RUNNER_TEMP/tq" >> "$GITHUB_PATH"
+
       - name: Test apps/redskilled
         if: contains(fromJSON(env.PACKAGES), 'apps/redskilled')
         run: pnpm -C apps/redskilled test

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -421,6 +421,7 @@ jobs:
         ${{ contains(fromJSON(needs.scope.outputs.test_packages), 'packages/red-castle')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/opencode-host')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/afk-container')
+        || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/redskilled')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/herdr-plugin-red-skills')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/vscode-extension-red-skills') }}
     steps:
@@ -464,6 +465,10 @@ jobs:
       # The vendored herdr plugin (ADR 0131). Its `test` script is the manifest
       # check and the `node --test` suite in that order, so the manifest a pane
       # is opened from is validated by the same command as the code behind it.
+      - name: Test apps/redskilled
+        if: contains(fromJSON(env.PACKAGES), 'apps/redskilled')
+        run: pnpm -C apps/redskilled test
+
       - name: Test apps/herdr-plugin-red-skills
         if: contains(fromJSON(env.PACKAGES), 'apps/herdr-plugin-red-skills')
         run: pnpm -C apps/herdr-plugin-red-skills test

--- a/apps/redskilled/tests/daemon-presence.test.ts
+++ b/apps/redskilled/tests/daemon-presence.test.ts
@@ -161,6 +161,13 @@ describe("the three silences a redskilled client can meet", () => {
       serverCommand: process.execPath,
       serverArgs: ["-e", "process.exit(1)"],
       readyTimeoutMs: 400,
+      // A held daemon is RETRYABLE: waiting is what a client owes one that is
+      // merely booting, and only patience running out tells that apart from one
+      // that is wedged. So this test must state its own patience — the product
+      // default is 30s, which is exactly this suite's timeout, and the test lost
+      // that race every time by a margin of zero.
+      reconnectTimeoutMs: 1_000,
+      reconnectInitialBackoffMs: 25,
     }).then((outcome) => outcome as never, (err: unknown) => err);
 
     expect(error).toBeInstanceOf(RedskilledDaemonHeldError);

--- a/apps/redskilled/tests/daemon-restart.test.ts
+++ b/apps/redskilled/tests/daemon-restart.test.ts
@@ -5,7 +5,7 @@ import { appendFile, mkdtemp, readFile, rm, truncate, writeFile } from "node:fs/
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseRecords } from "@reddb-io/toon";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildBudgetAccounting, parseMemoryBudget } from "../src/budget-accounting.js";
 import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import {
@@ -321,16 +321,33 @@ describe("the host event lane", () => {
     expect(daemon.hostState().workers.map((worker) => worker.worker_id)).toEqual(["w-live"]);
   });
 
-  it("keeps a half-written trailing line out, and a malformed middle line in view", async () => {
-    // Only an unterminated FINAL line is a crash. A broken line in the middle is
-    // a format bug, and swallowing it would hide the very thing that needs fixing.
+  it("keeps a half-written trailing line out, and names a malformed middle line rather than dying on it", async () => {
+    // Only an unterminated FINAL line is a crash. A broken line in the MIDDLE is
+    // a format bug — and #3651 is what treating it as fatal actually costs: one
+    // mixed-arity row a previous daemon generation had written took every
+    // `worker_dispatch` on the machine down, reported as "the daemon did not
+    // answer", pointing the operator at `provision` — the wrong repair for a
+    // healthy daemon. An append-only lane spanning generations WILL hold rows an
+    // older reader wrote differently, so a malformed row is skipped and COUNTED
+    // out loud. Skipping silently is what the warning exists to refuse.
     const lane = createRedskilledEventLane(join(await scratch("redskilled-lane-"), "lane.toonl"));
     await lane.record({ event: "worker-birth", worker: workerView({ worker_id: "w-1" }), ts: "2026-07-29T00:00:00.000Z" });
     const whole = await readFile(lane.path, "utf8");
+    const warned = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
-    expect(parseEventLane(`${whole}birth,w-2,`)).toHaveLength(1);
-    expect(() => parseEventLane(`${whole}birth,w-2,\nfine\n`)).toThrow();
-    expect(parseEventLane("")).toEqual([]);
+    try {
+      expect(parseEventLane(`${whole}birth,w-2,`)).toHaveLength(1);
+      expect(warned).not.toHaveBeenCalled();
+
+      // The good row before the ruins still comes back, and the ruins are named.
+      const survivors = parseEventLane(`${whole}birth,w-2,\nfine\n`);
+      expect(survivors.map((event) => event.worker_id)).toEqual(["w-1"]);
+      expect(warned.mock.calls.flat().join(" ")).toMatch(/malformed/);
+
+      expect(parseEventLane("")).toEqual([]);
+    } finally {
+      warned.mockRestore();
+    }
   });
 
   it("replays into the Workers still alive, last event per Worker winning", () => {

--- a/apps/redskilled/tests/daemon-stop.test.ts
+++ b/apps/redskilled/tests/daemon-stop.test.ts
@@ -211,13 +211,18 @@ describe("redskilled stop", () => {
     }, config);
     spawnedPids.push(worker.worker.pid);
 
-    const report = await stopRedskilledDaemon(paths, { settleTimeoutMs: 2_000 });
+    // The settle is a DEADLINE with an early return, so a generous one costs
+    // nothing when the drain is quick. At 2s this test was stricter than the
+    // product's own 5s default and failed on a loaded 4-core runner while
+    // passing here — `stopped: false` means only "did not finish the bounded
+    // drain in time", which says nothing about the behaviour under test.
+    const report = await stopRedskilledDaemon(paths, { settleTimeoutMs: 20_000 });
 
     expect(report.stopped).toBe(true);
     expect(isPidAlive(state.pid)).toBe(false);
     expect(await readRedskilledLeaseFile(paths.leasePath)).toBeUndefined();
     expect(isPidAlive(worker.worker.pid)).toBe(true);
-  });
+  }, 60_000);
 
   it("shuts the daemon down and reports what it was holding", async () => {
     const paths = await sessionPaths();
@@ -311,7 +316,10 @@ describe("redskilled stop", () => {
     const paths = await sessionPaths();
     const pid = await startSilentHolder(paths);
 
-    const report = await stopRedskilledDaemon(paths, { settleTimeoutMs: 2_000 });
+    // Same reasoning as the settle above: signalling a holder and confirming the
+    // pid is gone is not instant on a busy machine, and the deadline returns
+    // early when it is.
+    const report = await stopRedskilledDaemon(paths, { settleTimeoutMs: 20_000 });
 
     expect(report.running).toBe(true);
     expect(report.stopped).toBe(true);

--- a/apps/redskilled/tests/event-lane-query.test.ts
+++ b/apps/redskilled/tests/event-lane-query.test.ts
@@ -13,6 +13,28 @@ import {
 import type { RedskilledWorkerView } from "../src/host-state.js";
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Run a documented `tq` recipe, and say what is missing when `tq` is.
+ *
+ * `tq` is an external Rust binary rather than a workspace dependency, so an
+ * environment without it fails at `spawn tq ENOENT` — a message that names
+ * neither the tool nor the way to get it. This test is NEVER skipped for its
+ * absence: the recipes it runs are the ones the /redskilled skill hands an
+ * operator, and a recipe nothing executes is a recipe nothing keeps true.
+ */
+async function tq(args: readonly string[]): Promise<{ stdout: string }> {
+  try {
+    return await execFileAsync("tq", [...args]);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    throw new Error(
+      "these are the tq recipes the /redskilled skill documents, and tq is not on PATH. " +
+        "Install the prebuilt binary from the reddb-io/toon releases (tq-linux-x86_64-static), " +
+        "or `cargo install reddb-io-tq`. CI installs the pinned release.",
+    );
+  }
+}
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const DOC_PATH = join(ROOT, "plugins/dev/skills/engineering/redskilled/SKILL.md");
 const roots: string[] = [];
@@ -120,10 +142,10 @@ describe("queryable daemon worker-event log", () => {
     expect(docs).toContain(WORKER_STORY_QUERY);
     expect(docs).toContain(DRIFT_HEAL_COUNTS_QUERY);
 
-    const today = await execFileAsync("tq", ["-p", "toonl", "-o", "json", "-c", TODAY_PERFORMANCE_QUERY, path]);
+    const today = await tq(["-p", "toonl", "-o", "json", "-c", TODAY_PERFORMANCE_QUERY, path]);
     expect(today.stdout.trim().split("\n")).toHaveLength(5);
 
-    const story = await execFileAsync("tq", ["-p", "toonl", "-o", "json", "-c", WORKER_STORY_QUERY, path]);
+    const story = await tq(["-p", "toonl", "-o", "json", "-c", WORKER_STORY_QUERY, path]);
     const storyRows = story.stdout.trim().split("\n").map((line) => JSON.parse(line) as { kind: string });
     expect(storyRows.map((row) => row.kind)).toEqual([
       "worker-birth",
@@ -133,7 +155,7 @@ describe("queryable daemon worker-event log", () => {
       "worker-death",
     ]);
 
-    const counts = await execFileAsync("tq", [
+    const counts = await tq([
       "-p",
       "toonl",
       "-o",

--- a/apps/redskilled/tests/host-admission.test.ts
+++ b/apps/redskilled/tests/host-admission.test.ts
@@ -283,9 +283,16 @@ describe("the verdict is decided over live process state", () => {
   });
 });
 
+// The machine these assertions are ABOUT, stated rather than inherited.
+// `resolveHostCeiling` already accepts the CPU count; the tests just never
+// passed it, so `validation_count` derived from whatever host ran them — 3 on a
+// 12-core developer machine, something else on a 4-core CI runner. A test that
+// reads the machine it runs on is a test that only holds on that machine.
+const HOST = { availableParallelism: 12 } as const;
+
 describe("the ceiling a host admits against", () => {
   it("takes an operator's declaration over the derived share", () => {
-    expect(resolveHostCeiling({ REDSKILLED_MEMORY_CEILING: "6G", REDSKILLED_WORKER_CEILING: "4" }, 16 * GIB))
+    expect(resolveHostCeiling({ REDSKILLED_MEMORY_CEILING: "6G", REDSKILLED_WORKER_CEILING: "4" }, 16 * GIB, HOST))
       .toEqual({
         memory_bytes: 6 * GIB,
         worker_count: 4,
@@ -299,12 +306,12 @@ describe("the ceiling a host admits against", () => {
   });
 
   it("reads a percentage of the host, and `infinity` as no ceiling at all", () => {
-    expect(resolveHostCeiling({ REDSKILLED_MEMORY_CEILING: "50%" }, 16 * GIB).memory_bytes).toBe(8 * GIB);
-    expect(resolveHostCeiling({ REDSKILLED_MEMORY_CEILING: "infinity" }, 16 * GIB).memory_bytes).toBeNull();
+    expect(resolveHostCeiling({ REDSKILLED_MEMORY_CEILING: "50%" }, 16 * GIB, HOST).memory_bytes).toBe(8 * GIB);
+    expect(resolveHostCeiling({ REDSKILLED_MEMORY_CEILING: "infinity" }, 16 * GIB, HOST).memory_bytes).toBeNull();
   });
 
   it("still holds a real ceiling on a host nobody configured", () => {
-    const ceiling = resolveHostCeiling({}, 16 * GIB);
+    const ceiling = resolveHostCeiling({}, 16 * GIB, HOST);
 
     expect(ceiling.source).toBe("host-fraction");
     expect(ceiling.memory_bytes).toBeLessThan(16 * GIB);
@@ -313,7 +320,7 @@ describe("the ceiling a host admits against", () => {
   });
 
   it("lets the host configure a small interactive reservation", () => {
-    expect(resolveHostCeiling({ [REDSKILLED_INTERACTIVE_RESERVATION_ENV]: "2" }, 16 * GIB)
+    expect(resolveHostCeiling({ [REDSKILLED_INTERACTIVE_RESERVATION_ENV]: "2" }, 16 * GIB, HOST)
       .interactive_reservation).toBe(2);
   });
 });

--- a/apps/redskilled/tests/orphan-reaper.test.ts
+++ b/apps/redskilled/tests/orphan-reaper.test.ts
@@ -15,6 +15,15 @@ import {
 } from "../src/orphan-reaper.js";
 import { resolveRedskilledPaths } from "../src/paths.js";
 
+import { permitUnitDiscoveryForThisSuite } from "./support/test-host-isolation.js";
+
+// The sweep is what this suite tests, so the sandbox default that refuses it
+// would turn every assertion into "found nothing, expected nothing". Every
+// verdict below rests on a process fixture this file builds, never on what
+// the machine running it happens to hold.
+permitUnitDiscoveryForThisSuite();
+
+
 const roots: string[] = [];
 const daemons: RedskilledDaemon[] = [];
 

--- a/apps/redskilled/tests/reap-command.test.ts
+++ b/apps/redskilled/tests/reap-command.test.ts
@@ -8,6 +8,15 @@ import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import type { RedskilledProcessCensusRow } from "../src/orphan-reaper.js";
 import { resolveRedskilledPaths } from "../src/paths.js";
 
+import { permitUnitDiscoveryForThisSuite } from "./support/test-host-isolation.js";
+
+// The sweep is what this suite tests, so the sandbox default that refuses it
+// would turn every assertion into "found nothing, expected nothing". Every
+// verdict below rests on a process fixture this file builds, never on what
+// the machine running it happens to hold.
+permitUnitDiscoveryForThisSuite();
+
+
 const roots: string[] = [];
 const daemons: RedskilledDaemon[] = [];
 

--- a/apps/redskilled/tests/self-replacement.test.ts
+++ b/apps/redskilled/tests/self-replacement.test.ts
@@ -64,9 +64,41 @@ afterEach(async () => {
       () => undefined,
     );
   }
-  for (const child of children.splice(0)) child.kill("SIGKILL");
-  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+  for (const child of children.splice(0)) {
+    child.kill("SIGKILL");
+    // A signal is a request, not an exit. Removing the tree while the process is
+    // still between two writes is how this suite intermittently died on
+    // `ENOTEMPTY ... /state/deaths` — the directory the daemon was writing into
+    // as the directory came out from under it.
+    if (child.exitCode == null && child.signalCode == null) {
+      await new Promise((resolve) => child.once("exit", resolve));
+    }
+  }
+  for (const root of roots.splice(0)) await removeWhenQuiet(root);
 });
+
+/**
+ * Remove a session tree, retrying while something is still writing into it.
+ *
+ * The awaits above cover every process this file spawned — but not the SUCCESSOR,
+ * which by design is spawned by the daemon under test and whose handle this suite
+ * therefore never holds. It is asked to shut down over its socket, and a shutdown
+ * answered is not a process exited, so its last writes can still land after the
+ * teardown believes the host is quiet. Retrying is what can be done about a child
+ * that is not ours; failing loudly at the end is what keeps a genuinely stuck
+ * process from passing as a tidy one.
+ */
+async function removeWhenQuiet(root: string): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await rm(root, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt >= 40) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+}
 
 async function scratch(prefix: string): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), prefix));
@@ -816,8 +848,13 @@ describe("the working daemon, which reaches no idle boundary at all", () => {
     expect(spawns[0].join(" ")).toContain(basename(publishedBundle));
     expect(daemon.hostState().upgrade.replacement).toBe("in-progress");
     expect(daemon.hostState().upgrade.checks).toBeGreaterThan(0);
-    // It let go of the session first, exactly as the idle route does.
-    expect(await socketAnswers(paths.socketPath)).toBe(false);
+    // And it does let go of the session — but AFTER the successor is staged, not
+    // before. A successor is started while the incumbent still holds the socket
+    // precisely so a boot that fails is a takeover that never happened rather
+    // than a machine left with no daemon at all; the handover commits only once
+    // the successor has proven it can boot. So the spawn above is not the moment
+    // the socket goes quiet, and waiting for it is the honest assertion.
+    expect(await until(async () => !(await socketAnswers(paths.socketPath)), 5_000)).toBe(true);
   });
 
   it("takes its first look shortly after boot, not one whole interval later", async () => {

--- a/apps/redskilled/tests/support/test-host-isolation.ts
+++ b/apps/redskilled/tests/support/test-host-isolation.ts
@@ -16,6 +16,34 @@ const isolatedEnvironment = {
   REDSKILLED_TEST_HOST_ROOT: root,
 } as const;
 
+// Every line above isolates a PATH. Unit discovery isolates none of them: a
+// booting daemon asks the user's systemd for `red-worker-*` units, and systemd
+// has never heard of HOME. So a sandboxed daemon adopted the operator's REAL
+// Workers and counted them against budgets the tests had just declared — 77 of
+// 859 failing on a developer machine that happened to be draining a queue in
+// another checkout, and passing on an idle one.
+//
+// So the sandbox does not sweep by default. It sits OUTSIDE the pinned set
+// above because it is a feature switch rather than an identity: the suites that
+// test the sweep must be able to ask for it back, and `assertIsolatedHostIdentity`
+// would call that legitimate opt-in an escape.
+process.env.REDSKILLED_UNIT_DISCOVERY = "off";
+
+/**
+ * Let THIS suite sweep the host, for the suites whose subject is the sweep.
+ *
+ * The reaper and the WSL2 census cannot be tested with discovery off — it is the
+ * behaviour under test, so the safe default would silently assert that finding
+ * nothing is finding nothing. Such a suite must supply its own process fixtures
+ * and never let a verdict rest on what this machine happens to be running.
+ *
+ * Call it at module scope, before the daemon under test is spawned: a child
+ * inherits the environment as it stood at spawn, not as it stands at assertion.
+ */
+export function permitUnitDiscoveryForThisSuite(): void {
+  delete process.env.REDSKILLED_UNIT_DISCOVERY;
+}
+
 Object.assign(process.env, isolatedEnvironment);
 mkdirSync(isolatedEnvironment.HOME, { recursive: true });
 mkdirSync(isolatedEnvironment.XDG_RUNTIME_DIR, { recursive: true });

--- a/apps/redskilled/tests/unattended-demand.test.ts
+++ b/apps/redskilled/tests/unattended-demand.test.ts
@@ -111,13 +111,15 @@ describe("a registration drains with no session alive behind it", () => {
     // No poll is asked for, no tick is driven, no session stays alive.
     await registerRedskilledProject(paths, registration("acme/widgets", workspace), { readyTimeoutMs: 5_000 });
 
+    // Same deadline reasoning as its sibling below: this waits on a real Worker
+    // reaching disk, so it is sized for a loaded machine rather than a quiet one.
     await expect
-      .poll(async () => await readFile(join(workspace, "proof.txt"), "utf8").catch(() => ""), { timeout: 10_000 })
+      .poll(async () => await readFile(join(workspace, "proof.txt"), "utf8").catch(() => ""), { timeout: 30_000 })
       .toBe(workspace);
     // Asked for by the loop, not by this test: the daemon's own tick holds the
     // depth it planned against, from a poll nobody in this process requested.
     expect(daemon.demand()?.projects[0]?.queue_depth).toBe(3);
-  });
+  }, 60_000);
 });
 
 describe("a daemon that could not arm at start arms itself when it can", () => {
@@ -152,17 +154,24 @@ describe("a daemon that could not arm at start arms itself when it can", () => {
     expect(queueDiscovery.transport).toBeUndefined();
     await registerRedskilledProject(paths, registration("acme/widgets", workspace), { readyTimeoutMs: 5_000 });
     await expect
-      .poll(() => daemon.hostState().registrations?.[0]?.last_poll?.outcome, { timeout: 5_000 })
+      .poll(() => daemon.hostState().registrations?.[0]?.last_poll?.outcome, { timeout: 15_000 })
       .toBe("unconfigured");
     expect(daemon.workerCount()).toBe(0);
 
     credential = "a-token-that-exists-now";
 
+    // This waits on a real Worker being born and reaching disk, not on a state
+    // transition in memory — so the deadline has to fit the slowest machine that
+    // runs it, not the quietest. At 10s it passed alone and failed about one full
+    // suite run in four, which is the worst way for a gate to behave: red for
+    // reasons that have nothing to do with the change under review. Waiting
+    // longer costs nothing when it passes — the poll returns the moment the file
+    // is there.
     await expect
-      .poll(async () => await readFile(join(workspace, "proof.txt"), "utf8").catch(() => ""), { timeout: 10_000 })
+      .poll(async () => await readFile(join(workspace, "proof.txt"), "utf8").catch(() => ""), { timeout: 30_000 })
       .toBe(workspace);
     expect(daemon.hostState().registrations?.[0]?.last_poll?.outcome).toBe("counted");
-  });
+  }, 60_000);
 });
 
 describe("the sustain and the idle exit follow the poll outcome", () => {

--- a/apps/redskilled/tests/worker-birth.test.ts
+++ b/apps/redskilled/tests/worker-birth.test.ts
@@ -225,7 +225,13 @@ describe("the daemon accepts the workspace path as given", () => {
       systemdRun: null,
       userSession: false,
       jobObjects: { available: false, reason: expect.stringContaining("Windows backend") },
-      posix: { available: false, reason: expect.stringContaining("macOS backend") },
+      // POSIX shell placement stopped being "the macOS backend" when it became
+      // the fallback for a Linux host with no systemd, so it reports available
+      // here. It stays inside this test's invariant: `/bin/sh` is an absolute
+      // path the daemon was shipped knowing, and `nice` is null precisely
+      // BECAUSE the handed PATH is empty — both answers derive from the probe
+      // arguments, never from a directory a client named.
+      posix: { available: true, shell: "/bin/sh", nice: null },
     });
   });
 

--- a/apps/redskilled/tests/wsl2-host.test.ts
+++ b/apps/redskilled/tests/wsl2-host.test.ts
@@ -28,6 +28,15 @@ import {
 } from "../src/machine-scope.js";
 import { resolveRedskilledPaths, resolveSessionKey, REDSKILLED_SOCKET_FILE } from "../src/paths.js";
 import { censusRedskilledProcesses } from "../src/orphan-reaper.js";
+
+import { permitUnitDiscoveryForThisSuite } from "./support/test-host-isolation.js";
+
+// The sweep is what this suite tests, so the sandbox default that refuses it
+// would turn every assertion into "found nothing, expected nothing". Every
+// verdict below rests on a process fixture this file builds, never on what
+// the machine running it happens to hold.
+permitUnitDiscoveryForThisSuite();
+
 import { stopWorker } from "../src/reattach.js";
 import { launchWorker } from "../src/worker-launch.js";
 import { detectWorkerPlacementProbes, planWorkerPlacement } from "../src/worker-placement.js";


### PR DESCRIPTION
## What

`apps/redskilled` appears in **zero** CI jobs. The shard matrix runs `apps/dev`; the package job named five packages and the daemon was not among them. The host authority — the only process allowed to birth a Worker — has an 859-test suite that no pull request has ever run.

Wiring it in was refused once already (cf17494f4), on evidence: **8** failed on a clean runner, and a *different* **77** failed on a developer machine. A gate is not a gate until it is green, so the suite is fixed here and the wiring rides behind it.

**859 of 859 pass.** `pnpm typecheck --force` and `pnpm -C apps/dev test:invariants` are green.

## The 77 were one bug wearing many faces

`test-host-isolation.ts` pinned four **paths** — `HOME`, `XDG_RUNTIME_DIR`, the machine dir, its own root. Unit discovery is not a path: a booting daemon asks the user's systemd for `red-worker-*` units, and **systemd has never heard of `HOME`**. Every sandboxed daemon adopted the operator's live Workers and counted them against budgets the test had just declared — `expected 1, got 2` for anyone draining a queue in another checkout, and green on an idle machine.

The sandbox no longer sweeps by default, through the kill-switch that already existed for operators. It sits *outside* the pinned identity set because it is a feature switch, not an identity: `permitUnitDiscoveryForThisSuite()` hands it back to the three suites whose **subject** is the sweep — the reaper, the WSL2 census, `reap --report` — which supply their own process fixtures.

## The rest were tests outliving the designs they described

| Test | Described | Ships |
|---|---|---|
| `worker-birth` | POSIX placement is the macOS backend | It is also the fallback for a systemd-less Linux host |
| `daemon-restart` | A malformed middle lane row **throws** | It is skipped and counted out loud (#3651) |
| `daemon-presence` | A held daemon fails immediately | It is retryable — waiting is what a client owes one that is booting |
| `self-replacement` | The incumbent lets go, *then* spawns | The successor is staged **while** the incumbent still holds the socket |

Two are worth spelling out.

**#3651 is what "fatal" costs.** One mixed-arity row an older daemon generation had written took every `worker_dispatch` on the machine down, reported as *"the daemon did not answer"* and pointing the operator at `provision` — the wrong repair for a healthy daemon. The test still pinned the throw. It now asserts the survivors come back and the ruins get named.

**`daemon-presence` lost its race by a margin of zero.** It declared `readyTimeoutMs` and no reconnect budget, so it inherited the product default of `30_000`ms — precisely this suite's timeout. It states its own patience now.

One was a teardown that removed a directory out from under a live process (`ENOTEMPTY … /state/deaths`, intermittently). A signal is a request, not an exit, and the successor is spawned *by the daemon under test* — the one child the suite never holds a handle to. Teardown awaits the children it owns and retries for the one it cannot, failing loudly at the end so a genuinely stuck process cannot pass as a tidy one. Ran four times over to confirm.

## Verification

- `pnpm -C apps/redskilled test` — 94 files, 859 passed
- `pnpm typecheck --force` — 16/16
- `pnpm -C apps/dev test:invariants` — 202 passed
- `self-replacement` run 4x for the intermittent teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789231502&installation_model_id=20659&pr_number=3822&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3822&signature=5324fcabd10c5d82e0c3ce5d19b7cab8c6886e3c7600dc9dac57d862e6351432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->