### PR TITLE
resume: #3507

### DIFF
--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -57,6 +57,16 @@ on first attach or a rotated position it captures the new position, asks
 `host-state` for the current picture, and resumes event following from there.
 The missing prefix is never replayed or guessed.
 
+`host-state.topology` states the daemon's `platform` and whether its kernel is
+`native` or `wsl`. WSL is detected from the kernel release, not from an
+environment variable. On first attach, `followRedskilledPublicEvents` compares
+that daemon-side fact with its own kernel and returns `status: refused` for
+`wsl-daemon/native-windows-consumer` or
+`native-windows-daemon/wsl-consumer`. The refusal names that file-change
+notification does not cross the WSL boundary and returns no watch position.
+WSL on both sides and native Windows on both sides remain ordinary `baseline`
+attachments.
+
 Each public record is flat and total. It contains the following fields, with
 `null` used where a field does not apply:
 

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -88,6 +88,7 @@ import {
 } from "../project-registration.js";
 import { createRedskilledProjectHookRuntime } from "../project-hook.js";
 import { createRedskilledHostEventSinkRuntime } from "../host-event-sink.js";
+import { detectRedskilledHostTopology } from "../host-topology.js";
 import { pingAnswer } from "./ping-answer.js";
 import {
   detectUnitExitFacts,
@@ -228,6 +229,7 @@ export { RedskilledAlreadyRunningError } from "../daemon/errors.js";
 export async function startRedskilledDaemon(options: RedskilledDaemonOptions): Promise<RedskilledDaemon> {
   const { paths } = options;
   const daemonVersion = options.daemonVersion ?? "0.0.0-dev";
+  const hostTopology = options.hostTopology ?? detectRedskilledHostTopology();
   const idleMs = options.idleMs ?? DEFAULT_REDSKILLED_IDLE_MS;
   const clock = options.clock ?? (() => new Date().toISOString());
   const launch = options.launch ?? launchWorker;
@@ -681,6 +683,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       sessionKeyHash: paths.sessionKeyHash,
       pid: owner.pid,
       startedAt,
+      topology: hostTopology,
       ceiling,
       scope: describeMachineScope(machineClaimStore.claimPath, claimLabels, machineOwner),
       requestHealth: selfPingMonitor.health(),

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -29,6 +29,7 @@ import type {
 import { type RedskilledLaunchTemplate } from "../launch-template.js";
 import type { RedskilledPaths } from "../paths.js";
 import type { RedskilledHostEventSinks } from "../host-event-sink.js";
+import type { RedskilledHostTopology } from "../host-topology.js";
 import { type RedskilledRegistrationIntentStore,
 } from "../registration-intent-store.js";
 import { type RedskilledProjectRegistration,
@@ -87,6 +88,8 @@ import type {
 } from "../resource-incidents.js";
 export interface RedskilledDaemonOptions {
   readonly paths: RedskilledPaths;
+  /** Test seam; production detects the kernel-side topology at daemon start. */
+  readonly hostTopology?: RedskilledHostTopology;
   /** Operator-owned lifecycle hooks and desktop notification declarations. */
   readonly hostEventSinks?: RedskilledHostEventSinks;
   /** Hard deadline for each daemon-owned GitHub call; 0 or below disables it. */

--- a/apps/redskilled/src/event-lane-reader.ts
+++ b/apps/redskilled/src/event-lane-reader.ts
@@ -1,0 +1,224 @@
+/**
+ * event-lane-reader — read, replay, and follow the daemon's bounded event lane.
+ *
+ * The writer owns append and rotation. This module owns the other half of the
+ * contract: decoding a generation, rebuilding live Worker state, and refusing
+ * a public follower whose host topology cannot observe WSL-side file changes.
+ */
+import { readFile } from "node:fs/promises";
+import { decodeHostEventRow, decodeLaneRows } from "./event-lane-decode.js";
+import {
+  readPositionedEventLane,
+  type EventLanePosition,
+  type PositionedEventRead,
+} from "./event-lane-position.js";
+import {
+  REDSKILLED_DAEMON_EVENT_KINDS,
+  REDSKILLED_PUBLIC_HOST_EVENT_KINDS,
+  REDSKILLED_WORKER_EVENT_KINDS,
+  type RedskilledEventKind,
+  type RedskilledHostEvent,
+  type RedskilledPublicHostEvent,
+} from "./event-lane.js";
+import type { RedskilledWorkerView } from "./host-state.js";
+import {
+  detectRedskilledHostTopology,
+  evaluateRedskilledHostEventTopology,
+  readRedskilledHostTopology,
+  type RedskilledHostEventTopology,
+  type RedskilledHostTopology,
+} from "./host-topology.js";
+import type { RedskilledWorkerBudget } from "./worker-placement.js";
+
+type ToonlRecord = Record<string, string | number | boolean | null>;
+
+/** Every event on the lane at `path`; an absent lane is an empty history. */
+export async function readRedskilledEvents(path: string): Promise<RedskilledHostEvent[]> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  return parseEventLane(raw);
+}
+
+export type RedskilledEventLanePosition = EventLanePosition;
+export type RedskilledPositionedEventRead = PositionedEventRead<RedskilledHostEvent>;
+
+/** Read from one generation, reporting the current bounded lane after rotation. */
+export async function readRedskilledEventsFrom(
+  path: string,
+  position?: RedskilledEventLanePosition | null,
+): Promise<RedskilledPositionedEventRead> {
+  return await readPositionedEventLane(path, position, parseEventLane);
+}
+
+export type RedskilledPublicEventFollow<TBaseline> =
+  | {
+      readonly status: "events";
+      readonly events: readonly RedskilledPublicHostEvent[];
+      readonly position: RedskilledEventLanePosition | null;
+    }
+  | {
+      readonly status: "baseline";
+      readonly reason: "initial" | "position-rotated";
+      readonly baseline: TBaseline;
+      readonly events: readonly [];
+      readonly position: RedskilledEventLanePosition | null;
+    }
+  | {
+      readonly status: "refused";
+      readonly reason: "unsupported-topology";
+      readonly topology: Exclude<RedskilledHostEventTopology, "same-side">;
+      readonly detail: string;
+      readonly events: readonly [];
+      readonly position: null;
+    };
+
+export interface RedskilledPublicEventFollowOptions {
+  /** Test seam; production detects the consumer from its own kernel. */
+  readonly consumerTopology?: RedskilledHostTopology;
+}
+
+/**
+ * Follow only public host events, replacing a missing prefix with current state.
+ *
+ * The position is captured before `readBaseline` runs. An event racing the host
+ * read is therefore either already reflected by that state or appears again on
+ * the next follow; it is never silently skipped between the two authorities.
+ */
+export async function followRedskilledPublicEvents<TBaseline>(
+  path: string,
+  position: RedskilledEventLanePosition | null | undefined,
+  readBaseline: () => Promise<TBaseline>,
+  options: RedskilledPublicEventFollowOptions = {},
+): Promise<RedskilledPublicEventFollow<TBaseline>> {
+  const read = await readRedskilledEventsFrom(path, position);
+  if (position == null || read.status === "rebaseline-required") {
+    const baseline = await readBaseline();
+    const daemonTopology = readRedskilledHostTopology(baseline);
+    if (daemonTopology != null) {
+      const verdict = evaluateRedskilledHostEventTopology(
+        daemonTopology,
+        options.consumerTopology ?? detectRedskilledHostTopology(),
+      );
+      if (!verdict.observable && verdict.topology !== "same-side") {
+        return {
+          status: "refused",
+          reason: "unsupported-topology",
+          topology: verdict.topology,
+          detail: verdict.detail,
+          events: [],
+          position: null,
+        };
+      }
+    }
+    return {
+      status: "baseline",
+      reason: position == null ? "initial" : "position-rotated",
+      baseline,
+      events: [],
+      position: read.position,
+    };
+  }
+  return {
+    status: "events",
+    events: read.events.filter(isPublicHostEvent),
+    position: read.position,
+  };
+}
+
+function isPublicHostEvent(event: RedskilledHostEvent): event is RedskilledPublicHostEvent {
+  return (REDSKILLED_PUBLIC_HOST_EVENT_KINDS as readonly RedskilledEventKind[]).includes(event.kind);
+}
+
+/**
+ * Decode a lane's text into events: the crash-truncated tail is dropped, and
+ * historical rows no header can hold are skipped by `decodeLaneRows`. PURE.
+ */
+export function parseEventLane(raw: string): RedskilledHostEvent[] {
+  const lines = raw.split("\n");
+  // `split` leaves a trailing "" for a newline-terminated file; anything else in
+  // that slot is the half-written line a crash left behind.
+  lines.pop();
+  if (lines.length === 0) return [];
+  const { records, malformed } = decodeLaneRows(lines);
+  if (malformed.length > 0) {
+    console.warn(`redskilled event lane skipped ${malformed.length} malformed row(s) at line ${malformed.join(", ")}`);
+  }
+  return records.filter(isHostEventRecord).map(decodeHostEventRow);
+}
+
+/**
+ * Replay events into the Workers the daemon should still believe are alive.
+ *
+ * Last event per Worker wins: a birth admits it, a death or a budget kill
+ * retires it. Ordering is the lane's own, which is the order the daemon observed
+ * the facts in — a timestamp comparison would let a clock adjustment resurrect a
+ * Worker the daemon watched die. PURE.
+ */
+export function rehydrateWorkers(events: readonly RedskilledHostEvent[]): RedskilledWorkerView[] {
+  const alive = new Map<string, RedskilledWorkerView>();
+  for (const event of events) {
+    // A daemon's own stop retires nothing: the daemon left and every Worker it
+    // held is still running, which is exactly what the successor replays to find.
+    if ((REDSKILLED_DAEMON_EVENT_KINDS as readonly RedskilledEventKind[]).includes(event.kind)) continue;
+    if (event.kind === "worker-birth") alive.set(event.worker_id, toWorkerView(event));
+    else if (event.kind === "worker-death" || event.kind === "worker-budget-kill") alive.delete(event.worker_id);
+  }
+  return [...alive.values()];
+}
+
+/**
+ * How the previous daemon left, read off the lane a successor replays. PURE.
+ *
+ * `null` means the lane's last daemon never said goodbye — a crash, a kill, or a
+ * lane that has simply never seen a stop. That is the whole point of the answer:
+ * the successor tells a handover from a death by whether the predecessor's own
+ * stop is the last thing on the lane, not by guessing from the Workers it finds.
+ */
+export function lastRedskilledDaemonStop(
+  events: readonly RedskilledHostEvent[],
+): RedskilledHostEvent | null {
+  for (let index = events.length - 1; index >= 0; index--) {
+    const event = events[index];
+    if (event?.kind === "daemon-stop") return event;
+  }
+  return null;
+}
+
+/** The Worker view an event describes. PURE. */
+export function toWorkerView(event: RedskilledHostEvent): RedskilledWorkerView {
+  const budget: RedskilledWorkerBudget = {
+    ...(event.memory_high != null ? { memory_high: event.memory_high } : {}),
+    ...(event.memory_max != null ? { memory_max: event.memory_max } : {}),
+    ...(event.cpu_weight != null ? { cpu_weight: event.cpu_weight } : {}),
+  };
+  return {
+    worker_id: event.worker_id,
+    project_label: event.project_label,
+    pid: event.pid,
+    ...(event.pgid == null ? {} : { pgid: event.pgid }),
+    ...(event.proc_start_time == null
+      ? {}
+      : { proc_start_time: event.proc_start_time }),
+    started_at: event.ts,
+    workspace_path: event.workspace_path,
+    ...(event.fork_sha != null ? { fork_sha: event.fork_sha } : {}),
+    ...(event.log_path != null ? { log_path: event.log_path } : {}),
+    isolated: event.isolated,
+    ...(event.unit != null ? { unit: event.unit } : {}),
+    ...(Object.keys(budget).length > 0 ? { budget } : {}),
+    warnings: [],
+  };
+}
+
+function isHostEventRecord(record: ToonlRecord): boolean {
+  const kind = record.kind ?? record.event;
+  return record.version === 1 &&
+    typeof record.ts === "string" &&
+    typeof record.worker_id === "string" &&
+    ([...REDSKILLED_WORKER_EVENT_KINDS, ...REDSKILLED_DAEMON_EVENT_KINDS] as readonly unknown[]).includes(kind);
+}

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -27,7 +27,7 @@
  * so one segment header covers a whole writer's session and a reader never
  * special-cases an event kind's row.
  */
-import { appendFile, mkdir, open, readFile, rename, rm, stat, truncate, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, open, rename, rm, stat, truncate, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { encodeToonlLines } from "@reddb-io/toon";
 import {
@@ -51,14 +51,24 @@ export {
   type RecordDaemonStopInput,
   type RecordDaemonTakeoverFailedInput,
 } from "./daemon-events.js";
-import { decodeHostEventRow, decodeLaneRows } from "./event-lane-decode.js";
 import {
-  readPositionedEventLane,
-  type EventLanePosition,
-  type PositionedEventRead,
-} from "./event-lane-position.js";
+  readRedskilledEvents,
+  rehydrateWorkers,
+} from "./event-lane-reader.js";
+export {
+  followRedskilledPublicEvents,
+  lastRedskilledDaemonStop,
+  parseEventLane,
+  readRedskilledEvents,
+  readRedskilledEventsFrom,
+  rehydrateWorkers,
+  toWorkerView,
+  type RedskilledEventLanePosition,
+  type RedskilledPositionedEventRead,
+  type RedskilledPublicEventFollow,
+  type RedskilledPublicEventFollowOptions,
+} from "./event-lane-reader.js";
 import type { RedskilledWorkerView } from "./host-state.js";
-import type { RedskilledWorkerBudget } from "./worker-placement.js";
 type ToonlRecord = Record<string, string | number | boolean | null>;
 
 /**
@@ -599,165 +609,6 @@ async function dropIncompleteTail(path: string): Promise<void> {
   }
 }
 
-/** Every event on the lane at `path`; an absent lane is an empty history. */
-export async function readRedskilledEvents(path: string): Promise<RedskilledHostEvent[]> {
-  let raw: string;
-  try {
-    raw = await readFile(path, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
-    throw error;
-  }
-  return parseEventLane(raw);
-}
-
-export type RedskilledEventLanePosition = EventLanePosition;
-export type RedskilledPositionedEventRead = PositionedEventRead<RedskilledHostEvent>;
-
-/** Read from one generation, reporting the current bounded lane after rotation. */
-export async function readRedskilledEventsFrom(
-  path: string,
-  position?: RedskilledEventLanePosition | null,
-): Promise<RedskilledPositionedEventRead> {
-  return await readPositionedEventLane(path, position, parseEventLane);
-}
-
-export type RedskilledPublicEventFollow<TBaseline> =
-  | {
-      readonly status: "events";
-      readonly events: readonly RedskilledPublicHostEvent[];
-      readonly position: RedskilledEventLanePosition | null;
-    }
-  | {
-      readonly status: "baseline";
-      readonly reason: "initial" | "position-rotated";
-      readonly baseline: TBaseline;
-      readonly events: readonly [];
-      readonly position: RedskilledEventLanePosition | null;
-    };
-
-/**
- * Follow only public host events, replacing a missing prefix with current state.
- *
- * The position is captured before `readBaseline` runs. An event racing the host
- * read is therefore either already reflected by that state or appears again on
- * the next follow; it is never silently skipped between the two authorities.
- */
-export async function followRedskilledPublicEvents<TBaseline>(
-  path: string,
-  position: RedskilledEventLanePosition | null | undefined,
-  readBaseline: () => Promise<TBaseline>,
-): Promise<RedskilledPublicEventFollow<TBaseline>> {
-  const read = await readRedskilledEventsFrom(path, position);
-  if (position == null || read.status === "rebaseline-required") {
-    return {
-      status: "baseline",
-      reason: position == null ? "initial" : "position-rotated",
-      baseline: await readBaseline(),
-      events: [],
-      position: read.position,
-    };
-  }
-  return {
-    status: "events",
-    events: read.events.filter(isPublicHostEvent),
-    position: read.position,
-  };
-}
-
-function isPublicHostEvent(event: RedskilledHostEvent): event is RedskilledPublicHostEvent {
-  return (REDSKILLED_PUBLIC_HOST_EVENT_KINDS as readonly RedskilledEventKind[]).includes(event.kind);
-}
-
-/**
- * Decode a lane's text into events: the crash-truncated tail is dropped, and
- * historical rows no header can hold are skipped by `decodeLaneRows`. PURE.
- */
-export function parseEventLane(raw: string): RedskilledHostEvent[] {
-  const lines = raw.split("\n");
-  // `split` leaves a trailing "" for a newline-terminated file; anything else in
-  // that slot is the half-written line a crash left behind.
-  lines.pop();
-  if (lines.length === 0) return [];
-  const { records, malformed } = decodeLaneRows(lines);
-  if (malformed.length > 0) {
-    console.warn(`redskilled event lane skipped ${malformed.length} malformed row(s) at line ${malformed.join(", ")}`);
-  }
-  return records.filter(isHostEventRecord).map(decodeHostEventRow);
-}
-
-/**
- * Replay events into the Workers the daemon should still believe are alive.
- *
- * Last event per Worker wins: a birth admits it, a death or a budget kill
- * retires it. Ordering is the lane's own, which is the order the daemon observed
- * the facts in — a timestamp comparison would let a clock adjustment resurrect a
- * Worker the daemon watched die. PURE.
- */
-export function rehydrateWorkers(events: readonly RedskilledHostEvent[]): RedskilledWorkerView[] {
-  const alive = new Map<string, RedskilledWorkerView>();
-  for (const event of events) {
-    // A daemon's own stop retires nothing: the daemon left and every Worker it
-    // held is still running, which is exactly what the successor replays to find.
-    if ((REDSKILLED_DAEMON_EVENT_KINDS as readonly RedskilledEventKind[]).includes(event.kind)) continue;
-    if (event.kind === "worker-birth") alive.set(event.worker_id, toWorkerView(event));
-    else if (event.kind === "worker-death" || event.kind === "worker-budget-kill") alive.delete(event.worker_id);
-  }
-  return [...alive.values()];
-}
-
-/**
- * How the previous daemon left, read off the lane a successor replays. PURE.
- *
- * `null` means the lane's last daemon never said goodbye — a crash, a kill, or a
- * lane that has simply never seen a stop. That is the whole point of the answer:
- * the successor tells a handover from a death by whether the predecessor's own
- * stop is the last thing on the lane, not by guessing from the Workers it finds.
- */
-export function lastRedskilledDaemonStop(
-  events: readonly RedskilledHostEvent[],
-): RedskilledHostEvent | null {
-  for (let index = events.length - 1; index >= 0; index--) {
-    const event = events[index];
-    if (event?.kind === "daemon-stop") return event;
-  }
-  return null;
-}
-
-/** The Worker view an event describes. PURE. */
-export function toWorkerView(event: RedskilledHostEvent): RedskilledWorkerView {
-  const budget: RedskilledWorkerBudget = {
-    ...(event.memory_high != null ? { memory_high: event.memory_high } : {}),
-    ...(event.memory_max != null ? { memory_max: event.memory_max } : {}),
-    ...(event.cpu_weight != null ? { cpu_weight: event.cpu_weight } : {}),
-  };
-  return {
-    worker_id: event.worker_id,
-    project_label: event.project_label,
-    pid: event.pid,
-    ...(event.pgid == null ? {} : { pgid: event.pgid }),
-    ...(event.proc_start_time == null
-      ? {}
-      : { proc_start_time: event.proc_start_time }),
-    started_at: event.ts,
-    workspace_path: event.workspace_path,
-    ...(event.fork_sha != null ? { fork_sha: event.fork_sha } : {}),
-    ...(event.log_path != null ? { log_path: event.log_path } : {}),
-    isolated: event.isolated,
-    ...(event.unit != null ? { unit: event.unit } : {}),
-    ...(Object.keys(budget).length > 0 ? { budget } : {}),
-    warnings: [],
-  };
-}
-
 function toRow(event: RedskilledHostEvent): ToonlRecord {
   return { ...event };
-}
-
-function isHostEventRecord(record: ToonlRecord): boolean {
-  const kind = record.kind ?? record.event;
-  return record.version === 1 &&
-    typeof record.ts === "string" &&
-    typeof record.worker_id === "string" &&
-    ([...REDSKILLED_WORKER_EVENT_KINDS, ...REDSKILLED_DAEMON_EVENT_KINDS] as readonly unknown[]).includes(kind);
 }

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -31,6 +31,7 @@ import type { RedskilledQueueDiscovery, RedskilledQueueOutcome } from "./queue-d
 import type { RedskilledMajorHold, RedskilledReplacementHoldReason } from "./self-replace.js";
 import type { RedskilledWorkerBudget } from "./worker-placement.js";
 import type { ResourceIncidentSummary } from "./resource-incidents.js";
+import { isRedskilledHostTopology, type RedskilledHostTopology } from "./host-topology.js";
 
 export interface RedskilledResourceIncidentState {
   readonly source: "cgroup-v2-preferred";
@@ -320,6 +321,8 @@ export interface RedskilledHostState {
   readonly session_key_hash: string;
   readonly pid: number;
   readonly started_at: string;
+  /** The OS boundary that owns this daemon and its file-backed event lane. */
+  readonly topology?: RedskilledHostTopology;
   /** The machine-wide limits this daemon enforces, including each origin. */
   readonly ceiling?: RedskilledHostCeiling;
   /**
@@ -379,6 +382,8 @@ export interface BuildHostStateInput {
   readonly sessionKeyHash: string;
   readonly pid: number;
   readonly startedAt: string;
+  /** Explicit daemon-side topology; absent only for callers predating the fact. */
+  readonly topology?: RedskilledHostTopology;
   /** The resolved host policy. Older callers may still provide only its bytes. */
   readonly ceiling?: RedskilledHostCeiling;
   /** The scope block; absent leaves the document without one rather than inventing it. */
@@ -454,6 +459,7 @@ export function buildHostState(input: BuildHostStateInput): RedskilledHostState 
     session_key_hash: input.sessionKeyHash,
     pid: input.pid,
     started_at: input.startedAt,
+    ...(input.topology == null ? {} : { topology: input.topology }),
     ...(input.ceiling == null ? {} : { ceiling: input.ceiling }),
     ...(input.scope == null ? {} : { scope: input.scope }),
     ...(input.requestHealth == null ? {} : { request_health: input.requestHealth }),
@@ -583,6 +589,7 @@ export function isRedskilledHostState(value: unknown): value is RedskilledHostSt
     typeof state.session_key_hash === "string" &&
     Number.isInteger(state.pid) &&
     typeof state.started_at === "string" &&
+    (state.topology === undefined || isRedskilledHostTopology(state.topology)) &&
     (state.ceiling === undefined || isHostCeiling(state.ceiling)) &&
     Array.isArray(state.workers) &&
     Array.isArray(state.projects) &&

--- a/apps/redskilled/src/host-topology.ts
+++ b/apps/redskilled/src/host-topology.ts
@@ -1,0 +1,85 @@
+import { release } from "node:os";
+
+export type RedskilledHostEnvironment = "native" | "wsl";
+
+/** The kernel-side topology that owns the daemon and its event lane. */
+export interface RedskilledHostTopology {
+  readonly platform: NodeJS.Platform;
+  readonly environment: RedskilledHostEnvironment;
+}
+
+export type RedskilledHostEventTopology =
+  | "same-side"
+  | "wsl-daemon/native-windows-consumer"
+  | "native-windows-daemon/wsl-consumer";
+
+export interface RedskilledHostEventTopologyVerdict {
+  readonly observable: boolean;
+  readonly topology: RedskilledHostEventTopology;
+  readonly detail: string;
+}
+
+/** Detect WSL from uname's kernel release, never from unsettable process state. */
+export function detectRedskilledHostTopology(input: {
+  readonly platform?: NodeJS.Platform;
+  readonly release?: string;
+} = {}): RedskilledHostTopology {
+  const platform = input.platform ?? process.platform;
+  const kernelRelease = input.release ?? release();
+  return {
+    platform,
+    environment: platform === "linux" && /(?:microsoft|wsl)/i.test(kernelRelease) ? "wsl" : "native",
+  };
+}
+
+/** Validate topology read from a daemon document before trusting its boundary. */
+export function isRedskilledHostTopology(value: unknown): value is RedskilledHostTopology {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const topology = value as Record<string, unknown>;
+  return typeof topology.platform === "string" &&
+    (topology.environment === "native" || topology.environment === "wsl") &&
+    (topology.environment !== "wsl" || topology.platform === "linux");
+}
+
+/** Read an explicitly reported topology from a daemon document. */
+export function readRedskilledHostTopology(document: unknown): RedskilledHostTopology | null {
+  if (document === null || typeof document !== "object" || Array.isArray(document)) return null;
+  const topology = (document as Record<string, unknown>).topology;
+  return isRedskilledHostTopology(topology) ? topology : null;
+}
+
+/** State whether a file-backed event lane can notify this consumer. */
+export function evaluateRedskilledHostEventTopology(
+  daemon: RedskilledHostTopology,
+  consumer: RedskilledHostTopology,
+): RedskilledHostEventTopologyVerdict {
+  const daemonWsl = daemon.environment === "wsl";
+  const consumerWsl = consumer.environment === "wsl";
+  const daemonWindows = daemon.platform === "win32" && !daemonWsl;
+  const consumerWindows = consumer.platform === "win32" && !consumerWsl;
+  if (daemonWsl && consumerWindows) {
+    return {
+      observable: false,
+      topology: "wsl-daemon/native-windows-consumer",
+      detail: "WSL daemon -> native Windows consumer: file-change notification does not cross the WSL boundary",
+    };
+  }
+  if (daemonWindows && consumerWsl) {
+    return {
+      observable: false,
+      topology: "native-windows-daemon/wsl-consumer",
+      detail: "native Windows daemon -> WSL consumer: file-change notification does not cross the WSL boundary",
+    };
+  }
+  return {
+    observable: true,
+    topology: "same-side",
+    detail: `${describeHostSide(daemon)} daemon -> ${describeHostSide(consumer)} consumer is observable`,
+  };
+}
+
+function describeHostSide(topology: RedskilledHostTopology): string {
+  if (topology.environment === "wsl") return "WSL";
+  if (topology.platform === "win32") return "native Windows";
+  return `native ${topology.platform}`;
+}

--- a/apps/redskilled/tests/event-lane-topology.test.ts
+++ b/apps/redskilled/tests/event-lane-topology.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createRedskilledEventLane, followRedskilledPublicEvents } from "../src/event-lane.js";
+import { buildHostState } from "../src/host-state.js";
+import type { RedskilledHostTopology } from "../src/host-topology.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+const wsl: RedskilledHostTopology = { platform: "linux", environment: "wsl" };
+const windows: RedskilledHostTopology = { platform: "win32", environment: "native" };
+
+describe("a public host-event consumer's first attach", () => {
+  it("refuses only cross-WSL topologies before handing the consumer a watch position", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-event-topology-"));
+    roots.push(root);
+    const path = join(root, "redskilled.log.toonl");
+    const lane = createRedskilledEventLane(path);
+    const sameSide: Array<readonly [RedskilledHostTopology, RedskilledHostTopology, NonNullable<Awaited<ReturnType<typeof followRedskilledPublicEvents>>["position"]>]> = [];
+
+    await lane.recordWorker({
+      kind: "worker-birth",
+      worker: {
+        worker_id: "wBASE",
+        project_label: "acme/widgets",
+        pid: 41,
+        started_at: "2026-08-13T00:00:00.000Z",
+        workspace_path: "/tmp/workspace",
+        isolated: false,
+        warnings: [],
+      },
+      ts: "2026-08-13T00:00:00.000Z",
+    });
+
+    for (const [daemon, consumer, status] of [
+      [wsl, windows, "refused"],
+      [windows, wsl, "refused"],
+      [wsl, wsl, "baseline"],
+      [windows, windows, "baseline"],
+    ] as const) {
+      const followed = await followRedskilledPublicEvents(
+        path,
+        null,
+        async () => buildHostState({
+          daemonVersion: "3.18.1",
+          machineIdHash: "machine",
+          sessionKeyHash: "session",
+          pid: 42,
+          startedAt: "2026-08-13T00:00:00.000Z",
+          topology: daemon,
+        }),
+        { consumerTopology: consumer },
+      );
+
+      expect(followed.status).toBe(status);
+      if (followed.status === "refused") {
+        expect(followed.position).toBeNull();
+        expect(followed.events).toEqual([]);
+        expect(followed.detail).toMatch(/file-change notification does not cross the WSL boundary/);
+        expect(followed.topology).toMatch(/wsl.*native-windows|native-windows.*wsl/);
+      } else if (followed.status === "baseline" && followed.position != null) {
+        sameSide.push([daemon, consumer, followed.position]);
+      }
+    }
+
+    await lane.recordWorker({
+      kind: "worker-birth",
+      worker: {
+        worker_id: "wNEXT",
+        project_label: "acme/widgets",
+        pid: 43,
+        started_at: "2026-08-13T00:01:00.000Z",
+        workspace_path: "/tmp/workspace",
+        isolated: false,
+        warnings: [],
+      },
+      ts: "2026-08-13T00:01:00.000Z",
+    });
+    for (const [daemon, consumer, position] of sameSide) {
+      const followed = await followRedskilledPublicEvents(
+        path,
+        position,
+        async () => ({ topology: daemon }),
+        { consumerTopology: consumer },
+      );
+      expect(followed.status).toBe("events");
+      expect(followed.events.map((event) => event.worker_id)).toEqual(["wNEXT"]);
+    }
+  });
+});

--- a/apps/redskilled/tests/host-state.test.ts
+++ b/apps/redskilled/tests/host-state.test.ts
@@ -66,6 +66,20 @@ describe("redskilled host state", () => {
     });
   });
 
+  it("reports the daemon's WSL topology as an explicit host-state fact", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      hostTopology: { platform: "linux", environment: "wsl" },
+    });
+    running.push(daemon);
+
+    const state = await readRedskilledHostState(paths, { readyTimeoutMs: 5_000 });
+
+    expect(state.topology).toEqual({ platform: "linux", environment: "wsl" });
+    expect(isRedskilledHostState(state)).toBe(true);
+  });
+
   it("carries the host identity as a label, never as the socket's key", async () => {
     // Two sessions on the same host share the machine id and differ in socket.
     const first = await sessionPaths();

--- a/apps/redskilled/tests/host-topology.test.ts
+++ b/apps/redskilled/tests/host-topology.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectRedskilledHostTopology,
+  evaluateRedskilledHostEventTopology,
+  type RedskilledHostTopology,
+} from "../src/host-topology.js";
+
+describe("redskilled host topology", () => {
+  it("detects WSL from the kernel release without consulting the environment", () => {
+    const env = { WSL_DISTRO_NAME: undefined, WSL_INTEROP: undefined };
+
+    expect(detectRedskilledHostTopology({
+      platform: "linux",
+      release: "5.15.153.1-microsoft-standard-WSL2",
+    })).toEqual({ platform: "linux", environment: "wsl" });
+    expect(env).toEqual({ WSL_DISTRO_NAME: undefined, WSL_INTEROP: undefined });
+  });
+});
+
+describe("public host-event topology", () => {
+  it("names both cross-boundary refusals and admits both same-side Windows topologies", () => {
+    const wsl: RedskilledHostTopology = { platform: "linux", environment: "wsl" };
+    const windows: RedskilledHostTopology = { platform: "win32", environment: "native" };
+
+    expect([
+      evaluateRedskilledHostEventTopology(wsl, windows),
+      evaluateRedskilledHostEventTopology(windows, wsl),
+      evaluateRedskilledHostEventTopology(wsl, wsl),
+      evaluateRedskilledHostEventTopology(windows, windows),
+    ]).toEqual([
+      {
+        observable: false,
+        topology: "wsl-daemon/native-windows-consumer",
+        detail: "WSL daemon -> native Windows consumer: file-change notification does not cross the WSL boundary",
+      },
+      {
+        observable: false,
+        topology: "native-windows-daemon/wsl-consumer",
+        detail: "native Windows daemon -> WSL consumer: file-change notification does not cross the WSL boundary",
+      },
+      { observable: true, topology: "same-side", detail: "WSL daemon -> WSL consumer is observable" },
+      {
+        observable: true,
+        topology: "same-side",
+        detail: "native Windows daemon -> native Windows consumer is observable",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3507 -->
🤖 **Re-seed trail** — #3507 on `afk/3507-detect-wsl-and-refuse-the-cross-boundary`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3507; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3507 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/redskilled`, `packages/red-castle`]
{"schema":"red.afk.validation.v1","name":"feedback:pnpm -C apps/dev test:invariants","status":"failed","command":"pnpm -C apps/dev test:invariants","exitCode":1,"durationMs":52,"summary":"failing: FAIL tests/file-size-guard.test.ts > file-size ratchet — a split nothing enforces is a split that comes back > holds the live tree to the threshold and the shrink-only baseline —  - Array [] + Array [ +   Object { +     \"kind\": \"over-threshold\", +     \"lines\": 808, +     \"path\": \"apps/redskilled/src/event-lane.ts\", +     \"reason\": \"apps/redskilled/src/event-lane.ts is 808 lines, over the 800-line threshold. Split it by domain — the baseline records debt that predates this ratchet, never a new file.\", +   }, + ]   ❯ tests/file-size-guard.test.ts:46:7      44|         : `file-size ratchet: ${findings.length} finding(s).\\n${render…      45|           `Baseline: apps/dev/src/core/file-size-guard.ts (FILE_SIZE_B…      46|     ).toEqual([]);        |       ^      47|   });      48|   ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯"}
Verdict: mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted.
```

Closes #3507