### PR TITLE
fix: #3802 Heavy validation admission and redskilled reads respect host budgets

### DIFF
--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -382,13 +382,14 @@ export async function runCommand(options: RunOptions): Promise<number> {
     },
     onGateWait: (notice) => {
       const waiting = notice.state === "waiting";
+      const stall = notice.infraEvidence?.kind === "stall" ? notice.infraEvidence : undefined;
       if (current.attemptDir !== "") {
         const line = waiting
           ? `⏳ /afk gate: waiting on ${notice.subject} (pid ${notice.pid}).`
           : notice.state === "stalled"
             ? `⛔ /afk gate: reaped stalled ${notice.subject} (pid ${notice.pid}); ` +
-              `${notice.infraEvidence?.cpuDeltaMs ?? 0}ms CPU over ` +
-              `${notice.infraEvidence?.sampleWindowMs ?? 0}ms.`
+              `${stall?.cpuDeltaMs ?? 0}ms CPU over ` +
+              `${stall?.sampleWindowMs ?? 0}ms.`
             : `✅ /afk gate: ${notice.subject} exited (pid ${notice.pid}).`;
         gateWaitPublication = gateWaitPublication.then(async () => {
           await updateState(workerStatePath(current.attemptDir), {
@@ -409,8 +410,8 @@ export async function runCommand(options: RunOptions): Promise<number> {
             deadline: notice.deadline,
             escalation: notice.escalation,
             infra: notice.infraEvidence?.kind ?? "",
-            cpu_delta_ms: notice.infraEvidence?.cpuDeltaMs ?? 0,
-            sample_window_ms: notice.infraEvidence?.sampleWindowMs ?? 0,
+            cpu_delta_ms: stall?.cpuDeltaMs ?? 0,
+            sample_window_ms: stall?.sampleWindowMs ?? 0,
             wall_time_ms: notice.infraEvidence?.wallTimeMs ?? 0,
           }, line);
         }).catch(() => {});

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -6,7 +6,6 @@ export { readStandingDrain, type StandingDrainConfig } from "./standing-drain-co
 
 /**
  * config.ts — TypeScript port of scripts/config.sh.
- *
  * Loads the dev config from `.red/config.yaml`. Per ADR 0042 the canonical
  * location is the namespaced `plugins.dev.afk.*` block; the legacy top-level
  * `afk.*` block is still read as a back-compat fallback. `loadConfig` folds the

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -58,12 +58,9 @@ export interface ExecResult {
   stdout: string;
   stderr: string;
   /** Typed infrastructure evidence from the real validation process boundary. */
-  infraEvidence?: {
-    kind: "stall";
-    wallTimeMs: number;
-    sampleWindowMs: number;
-    cpuDeltaMs: number;
-  };
+  infraEvidence?:
+    | { kind: "stall"; wallTimeMs: number; sampleWindowMs: number; cpuDeltaMs: number }
+    | { kind: "admission-timeout"; wallTimeMs: number };
   /**
    * The ABSOLUTE directory the command actually ran in, when the executor
    * rewrote the `-C` token (#3041). The AFK gate is posed with a branch NAME;
@@ -87,6 +84,8 @@ export interface ExecResult {
 export interface FeedbackExecOptions {
   /** Explicit validation subprocess environment. Never default to the worker shell. */
   env: NodeJS.ProcessEnv;
+  /** Castle's command classification; the host adapter decides admission. */
+  weight?: "light" | "heavy";
 }
 
 /** Injected `pnpm` executor. Receives a full argv (incl. the `pnpm` head). */
@@ -228,6 +227,13 @@ export interface PackageLayout {
 export const FEEDBACK_SCRIPTS = ["test", "typecheck", "lint", "build"] as const;
 export type FeedbackScript = (typeof FEEDBACK_SCRIPTS)[number];
 
+/** Castle owns validation meaning; redskilled only sees a generic lease request. */
+export function validationWeight(scope: string, script: string): "light" | "heavy" {
+  return scope === "." && (script === "test" || script === "typecheck" || script === "build")
+    ? "heavy"
+    : "light";
+}
+
 /** The literal sidecar schema id. */
 export const VALIDATION_SCHEMA = "red.afk.validation.v1" as const;
 
@@ -257,7 +263,7 @@ export interface ValidationRecord {
    */
   suspectInfra?: true;
   /** The command ran, but infrastructure reaped it after observing no progress. */
-  infra?: "stall";
+  infra?: "stall" | "admission-timeout";
   /** What the host was carrying while this check ran, when it was measured. */
   resources?: ValidationResourceEvidence;
 }
@@ -403,7 +409,7 @@ export function buildValidationRecord(input: {
   summary?: string;
   setup?: string;
   suspectInfra?: boolean;
-  infra?: "stall";
+  infra?: "stall" | "admission-timeout";
   resources?: ValidationResourceEvidence;
 }): ValidationRecord {
   const record: ValidationRecord = {
@@ -437,7 +443,7 @@ function buildRanRecord(input: {
   output: string;
   summary: string;
   setup?: string;
-  infra?: "stall";
+  infra?: "stall" | "admission-timeout";
   resources?: ValidationResourceEvidence;
 }): ValidationRecord {
   const suspect = isSuspectInfraFailure({
@@ -747,7 +753,10 @@ async function runChecksForBaseline(
     if (!layout.hasScript(scope, command)) continue;
     const dir = scopeDir(baselineWorktree, scope);
     const cacheKey = `${scope} ${command}`;
-    const result = executed.get(cacheKey) ?? (await exec(["pnpm", "-C", dir, command], { env }));
+    const result = executed.get(cacheKey) ?? (await exec(["pnpm", "-C", dir, command], {
+      env,
+      weight: validationWeight(scope, command),
+    }));
     executed.set(cacheKey, result);
     if (result.code === 0) {
       out.set(name, { status: "passed" });
@@ -995,7 +1004,10 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
 
       const composed = composeValidationCommand({ target, scope, script, extraArgs: excludeArgs });
       const start = now();
-      const result = await exec(composed.args, { env: subprocessEnv });
+      const result = await exec(composed.args, {
+        env: subprocessEnv,
+        weight: validationWeight(scope, script),
+      });
       const durationMs = now() - start;
       const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
       if (status === "failed") failed = true;
@@ -1032,7 +1044,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     const scope = ".";
     const composed = composeValidationCommand({ target, scope: ".", script: "typecheck" });
     const start = now();
-    const result = await exec(composed.args, { env: subprocessEnv });
+    const result = await exec(composed.args, { env: subprocessEnv, weight: "heavy" });
     const durationMs = now() - start;
     const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
     if (status === "failed") failed = true;
@@ -1079,7 +1091,10 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     }
     const composed = composeValidationCommand({ target, scope: run.scope, script: run.script });
     const start = now();
-    const result = await exec(composed.args, { env: subprocessEnv });
+    const result = await exec(composed.args, {
+      env: subprocessEnv,
+      weight: validationWeight(run.scope, run.script),
+    });
     const durationMs = now() - start;
     const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
     if (status === "failed") failed = true;

--- a/apps/dev/src/core/verdict.ts
+++ b/apps/dev/src/core/verdict.ts
@@ -27,6 +27,7 @@ export type EnvironmentCause =
   | "prior-environment"
   | "suspect-infra"
   | "stall"
+  | "admission-timeout"
   | "oom"
   | "setup"
   | "baseline"
@@ -120,6 +121,7 @@ function checkEnvironmentCause(
     const record = check.record;
     if (record.suspectInfra === true && !subsecondFailuresAreBranchFault) return "suspect-infra";
     if (record.infra === "stall") return "stall";
+    if (record.infra === "admission-timeout") return "admission-timeout";
     const summary = record.summary ?? "";
     if (record.exitCode === 137 || summary.includes("SIGKILL") || /\b137\b/.test(summary)) return "oom";
     if (

--- a/apps/dev/src/runtime/exec.ts
+++ b/apps/dev/src/runtime/exec.ts
@@ -71,12 +71,9 @@ export interface ExecOutput {
   resources?: import("../core/validation-resources.js").ValidationResourceEvidence;
 }
 
-export interface ValidationInfraEvidence {
-  kind: "stall";
-  wallTimeMs: number;
-  sampleWindowMs: number;
-  cpuDeltaMs: number;
-}
+export type ValidationInfraEvidence =
+  | { kind: "stall"; wallTimeMs: number; sampleWindowMs: number; cpuDeltaMs: number }
+  | { kind: "admission-timeout"; wallTimeMs: number };
 
 export interface ValidationStallDetection {
   /** Do not judge CPU idleness until the command exceeds its normal envelope. */
@@ -345,7 +342,7 @@ export function execTool(cmd: string, args: readonly string[], opts: ExecOptions
         return;
       }
       if (timedOut || signal !== null) {
-        const stallMessage = infraEvidence
+        const stallMessage = infraEvidence?.kind === "stall"
           ? `validation child stalled: ${infraEvidence.cpuDeltaMs}ms CPU over ` +
             `${infraEvidence.sampleWindowMs}ms while wall time reached ${infraEvidence.wallTimeMs}ms`
           : undefined;

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -52,12 +52,6 @@ import {
 import type { BackpressureExec } from "../core/backpressure.js";
 import type { PostWorkerFormatExec } from "../core/post-worker-format.js";
 import {
-  acquireRedskilledResourceLease,
-  releaseRedskilledResourceLease,
-  renewRedskilledResourceLease,
-} from "@reddb-io/redskilled/client";
-import { resolveRedskilledPaths } from "@reddb-io/redskilled/paths";
-import {
   DEFAULT_VALIDATION_STALL_DETECTION,
   execTool,
   pnpm as runPnpm,
@@ -70,6 +64,7 @@ import { createPathLock } from "./land-lock.js";
 import type { LandLockWaitInfo } from "../core/land-lock.js";
 import type { BranchReversionGeometry } from "../core/branch-reversion.js";
 import { withValidationResourceEvidence } from "./validation-resources.js";
+import { acquireHeavyValidationLease, HEAVY_VALIDATION_WAIT_MS } from "./heavy-validation-lease.js";
 
 /**
  * Is `token` an ALREADY-MATERIALISED checkout rather than a branch name (#2339)?
@@ -270,16 +265,8 @@ export type GateWaitSink = (notice: GateWaitNotice) => void;
  * far under the revalidation cycle it protects.
  */
 const WORKTREE_LOCK_WAIT_MS = 10 * 60_000;
-/** A holder that has not finished a materialise in this long has crashed. */
 const WORKTREE_LOCK_STALE_MS = 20 * 60_000;
-const GATE_LOCK_WAIT_MS = 60 * 60_000;
-const GATE_LEASE_TTL_MS = 30_000;
-/**
- * How often a still-blocked waiter re-announces itself. The first poll speaks
- * IMMEDIATELY — a wait nobody hears about for 30s is still a wait nobody can
- * see at second 1 — and every later notice is spaced so a 60-minute gate-lock
- * wait costs ~120 log lines rather than ~7200.
- */
+/** Re-announce a blocked waiter after its immediate first notice. */
 export const LOCK_WAIT_NOTICE_INTERVAL_MS = 30_000;
 
 /** `754321` → `12m34s`. Coarse on purpose: the reader wants an order of
@@ -430,56 +417,18 @@ const defaultIO: FeedbackWorktreeIO = {
     );
   },
   gateLock: async (_root, onWait, admission) => {
-    const paths = resolveRedskilledPaths();
-    const workerId = admission?.workerId;
-    const started = Date.now();
-    onWait?.({
-      lock: "validation-gate",
-      state: "waiting",
-      path: "redskilled:validation-heavy",
-      waitedMs: 0,
-      remainingMs: GATE_LOCK_WAIT_MS,
-      message: "⏳ /afk gate: waiting for host heavy-validation admission.",
+    return acquireHeavyValidationLease({
+      minimumAvailableMemoryMb: admission?.minimumAvailableMemoryMb ?? 4_096,
+      ...(admission?.workerId == null ? {} : { workerId: admission.workerId }),
+      notice: (notice) => onWait?.({
+        lock: "validation-gate",
+        state: notice.state,
+        path: "redskilled:validation-heavy",
+        waitedMs: notice.waitedMs,
+        remainingMs: notice.state === "waiting" ? HEAVY_VALIDATION_WAIT_MS : 0,
+        message: notice.message,
+      }),
     });
-    try {
-      const lease = await acquireRedskilledResourceLease(paths, {
-        resource: "validation-heavy",
-        holder_id: workerId ?? `process:${process.pid}`,
-        ...(workerId == null ? {} : { worker_id: workerId }),
-        minimum_available_memory_bytes: (admission?.minimumAvailableMemoryMb ?? 4_096) * 1024 ** 2,
-        ttl_ms: GATE_LEASE_TTL_MS,
-        wait_timeout_ms: GATE_LOCK_WAIT_MS,
-      });
-      onWait?.({
-        lock: "validation-gate",
-        state: "acquired",
-        path: "redskilled:validation-heavy",
-        waitedMs: Date.now() - started,
-        remainingMs: 0,
-        message: "✅ /afk gate: host granted heavy-validation admission.",
-      });
-      let renewal = Promise.resolve();
-      const timer = setInterval(() => {
-        renewal = renewal.then(() => renewRedskilledResourceLease(paths, lease.lease_id, GATE_LEASE_TTL_MS).then(() => undefined))
-          .catch(() => undefined);
-      }, GATE_LEASE_TTL_MS / 3);
-      timer.unref();
-      return async () => {
-        clearInterval(timer);
-        await renewal;
-        await releaseRedskilledResourceLease(paths, lease.lease_id).catch(() => undefined);
-      };
-    } catch (error) {
-      onWait?.({
-        lock: "validation-gate",
-        state: "timed-out",
-        path: "redskilled:validation-heavy",
-        waitedMs: Date.now() - started,
-        remainingMs: 0,
-        message: `⛔ /afk gate: heavy-validation admission failed: ${error instanceof Error ? error.message : String(error)}`,
-      });
-      return null;
-    }
   },
 };
 
@@ -695,7 +644,7 @@ export function makeFeedbackWorktree(
         code: 1,
         stdout: "",
         stderr: "host heavy-validation admission timed out; validation blocked",
-        infraEvidence: { kind: "admission-timeout", wallTimeMs: GATE_LOCK_WAIT_MS },
+        infraEvidence: { kind: "admission-timeout", wallTimeMs: HEAVY_VALIDATION_WAIT_MS },
       };
     }
     try {

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -52,9 +52,11 @@ import {
 import type { BackpressureExec } from "../core/backpressure.js";
 import type { PostWorkerFormatExec } from "../core/post-worker-format.js";
 import {
-  readRedskilledHostConfig,
-  resolveRedskilledHostSettings,
-} from "@reddb-io/redskilled/host-config";
+  acquireRedskilledResourceLease,
+  releaseRedskilledResourceLease,
+  renewRedskilledResourceLease,
+} from "@reddb-io/redskilled/client";
+import { resolveRedskilledPaths } from "@reddb-io/redskilled/paths";
 import {
   DEFAULT_VALIDATION_STALL_DETECTION,
   execTool,
@@ -64,7 +66,7 @@ import {
   type ValidationStallDetection,
 } from "./exec.js";
 import * as gitx from "./git.js";
-import { createPathLock, createPathSemaphore } from "./land-lock.js";
+import { createPathLock } from "./land-lock.js";
 import type { LandLockWaitInfo } from "../core/land-lock.js";
 import type { BranchReversionGeometry } from "../core/branch-reversion.js";
 import { withValidationResourceEvidence } from "./validation-resources.js";
@@ -206,11 +208,12 @@ export interface FeedbackWorktreeIO {
    * in-process, which is all a single-process fixture needs.
    */
   lock?(dest: string, onWait?: LockWaitSink): Promise<(() => Promise<void>) | null>;
-  /**
-   * Host-wide sized semaphore for validation commands. Every live worker and
-   * no-agent reconcile manager binds the same `.red/state` slot set.
-   */
-  gateLock?(root: string, onWait?: LockWaitSink): Promise<(() => Promise<void>) | null>;
+  /** Host-daemon resource lease used only for Castle-classified heavy commands. */
+  gateLock?(
+    root: string,
+    onWait?: LockWaitSink,
+    admission?: { readonly minimumAvailableMemoryMb: number; readonly workerId?: string },
+  ): Promise<(() => Promise<void>) | null>;
 }
 
 /**
@@ -270,7 +273,7 @@ const WORKTREE_LOCK_WAIT_MS = 10 * 60_000;
 /** A holder that has not finished a materialise in this long has crashed. */
 const WORKTREE_LOCK_STALE_MS = 20 * 60_000;
 const GATE_LOCK_WAIT_MS = 60 * 60_000;
-const GATE_LOCK_STALE_MS = 24 * 60 * 60_000;
+const GATE_LEASE_TTL_MS = 30_000;
 /**
  * How often a still-blocked waiter re-announces itself. The first poll speaks
  * IMMEDIATELY — a wait nobody hears about for 30s is still a wait nobody can
@@ -426,19 +429,57 @@ const defaultIO: FeedbackWorktreeIO = {
       }).acquire(),
     );
   },
-  gateLock: async (root, onWait) => {
-    const stateDir = join(root, ".red", "state");
-    await mkdir(stateDir, { recursive: true });
-    const hostConfig = await readRedskilledHostConfig();
-    const capacity = resolveRedskilledHostSettings({ config: hostConfig }).ceiling.validation_count ?? 1;
-    return acquireAnnounced("validation-gate", onWait, (report) =>
-      createPathSemaphore(join(stateDir, "validation-gate.lock"), `validation-gate:${process.pid}`, capacity, {
-        waitTimeoutMs: GATE_LOCK_WAIT_MS,
-        staleAfterMs: GATE_LOCK_STALE_MS,
-        pollMs: 500,
-        ...(report ? { onWait: report } : {}),
-      }).acquire(),
-    );
+  gateLock: async (_root, onWait, admission) => {
+    const paths = resolveRedskilledPaths();
+    const workerId = admission?.workerId;
+    const started = Date.now();
+    onWait?.({
+      lock: "validation-gate",
+      state: "waiting",
+      path: "redskilled:validation-heavy",
+      waitedMs: 0,
+      remainingMs: GATE_LOCK_WAIT_MS,
+      message: "⏳ /afk gate: waiting for host heavy-validation admission.",
+    });
+    try {
+      const lease = await acquireRedskilledResourceLease(paths, {
+        resource: "validation-heavy",
+        holder_id: workerId ?? `process:${process.pid}`,
+        ...(workerId == null ? {} : { worker_id: workerId }),
+        minimum_available_memory_bytes: (admission?.minimumAvailableMemoryMb ?? 4_096) * 1024 ** 2,
+        ttl_ms: GATE_LEASE_TTL_MS,
+        wait_timeout_ms: GATE_LOCK_WAIT_MS,
+      });
+      onWait?.({
+        lock: "validation-gate",
+        state: "acquired",
+        path: "redskilled:validation-heavy",
+        waitedMs: Date.now() - started,
+        remainingMs: 0,
+        message: "✅ /afk gate: host granted heavy-validation admission.",
+      });
+      let renewal = Promise.resolve();
+      const timer = setInterval(() => {
+        renewal = renewal.then(() => renewRedskilledResourceLease(paths, lease.lease_id, GATE_LEASE_TTL_MS).then(() => undefined))
+          .catch(() => undefined);
+      }, GATE_LEASE_TTL_MS / 3);
+      timer.unref();
+      return async () => {
+        clearInterval(timer);
+        await renewal;
+        await releaseRedskilledResourceLease(paths, lease.lease_id).catch(() => undefined);
+      };
+    } catch (error) {
+      onWait?.({
+        lock: "validation-gate",
+        state: "timed-out",
+        path: "redskilled:validation-heavy",
+        waitedMs: Date.now() - started,
+        remainingMs: 0,
+        message: `⛔ /afk gate: heavy-validation admission failed: ${error instanceof Error ? error.message : String(error)}`,
+      });
+      return null;
+    }
   },
 };
 
@@ -506,7 +547,12 @@ export interface FeedbackWorktreeOptions {
    */
   rebaseOnto?: string;
   /** Resource budget applied to validation subprocesses (#1758). */
-  resourceBudget?: { nodeMaxOldSpaceMb?: number; vitestMaxWorkers?: number; turboConcurrency?: number };
+  resourceBudget?: {
+    nodeMaxOldSpaceMb?: number;
+    vitestMaxWorkers?: number;
+    turboConcurrency?: number;
+    heavyAvailableMemoryMb?: number;
+  };
   /**
    * Where a BLOCKED wait announces itself (#2985). Both host-wide locks here
    * can hold a worker for tens of minutes with no child process and no write,
@@ -636,15 +682,20 @@ export function makeFeedbackWorktree(
   }
 
   async function runValidationCommand(
+    weight: "light" | "heavy",
     run: () => Promise<ExecOutput>,
   ): Promise<ExecOutput> {
-    if (!io.gateLock) return run();
-    const release = await io.gateLock(root, onLockWait);
+    if (weight === "light" || !io.gateLock) return run();
+    const release = await io.gateLock(root, onLockWait, {
+      minimumAvailableMemoryMb: resourceBudget.heavyAvailableMemoryMb ?? 4_096,
+      ...(process.env.RED_AFK_WORKER_ID == null ? {} : { workerId: process.env.RED_AFK_WORKER_ID }),
+    });
     if (release === null) {
       return {
         code: 1,
         stdout: "",
-        stderr: "host-wide validation gate lock timed out; validation blocked",
+        stderr: "host heavy-validation admission timed out; validation blocked",
+        infraEvidence: { kind: "admission-timeout", wallTimeMs: GATE_LOCK_WAIT_MS },
       };
     }
     try {
@@ -914,7 +965,7 @@ export function makeFeedbackWorktree(
       }
       const rewritten = resolve(scope === "." ? base : join(base, scope));
       const rest = args.filter((_, i) => i !== 0 && i !== cIdx && i !== cIdx + 1);
-      const r = await runValidationCommand(() =>
+      const r = await runValidationCommand(opts?.weight ?? "light", () =>
         runGateChild(`pnpm ${rest[0] ?? "validation"}`, (onSpawn) =>
           io.pnpm(["-C", rewritten, ...rest], { cwd: root, env, onSpawn, stallDetection })
         )
@@ -935,7 +986,7 @@ export function makeFeedbackWorktree(
       };
     }
     const head = args[0] === "pnpm" ? args.slice(1) : args;
-    const r = await runValidationCommand(() =>
+    const r = await runValidationCommand(opts?.weight ?? "light", () =>
       runGateChild(`pnpm ${head[0] ?? "validation"}`, (onSpawn) =>
         io.pnpm(head, { cwd: root, env, onSpawn, stallDetection })
       )
@@ -963,7 +1014,7 @@ export function makeFeedbackWorktree(
       return { code: 1, stdout: "", stderr: setupFailureMessage(cwd) };
     }
     const env = buildFeedbackSubprocessEnv(process.env, resourceBudget);
-    const r = await runValidationCommand(() =>
+    const r = await runValidationCommand("heavy", () =>
       runGateChild("sh backpressure", (onSpawn) =>
         io.exec("sh", ["-c", command], { cwd: dir, timeoutMs, env, onSpawn, stallDetection })
       )

--- a/apps/dev/src/runtime/heavy-validation-lease.ts
+++ b/apps/dev/src/runtime/heavy-validation-lease.ts
@@ -1,0 +1,55 @@
+/** Redskilled adapter for Castle-classified heavy validation commands. */
+import {
+  acquireRedskilledResourceLease,
+  releaseRedskilledResourceLease,
+  renewRedskilledResourceLease,
+} from "@reddb-io/redskilled/resource-lease-client";
+import { resolveRedskilledPaths } from "@reddb-io/redskilled/paths";
+
+export const HEAVY_VALIDATION_WAIT_MS = 60 * 60_000;
+const LEASE_TTL_MS = 30_000;
+
+export interface HeavyValidationLeaseNotice {
+  readonly state: "waiting" | "acquired" | "timed-out";
+  readonly waitedMs: number;
+  readonly message: string;
+}
+
+export async function acquireHeavyValidationLease(input: {
+  readonly minimumAvailableMemoryMb: number;
+  readonly workerId?: string;
+  readonly notice?: (notice: HeavyValidationLeaseNotice) => void;
+}): Promise<(() => Promise<void>) | null> {
+  const paths = resolveRedskilledPaths();
+  const started = Date.now();
+  input.notice?.({ state: "waiting", waitedMs: 0, message: "⏳ /afk gate: waiting for host heavy-validation admission." });
+  try {
+    const lease = await acquireRedskilledResourceLease(paths, {
+      resource: "validation-heavy",
+      holder_id: input.workerId ?? `process:${process.pid}`,
+      ...(input.workerId == null ? {} : { worker_id: input.workerId }),
+      minimum_available_memory_bytes: input.minimumAvailableMemoryMb * 1024 ** 2,
+      ttl_ms: LEASE_TTL_MS,
+      wait_timeout_ms: HEAVY_VALIDATION_WAIT_MS,
+    });
+    input.notice?.({ state: "acquired", waitedMs: Date.now() - started, message: "✅ /afk gate: host granted heavy-validation admission." });
+    let renewal = Promise.resolve();
+    const timer = setInterval(() => {
+      renewal = renewal.then(() => renewRedskilledResourceLease(paths, lease.lease_id, LEASE_TTL_MS).then(() => undefined))
+        .catch(() => undefined);
+    }, LEASE_TTL_MS / 3);
+    timer.unref();
+    return async () => {
+      clearInterval(timer);
+      await renewal;
+      await releaseRedskilledResourceLease(paths, lease.lease_id).catch(() => undefined);
+    };
+  } catch (error) {
+    input.notice?.({
+      state: "timed-out",
+      waitedMs: Date.now() - started,
+      message: `⛔ /afk gate: heavy-validation admission failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return null;
+  }
+}

--- a/apps/dev/tests/exec.test.ts
+++ b/apps/dev/tests/exec.test.ts
@@ -64,7 +64,9 @@ describe("execTool", () => {
         kind: "stall",
         cpuDeltaMs: 0,
       });
-      expect(r.infraEvidence!.sampleWindowMs).toBeGreaterThanOrEqual(100);
+      expect(r.infraEvidence?.kind).toBe("stall");
+      if (r.infraEvidence?.kind !== "stall") throw new Error("expected stall evidence");
+      expect(r.infraEvidence.sampleWindowMs).toBeGreaterThanOrEqual(100);
       expect(r.infraEvidence!.wallTimeMs).toBeGreaterThanOrEqual(200);
       expect(r.stderr).toContain("validation child stalled");
     },

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -370,8 +370,8 @@ describe("makeFeedbackWorktree declared setup authority (#3268)", () => {
   });
 });
 
-describe("host-wide validation gate semaphore (#2487)", () => {
-  it("never runs a reconcile gate command alongside a live worker gate command", async () => {
+describe("host-wide heavy-validation admission (#3802)", () => {
+  it("never runs two heavy commands concurrently and never serializes a light command", async () => {
     let held = false;
     const waiters: Array<() => void> = [];
     const releases: Array<() => void> = [];
@@ -408,17 +408,22 @@ describe("host-wide validation gate semaphore (#2487)", () => {
       cacheEnabled: false,
     });
 
-    const first = worker.pnpm(["pnpm", "-C", "afk/wLIVE/1-work", "test"]);
+    const first = worker.pnpm(["pnpm", "-C", "afk/wLIVE/1-work", "test"], { env: {}, weight: "heavy" });
     while (releases.length < 1) await new Promise<void>((resolve) => setImmediate(resolve));
-    const second = reconcile.pnpm(["pnpm", "-C", "afk/wBOOT/2-reconcile", "test"]);
+    const light = reconcile.pnpm(["pnpm", "-C", "afk/wBOOT/2-reconcile", "lint"], { env: {}, weight: "light" });
+    while (releases.length < 2) await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(maxActive).toBe(2);
+    releases.pop()?.();
+    await light;
+    const second = reconcile.pnpm(["pnpm", "-C", "afk/wBOOT/2-reconcile", "test"], { env: {}, weight: "heavy" });
     await new Promise<void>((resolve) => setImmediate(resolve));
 
-    expect(maxActive).toBe(1);
+    expect(active).toBe(1);
     releases.shift()?.();
     while (releases.length < 1) await new Promise<void>((resolve) => setImmediate(resolve));
     releases.shift()?.();
     await Promise.all([first, second]);
-    expect(maxActive).toBe(1);
+    expect(maxActive).toBe(2);
   });
 });
 
@@ -1184,7 +1189,7 @@ describe("the gate's lock waits reach the caller's sink (#2985)", () => {
       cacheEnabled: false,
       onLockWait: sink,
     });
-    await fb.pnpm(["pnpm", "-C", "afk/wAAAA/1-x", "test"]);
+    await fb.pnpm(["pnpm", "-C", "afk/wAAAA/1-x", "test"], { env: {}, weight: "heavy" });
 
     expect(reached.map((r) => r.lock).sort()).toEqual(["feedback-worktree", "validation-gate"]);
     // A sink that reaches only one lock leaves the other silent — which is the
@@ -1213,7 +1218,7 @@ describe("the gate's lock waits reach the caller's sink (#2985)", () => {
     };
 
     const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io, { cacheEnabled: false });
-    await fb.pnpm(["pnpm", "-C", "afk/wAAAA/1-x", "test"]);
+    await fb.pnpm(["pnpm", "-C", "afk/wAAAA/1-x", "test"], { env: {}, weight: "heavy" });
 
     expect(seen).toEqual([undefined, undefined]);
   });

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -49,6 +49,50 @@ describe("buildFeedbackSubprocessEnv resource budget (#1758)", () => {
   });
 });
 
+describe("validation host-resource classification (#3802)", () => {
+  it("marks only root/workspace test, typecheck and build as heavy", async () => {
+    const calls: Array<{ argv: string[]; weight: string | undefined }> = [];
+    const exec: Exec = async (argv, options) => {
+      calls.push({ argv, weight: options?.weight });
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const layout = fakeLayout({
+      packages: [".", "apps/dev"],
+      scripts: {
+        ".": ["test", "typecheck", "lint", "build"],
+        "apps/dev": ["test", "typecheck", "lint", "build"],
+      },
+    });
+
+    await runFeedback(exec, {
+      worktree: "/repo",
+      scopes: ["apps/dev"],
+      layout,
+      now: fakeClock(),
+      root: "/repo",
+      worktreeKind: "checkout",
+      dirExists: () => true,
+    });
+    await runFeedback(exec, {
+      worktree: "/repo",
+      scopes: ["."],
+      layout,
+      now: fakeClock(),
+      root: "/repo",
+      worktreeKind: "checkout",
+      dirExists: () => true,
+    });
+
+    const classified = new Map(calls.map((call) => [call.argv.join(" "), call.weight]));
+    expect(classified.get("pnpm -C /repo/apps/dev test")).toBe("light");
+    expect(classified.get("pnpm -C /repo/apps/dev build")).toBe("light");
+    expect(classified.get("pnpm -C /repo typecheck")).toBe("heavy");
+    expect(classified.get("pnpm -C /repo test")).toBe("heavy");
+    expect(classified.get("pnpm -C /repo build")).toBe("heavy");
+    expect(classified.get("pnpm -C /repo lint")).toBe("light");
+  });
+});
+
 /**
  * Fake package layout: `packages` is the set of dirs that carry a package.json
  * (the root is `"."`), `scripts` maps each scope to the scripts it declares.
@@ -284,6 +328,26 @@ describe("runFeedback", () => {
     expect(check?.record.summary).toContain("validation child stalled");
     expect(verdictIsEnvironment(result)).toBe(true);
     expect(calls).toHaveLength(1);
+  });
+
+  it("records heavy admission timeout as infrastructure and never branch fault", async () => {
+    const result = await runFeedback(async () => ({
+      code: 1,
+      stdout: "",
+      stderr: "host heavy-validation admission timed out",
+      infraEvidence: { kind: "admission-timeout", wallTimeMs: 60_000 },
+    }), {
+      worktree: "/repo",
+      scopes: ["."],
+      layout: fakeLayout({ packages: ["."], scripts: { ".": ["test"] } }),
+      now: fakeClock(),
+      root: "/repo",
+      worktreeKind: "checkout",
+      dirExists: () => true,
+    });
+
+    expect(result.checks[0]?.record.infra).toBe("admission-timeout");
+    expect(verdictIsEnvironment(result)).toBe(true);
   });
 
   it("produces the exact red.afk.validation.v1 sidecar record shape", async () => {

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -21,6 +21,7 @@
     "./project-registration": "./src/project-registration.ts",
     "./resource-incidents": "./src/resource-incidents.ts",
     "./resource-lease": "./src/resource-lease.ts",
+    "./resource-lease-client": "./src/resource-lease-client.ts",
     "./protocol": "./src/protocol.ts",
     "./queue-discovery": "./src/queue-discovery.ts",
     "./reattach": "./src/reattach.ts",

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -20,6 +20,7 @@
     "./project-breaker": "./src/project-breaker.ts",
     "./project-registration": "./src/project-registration.ts",
     "./resource-incidents": "./src/resource-incidents.ts",
+    "./resource-lease": "./src/resource-lease.ts",
     "./protocol": "./src/protocol.ts",
     "./queue-discovery": "./src/queue-discovery.ts",
     "./reattach": "./src/reattach.ts",

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -57,6 +57,7 @@ import {
   isRedskilledProjectRegistered,
   isRedskilledProjectRenewed,
   isRedskilledProjectReset,
+  isRedskilledResourceLeaseReleased,
   isRedskilledReapResult,
   isRedskilledStatuslinePayload,
   isRedskilledStatuslineRender,
@@ -68,6 +69,7 @@ import {
   type RedskilledProjectRegistered,
   type RedskilledProjectRenewed,
   type RedskilledProjectReset,
+  type RedskilledResourceLeaseReleased,
   type RedskilledReapResult,
   type RedskilledRequest,
   type RedskilledStatuslinePayload,
@@ -81,6 +83,11 @@ import {
   type RedskilledMechanicalHealStamp,
   type RedskilledWorkerStarted,
 } from "./protocol.js";
+import {
+  isRedskilledResourceLease,
+  type RedskilledResourceLease,
+  type RedskilledResourceLeaseRequest,
+} from "./resource-lease.js";
 import {
   REDSKILLED_DASHBOARD_DEFAULTS,
   REDSKILLED_STATUSLINE_DEFAULTS,
@@ -504,6 +511,42 @@ export async function readRedskilledHostState(
 ): Promise<RedskilledHostState> {
   const value = await requestRedskilled(paths, { op: "host-state" }, config);
   if (!isRedskilledHostState(value)) throw new Error("redskilled daemon returned a malformed host state");
+  return value;
+}
+
+/** Acquire one generic host resource. The daemon, not a checkout lock, owns the wait. */
+export async function acquireRedskilledResourceLease(
+  paths: RedskilledPaths,
+  request: RedskilledResourceLeaseRequest,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledResourceLease> {
+  const value = await requestRedskilled(paths, { op: "resource-acquire", request }, {
+    ...config,
+    requestTimeoutMs: Math.max(config.requestTimeoutMs ?? 0, request.wait_timeout_ms + 1_000),
+  });
+  if (!isRedskilledResourceLease(value)) throw new Error("redskilled daemon returned a malformed resource lease");
+  return value;
+}
+
+export async function renewRedskilledResourceLease(
+  paths: RedskilledPaths,
+  leaseId: string,
+  ttlMs: number,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledResourceLease | null> {
+  const value = await requestRedskilled(paths, { op: "resource-renew", lease_id: leaseId, ttl_ms: ttlMs }, config);
+  if (value === null) return null;
+  if (!isRedskilledResourceLease(value)) throw new Error("redskilled daemon returned a malformed renewed resource lease");
+  return value;
+}
+
+export async function releaseRedskilledResourceLease(
+  paths: RedskilledPaths,
+  leaseId: string,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledResourceLeaseReleased> {
+  const value = await requestRedskilled(paths, { op: "resource-release", lease_id: leaseId }, config);
+  if (!isRedskilledResourceLeaseReleased(value)) throw new Error("redskilled daemon returned a malformed resource release");
   return value;
 }
 

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -57,7 +57,6 @@ import {
   isRedskilledProjectRegistered,
   isRedskilledProjectRenewed,
   isRedskilledProjectReset,
-  isRedskilledResourceLeaseReleased,
   isRedskilledReapResult,
   isRedskilledStatuslinePayload,
   isRedskilledStatuslineRender,
@@ -69,7 +68,6 @@ import {
   type RedskilledProjectRegistered,
   type RedskilledProjectRenewed,
   type RedskilledProjectReset,
-  type RedskilledResourceLeaseReleased,
   type RedskilledReapResult,
   type RedskilledRequest,
   type RedskilledStatuslinePayload,
@@ -83,11 +81,6 @@ import {
   type RedskilledMechanicalHealStamp,
   type RedskilledWorkerStarted,
 } from "./protocol.js";
-import {
-  isRedskilledResourceLease,
-  type RedskilledResourceLease,
-  type RedskilledResourceLeaseRequest,
-} from "./resource-lease.js";
 import {
   REDSKILLED_DASHBOARD_DEFAULTS,
   REDSKILLED_STATUSLINE_DEFAULTS,
@@ -514,41 +507,6 @@ export async function readRedskilledHostState(
   return value;
 }
 
-/** Acquire one generic host resource. The daemon, not a checkout lock, owns the wait. */
-export async function acquireRedskilledResourceLease(
-  paths: RedskilledPaths,
-  request: RedskilledResourceLeaseRequest,
-  config: RedskilledClientConfig = {},
-): Promise<RedskilledResourceLease> {
-  const value = await requestRedskilled(paths, { op: "resource-acquire", request }, {
-    ...config,
-    requestTimeoutMs: Math.max(config.requestTimeoutMs ?? 0, request.wait_timeout_ms + 1_000),
-  });
-  if (!isRedskilledResourceLease(value)) throw new Error("redskilled daemon returned a malformed resource lease");
-  return value;
-}
-
-export async function renewRedskilledResourceLease(
-  paths: RedskilledPaths,
-  leaseId: string,
-  ttlMs: number,
-  config: RedskilledClientConfig = {},
-): Promise<RedskilledResourceLease | null> {
-  const value = await requestRedskilled(paths, { op: "resource-renew", lease_id: leaseId, ttl_ms: ttlMs }, config);
-  if (value === null) return null;
-  if (!isRedskilledResourceLease(value)) throw new Error("redskilled daemon returned a malformed renewed resource lease");
-  return value;
-}
-
-export async function releaseRedskilledResourceLease(
-  paths: RedskilledPaths,
-  leaseId: string,
-  config: RedskilledClientConfig = {},
-): Promise<RedskilledResourceLeaseReleased> {
-  const value = await requestRedskilled(paths, { op: "resource-release", lease_id: leaseId }, config);
-  if (!isRedskilledResourceLeaseReleased(value)) throw new Error("redskilled daemon returned a malformed resource release");
-  return value;
-}
 
 /** Run the daemon-owned orphan census, optionally stopping at the report. */
 export async function reapRedskilledProcesses(

--- a/apps/redskilled/src/daemon-events.ts
+++ b/apps/redskilled/src/daemon-events.ts
@@ -94,6 +94,7 @@ function buildDaemonLifecycleEvent(
     systemd_result: null,
     memory_peak_bytes: null,
     memory_swap_peak_bytes: null,
+    pids_peak: null,
     journal_tail: null,
     reason,
   };

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
 import type { Server, Socket } from "node:net";
+import { freemem } from "node:os";
 import { dirname } from "node:path";
 import { isPidAlive } from "@reddb-io/shared/resident-core.js";
 import { planRegistrationBootRecovery, recordDaemonBootRecovery } from "./boot-recovery.js";
@@ -10,6 +11,7 @@ import { RedskilledAlreadyRunningError } from "./errors.js";
 import {
   appendRedskilledMetricObservation,
   replayRedskilledMetricObservations,
+  shouldCheckpointMetricObservation,
 } from "./metric-history.js";
 import {
   deriveWorkerScopeCeiling,
@@ -72,6 +74,8 @@ import { workerSpecFromLaunch, type RedskilledLaunchTemplate } from "../launch-t
 import {
   createRedskilledRegistrationIntentStore,
 } from "../registration-intent-store.js";
+import { createRedskilledResourceLeaseRuntime } from "../resource-lease.js";
+import { createRedskilledResourceLeaseStore } from "../resource-lease-store.js";
 import {
   buildRegistrationLapse,
   buildRegistrationStop,
@@ -341,6 +345,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const eventLane = options.eventLane ?? createRedskilledEventLane(paths.eventLanePath);
   const registrationIntentStore = options.registrationIntentStore ??
     createRedskilledRegistrationIntentStore(paths.registrationIntentPath);
+  const resourceLeaseStore = options.resourceLeaseStore ??
+    createRedskilledResourceLeaseStore(paths.resourceLeasePath);
   const liveness = options.liveness ?? detectWorkerLiveness;
   const unitExitFacts = options.unitExitFacts ?? detectUnitExitFacts;
   const livenessGraceMs = options.livenessGraceMs ?? REDSKILLED_LIVENESS_GRACE_MS;
@@ -387,6 +393,13 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const demandMs = options.demandMs ?? DEFAULT_REDSKILLED_DEMAND_MS;
   const demandBackoffMs = options.demandBackoffMs ?? REDSKILLED_DEMAND_BACKOFF_MS;
   const workers = new Map<string, RedskilledWorkerView>();
+  const restoredResourceLeases = await resourceLeaseStore.read().catch(() => []);
+  const resourceLeases = createRedskilledResourceLeaseRuntime({
+    nowMs: () => Date.parse(clock()),
+    availableMemoryBytes: options.availableMemoryBytes ?? freemem,
+    restored: restoredResourceLeases,
+    changed: (leases) => resourceLeaseStore.replace(leases),
+  });
   // Concurrent socket admissions for the same trunk join one in-flight fetch.
   // A demand burst additionally retains its resolved promise for the whole tick.
   const trunkRefreshes = new Map<string, Promise<string>>();
@@ -410,6 +423,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // exception that is already durable — they mirror the host event lane, which is
   // replayed into them at boot.
   let observations: RedskilledWorkerMetricObservation[] = [];
+  const metricCheckpoints = new Map<string, RedskilledWorkerMetricObservation>();
+  const workerHighWater = new Map<string, { memory: number; swap: number; pids: number }>();
   let outcomeMarks: RedskilledWorkerOutcomeMark[] = [];
   // Boot attributions and deaths this daemon observed share one surface feed.
   // The latter stay durable through the host event lane and are replayed below;
@@ -675,7 +690,6 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
 
   function hostState(): RedskilledHostState {
     const now = clock();
-    expireLapsedRegistrations(now);
     return buildHostState({
       now,
       daemonVersion,
@@ -760,7 +774,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     observations = appended.observations;
     // The host event lane is the daemon's one durable history. Persist the
     // projection needed for rates there, never in a metrics sidecar.
-    void eventLane.recordWorker(appended.record).catch(() => undefined);
+    const latest = observations.at(-1)!;
+    if (shouldCheckpointMetricObservation(metricCheckpoints.get(worker.worker_id), latest)) {
+      metricCheckpoints.set(worker.worker_id, latest);
+      void eventLane.recordWorker(appended.record).catch(() => undefined);
+    }
   }
 
   /**
@@ -1188,6 +1206,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     reattached.delete(workerId);
     logLines.delete(workerId);
     displays.delete(workerId);
+    void resourceLeases.releaseHolder(workerId).catch(() => undefined);
   }
 
   /**
@@ -1664,7 +1683,21 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     const ts = clock();
     // The same instant the lane records, so the outcome rate and the lane never
     // describe the same ending at two different times.
-    const input: RecordWorkerEventInput = { kind, worker, ts, detail, ...facts };
+    const high = workerHighWater.get(worker.worker_id);
+    const input: RecordWorkerEventInput = {
+      kind,
+      worker,
+      ts,
+      detail,
+      ...facts,
+      ...((kind === "worker-death" || kind === "worker-budget-kill") && high != null
+        ? {
+            memoryPeakBytes: Math.max(facts.memoryPeakBytes ?? 0, high.memory),
+            memorySwapPeakBytes: Math.max(facts.memorySwapPeakBytes ?? 0, high.swap),
+            pidsPeak: Math.max(facts.pidsPeak ?? 0, high.pids),
+          }
+        : {}),
+    };
     if (kind === "worker-death" || kind === "worker-budget-kill") {
       const mark: RedskilledWorkerOutcomeMark = { worker_id: worker.worker_id, ts, outcome: kind };
       outcomeMarks = pruneRedskilledMetricHistory([...outcomeMarks, mark], (entry) => entry.ts, { now: clock() });
@@ -1776,6 +1809,22 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     lastSampledAt = clock();
     recordWorkerCpuReadings(workers, reading.cpu_seconds, lastSampledAt);
     await resourceIncidents.ingest(Object.values(reading.resource_samples ?? {}), lastSampledAt);
+    for (const [workerId, sample] of Object.entries(reading.resource_samples ?? {})) {
+      const previous = workerHighWater.get(workerId) ?? { memory: 0, swap: 0, pids: 0 };
+      const next = {
+        memory: Math.max(previous.memory, sample.memory.peak_bytes),
+        swap: Math.max(previous.swap, sample.memory.swap_peak_bytes ?? 0),
+        pids: Math.max(previous.pids, sample.pids.peak),
+      };
+      if (next.memory === previous.memory && next.swap === previous.swap && next.pids === previous.pids) continue;
+      workerHighWater.set(workerId, next);
+      const worker = workers.get(workerId);
+      if (worker != null) record("worker-resource", worker, null, {
+        memoryPeakBytes: next.memory,
+        memorySwapPeakBytes: next.swap,
+        pidsPeak: next.pids,
+      });
+    }
     const { terminations } = evaluateWorkerBudgets({
       workers: live,
       rss,
@@ -2193,6 +2242,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     // Worker it holds a budget for and no record of.
     await eventLane.flush().catch(() => undefined);
     await registrationIntentStore.flush().catch(() => undefined);
+    await resourceLeaseStore.flush().catch(() => undefined);
     // Ownership records go first while the socket still proves this daemon is
     // reachable. If either release stalls or fails, the old daemon stays bound
     // and no successor mistakes a live, socketless pid for the singleton.
@@ -2210,6 +2260,19 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // in the window between binding and replay would be told this session holds
   // nothing, and would then birth a second Worker for work already running.
   const laneEvents = await eventLane.read().catch(() => []);
+  for (const event of laneEvents) {
+    if (event.worker_id === "" || event.worker_id.startsWith("daemon:")) continue;
+    const previous = workerHighWater.get(event.worker_id);
+    if (previous == null && event.memory_peak_bytes == null && event.memory_swap_peak_bytes == null && event.pids_peak == null) {
+      continue;
+    }
+    const prior = previous ?? { memory: 0, swap: 0, pids: 0 };
+    workerHighWater.set(event.worker_id, {
+      memory: Math.max(prior.memory, event.memory_peak_bytes ?? 0),
+      swap: Math.max(prior.swap, event.memory_swap_peak_bytes ?? 0),
+      pids: Math.max(prior.pids, event.pids_peak ?? 0),
+    });
+  }
   // A successor must render yesterday's loss too. The event lane is the durable
   // host witness, so replaying it here restores the exact feed a live exit updates
   // above without asking a project artifact that an early Worker never created.
@@ -2240,6 +2303,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     { now: clock() },
   );
   observations = replayRedskilledMetricObservations(laneEvents, clock());
+  for (const observation of observations) metricCheckpoints.set(observation.worker_id, observation);
   const replayed = rehydrateWorkers(laneEvents);
   // Census active units before attributing deaths: an active unit is re-attachable, not dead.
   const activeUnits = new Set(await Promise.resolve(unitInventory()).catch(() => []));
@@ -2273,6 +2337,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     workers.set(worker.worker_id, worker);
     reattached.add(worker.worker_id);
     record("worker-birth", worker, "adopted from an active unit with no birth on this lane");
+  }
+  for (const lease of resourceLeases.snapshot()) {
+    if (lease.worker_id != null && !workers.has(lease.worker_id)) {
+      await resourceLeases.release(lease.lease_id).catch(() => undefined);
+    }
   }
   const bootRecovery = planRegistrationBootRecovery(restoredRegistrations, workers.values(), startedAt);
   for (const held of bootRecovery.live) registrations.set(held.project_label, held);
@@ -2343,6 +2412,19 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       }
       if (request.op === "worker-heartbeat") {
         return { id: request.id, ok: true, value: publishWorkerHeartbeat(request.heartbeat) };
+      }
+      if (request.op === "resource-acquire") {
+        return { id: request.id, ok: true, value: await resourceLeases.acquire(request.request) };
+      }
+      if (request.op === "resource-renew") {
+        return { id: request.id, ok: true, value: await resourceLeases.renew(request.lease_id, request.ttl_ms) };
+      }
+      if (request.op === "resource-release") {
+        return {
+          id: request.id,
+          ok: true,
+          value: { version: 1, lease_id: request.lease_id, released: await resourceLeases.release(request.lease_id) },
+        };
       }
       if (request.op === "project-register") {
         const value = registerProject(request.registration, request.session_project);
@@ -2442,6 +2524,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     killWorkerOverBudget,
     sampleMemoryBudgets,
     renewLease,
+    resourceLeases,
     pollRepositoryActivity,
     pollGithubBalance,
     githubBalance: () => lastBalance,
@@ -2461,10 +2544,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     },
     releaseWorker(workerId) {
       const worker = workers.get(workerId);
-      const removed = workers.delete(workerId);
-      reattached.delete(workerId);
-      logLines.delete(workerId);
-      displays.delete(workerId);
+      const removed = worker != null;
+      if (worker != null) forgetWorker(workerId);
       if (worker) record("worker-death", worker, "released by the daemon");
       armIdleTimer();
       return removed;
@@ -2472,6 +2553,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     workerCount: () => workers.size,
     registerProject,
     renewProject,
+    sweepRegistrations: () => expireLapsedRegistrations(clock()),
     resetProjectBirthBreaker,
     deregisterProject,
     registrations: () => hostState().registrations ?? [],

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
 import type { Server, Socket } from "node:net";
-import { freemem } from "node:os";
 import { dirname } from "node:path";
 import { isPidAlive } from "@reddb-io/shared/resident-core.js";
 import { planRegistrationBootRecovery, recordDaemonBootRecovery } from "./boot-recovery.js";
@@ -63,6 +62,8 @@ import {
 } from "../memory-sampler.js";
 import { resolveResourceIncidentRuntime } from "./resource-incident-runtime.js";
 import { recordWorkerCpuReadings } from "./worker-cpu.js";
+import { foldWorkerHighWater, replayWorkerHighWater, terminalHighWaterFacts } from "./worker-high-water.js";
+import { handleResourceLeaseRequest, releaseOrphanedResourceLeases, resolveResourceLeaseRuntime } from "./resource-lease-runtime.js";
 import {
   createRedskilledMachineClaimStore,
   currentMachineOwner,
@@ -74,8 +75,6 @@ import { workerSpecFromLaunch, type RedskilledLaunchTemplate } from "../launch-t
 import {
   createRedskilledRegistrationIntentStore,
 } from "../registration-intent-store.js";
-import { createRedskilledResourceLeaseRuntime } from "../resource-lease.js";
-import { createRedskilledResourceLeaseStore } from "../resource-lease-store.js";
 import {
   buildRegistrationLapse,
   buildRegistrationStop,
@@ -345,8 +344,6 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const eventLane = options.eventLane ?? createRedskilledEventLane(paths.eventLanePath);
   const registrationIntentStore = options.registrationIntentStore ??
     createRedskilledRegistrationIntentStore(paths.registrationIntentPath);
-  const resourceLeaseStore = options.resourceLeaseStore ??
-    createRedskilledResourceLeaseStore(paths.resourceLeasePath);
   const liveness = options.liveness ?? detectWorkerLiveness;
   const unitExitFacts = options.unitExitFacts ?? detectUnitExitFacts;
   const livenessGraceMs = options.livenessGraceMs ?? REDSKILLED_LIVENESS_GRACE_MS;
@@ -393,12 +390,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const demandMs = options.demandMs ?? DEFAULT_REDSKILLED_DEMAND_MS;
   const demandBackoffMs = options.demandBackoffMs ?? REDSKILLED_DEMAND_BACKOFF_MS;
   const workers = new Map<string, RedskilledWorkerView>();
-  const restoredResourceLeases = await resourceLeaseStore.read().catch(() => []);
-  const resourceLeases = createRedskilledResourceLeaseRuntime({
-    nowMs: () => Date.parse(clock()),
-    availableMemoryBytes: options.availableMemoryBytes ?? freemem,
-    restored: restoredResourceLeases,
-    changed: (leases) => resourceLeaseStore.replace(leases),
+  const { runtime: resourceLeases, store: resourceLeaseStore } = await resolveResourceLeaseRuntime({
+    paths, clock,
+    ...(options.resourceLeaseStore == null ? {} : { store: options.resourceLeaseStore }),
+    ...(options.availableMemoryBytes == null ? {} : { availableMemoryBytes: options.availableMemoryBytes }),
   });
   // Concurrent socket admissions for the same trunk join one in-flight fetch.
   // A demand burst additionally retains its resolved promise for the whole tick.
@@ -414,17 +409,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // In memory beside the log lines and for the same reason: a display record is a
   // live progress note, and a durable copy would outlive the Worker it describes.
   const displays = new Map<string, RedskilledWorkerDisplayRecord>();
-  // What the daemon has SEEN, kept only as long as a window can ask about it.
-  // The displays map holds the latest record per Worker and nothing else, so a
-  // rate — which is a difference between two instants — has no ingredient there;
-  // these two lanes are that ingredient. In memory beside the displays and for
-  // the same reason: they are live progress notes, and a durable copy would be a
-  // third authority on a Worker's story (ADR 0130). The outcome marks are the one
-  // exception that is already durable — they mirror the host event lane, which is
-  // replayed into them at boot.
+  // Observations stay in memory; sparse checkpoints and outcomes replay from
+  // the authoritative event lane after daemon handover (ADR 0130).
   let observations: RedskilledWorkerMetricObservation[] = [];
   const metricCheckpoints = new Map<string, RedskilledWorkerMetricObservation>();
-  const workerHighWater = new Map<string, { memory: number; swap: number; pids: number }>();
+  let workerHighWater = replayWorkerHighWater([]);
   let outcomeMarks: RedskilledWorkerOutcomeMark[] = [];
   // Boot attributions and deaths this daemon observed share one surface feed.
   // The latter stay durable through the host event lane and are replayed below;
@@ -1661,13 +1650,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     return tracked;
   }
 
-  /**
-   * Append one event, without making the caller wait for the disk.
-   *
-   * The lane serialises its own appends, so ordering survives the fire-and-
-   * forget; what a failed write must not do is take down the daemon that still
-   * holds the live Worker the event was about.
-   */
+  /** Append one ordered event without making the live daemon wait for disk. */
   function record(
     kind: RedskilledWorkerEventKind,
     worker: RedskilledWorkerView,
@@ -1676,26 +1659,18 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       readonly refusal?: string | null;
     } = {},
   ): void {
-    // A stopped daemon writes nothing. Its beliefs about who is alive stopped
-    // being authoritative when it let go of the session, and the next daemon
-    // re-derives every one of them by asking the host directly.
+    // A stopped daemon is no longer authoritative; its successor re-derives state.
     if (stopping) return;
     const ts = clock();
-    // The same instant the lane records, so the outcome rate and the lane never
-    // describe the same ending at two different times.
-    const high = workerHighWater.get(worker.worker_id);
+    // Outcome rates and lane records share this instant.
     const input: RecordWorkerEventInput = {
       kind,
       worker,
       ts,
       detail,
       ...facts,
-      ...((kind === "worker-death" || kind === "worker-budget-kill") && high != null
-        ? {
-            memoryPeakBytes: Math.max(facts.memoryPeakBytes ?? 0, high.memory),
-            memorySwapPeakBytes: Math.max(facts.memorySwapPeakBytes ?? 0, high.swap),
-            pidsPeak: Math.max(facts.pidsPeak ?? 0, high.pids),
-          }
+      ...((kind === "worker-death" || kind === "worker-budget-kill")
+        ? terminalHighWaterFacts(workerHighWater, worker.worker_id, facts)
         : {}),
     };
     if (kind === "worker-death" || kind === "worker-budget-kill") {
@@ -1782,26 +1757,14 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     return true;
   }
 
-  /**
-   * One tick of the floor: sample the whole set, terminate what is over budget.
-   *
-   * The sample is taken ONCE for every Worker the daemon holds, so the tick's
-   * cost is the host's process table rather than the Worker count. An empty set
-   * is not sampled at all — there is nothing to measure and nothing to kill.
-   *
-   * The tick's CPU reading is recorded on every Worker it measured and acted on
-   * by nothing here: this tick enforces the memory budget, exactly as it did
-   * before the second number existed.
-   */
+  /** Sample all Workers once, record resources, and enforce memory budgets. */
   async function sampleMemoryBudgets(): Promise<readonly RedskilledBudgetTermination[]> {
     const live = [...workers.values()];
     let reading: RedskilledTreeReading = { rss: {}, cpu_seconds: {}, processes: {}, sources: {} };
     if (live.length > 0) try {
       reading = await treeSampler(live);
     } catch {
-      // A sampler that could not read the host measured nothing, and a Worker
-      // nothing measured is never killed on suspicion — nor is the last reading
-      // re-dated, because a failed tick must age the payload rather than refresh it.
+      // A failed sample measures nothing and never kills on suspicion.
       reading = { rss: {}, cpu_seconds: {}, processes: {}, sources: {} };
     }
     const rss = reading.rss;
@@ -1810,14 +1773,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     recordWorkerCpuReadings(workers, reading.cpu_seconds, lastSampledAt);
     await resourceIncidents.ingest(Object.values(reading.resource_samples ?? {}), lastSampledAt);
     for (const [workerId, sample] of Object.entries(reading.resource_samples ?? {})) {
-      const previous = workerHighWater.get(workerId) ?? { memory: 0, swap: 0, pids: 0 };
-      const next = {
-        memory: Math.max(previous.memory, sample.memory.peak_bytes),
-        swap: Math.max(previous.swap, sample.memory.swap_peak_bytes ?? 0),
-        pids: Math.max(previous.pids, sample.pids.peak),
-      };
-      if (next.memory === previous.memory && next.swap === previous.swap && next.pids === previous.pids) continue;
-      workerHighWater.set(workerId, next);
+      const next = foldWorkerHighWater(workerHighWater, workerId, sample);
+      if (next == null) continue;
       const worker = workers.get(workerId);
       if (worker != null) record("worker-resource", worker, null, {
         memoryPeakBytes: next.memory,
@@ -2260,19 +2217,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // in the window between binding and replay would be told this session holds
   // nothing, and would then birth a second Worker for work already running.
   const laneEvents = await eventLane.read().catch(() => []);
-  for (const event of laneEvents) {
-    if (event.worker_id === "" || event.worker_id.startsWith("daemon:")) continue;
-    const previous = workerHighWater.get(event.worker_id);
-    if (previous == null && event.memory_peak_bytes == null && event.memory_swap_peak_bytes == null && event.pids_peak == null) {
-      continue;
-    }
-    const prior = previous ?? { memory: 0, swap: 0, pids: 0 };
-    workerHighWater.set(event.worker_id, {
-      memory: Math.max(prior.memory, event.memory_peak_bytes ?? 0),
-      swap: Math.max(prior.swap, event.memory_swap_peak_bytes ?? 0),
-      pids: Math.max(prior.pids, event.pids_peak ?? 0),
-    });
-  }
+  workerHighWater = replayWorkerHighWater(laneEvents);
   // A successor must render yesterday's loss too. The event lane is the durable
   // host witness, so replaying it here restores the exact feed a live exit updates
   // above without asking a project artifact that an early Worker never created.
@@ -2338,11 +2283,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     reattached.add(worker.worker_id);
     record("worker-birth", worker, "adopted from an active unit with no birth on this lane");
   }
-  for (const lease of resourceLeases.snapshot()) {
-    if (lease.worker_id != null && !workers.has(lease.worker_id)) {
-      await resourceLeases.release(lease.lease_id).catch(() => undefined);
-    }
-  }
+  await releaseOrphanedResourceLeases(resourceLeases, new Set(workers.keys()));
   const bootRecovery = planRegistrationBootRecovery(restoredRegistrations, workers.values(), startedAt);
   for (const held of bootRecovery.live) registrations.set(held.project_label, held);
   for (const held of bootRecovery.recoverable) recoverableRegistrations.set(held.project_label, held);
@@ -2386,45 +2327,22 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       if (request.op === "host-state") return { id: request.id, ok: true, value: hostState() };
       if (request.op === "reap") return { id: request.id, ok: true, value: await orphanReaper.reap(request.report === true) };
       if (request.op === "statusline-payload") {
-        // A host read, permitted from any project: seeing the machine is the
-        // requirement, and a session that could not would diagnose contention
-        // by leaving the session it is in.
-        //
-        // The SKELETON — Workers, projects and budget — is served whatever the
-        // request says, because rule 9 already entitles a session to the whole
-        // machine and withholding it would buy only a second round trip (ADR
-        // 0132 decision 2). What scales with Worker count travels on request,
-        // and a request that names no extras is a client pinned to a bundle
-        // that predates them: it asked for everything by saying nothing.
+        // Always serve the machine skeleton; only per-Worker extras are optional.
         return { id: request.id, ok: true, value: withholdStatuslineExtras(statuslinePayload(), request.extras) };
       }
       if (request.op === "statusline-string") {
-        // The same host read, already rendered. The daemon renders it from the
-        // payload the other op returns — one call of a pure function — so the
-        // two surfaces are the same answer twice and never two answers.
+        // Render the same pure snapshot as the payload operation.
         return { id: request.id, ok: true, value: statuslineString(request.render) };
       }
       if (request.op === "statusline-dashboard") {
-        // The third of the statusline family, and the same host read again: one
-        // call of a pure function on the payload the first op returns, so a pane
-        // and a line are the same answer twice and never two answers.
+        // Render the dashboard from that same pure snapshot.
         return { id: request.id, ok: true, value: statuslineDashboard(request.dashboard) };
       }
       if (request.op === "worker-heartbeat") {
         return { id: request.id, ok: true, value: publishWorkerHeartbeat(request.heartbeat) };
       }
-      if (request.op === "resource-acquire") {
-        return { id: request.id, ok: true, value: await resourceLeases.acquire(request.request) };
-      }
-      if (request.op === "resource-renew") {
-        return { id: request.id, ok: true, value: await resourceLeases.renew(request.lease_id, request.ttl_ms) };
-      }
-      if (request.op === "resource-release") {
-        return {
-          id: request.id,
-          ok: true,
-          value: { version: 1, lease_id: request.lease_id, released: await resourceLeases.release(request.lease_id) },
-        };
+      if (request.op === "resource-acquire" || request.op === "resource-renew" || request.op === "resource-release") {
+        return handleResourceLeaseRequest(request, resourceLeases);
       }
       if (request.op === "project-register") {
         const value = registerProject(request.registration, request.session_project);

--- a/apps/redskilled/src/daemon/metric-history.ts
+++ b/apps/redskilled/src/daemon/metric-history.ts
@@ -15,6 +15,23 @@ export interface AppendedRedskilledMetricObservation {
   readonly record: RecordWorkerEventInput;
 }
 
+export const REDSKILLED_METRIC_CHECKPOINT_MS = 5 * 60_000;
+
+/** Persist first/changed rate endpoints immediately; checkpoint idle repeats sparsely. */
+export function shouldCheckpointMetricObservation(
+  previous: RedskilledWorkerMetricObservation | undefined,
+  next: RedskilledWorkerMetricObservation,
+): boolean {
+  if (previous == null) return true;
+  if (
+    previous.tokens !== next.tokens ||
+    previous.tools !== next.tools ||
+    previous.runner !== next.runner ||
+    previous.model !== next.model
+  ) return true;
+  return Date.parse(next.observed_at) - Date.parse(previous.observed_at) >= REDSKILLED_METRIC_CHECKPOINT_MS;
+}
+
 /** Project one published display into both the live history and durable event input. PURE. */
 export function appendRedskilledMetricObservation(
   history: readonly RedskilledWorkerMetricObservation[],

--- a/apps/redskilled/src/daemon/resource-lease-runtime.ts
+++ b/apps/redskilled/src/daemon/resource-lease-runtime.ts
@@ -1,0 +1,49 @@
+/** Daemon integration for the generic host-resource lease authority. */
+import { freemem } from "node:os";
+import type { RedskilledPaths } from "../paths.js";
+import type { RedskilledRequest, RedskilledResponse } from "../protocol.js";
+import { createRedskilledResourceLeaseRuntime, type RedskilledResourceLeaseRuntime } from "../resource-lease.js";
+import { createRedskilledResourceLeaseStore, type RedskilledResourceLeaseStore } from "../resource-lease-store.js";
+
+export async function resolveResourceLeaseRuntime(input: {
+  readonly paths: RedskilledPaths;
+  readonly store?: RedskilledResourceLeaseStore;
+  readonly availableMemoryBytes?: () => number | Promise<number>;
+  readonly clock: () => string;
+}): Promise<{ readonly runtime: RedskilledResourceLeaseRuntime; readonly store: RedskilledResourceLeaseStore }> {
+  const store = input.store ?? createRedskilledResourceLeaseStore(input.paths.resourceLeasePath);
+  const restored = await store.read().catch(() => []);
+  return {
+    store,
+    runtime: createRedskilledResourceLeaseRuntime({
+      nowMs: () => Date.parse(input.clock()),
+      availableMemoryBytes: input.availableMemoryBytes ?? freemem,
+      restored,
+      changed: (leases) => store.replace(leases),
+    }),
+  };
+}
+
+type ResourceLeaseRequest = Extract<RedskilledRequest, { op: "resource-acquire" | "resource-renew" | "resource-release" }>;
+
+export async function handleResourceLeaseRequest(
+  request: ResourceLeaseRequest,
+  runtime: RedskilledResourceLeaseRuntime,
+): Promise<RedskilledResponse> {
+  if (request.op === "resource-acquire") return { id: request.id, ok: true, value: await runtime.acquire(request.request) };
+  if (request.op === "resource-renew") return { id: request.id, ok: true, value: await runtime.renew(request.lease_id, request.ttl_ms) };
+  return {
+    id: request.id,
+    ok: true,
+    value: { version: 1, lease_id: request.lease_id, released: await runtime.release(request.lease_id) },
+  };
+}
+
+export async function releaseOrphanedResourceLeases(
+  runtime: RedskilledResourceLeaseRuntime,
+  liveWorkerIds: ReadonlySet<string>,
+): Promise<void> {
+  await Promise.all(runtime.snapshot()
+    .filter((lease) => lease.worker_id != null && !liveWorkerIds.has(lease.worker_id))
+    .map((lease) => runtime.release(lease.lease_id).catch(() => false)));
+}

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -86,6 +86,8 @@ import type {
   ResourceIncidentStore,
   ResourceIncidentTracker,
 } from "../resource-incidents.js";
+import type { RedskilledResourceLeaseRuntime } from "../resource-lease.js";
+import type { RedskilledResourceLeaseStore } from "../resource-lease-store.js";
 export interface RedskilledDaemonOptions {
   readonly paths: RedskilledPaths;
   /** Test seam; production detects the kernel-side topology at daemon start. */
@@ -135,6 +137,10 @@ export interface RedskilledDaemonOptions {
   readonly eventLane?: RedskilledEventLane;
   /** The durable registration snapshot; defaults to this session's own. */
   readonly registrationIntentStore?: RedskilledRegistrationIntentStore;
+  /** Durable generic host-resource authority; injected for handover tests. */
+  readonly resourceLeaseStore?: RedskilledResourceLeaseStore;
+  /** Real available memory, sampled only while deciding generic resource admission. */
+  readonly availableMemoryBytes?: () => number | Promise<number>;
   /** How the daemon asks whether a re-attached Worker is still running. */
   readonly liveness?: RedskilledLivenessProbe;
   /** How the daemon reads systemd's retained exit receipt for a dead Worker unit. */
@@ -462,9 +468,11 @@ export interface RedskilledDaemon {
       readonly launch?: RedskilledLaunchTemplate;
     },
   ): RedskilledProjectRenewed;
+  /** Run the registration liveness belt once; snapshot reads never invoke it. */
+  sweepRegistrations(): readonly RedskilledProjectRegistration[];
   /** Explicitly clear this project's birth breaker. */
   resetProjectBirthBreaker(projectLabel: string, sessionProject?: string): RedskilledProjectReset;
-  /** The registrations this daemon holds, ordered by project label; lapsed ones swept. */
+  /** The registrations this daemon currently holds, ordered by project label. Pure snapshot. */
   registrations(): readonly RedskilledProjectRegistration[];
   hostState(): RedskilledHostState;
   /** Run the background trunk-refresh body now; exposed so timer behavior is fixture-driven. */
@@ -502,6 +510,8 @@ export interface RedskilledDaemon {
    * read, never a reason for a serving daemon to fall over.
    */
   renewLease(): Promise<RedskilledLease | null>;
+  /** Generic host-resource lease runtime, exposed for deterministic fixtures. */
+  readonly resourceLeases: RedskilledResourceLeaseRuntime;
   /**
    * Store one Worker's last logged line, exactly as it was published.
    *

--- a/apps/redskilled/src/daemon/worker-high-water.ts
+++ b/apps/redskilled/src/daemon/worker-high-water.ts
@@ -1,0 +1,65 @@
+/** Durable per-Worker resource peaks folded across samples and daemon handover. */
+import type { RecordWorkerEventInput, RedskilledHostEvent } from "../event-lane.js";
+import type { RedskilledResourceSample } from "../resource-incidents.js";
+
+export interface WorkerHighWater {
+  readonly memory: number;
+  readonly swap: number;
+  readonly pids: number;
+}
+
+export type WorkerHighWaterMap = Map<string, WorkerHighWater>;
+
+const EMPTY: WorkerHighWater = { memory: 0, swap: 0, pids: 0 };
+
+export function replayWorkerHighWater(events: readonly RedskilledHostEvent[]): WorkerHighWaterMap {
+  const highWater: WorkerHighWaterMap = new Map();
+  for (const event of events) {
+    if (event.worker_id === "" || event.worker_id.startsWith("daemon:")) continue;
+    const previous = highWater.get(event.worker_id);
+    if (previous == null && event.memory_peak_bytes == null && event.memory_swap_peak_bytes == null && event.pids_peak == null) continue;
+    highWater.set(event.worker_id, merge(previous ?? EMPTY, {
+      memory: event.memory_peak_bytes ?? 0,
+      swap: event.memory_swap_peak_bytes ?? 0,
+      pids: event.pids_peak ?? 0,
+    }));
+  }
+  return highWater;
+}
+
+export function foldWorkerHighWater(
+  highWater: WorkerHighWaterMap,
+  workerId: string,
+  sample: RedskilledResourceSample,
+): WorkerHighWater | null {
+  const previous = highWater.get(workerId) ?? EMPTY;
+  const next = merge(previous, {
+    memory: sample.memory.peak_bytes,
+    swap: sample.memory.swap_peak_bytes ?? 0,
+    pids: sample.pids.peak,
+  });
+  if (next.memory === previous.memory && next.swap === previous.swap && next.pids === previous.pids) return null;
+  highWater.set(workerId, next);
+  return next;
+}
+
+export function terminalHighWaterFacts(
+  highWater: WorkerHighWaterMap,
+  workerId: string,
+  facts: Omit<RecordWorkerEventInput, "kind" | "worker" | "ts" | "detail">,
+): Pick<RecordWorkerEventInput, "memoryPeakBytes" | "memorySwapPeakBytes" | "pidsPeak"> | undefined {
+  const high = highWater.get(workerId);
+  return high == null ? undefined : {
+    memoryPeakBytes: Math.max(facts.memoryPeakBytes ?? 0, high.memory),
+    memorySwapPeakBytes: Math.max(facts.memorySwapPeakBytes ?? 0, high.swap),
+    pidsPeak: Math.max(facts.pidsPeak ?? 0, high.pids),
+  };
+}
+
+function merge(left: WorkerHighWater, right: WorkerHighWater): WorkerHighWater {
+  return {
+    memory: Math.max(left.memory, right.memory),
+    swap: Math.max(left.swap, right.swap),
+    pids: Math.max(left.pids, right.pids),
+  };
+}

--- a/apps/redskilled/src/event-lane-decode.ts
+++ b/apps/redskilled/src/event-lane-decode.ts
@@ -85,6 +85,7 @@ export function decodeHostEventRow(record: ToonlRecord): RedskilledHostEvent {
     systemd_result: text(record.systemd_result),
     memory_peak_bytes: numberOrNull(record.memory_peak_bytes),
     memory_swap_peak_bytes: numberOrNull(record.memory_swap_peak_bytes),
+    pids_peak: numberOrNull(record.pids_peak),
     journal_tail: text(record.journal_tail),
     // Legacy rows predate daemon stop reasons; absence remains honest.
     reason: text(record.reason),

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -82,6 +82,7 @@ export type RedskilledWorkerEventKind =
   | "worker-birth"
   | "worker-activity"
   | "worker-metrics"
+  | "worker-resource"
   | "worker-drift"
   | "worker-heal"
   | "worker-death"
@@ -91,6 +92,7 @@ export const REDSKILLED_WORKER_EVENT_KINDS = [
   "worker-birth",
   "worker-activity",
   "worker-metrics",
+  "worker-resource",
   "worker-drift",
   "worker-heal",
   "worker-death",
@@ -99,6 +101,7 @@ export const REDSKILLED_WORKER_EVENT_KINDS = [
   "worker-birth",
   "worker-activity",
   "worker-metrics",
+  "worker-resource",
   "worker-drift",
   "worker-heal",
   "worker-death",
@@ -233,6 +236,8 @@ export interface RedskilledHostEvent {
   readonly memory_peak_bytes: number | null;
   /** Peak swap charged to the unit, in bytes. */
   readonly memory_swap_peak_bytes: number | null;
+  /** Peak process count observed for the Worker's unit/tree. */
+  readonly pids_peak: number | null;
   /** Bounded unit journal tail retained when the transient unit was collected. */
   readonly journal_tail: string | null;
 }
@@ -262,6 +267,7 @@ export interface RecordEventInput {
   readonly systemdResult?: string | null;
   readonly memoryPeakBytes?: number | null;
   readonly memorySwapPeakBytes?: number | null;
+  readonly pidsPeak?: number | null;
   readonly journalTail?: string | null;
   readonly reason?: string | null;
 }
@@ -277,6 +283,7 @@ export interface RecordWorkerEventInput {
   readonly systemdResult?: string | null;
   readonly memoryPeakBytes?: number | null;
   readonly memorySwapPeakBytes?: number | null;
+  readonly pidsPeak?: number | null;
   readonly journalTail?: string | null;
   readonly admissionVerdict?: string | null;
   readonly phase?: string | null;
@@ -337,6 +344,7 @@ export function buildHostEvent(input: RecordEventInput | RecordWorkerEventInput)
     systemd_result: input.systemdResult ?? null,
     memory_peak_bytes: input.memoryPeakBytes ?? null,
     memory_swap_peak_bytes: input.memorySwapPeakBytes ?? null,
+    pids_peak: input.pidsPeak ?? null,
     journal_tail: input.journalTail ?? null,
     reason: "reason" in input ? input.reason ?? null : null,
   };
@@ -376,6 +384,7 @@ export function buildDemandRefusalEvent(input: RecordDemandRefusalInput): Redski
     systemd_result: null,
     memory_peak_bytes: null,
     memory_swap_peak_bytes: null,
+    pids_peak: null,
     journal_tail: null,
     reason: null,
   };

--- a/apps/redskilled/src/paths.ts
+++ b/apps/redskilled/src/paths.ts
@@ -57,6 +57,8 @@ export interface RedskilledPaths {
   readonly eventLanePath: string;
   /** The durable project registrations a successor daemon rehydrates. */
   readonly registrationIntentPath: string;
+  /** Generic host-resource leases retained across daemon handover. */
+  readonly resourceLeasePath: string;
   /** The canonical claim path resolved for this host and resolver environment. */
   readonly machineClaimPathOfThisHost: string;
   /**
@@ -144,6 +146,7 @@ export function resolveRedskilledPaths(options: ResolveRedskilledPathsOptions = 
     // the socket stranded every drain when one process resolved XDG_RUNTIME_DIR
     // and its successor used the uid fallback (or vice versa).
     registrationIntentPath: join(redskilledHomeDir(homeDir), "redskilled.registrations.toon"),
+    resourceLeasePath: join(redskilledHomeDir(homeDir), "redskilled.resources.toon"),
     machineClaimPathOfThisHost,
     machineClaimPath: options.machineClaimPath ?? machineClaimPathOfThisHost,
   };

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -99,6 +99,7 @@ import type { RedskilledStatuslineMode, RedskilledStatuslineRender } from "@redd
 import { isRedskilledDashboard, type RedskilledDashboard } from "@reddb-io/redskilled-render";
 import type { RedskilledWorkerDisplay } from "./worker-display.js";
 import type { RedskilledWorkerSpec } from "./worker-launch.js";
+import type { RedskilledResourceLease, RedskilledResourceLeaseRequest } from "./resource-lease.js";
 
 /** The wire version. A daemon states it; a client that cannot read it must not proceed. */
 export const REDSKILLED_PROTOCOL_VERSION = 1;
@@ -204,6 +205,9 @@ export type RedskilledRequest =
   | { id: string; op: "worker-start"; spec: RedskilledWorkerSpec; session_project?: string }
   | { id: string; op: "worker-command"; command: RedskilledWorkerCommandRequest }
   | { id: string; op: "worker-heartbeat"; heartbeat: RedskilledWorkerHeartbeatRequest }
+  | { id: string; op: "resource-acquire"; request: RedskilledResourceLeaseRequest }
+  | { id: string; op: "resource-renew"; lease_id: string; ttl_ms?: number }
+  | { id: string; op: "resource-release"; lease_id: string }
   | { id: string; op: "project-register"; registration: RedskilledProjectRegistrationRequest; session_project?: string }
   | {
     id: string;
@@ -230,6 +234,20 @@ export type RedskilledRequest =
 export type RedskilledResponse =
   | { id: string; ok: true; value: unknown }
   | { id: string; ok: false; error: string };
+
+export interface RedskilledResourceLeaseReleased {
+  readonly version: 1;
+  readonly lease_id: string;
+  readonly released: boolean;
+}
+
+export function isRedskilledResourceLeaseReleased(value: unknown): value is RedskilledResourceLeaseReleased {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const released = value as Record<string, unknown>;
+  return released.version === 1 && typeof released.lease_id === "string" && typeof released.released === "boolean";
+}
+
+export type { RedskilledResourceLease };
 
 export interface RedskilledPong {
   readonly pong: true;

--- a/apps/redskilled/src/registration-intent-store.ts
+++ b/apps/redskilled/src/registration-intent-store.ts
@@ -32,6 +32,8 @@ export function createRedskilledRegistrationIntentStore(
 ): RedskilledRegistrationIntentStore {
   let tail: Promise<unknown> = Promise.resolve();
   let failure: unknown | null = null;
+  let pending: readonly RedskilledProjectRegistration[] | null = null;
+  let draining = false;
 
   async function read(): Promise<readonly RedskilledProjectRegistration[]> {
     await tail;
@@ -63,16 +65,32 @@ export function createRedskilledRegistrationIntentStore(
   return {
     read,
     replace(registrations) {
-      const writeSnapshot = tail.then(() => write(registrations));
-      tail = writeSnapshot.then(
+      pending = [...registrations];
+      if (!draining) {
+        draining = true;
+        tail = tail.then(async () => {
+          while (pending !== null) {
+            const next = pending;
+            pending = null;
+            await write(next);
+          }
+        }).then(
+          () => {
+            failure = null;
+            draining = false;
+          },
+          (error: unknown) => {
+            failure = error;
+            draining = false;
+          },
+        );
+      }
+      return tail.then(
         () => {
-          failure = null;
+          if (failure != null) throw failure;
         },
-        (error: unknown) => {
-          failure = error;
-        },
+        (error: unknown) => { throw error; },
       );
-      return writeSnapshot;
     },
     async flush() {
       await tail;

--- a/apps/redskilled/src/resource-lease-client.ts
+++ b/apps/redskilled/src/resource-lease-client.ts
@@ -1,0 +1,44 @@
+/** Client boundary for daemon-owned generic host-resource admission. */
+import { requestRedskilled, type RedskilledClientConfig } from "./client.js";
+import type { RedskilledPaths } from "./paths.js";
+import { isRedskilledResourceLeaseReleased, type RedskilledResourceLeaseReleased } from "./protocol.js";
+import {
+  isRedskilledResourceLease,
+  type RedskilledResourceLease,
+  type RedskilledResourceLeaseRequest,
+} from "./resource-lease.js";
+
+export async function acquireRedskilledResourceLease(
+  paths: RedskilledPaths,
+  request: RedskilledResourceLeaseRequest,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledResourceLease> {
+  const value = await requestRedskilled(paths, { op: "resource-acquire", request }, {
+    ...config,
+    requestTimeoutMs: Math.max(config.requestTimeoutMs ?? 0, request.wait_timeout_ms + 1_000),
+  });
+  if (!isRedskilledResourceLease(value)) throw new Error("redskilled daemon returned a malformed resource lease");
+  return value;
+}
+
+export async function renewRedskilledResourceLease(
+  paths: RedskilledPaths,
+  leaseId: string,
+  ttlMs: number,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledResourceLease | null> {
+  const value = await requestRedskilled(paths, { op: "resource-renew", lease_id: leaseId, ttl_ms: ttlMs }, config);
+  if (value === null) return null;
+  if (!isRedskilledResourceLease(value)) throw new Error("redskilled daemon returned a malformed renewed resource lease");
+  return value;
+}
+
+export async function releaseRedskilledResourceLease(
+  paths: RedskilledPaths,
+  leaseId: string,
+  config: RedskilledClientConfig = {},
+): Promise<RedskilledResourceLeaseReleased> {
+  const value = await requestRedskilled(paths, { op: "resource-release", lease_id: leaseId }, config);
+  if (!isRedskilledResourceLeaseReleased(value)) throw new Error("redskilled daemon returned a malformed resource release");
+  return value;
+}

--- a/apps/redskilled/src/resource-lease-store.ts
+++ b/apps/redskilled/src/resource-lease-store.ts
@@ -1,0 +1,69 @@
+/** Durable generic host-resource authority across daemon handover. */
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import { isRedskilledResourceLease, type RedskilledResourceLease } from "./resource-lease.js";
+
+export interface RedskilledResourceLeaseStore {
+  read(): Promise<readonly RedskilledResourceLease[]>;
+  replace(leases: readonly RedskilledResourceLease[]): Promise<void>;
+  flush(): Promise<void>;
+}
+
+export function createRedskilledResourceLeaseStore(path: string): RedskilledResourceLeaseStore {
+  let pending: readonly RedskilledResourceLease[] | null = null;
+  let tail: Promise<void> = Promise.resolve();
+  let failure: unknown = null;
+
+  async function write(leases: readonly RedskilledResourceLease[]): Promise<void> {
+    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+    const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+    await writeFile(temporary, `${encode({ version: 1, leases: [...leases] } as unknown as JsonValue)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(temporary, path);
+  }
+
+  function schedule(): Promise<void> {
+    tail = tail.then(async () => {
+      while (pending !== null) {
+        const next = pending;
+        pending = null;
+        await write(next);
+      }
+      failure = null;
+    }).catch((error: unknown) => {
+      failure = error;
+    });
+    return tail;
+  }
+
+  return {
+    async read() {
+      await tail;
+      try {
+        const raw = await readFile(path, "utf8");
+        let parsed: unknown;
+        try { parsed = JSON.parse(raw); } catch { parsed = decode(raw.trim()); }
+        if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+        const leases = (parsed as Record<string, unknown>).leases;
+        return Array.isArray(leases) ? leases.filter(isRedskilledResourceLease) : [];
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+        throw error;
+      }
+    },
+    replace(leases) {
+      pending = [...leases];
+      return schedule();
+    },
+    async flush() {
+      await tail;
+      if (pending !== null) await schedule();
+      await tail;
+      if (failure != null) throw failure;
+    },
+  };
+}

--- a/apps/redskilled/src/resource-lease-store.ts
+++ b/apps/redskilled/src/resource-lease-store.ts
@@ -45,8 +45,7 @@ export function createRedskilledResourceLeaseStore(path: string): RedskilledReso
       await tail;
       try {
         const raw = await readFile(path, "utf8");
-        let parsed: unknown;
-        try { parsed = JSON.parse(raw); } catch { parsed = decode(raw.trim()); }
+        const parsed: unknown = decode(raw.trim());
         if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return [];
         const leases = (parsed as Record<string, unknown>).leases;
         return Array.isArray(leases) ? leases.filter(isRedskilledResourceLease) : [];

--- a/apps/redskilled/src/resource-lease.ts
+++ b/apps/redskilled/src/resource-lease.ts
@@ -1,0 +1,193 @@
+/** Generic, host-scoped resource admission. Domain-specific classification stays in callers. */
+import { randomUUID } from "node:crypto";
+
+export const DEFAULT_REDSKILLED_RESOURCE_LEASE_TTL_MS = 30_000;
+export const DEFAULT_REDSKILLED_RESOURCE_SAFETY_POLL_MS = 5_000;
+
+export interface RedskilledResourceLeaseRequest {
+  readonly resource: string;
+  readonly holder_id: string;
+  readonly worker_id?: string;
+  readonly minimum_available_memory_bytes: number;
+  readonly ttl_ms: number;
+  readonly wait_timeout_ms: number;
+}
+
+export interface RedskilledResourceLease {
+  readonly version: 1;
+  readonly lease_id: string;
+  readonly resource: string;
+  readonly holder_id: string;
+  readonly worker_id?: string;
+  readonly minimum_available_memory_bytes: number;
+  readonly acquired_at: string;
+  readonly renewed_at: string;
+  readonly expires_at: string;
+}
+
+export class RedskilledResourceAdmissionTimeoutError extends Error {
+  constructor(readonly resource: string, readonly waitTimeoutMs: number) {
+    super(`host resource admission timed out after ${waitTimeoutMs}ms while waiting for ${JSON.stringify(resource)}`);
+    this.name = "RedskilledResourceAdmissionTimeoutError";
+  }
+}
+
+export interface RedskilledResourceLeaseRuntime {
+  acquire(request: RedskilledResourceLeaseRequest): Promise<RedskilledResourceLease>;
+  renew(leaseId: string, ttlMs?: number): Promise<RedskilledResourceLease | null>;
+  release(leaseId: string): Promise<boolean>;
+  releaseHolder(holderId: string): Promise<number>;
+  snapshot(): readonly RedskilledResourceLease[];
+}
+
+export function isRedskilledResourceLease(value: unknown): value is RedskilledResourceLease {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const lease = value as Record<string, unknown>;
+  return lease.version === 1 &&
+    typeof lease.lease_id === "string" && lease.lease_id !== "" &&
+    typeof lease.resource === "string" && lease.resource !== "" &&
+    typeof lease.holder_id === "string" && lease.holder_id !== "" &&
+    (lease.worker_id === undefined || (typeof lease.worker_id === "string" && lease.worker_id !== "")) &&
+    typeof lease.minimum_available_memory_bytes === "number" &&
+    typeof lease.acquired_at === "string" &&
+    typeof lease.renewed_at === "string" &&
+    typeof lease.expires_at === "string";
+}
+
+export function createRedskilledResourceLeaseRuntime(options: {
+  readonly nowMs?: () => number;
+  readonly availableMemoryBytes: () => number | Promise<number>;
+  readonly restored?: readonly RedskilledResourceLease[];
+  readonly safetyPollMs?: number;
+  readonly changed?: (leases: readonly RedskilledResourceLease[]) => Promise<void> | void;
+}): RedskilledResourceLeaseRuntime {
+  const nowMs = options.nowMs ?? (() => Date.now());
+  const safetyPollMs = Math.max(1, options.safetyPollMs ?? DEFAULT_REDSKILLED_RESOURCE_SAFETY_POLL_MS);
+  const leases = new Map(
+    (options.restored ?? []).filter(isRedskilledResourceLease).map((lease) => [lease.lease_id, lease]),
+  );
+  const waiters = new Set<() => void>();
+
+  const snapshot = (): readonly RedskilledResourceLease[] => [...leases.values()];
+  const persist = async (): Promise<void> => { await options.changed?.(snapshot()); };
+  const wake = (): void => {
+    const current = [...waiters];
+    waiters.clear();
+    for (const resolve of current) resolve();
+  };
+  const pruneExpired = async (): Promise<void> => {
+    const now = nowMs();
+    let changed = false;
+    for (const [id, lease] of leases) {
+      if (Date.parse(lease.expires_at) <= now) {
+        leases.delete(id);
+        changed = true;
+      }
+    }
+    if (changed) {
+      await persist();
+      wake();
+    }
+  };
+  const waitForChange = async (ms: number): Promise<void> => {
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        waiters.delete(finish);
+        resolve();
+      };
+      const timer = setTimeout(finish, Math.max(0, ms));
+      waiters.add(finish);
+    });
+  };
+
+  return {
+    async acquire(request) {
+      if (request.resource.trim() === "" || request.holder_id.trim() === "") {
+        throw new Error("host resource admission requires non-empty resource and holder_id");
+      }
+      if (!Number.isFinite(request.minimum_available_memory_bytes) || request.minimum_available_memory_bytes < 0 ||
+        !Number.isFinite(request.ttl_ms) || request.ttl_ms <= 0 ||
+        !Number.isFinite(request.wait_timeout_ms) || request.wait_timeout_ms < 0) {
+        throw new Error("host resource admission received invalid memory, TTL, or wait bounds");
+      }
+      const started = nowMs();
+      const deadline = started + Math.max(0, request.wait_timeout_ms);
+      for (;;) {
+        await pruneExpired();
+        const conflict = [...leases.values()].some((lease) => lease.resource === request.resource);
+        const available = await options.availableMemoryBytes();
+        // Re-check after the host sample: another async acquire may have spent
+        // the resource while this one was awaiting memory.
+        const stillFree = ![...leases.values()].some((lease) => lease.resource === request.resource);
+        if (!conflict && stillFree && Number.isFinite(available) && available >= request.minimum_available_memory_bytes) {
+          const now = nowMs();
+          const instant = new Date(now).toISOString();
+          const lease: RedskilledResourceLease = {
+            version: 1,
+            lease_id: randomUUID(),
+            resource: request.resource,
+            holder_id: request.holder_id,
+            ...(request.worker_id == null ? {} : { worker_id: request.worker_id }),
+            minimum_available_memory_bytes: request.minimum_available_memory_bytes,
+            acquired_at: instant,
+            renewed_at: instant,
+            expires_at: new Date(now + Math.max(1, request.ttl_ms)).toISOString(),
+          };
+          leases.set(lease.lease_id, lease);
+          await persist();
+          return lease;
+        }
+        const remaining = deadline - nowMs();
+        if (remaining <= 0) {
+          throw new RedskilledResourceAdmissionTimeoutError(request.resource, request.wait_timeout_ms);
+        }
+        const nextExpiry = Math.min(
+          ...[...leases.values()]
+            .filter((lease) => lease.resource === request.resource)
+            .map((lease) => Math.max(1, Date.parse(lease.expires_at) - nowMs())),
+          safetyPollMs,
+          remaining,
+        );
+        await waitForChange(nextExpiry);
+      }
+    },
+    async renew(leaseId, ttlMs = DEFAULT_REDSKILLED_RESOURCE_LEASE_TTL_MS) {
+      await pruneExpired();
+      const held = leases.get(leaseId);
+      if (held == null) return null;
+      const now = nowMs();
+      const renewed = {
+        ...held,
+        renewed_at: new Date(now).toISOString(),
+        expires_at: new Date(now + Math.max(1, ttlMs)).toISOString(),
+      };
+      leases.set(leaseId, renewed);
+      await persist();
+      return renewed;
+    },
+    async release(leaseId) {
+      if (!leases.delete(leaseId)) return false;
+      await persist();
+      wake();
+      return true;
+    },
+    async releaseHolder(holderId) {
+      let released = 0;
+      for (const [id, lease] of leases) {
+        if (lease.holder_id !== holderId && lease.worker_id !== holderId) continue;
+        leases.delete(id);
+        released += 1;
+      }
+      if (released > 0) {
+        await persist();
+        wake();
+      }
+      return released;
+    },
+    snapshot,
+  };
+}

--- a/apps/redskilled/tests/daemon-restart.test.ts
+++ b/apps/redskilled/tests/daemon-restart.test.ts
@@ -441,6 +441,7 @@ function laneEvent(event: RedskilledHostEvent["event"], workerId: string): Redsk
     systemd_result: null,
     memory_peak_bytes: null,
     memory_swap_peak_bytes: null,
+    pids_peak: null,
     journal_tail: null,
     reason: null,
   };

--- a/apps/redskilled/tests/demand-producer.test.ts
+++ b/apps/redskilled/tests/demand-producer.test.ts
@@ -492,6 +492,7 @@ describe("a death reported by the daemon drives the project's breaker", () => {
       systemd_result: null,
       memory_peak_bytes: null,
       memory_swap_peak_bytes: null,
+      pids_peak: null,
       journal_tail: null,
       reason: null,
     };

--- a/apps/redskilled/tests/event-lane-query.test.ts
+++ b/apps/redskilled/tests/event-lane-query.test.ts
@@ -73,6 +73,8 @@ function workerEvent(kind: RecordWorkerEventInput["kind"]): RecordWorkerEventInp
       return { ...common, phase: "coding", step: "implementing" };
     case "worker-metrics":
       return { ...common, tokens: 42_000, tools: 31, runner: "codex", model: "gpt-5.6" };
+    case "worker-resource":
+      return { ...common, memoryPeakBytes: 1024, memorySwapPeakBytes: 512, pidsPeak: 7 };
     case "worker-drift":
       return { ...common, baseHeadSha: "bbbb2222", baseCommitsAhead: 3 };
     case "worker-heal":

--- a/apps/redskilled/tests/metric-history.test.ts
+++ b/apps/redskilled/tests/metric-history.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  REDSKILLED_METRIC_CHECKPOINT_MS,
+  shouldCheckpointMetricObservation,
+} from "../src/daemon/metric-history.js";
+import type { RedskilledWorkerMetricObservation } from "../src/live-metrics.js";
+
+const first: RedskilledWorkerMetricObservation = {
+  worker_id: "w1",
+  observed_at: "2026-08-13T12:00:00.000Z",
+  tokens: 100,
+  tools: 2,
+  runner: "codex",
+  model: "gpt-5.6",
+};
+
+describe("durable metric checkpoint coalescing (#3802)", () => {
+  it("preserves changed endpoints and bounds identical samples to one per five minutes", () => {
+    expect(shouldCheckpointMetricObservation(undefined, first)).toBe(true);
+    expect(shouldCheckpointMetricObservation(first, {
+      ...first,
+      observed_at: new Date(Date.parse(first.observed_at) + REDSKILLED_METRIC_CHECKPOINT_MS - 1).toISOString(),
+    })).toBe(false);
+    expect(shouldCheckpointMetricObservation(first, {
+      ...first,
+      observed_at: new Date(Date.parse(first.observed_at) + REDSKILLED_METRIC_CHECKPOINT_MS).toISOString(),
+    })).toBe(true);
+    expect(shouldCheckpointMetricObservation(first, {
+      ...first,
+      observed_at: "2026-08-13T12:01:00.000Z",
+      tokens: 101,
+    })).toBe(true);
+  });
+});

--- a/apps/redskilled/tests/public-host-event-contract.test.ts
+++ b/apps/redskilled/tests/public-host-event-contract.test.ts
@@ -30,6 +30,7 @@ const PUBLIC_HOST_EVENT_FIELDS = [
   "pgid",
   "phase",
   "pid",
+  "pids_peak",
   "proc_start_time",
   "project_label",
   "reason",

--- a/apps/redskilled/tests/registration-sustain.test.ts
+++ b/apps/redskilled/tests/registration-sustain.test.ts
@@ -194,6 +194,48 @@ describe("sustainProjectRegistration — what holds a lease up", () => {
 });
 
 describe("a registration outlives its window while the project still drains", () => {
+  it("keeps host-state and statusline reads as pure snapshots", async () => {
+    const snapshots: RedskilledProjectRegistration[][] = [];
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      demandMs: 0,
+      clock: () => T0,
+      launch: recordingLaunch([]),
+      registrationIntentStore: {
+        read: async () => [],
+        replace: async (registrations) => { snapshots.push([...registrations]); },
+        flush: async () => {},
+      },
+    });
+    running.push(daemon);
+    daemon.registerProject(request());
+    daemon.trackWorker({
+      worker_id: "wLIVE",
+      project_label: "acme/widgets",
+      pid: 42,
+      started_at: T0,
+      workspace_path: "/tmp/acme-widgets",
+      isolated: true,
+      unit: "red-worker-wLIVE.service",
+      warnings: [],
+    });
+    const before = daemon.hostState().registrations![0]!;
+    const writes = snapshots.length;
+
+    for (let index = 0; index < 100; index += 1) {
+      daemon.hostState();
+      daemon.statuslinePayload();
+    }
+
+    const after = daemon.hostState().registrations![0]!;
+    expect(after.renewals).toBe(before.renewals);
+    expect(after.sustains).toBe(before.sustains);
+    expect(after.renew_by).toBe(before.renew_by);
+    expect(snapshots).toHaveLength(writes);
+  });
+
   it("survives a daemon replacement and resumes polling without project_start", async () => {
     const paths = await sessionPaths();
     const first = await startRedskilledDaemon({
@@ -383,6 +425,7 @@ describe("a project that no longer intends to drain lapses, and says so", () => 
     expect(daemon.hostState().registrations).toHaveLength(1);
 
     clock.advance(WINDOW_MS);
+    daemon.sweepRegistrations();
     const state = daemon.hostState();
     expect(state.registrations).toEqual([]);
     // NOT just an absence: a project missing from the set could be one that never
@@ -412,6 +455,7 @@ describe("a project that no longer intends to drain lapses, and says so", () => 
     // is what entitles one bounded recovery poll after a scheduling lapse.
     await daemon.pollQueueDiscovery();
     await new Promise((resolve) => setTimeout(resolve, 50));
+    daemon.sweepRegistrations();
     const lapsed = daemon.hostState();
     expect(lapsed.registrations).toEqual([]);
 
@@ -459,6 +503,7 @@ describe("a project that no longer intends to drain lapses, and says so", () => 
 
     // Miss the registration deadline and the complete ordinary recovery window.
     clock.advance(WINDOW_MS * 3);
+    daemon.sweepRegistrations();
     const stopped = daemon.hostState();
     expect(stopped.registrations).toEqual([]);
     const rendered = renderRedskilledStatusline(

--- a/apps/redskilled/tests/resource-high-water.test.ts
+++ b/apps/redskilled/tests/resource-high-water.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { createRedskilledEventLane, readRedskilledEvents } from "../src/event-lane.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+
+const roots: string[] = [];
+const running: RedskilledDaemon[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("Worker resource high-water handover (#3802)", () => {
+  it("fills a terminal record from durable samples after the unit has vanished", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-high-water-"));
+    roots.push(root);
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const worker: RedskilledWorkerView = {
+      worker_id: "wHIGH",
+      project_label: "acme/widgets",
+      pid: 4242,
+      started_at: "2026-08-13T12:00:00.000Z",
+      workspace_path: "/tmp/workspace",
+      isolated: true,
+      unit: "red-worker-wHIGH.service",
+      warnings: [],
+    };
+    const lane = createRedskilledEventLane(paths.eventLanePath);
+    await lane.recordWorker({ kind: "worker-birth", worker, ts: worker.started_at });
+    await lane.recordWorker({
+      kind: "worker-resource",
+      worker,
+      ts: "2026-08-13T12:05:00.000Z",
+      memoryPeakBytes: 3_000,
+      memorySwapPeakBytes: 700,
+      pidsPeak: 19,
+    });
+    await lane.flush();
+
+    const daemon = await startRedskilledDaemon({
+      paths,
+      sampleMs: 0,
+      liveness: () => false,
+      unitInventory: () => [],
+      unitExitFacts: () => null,
+    });
+    running.push(daemon);
+    await daemon.flushEvents();
+
+    const death = [...await readRedskilledEvents(paths.eventLanePath)].reverse()
+      .find((event) => event.kind === "worker-death");
+    expect(death).toMatchObject({
+      worker_id: "wHIGH",
+      memory_peak_bytes: 3_000,
+      memory_swap_peak_bytes: 700,
+      pids_peak: 19,
+    });
+  });
+});

--- a/apps/redskilled/tests/resource-lease-daemon.test.ts
+++ b/apps/redskilled/tests/resource-lease-daemon.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   acquireRedskilledResourceLease,
   releaseRedskilledResourceLease,
-} from "../src/client.js";
+} from "../src/resource-lease-client.js";
 import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import { resolveRedskilledPaths } from "../src/paths.js";
 

--- a/apps/redskilled/tests/resource-lease-daemon.test.ts
+++ b/apps/redskilled/tests/resource-lease-daemon.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireRedskilledResourceLease,
+  releaseRedskilledResourceLease,
+} from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+
+const roots: string[] = [];
+const running: RedskilledDaemon[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("daemon-owned generic resource admission (#3802)", () => {
+  it("retains one lease across daemon handover and wakes the waiter on release", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-resource-daemon-"));
+    roots.push(root);
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const firstDaemon = await startRedskilledDaemon({
+      paths,
+      sampleMs: 0,
+      availableMemoryBytes: () => 8 * 1024 ** 3,
+    });
+    running.push(firstDaemon);
+    const first = await acquireRedskilledResourceLease(paths, {
+      resource: "validation-heavy",
+      holder_id: "wFIRST",
+      minimum_available_memory_bytes: 4 * 1024 ** 3,
+      ttl_ms: 60_000,
+      wait_timeout_ms: 5_000,
+    });
+    await firstDaemon.stop({ reason: "replaced" });
+    running.splice(running.indexOf(firstDaemon), 1);
+
+    const successor = await startRedskilledDaemon({
+      paths,
+      sampleMs: 0,
+      availableMemoryBytes: () => 8 * 1024 ** 3,
+    });
+    running.push(successor);
+    let admitted = false;
+    const waiting = acquireRedskilledResourceLease(paths, {
+      resource: "validation-heavy",
+      holder_id: "wSECOND",
+      minimum_available_memory_bytes: 4 * 1024 ** 3,
+      ttl_ms: 60_000,
+      wait_timeout_ms: 5_000,
+    }).then((lease) => { admitted = true; return lease; });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(admitted).toBe(false);
+
+    await releaseRedskilledResourceLease(paths, first.lease_id);
+    const second = await waiting;
+    expect(second.holder_id).toBe("wSECOND");
+    await releaseRedskilledResourceLease(paths, second.lease_id);
+  });
+});

--- a/apps/redskilled/tests/resource-lease.test.ts
+++ b/apps/redskilled/tests/resource-lease.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  RedskilledResourceAdmissionTimeoutError,
+  createRedskilledResourceLeaseRuntime,
+  type RedskilledResourceLease,
+} from "../src/resource-lease.js";
+
+function clock(start = 0) {
+  let now = start;
+  return {
+    now: () => now,
+    advance: (ms: number) => { now += ms; },
+  };
+}
+
+describe("generic host resource leases (#3802)", () => {
+  it("atomically admits one of two simultaneous requests", async () => {
+    const runtime = createRedskilledResourceLeaseRuntime({
+      availableMemoryBytes: async () => {
+        await new Promise((resolve) => setImmediate(resolve));
+        return 10_000;
+      },
+      safetyPollMs: 5,
+    });
+    const request = (holder_id: string) => runtime.acquire({
+      resource: "validation-heavy", holder_id,
+      minimum_available_memory_bytes: 1, ttl_ms: 1_000, wait_timeout_ms: 100,
+    });
+    const firstRequest = request("w1");
+    const secondRequest = request("w2");
+    const winner = await Promise.race([firstRequest, secondRequest]);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(runtime.snapshot()).toHaveLength(1);
+    await runtime.release(winner.lease_id);
+    const leases = await Promise.all([firstRequest, secondRequest]);
+    expect(new Set(leases.map((lease) => lease.holder_id))).toEqual(new Set(["w1", "w2"]));
+  });
+
+  it("admits only after both the conflicting lease and memory pressure clear", async () => {
+    const time = clock();
+    let available = 8_192;
+    const runtime = createRedskilledResourceLeaseRuntime({
+      nowMs: time.now,
+      availableMemoryBytes: () => available,
+      safetyPollMs: 5,
+    });
+    const first = await runtime.acquire({
+      resource: "validation-heavy",
+      holder_id: "wFIRST",
+      minimum_available_memory_bytes: 4_096,
+      ttl_ms: 1_000,
+      wait_timeout_ms: 100,
+    });
+
+    let second: RedskilledResourceLease | undefined;
+    const waiting = runtime.acquire({
+      resource: "validation-heavy",
+      holder_id: "wSECOND",
+      minimum_available_memory_bytes: 4_096,
+      ttl_ms: 1_000,
+      wait_timeout_ms: 100,
+    }).then((lease) => { second = lease; });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(second).toBeUndefined();
+
+    available = 2_048;
+    await runtime.release(first.lease_id);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(second).toBeUndefined();
+
+    available = 8_192;
+    await waiting;
+    expect(second?.holder_id).toBe("wSECOND");
+  });
+
+  it("release, holder death and TTL expiry wake waiters", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = createRedskilledResourceLeaseRuntime({
+        availableMemoryBytes: () => 10_000,
+        safetyPollMs: 5_000,
+      });
+      const first = await runtime.acquire({
+        resource: "validation-heavy", holder_id: "w1",
+        minimum_available_memory_bytes: 1, ttl_ms: 10_000, wait_timeout_ms: 30_000,
+      });
+      const afterRelease = runtime.acquire({
+        resource: "validation-heavy", holder_id: "w2",
+        minimum_available_memory_bytes: 1, ttl_ms: 10_000, wait_timeout_ms: 30_000,
+      });
+      await runtime.release(first.lease_id);
+      const second = await afterRelease;
+
+      const afterDeath = runtime.acquire({
+        resource: "validation-heavy", holder_id: "w3",
+        minimum_available_memory_bytes: 1, ttl_ms: 10_000, wait_timeout_ms: 30_000,
+      });
+      await runtime.releaseHolder(second.holder_id);
+      const third = await afterDeath;
+
+      const afterExpiry = runtime.acquire({
+        resource: "validation-heavy", holder_id: "w4",
+        minimum_available_memory_bytes: 1, ttl_ms: 10_000, wait_timeout_ms: 30_000,
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect((await afterExpiry).holder_id).toBe("w4");
+      expect(third.holder_id).toBe("w3");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("restores authority across daemon replacement and times out as infrastructure", async () => {
+    vi.useFakeTimers();
+    try {
+      const first = createRedskilledResourceLeaseRuntime({ availableMemoryBytes: () => 10_000 });
+      const held = await first.acquire({
+        resource: "validation-heavy", holder_id: "w1",
+        minimum_available_memory_bytes: 1, ttl_ms: 10_000, wait_timeout_ms: 30_000,
+      });
+      const successor = createRedskilledResourceLeaseRuntime({
+        availableMemoryBytes: () => 10_000,
+        restored: [held],
+        safetyPollMs: 5_000,
+      });
+      const waiting = successor.acquire({
+        resource: "validation-heavy", holder_id: "w2",
+        minimum_available_memory_bytes: 1, ttl_ms: 10_000, wait_timeout_ms: 30_000,
+      });
+      await vi.advanceTimersByTimeAsync(9_999);
+      let admitted = false;
+      void waiting.then(() => { admitted = true; });
+      await Promise.resolve();
+      expect(admitted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect((await waiting).holder_id).toBe("w2");
+
+      const timedOut = expect(successor.acquire({
+        resource: "validation-heavy", holder_id: "w3",
+        minimum_available_memory_bytes: 1, ttl_ms: 10_000, wait_timeout_ms: 1_000,
+      })).rejects.toBeInstanceOf(RedskilledResourceAdmissionTimeoutError);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await timedOut;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/red-castle/src/engine/gate-executor.test.ts
+++ b/packages/red-castle/src/engine/gate-executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { CASTLE_VALIDATION_SCHEMA } from "./gate-constants.js";
 import { makeHeadlessGateSink, makeInteractiveGateSink } from "./gate-sink.js";
-import { classifyFinding, runCastleGate, type RunCastleGateInput } from "./gate-executor.js";
+import { classifyFinding, runCastleGate, validationResourceClass, type RunCastleGateInput } from "./gate-executor.js";
 
 function baseInput(): RunCastleGateInput {
   let tick = 0;
@@ -50,14 +50,26 @@ describe("castle gate executor", () => {
       triggerPackages: ["packages/core"],
       packages: ["apps/dev", "packages/core"],
     });
-    expect(input.feedbackExec).toHaveBeenCalledWith(["pnpm", "-C", "/repo/packages/core", "test"]);
+    expect(input.feedbackExec).toHaveBeenCalledWith(
+      ["pnpm", "-C", "/repo/packages/core", "test"],
+      { weight: "light" },
+    );
     expect(input.backpressureExec).toHaveBeenCalledWith({
       command: "pnpm smoke",
       cwd: "/repo",
       timeoutMs: 600000,
+      weight: "heavy",
     });
     expect(result.checks.map((check) => check.name)).toContain("backpressure:pnpm smoke");
     expect(JSON.parse(result.sidecar[0]!).schema).toBe(CASTLE_VALIDATION_SCHEMA);
+  });
+
+  it("classifies only root/workspace test, typecheck and build as heavy", () => {
+    expect(validationResourceClass(".", "test")).toBe("heavy");
+    expect(validationResourceClass(".", "typecheck")).toBe("heavy");
+    expect(validationResourceClass(".", "build")).toBe("heavy");
+    expect(validationResourceClass(".", "lint")).toBe("light");
+    expect(validationResourceClass("packages/core", "test")).toBe("light");
   });
 
   it("blocks through the headless sink on intent findings before validation evidence is recorded", async () => {

--- a/packages/red-castle/src/engine/gate-executor.ts
+++ b/packages/red-castle/src/engine/gate-executor.ts
@@ -29,11 +29,13 @@ export interface ExecResult {
   stderr: string;
 }
 
-export type FeedbackExec = (args: string[]) => Promise<ExecResult>;
+export type ValidationResourceClass = "light" | "heavy";
+export type FeedbackExec = (args: string[], options?: { weight: ValidationResourceClass }) => Promise<ExecResult>;
 export type BackpressureExec = (input: {
   command: string;
   cwd: string;
   timeoutMs: number;
+  weight?: ValidationResourceClass;
 }) => Promise<ExecResult>;
 
 export interface ScriptLayout extends PackageLayout {
@@ -88,6 +90,13 @@ export interface CastleGateResult {
 function gateWeightForScope(scope: ValidationScope): GateWeightClass {
   if (scope.type === "whole-workspace") return "full-workspace";
   return scope.packages.length > 1 ? "heavy-cone" : "light-cone";
+}
+
+/** Castle classifies command meaning; the host only admits a generic weight. */
+export function validationResourceClass(scope: string, script: string): ValidationResourceClass {
+  return scope === "." && (script === "test" || script === "typecheck" || script === "build")
+    ? "heavy"
+    : "light";
 }
 
 export function classifyFinding(finding: GateFinding): "mechanical" | "intent" {
@@ -167,7 +176,9 @@ async function runFeedbackChecks(
       const dir = scopeDir(input.worktree, scope);
       const command = `pnpm -C ${dir} ${script}`;
       const start = input.now();
-      const result = await input.feedbackExec(["pnpm", "-C", dir, script]);
+      const result = await input.feedbackExec(["pnpm", "-C", dir, script], {
+        weight: validationResourceClass(scope, script),
+      });
       const durationMs = input.now() - start;
       const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
       if (status === "failed") ok = false;
@@ -200,7 +211,7 @@ async function runBackpressureChecks(
     if (command === "") continue;
     const name = `backpressure:${command}`;
     const start = input.now();
-    const result = await input.backpressureExec({ command, cwd: input.worktree, timeoutMs });
+    const result = await input.backpressureExec({ command, cwd: input.worktree, timeoutMs, weight: "heavy" });
     const durationMs = input.now() - start;
     const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
     if (status === "failed") ok = false;


### PR DESCRIPTION
Automated AFK landing for #3802. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3802

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789251454&installation_model_id=20659&pr_number=3859&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3859&signature=f0ba7d6b5a8f443673865949636cac5cf149ec2bc78b4e2ab2ecf2ed5442be87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->