### PR TITLE
fix: #3831 Spin evaluator: pure pattern detection over runner-stream sequences

### DIFF
--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -44,6 +44,7 @@ export * from "./runner-types.js";
 export * from "./state-transition.js";
 export * from "./singleton-event-lane.js";
 export * from "./singleton-lease.js";
+export * from "./spin-evaluator.js";
 export {
   CLAIM_MARKER_VERSION,
   ClaimVerificationError,

--- a/packages/red-castle/src/engine/spin-evaluator.test.ts
+++ b/packages/red-castle/src/engine/spin-evaluator.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { evaluateSpin } from "./index.js";
+
+describe("evaluateSpin", () => {
+  it("names a repeated action-observation Spin", () => {
+    expect(
+      evaluateSpin([
+        { kind: "action", content: "run pnpm test" },
+        { kind: "observation", content: "1 test failed" },
+        { kind: "action", content: "run pnpm test" },
+        { kind: "observation", content: "1 test failed" },
+        { kind: "action", content: "run pnpm test" },
+        { kind: "observation", content: "1 test failed" },
+      ]),
+    ).toEqual({ pattern: "repeated-action-observation" });
+  });
+
+  it("names an error streak for the same action", () => {
+    expect(
+      evaluateSpin([
+        { kind: "action", content: "compile src/index.ts" },
+        { kind: "error", content: "type mismatch" },
+        { kind: "action", content: "compile src/index.ts" },
+        { kind: "error", content: "still does not compile" },
+        { kind: "action", content: "compile src/index.ts" },
+        { kind: "error", content: "type mismatch at line 42" },
+      ]),
+    ).toEqual({ pattern: "error-streak" });
+  });
+
+  it("names a monologue with no intervening tool activity", () => {
+    expect(
+      evaluateSpin([
+        { kind: "message", content: "I should inspect the failure." },
+        { kind: "message", content: "Perhaps the parser is responsible." },
+        { kind: "message", content: "I could inspect the parser." },
+        { kind: "message", content: "The types may also be relevant." },
+        { kind: "message", content: "I should compare the inputs." },
+        { kind: "message", content: "Let me think about that." },
+      ]),
+    ).toEqual({ pattern: "monologue" });
+  });
+
+  it("names two action-observation pairs cycling in ping-pong", () => {
+    expect(
+      evaluateSpin([
+        { kind: "action", content: "enable strict mode" },
+        { kind: "observation", content: "parser test fails" },
+        { kind: "action", content: "disable strict mode" },
+        { kind: "observation", content: "typecheck fails" },
+        { kind: "action", content: "enable strict mode" },
+        { kind: "observation", content: "parser test fails" },
+        { kind: "action", content: "disable strict mode" },
+        { kind: "observation", content: "typecheck fails" },
+        { kind: "action", content: "enable strict mode" },
+        { kind: "observation", content: "parser test fails" },
+        { kind: "action", content: "disable strict mode" },
+        { kind: "observation", content: "typecheck fails" },
+      ]),
+    ).toEqual({ pattern: "alternating-ping-pong" });
+  });
+
+  it("compares actions and observations semantically across volatile tokens", () => {
+    expect(
+      evaluateSpin([
+        { kind: "action", content: "inspect pid=4101 at 0xaaa111" },
+        {
+          kind: "observation",
+          content:
+            "failed at 2026-08-13T18:01:02.003Z from 0xbbb111 on 10.0.0.1:4101",
+        },
+        { kind: "action", content: "inspect pid=5277 at 0xaaa222" },
+        {
+          kind: "observation",
+          content:
+            "failed at 2026-08-13T18:02:03.004Z from 0xbbb222 on 10.0.0.2:5277",
+        },
+        { kind: "action", content: "inspect pid=6388 at 0xaaa333" },
+        {
+          kind: "observation",
+          content:
+            "failed at 2026-08-13T18:03:04.005Z from 0xbbb333 on 10.0.0.3:6388",
+        },
+      ]),
+    ).toEqual({ pattern: "repeated-action-observation" });
+  });
+
+  it("returns null for near misses that are genuinely advancing", () => {
+    expect(
+      evaluateSpin([
+        { kind: "action", content: "test shard 1" },
+        { kind: "observation", content: "1 test failed" },
+        { kind: "action", content: "test shard 2" },
+        { kind: "observation", content: "1 test failed" },
+        { kind: "action", content: "test shard 3" },
+        { kind: "observation", content: "1 test failed" },
+      ]),
+    ).toBeNull();
+
+    expect(
+      evaluateSpin([
+        { kind: "action", content: "compile package alpha" },
+        { kind: "error", content: "type mismatch" },
+        { kind: "action", content: "compile package beta" },
+        { kind: "error", content: "type mismatch" },
+        { kind: "action", content: "compile package gamma" },
+        { kind: "error", content: "type mismatch" },
+      ]),
+    ).toBeNull();
+
+    expect(
+      evaluateSpin([
+        { kind: "message", content: "First thought" },
+        { kind: "message", content: "Second thought" },
+        { kind: "action", content: "inspect the source" },
+        { kind: "message", content: "Third thought" },
+        { kind: "message", content: "Fourth thought" },
+        { kind: "message", content: "Fifth thought" },
+      ]),
+    ).toBeNull();
+
+    expect(
+      evaluateSpin([
+        { kind: "action", content: "set mode A" },
+        { kind: "observation", content: "failure A" },
+        { kind: "action", content: "set mode B" },
+        { kind: "observation", content: "failure B" },
+        { kind: "action", content: "set mode A" },
+        { kind: "observation", content: "failure A" },
+        { kind: "action", content: "set mode B" },
+        { kind: "observation", content: "failure B" },
+        { kind: "action", content: "set mode A" },
+        { kind: "observation", content: "failure A" },
+        { kind: "action", content: "set mode C" },
+        { kind: "observation", content: "failure C" },
+      ]),
+    ).toBeNull();
+  });
+});

--- a/packages/red-castle/src/engine/spin-evaluator.ts
+++ b/packages/red-castle/src/engine/spin-evaluator.ts
@@ -1,0 +1,134 @@
+export const SPIN_THRESHOLDS = {
+  repeatedActionObservationPairs: 3,
+  errorStreakPairs: 3,
+  monologueMessages: 6,
+  alternatingPingPongCycles: 3,
+} as const;
+
+export type NormalizedRunnerStreamEvent =
+  | { readonly kind: "action"; readonly content: string }
+  | { readonly kind: "observation"; readonly content: string }
+  | { readonly kind: "error"; readonly content: string }
+  | { readonly kind: "message"; readonly content: string };
+
+export type SpinPattern =
+  | "repeated-action-observation"
+  | "error-streak"
+  | "monologue"
+  | "alternating-ping-pong";
+
+export interface SpinVerdict {
+  readonly pattern: SpinPattern;
+}
+
+const ISO_TIMESTAMP =
+  /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\b/gi;
+const PROCESS_ID = /\b(?:pid|process\s+id)\s*[:=#]?\s*\d+\b/gi;
+const HEX_ADDRESS = /\b0x[0-9a-f]+\b/gi;
+const IPV4_ADDRESS = /\b(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?\b/g;
+
+function semanticContent(content: string): string {
+  return content
+    .replace(ISO_TIMESTAMP, "<timestamp>")
+    .replace(PROCESS_ID, "<pid>")
+    .replace(HEX_ADDRESS, "<address>")
+    .replace(IPV4_ADDRESS, "<address>");
+}
+
+function sameContent(left: string, right: string): boolean {
+  return semanticContent(left) === semanticContent(right);
+}
+
+export function evaluateSpin(
+  events: readonly NormalizedRunnerStreamEvent[],
+): SpinVerdict | null {
+  const monologueTail = events.slice(-SPIN_THRESHOLDS.monologueMessages);
+  if (
+    monologueTail.length === SPIN_THRESHOLDS.monologueMessages &&
+    monologueTail.every((event) => event.kind === "message")
+  ) {
+    return { pattern: "monologue" };
+  }
+
+  const pingPongEventCount = SPIN_THRESHOLDS.alternatingPingPongCycles * 4;
+  const pingPongTail = events.slice(-pingPongEventCount);
+  const [actionA, observationA, actionB, observationB] = pingPongTail;
+  if (
+    pingPongTail.length === pingPongEventCount &&
+    actionA?.kind === "action" &&
+    observationA?.kind === "observation" &&
+    actionB?.kind === "action" &&
+    observationB?.kind === "observation" &&
+    (!sameContent(actionA.content, actionB.content) ||
+      !sameContent(observationA.content, observationB.content))
+  ) {
+    let alternating = true;
+    for (let index = 0; index < pingPongTail.length; index += 4) {
+      const cycle = pingPongTail.slice(index, index + 4);
+      if (
+        cycle[0]?.kind !== "action" ||
+        !sameContent(cycle[0].content, actionA.content) ||
+        cycle[1]?.kind !== "observation" ||
+        !sameContent(cycle[1].content, observationA.content) ||
+        cycle[2]?.kind !== "action" ||
+        !sameContent(cycle[2].content, actionB.content) ||
+        cycle[3]?.kind !== "observation" ||
+        !sameContent(cycle[3].content, observationB.content)
+      ) {
+        alternating = false;
+        break;
+      }
+    }
+    if (alternating) return { pattern: "alternating-ping-pong" };
+  }
+
+  const errorPairCount = SPIN_THRESHOLDS.errorStreakPairs;
+  const errorTail = events.slice(-errorPairCount * 2);
+  const firstErrorAction = errorTail[0];
+  if (
+    errorTail.length === errorPairCount * 2 &&
+    firstErrorAction?.kind === "action"
+  ) {
+    let errorStreak = true;
+    for (let index = 0; index < errorTail.length; index += 2) {
+      const action = errorTail[index];
+      const error = errorTail[index + 1];
+      if (
+        action?.kind !== "action" ||
+        error?.kind !== "error" ||
+        !sameContent(action.content, firstErrorAction.content)
+      ) {
+        errorStreak = false;
+        break;
+      }
+    }
+    if (errorStreak) return { pattern: "error-streak" };
+  }
+
+  const pairCount = SPIN_THRESHOLDS.repeatedActionObservationPairs;
+  const tail = events.slice(-pairCount * 2);
+  if (tail.length !== pairCount * 2) return null;
+
+  const [firstAction, firstObservation] = tail;
+  if (
+    firstAction?.kind !== "action" ||
+    firstObservation?.kind !== "observation"
+  ) {
+    return null;
+  }
+
+  for (let index = 0; index < tail.length; index += 2) {
+    const action = tail[index];
+    const observation = tail[index + 1];
+    if (
+      action?.kind !== "action" ||
+      observation?.kind !== "observation" ||
+      !sameContent(action.content, firstAction.content) ||
+      !sameContent(observation.content, firstObservation.content)
+    ) {
+      return null;
+    }
+  }
+
+  return { pattern: "repeated-action-observation" };
+}


### PR DESCRIPTION
Automated AFK landing for #3831. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3831

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789242083&installation_model_id=20659&pr_number=3848&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3848&signature=9d8ac7676390a8ecdd14d1906ff4fc83b8b55a878e6101c813101c5e47c6cfc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->