### PR TITLE
fix: #3836 Spin wiring: detect on the Worker stream, steer once, log the episode

### DIFF
--- a/apps/dev/src/commands/run/implementer-run-agent.ts
+++ b/apps/dev/src/commands/run/implementer-run-agent.ts
@@ -1,5 +1,8 @@
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { createSpinStreamProcessor } from "@reddb-io/red-castle/engine";
+import { encode } from "@reddb-io/toon";
 import type { CastleWorkerLaneBridge } from "../../core/castle-worker-lane-bridge.js";
 import type { ConfigValues } from "../../core/config.js";
 import { getConfig } from "../../core/config.js";
@@ -49,6 +52,15 @@ export function makeImplementerRunAgent(
   let prepared: PreparedImplementerEnvironment | undefined;
 
   return (input) => {
+    const spinStream = createSpinStreamProcessor({
+      workerLog: {
+        append: (record) =>
+          options.castleBridge.record(record.kind, record.payload),
+      },
+      steer: (message) => {
+        writeFileSync(steerFilePath, encode({ text: message }), "utf8");
+      },
+    });
     const attemptDir = input.cwd ?? options.current.attemptDir;
     if (!prepared || preparedDir !== attemptDir) {
       const baseline = Number(
@@ -81,6 +93,7 @@ export function makeImplementerRunAgent(
       },
       implementer: environment.runtime,
       onAgentEvent: (event) => {
+        void spinStream.observe(event).catch(() => {});
         if (!startupRecorded) {
           startupRecorded = true;
           environment.recordRunnerStartup(

--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -45,6 +45,7 @@ export * from "./state-transition.js";
 export * from "./singleton-event-lane.js";
 export * from "./singleton-lease.js";
 export * from "./spin-evaluator.js";
+export * from "./spin-stream.js";
 export {
   CLAIM_MARKER_VERSION,
   ClaimVerificationError,

--- a/packages/red-castle/src/engine/spin-stream.test.ts
+++ b/packages/red-castle/src/engine/spin-stream.test.ts
@@ -1,0 +1,53 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createCastleLaneWriters,
+  createEnginePaths,
+  createSpinStreamProcessor,
+  readCastleLaneRecords,
+} from "./index.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("Spin runner-stream processing", () => {
+  it("logs and steers a continuing Spin exactly once per episode", async () => {
+    const root = await mkdtemp(join(tmpdir(), "spin-stream-"));
+    roots.push(root);
+    const workerLog = createCastleLaneWriters(
+      createEnginePaths(join(root, ".red")),
+      { clock: () => "2026-08-13T00:00:00.000Z" },
+    ).worker("wSPIN");
+    const steers: string[] = [];
+    const stream = createSpinStreamProcessor({
+      workerLog,
+      steer: (message) => {
+        steers.push(message);
+      },
+    });
+
+    for (let index = 1; index <= 7; index += 1) {
+      await stream.observe({
+        type: "text",
+        message: `unproductive thought ${index}`,
+        iteration: 1,
+        timestamp: new Date(0),
+      });
+    }
+
+    expect(await readCastleLaneRecords(workerLog.path)).toEqual([
+      {
+        at: "2026-08-13T00:00:00.000Z",
+        kind: "worker.spin",
+        payload: { pattern: "monologue" },
+      },
+    ]);
+    expect(steers).toHaveLength(1);
+    expect(steers[0]).toContain("monologue");
+  });
+});

--- a/packages/red-castle/src/engine/spin-stream.test.ts
+++ b/packages/red-castle/src/engine/spin-stream.test.ts
@@ -50,4 +50,44 @@ describe("Spin runner-stream processing", () => {
     expect(steers).toHaveLength(1);
     expect(steers[0]).toContain("monologue");
   });
+
+  it("normalizes runner tool calls and results for Spin evaluation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "spin-stream-"));
+    roots.push(root);
+    const workerLog = createCastleLaneWriters(
+      createEnginePaths(join(root, ".red")),
+      { clock: () => "2026-08-13T00:00:00.000Z" },
+    ).worker("wPAIR");
+    const steers: string[] = [];
+    const stream = createSpinStreamProcessor({
+      workerLog,
+      steer: (message) => {
+        steers.push(message);
+      },
+    });
+
+    for (let index = 0; index < 3; index += 1) {
+      await stream.observe({
+        type: "toolCall",
+        name: "Bash",
+        formattedArgs: "pnpm test",
+        iteration: 1,
+        timestamp: new Date(0),
+      });
+      await stream.observe({
+        type: "result",
+        result: "1 test failed",
+        iteration: 1,
+        timestamp: new Date(0),
+      });
+    }
+
+    expect((await readCastleLaneRecords(workerLog.path))[0]).toMatchObject({
+      kind: "worker.spin",
+      payload: { pattern: "repeated-action-observation" },
+    });
+    expect(steers).toEqual([
+      expect.stringContaining("repeated-action-observation"),
+    ]);
+  });
 });

--- a/packages/red-castle/src/engine/spin-stream.ts
+++ b/packages/red-castle/src/engine/spin-stream.ts
@@ -1,5 +1,4 @@
 import type { AgentStreamEvent } from "../AgentStreamEmitter.js";
-import type { CastleLaneWriter } from "./lane-writers.js";
 import {
   evaluateSpin,
   SPIN_THRESHOLDS,
@@ -9,7 +8,12 @@ import {
 } from "./spin-evaluator.js";
 
 export interface SpinStreamProcessorOptions {
-  readonly workerLog: Pick<CastleLaneWriter, "append">;
+  readonly workerLog: {
+    append(record: {
+      readonly kind: "worker.spin";
+      readonly payload: { readonly pattern: SpinPattern };
+    }): unknown | Promise<unknown>;
+  };
   readonly steer?: (message: string) => void | Promise<void>;
 }
 
@@ -63,11 +67,13 @@ export function createSpinStreamProcessor(
       if (!verdict || verdict.pattern === lastReportedPattern) return verdict;
       lastReportedPattern = verdict.pattern;
 
-      await options.workerLog.append({
+      const logWrite = options.workerLog.append({
         kind: "worker.spin",
         payload: { pattern: verdict.pattern },
       });
-      await options.steer?.(renderSpinSteer(verdict.pattern));
+      const steerWrite = options.steer?.(renderSpinSteer(verdict.pattern));
+      await logWrite;
+      await steerWrite;
       return verdict;
     },
   };

--- a/packages/red-castle/src/engine/spin-stream.ts
+++ b/packages/red-castle/src/engine/spin-stream.ts
@@ -1,0 +1,65 @@
+import type { AgentStreamEvent } from "../AgentStreamEmitter.js";
+import type { CastleLaneWriter } from "./lane-writers.js";
+import {
+  evaluateSpin,
+  SPIN_THRESHOLDS,
+  type NormalizedRunnerStreamEvent,
+  type SpinPattern,
+  type SpinVerdict,
+} from "./spin-evaluator.js";
+
+export interface SpinStreamProcessorOptions {
+  readonly workerLog: Pick<CastleLaneWriter, "append">;
+  readonly steer?: (message: string) => void | Promise<void>;
+}
+
+export interface SpinStreamProcessor {
+  observe(event: AgentStreamEvent): Promise<SpinVerdict | null>;
+}
+
+const MAX_SPIN_WINDOW = Math.max(
+  SPIN_THRESHOLDS.monologueMessages,
+  SPIN_THRESHOLDS.repeatedActionObservationPairs * 2,
+  SPIN_THRESHOLDS.errorStreakPairs * 2,
+  SPIN_THRESHOLDS.alternatingPingPongCycles * 4,
+);
+
+function normalizeSpinEvent(
+  event: AgentStreamEvent,
+): NormalizedRunnerStreamEvent | null {
+  if (event.type === "text") {
+    return { kind: "message", content: event.message };
+  }
+  return null;
+}
+
+export function renderSpinSteer(pattern: SpinPattern): string {
+  return `Spin detected: ${pattern}. Break this pattern and take a materially different approach.`;
+}
+
+export function createSpinStreamProcessor(
+  options: SpinStreamProcessorOptions,
+): SpinStreamProcessor {
+  const events: NormalizedRunnerStreamEvent[] = [];
+  let lastReportedPattern: SpinPattern | undefined;
+
+  return {
+    async observe(event) {
+      const normalized = normalizeSpinEvent(event);
+      if (!normalized) return null;
+      events.push(normalized);
+      if (events.length > MAX_SPIN_WINDOW) events.shift();
+
+      const verdict = evaluateSpin(events);
+      if (!verdict || verdict.pattern === lastReportedPattern) return verdict;
+      lastReportedPattern = verdict.pattern;
+
+      await options.workerLog.append({
+        kind: "worker.spin",
+        payload: { pattern: verdict.pattern },
+      });
+      await options.steer?.(renderSpinSteer(verdict.pattern));
+      return verdict;
+    },
+  };
+}

--- a/packages/red-castle/src/engine/spin-stream.ts
+++ b/packages/red-castle/src/engine/spin-stream.ts
@@ -30,6 +30,15 @@ function normalizeSpinEvent(
   if (event.type === "text") {
     return { kind: "message", content: event.message };
   }
+  if (event.type === "toolCall") {
+    return {
+      kind: "action",
+      content: `${event.name} ${event.formattedArgs}`,
+    };
+  }
+  if (event.type === "result") {
+    return { kind: "observation", content: event.result };
+  }
   return null;
 }
 


### PR DESCRIPTION
Automated AFK landing for #3836. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3836

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789243041&installation_model_id=20659&pr_number=3849&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3849&signature=5f34129737f1decf69c0c7ab39813bbecf6b39c56e321e60f5ba277e0a6cd52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->