### PR TITLE
fix: #3833 paths: frontmatter — parse, glob matcher, format validation

### DIFF
--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -36,10 +36,7 @@ export { readStandingDrain, type StandingDrainConfig } from "./standing-drain-co
  * `config_get` in the shell — callers compare against literals like "false".
  */
 
-import {
-  DEFAULT_FLEET_WIDTH_CONFIG,
-  FLEET_WIDTH_CONFIG_KEY,
-} from "@reddb-io/shared/default-fleet-width.js";
+import { DEFAULT_FLEET_WIDTH_CONFIG, FLEET_WIDTH_CONFIG_KEY } from "@reddb-io/shared/default-fleet-width.js";
 
 /** Documented v1 defaults — the only way to expand the schema. */
 export const CONFIG_DEFAULTS = {

--- a/scripts/fixtures/marketplace-manifests/valid/basic/plugins/alpha/skills/core/do-thing/SKILL.md
+++ b/scripts/fixtures/marketplace-manifests/valid/basic/plugins/alpha/skills/core/do-thing/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: do-thing
+description: Exercise the valid marketplace path-brief fixture.
+paths:
+  - apps/dev/**/*.ts
+---
+
 # Do Thing
 
 Fixture skill.

--- a/scripts/fixtures/skill-frontmatter/compliant/plugins/demo/skills/good/SKILL.md
+++ b/scripts/fixtures/skill-frontmatter/compliant/plugins/demo/skills/good/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: good
 description: Use when testing a valid skill frontmatter fixture.
+paths:
+  - apps/dev/**/*.{ts,tsx}
 allowed-tools:
   - Bash
   - Read

--- a/scripts/fixtures/skill-frontmatter/violating/plugins/demo/skills/malformed-paths/SKILL.md
+++ b/scripts/fixtures/skill-frontmatter/violating/plugins/demo/skills/malformed-paths/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: malformed-paths
+description: Use when testing malformed path-brief frontmatter.
+paths:
+  - apps/dev/[broken.ts
+---
+
+# Malformed paths
+
+**Exercise the malformed glob fixture.**

--- a/scripts/lib/path-briefs.mjs
+++ b/scripts/lib/path-briefs.mjs
@@ -1,0 +1,192 @@
+/** Error raised when a SKILL.md declares an invalid `paths:` field. */
+export class SkillPathsError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "SkillPathsError";
+  }
+}
+
+function frontmatterLines(source) {
+  const lines = source.split(/\r?\n/);
+  if (lines[0] !== "---") return [];
+  const end = lines.indexOf("---", 1);
+  if (end === -1) throw new SkillPathsError("frontmatter has no closing --- delimiter");
+  return lines.slice(1, end);
+}
+
+function unquote(value) {
+  if (value.startsWith('"') && value.endsWith('"')) return JSON.parse(value);
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replaceAll("''", "'");
+  }
+  return value;
+}
+
+function parseInlineList(value) {
+  const body = value.slice(1, -1);
+  const items = [];
+  let item = "";
+  let quote = "";
+  let braceDepth = 0;
+  for (let index = 0; index < body.length; index += 1) {
+    const character = body[index];
+    if (quote) {
+      item += character;
+      if (character === quote && body[index - 1] !== "\\") quote = "";
+    } else if (character === '"' || character === "'") {
+      quote = character;
+      item += character;
+    } else if (character === "{") {
+      braceDepth += 1;
+      item += character;
+    } else if (character === "}") {
+      braceDepth -= 1;
+      item += character;
+    } else if (character === "," && braceDepth === 0) {
+      items.push(unquote(item.trim()));
+      item = "";
+    } else {
+      item += character;
+    }
+  }
+  items.push(unquote(item.trim()));
+  return items;
+}
+
+function invalidGlob(glob, reason) {
+  throw new SkillPathsError(`invalid paths glob ${JSON.stringify(glob)}: ${reason}`);
+}
+
+/** Reject glob spellings that are ambiguous, malformed, or leave the repo. */
+export function validatePathGlob(glob) {
+  if (typeof glob !== "string" || glob.length === 0) invalidGlob(glob, "expected a non-empty string");
+  if (glob !== glob.trim()) invalidGlob(glob, "leading or trailing whitespace is not allowed");
+  if (glob.includes("\\")) invalidGlob(glob, "use repository-relative / separators");
+  if (glob.startsWith("/") || /^[A-Za-z]:\//.test(glob)) invalidGlob(glob, "absolute paths are not allowed");
+  const segments = glob.split("/");
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    invalidGlob(glob, "empty, . and .. path segments are not allowed");
+  }
+  if (segments.some((segment) => segment.includes("**") && segment !== "**")) {
+    invalidGlob(glob, "** must occupy a complete path segment");
+  }
+
+  let bracket = false;
+  let bracketStart = -1;
+  let brace = false;
+  let braceStart = -1;
+  for (let index = 0; index < glob.length; index += 1) {
+    const character = glob[index];
+    if (character === "[") {
+      if (bracket) invalidGlob(glob, "nested character classes are not supported");
+      bracket = true;
+      bracketStart = index;
+    } else if (character === "]") {
+      if (!bracket) invalidGlob(glob, "unmatched ]");
+      const body = glob.slice(bracketStart + 1, index).replace(/^!/, "");
+      if (body.length === 0) invalidGlob(glob, "empty character class");
+      bracket = false;
+    } else if (!bracket && character === "{") {
+      if (brace) invalidGlob(glob, "nested brace alternatives are not supported");
+      brace = true;
+      braceStart = index;
+    } else if (!bracket && character === "}") {
+      if (!brace) invalidGlob(glob, "unmatched }");
+      const alternatives = glob.slice(braceStart + 1, index).split(",");
+      if (alternatives.length < 2 || alternatives.some((alternative) => alternative.length === 0)) {
+        invalidGlob(glob, "brace alternatives require two or more non-empty values");
+      }
+      brace = false;
+    }
+  }
+  if (bracket) invalidGlob(glob, "unclosed character class");
+  if (brace) invalidGlob(glob, "unclosed brace alternative");
+  return glob;
+}
+
+function validated(paths) {
+  for (const path of paths) validatePathGlob(path);
+  return paths;
+}
+
+function escapeRegex(value) {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}
+
+function globSource(glob) {
+  let source = "";
+  for (let index = 0; index < glob.length; index += 1) {
+    const character = glob[index];
+    if (character === "*" && glob[index + 1] === "*") {
+      index += 1;
+      if (glob[index + 1] === "/") {
+        index += 1;
+        source += "(?:[^/]+/)*";
+      } else {
+        source += ".*";
+      }
+    } else if (character === "*") {
+      source += "[^/]*";
+    } else if (character === "?") {
+      source += "[^/]";
+    } else if (character === "[") {
+      const end = glob.indexOf("]", index + 1);
+      let body = glob.slice(index + 1, end);
+      if (body.startsWith("!")) body = `^${body.slice(1)}`;
+      source += `[${body}]`;
+      index = end;
+    } else if (character === "{") {
+      const end = glob.indexOf("}", index + 1);
+      const alternatives = glob.slice(index + 1, end).split(",");
+      source += `(?:${alternatives.map(escapeRegex).join("|")})`;
+      index = end;
+    } else {
+      source += escapeRegex(character);
+    }
+  }
+  return source;
+}
+
+/** True when one validated repository-relative glob matches a file path. */
+export function pathMatchesGlob(filePath, glob) {
+  validatePathGlob(glob);
+  const candidate = filePath.replaceAll("\\", "/").replace(/^\.\//, "");
+  return new RegExp(`^${globSource(glob)}$`).test(candidate);
+}
+
+/** Return declared briefs matching `filePath`, preserving declaration order. */
+export function matchPathBriefs(briefs, filePath) {
+  return briefs.filter((brief) => brief.paths.some((glob) => pathMatchesGlob(filePath, glob)));
+}
+
+/** Parse the optional `paths:` frontmatter field into its ordered glob list. */
+export function parseSkillPaths(source) {
+  const lines = frontmatterLines(source);
+  const declarations = lines
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => /^paths:/.test(line));
+  if (declarations.length === 0) return [];
+  if (declarations.length > 1) throw new SkillPathsError("paths must be declared only once");
+  const pathsLine = declarations[0].index;
+
+  const inline = lines[pathsLine].match(/^paths:\s*(\[.*\])\s*$/);
+  if (inline) {
+    const paths = parseInlineList(inline[1]);
+    if (paths.length === 0 || paths.some((path) => path === "")) {
+      throw new SkillPathsError("paths must be a non-empty glob list");
+    }
+    return validated(paths);
+  }
+  if (!/^paths:\s*$/.test(lines[pathsLine])) {
+    throw new SkillPathsError("paths must be a non-empty glob list");
+  }
+
+  const paths = [];
+  for (let index = pathsLine + 1; index < lines.length; index += 1) {
+    const match = lines[index].match(/^\s+-\s+(.+?)\s*$/);
+    if (!match) break;
+    paths.push(unquote(match[1]));
+  }
+  if (paths.length === 0) throw new SkillPathsError("paths must be a non-empty glob list");
+  return validated(paths);
+}

--- a/scripts/lint-skill-frontmatter.sh
+++ b/scripts/lint-skill-frontmatter.sh
@@ -5,13 +5,15 @@
 #   1. `name` must equal the skill directory name.
 #   2. `description` must be present and non-empty.
 #   3. Tool grant fields, when present, must not grant a bare wildcard (`*`).
+#   4. `paths`, when present, must be a non-empty list of valid repo-relative globs.
 #
 # Usage:
 #   scripts/lint-skill-frontmatter.sh [--root DIR]
 
 set -uo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$SCRIPT_ROOT"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -121,6 +123,11 @@ while IFS= read -r file; do
     printf 'FAIL  %s\n      > no-wildcard-tool-grant: %s must not grant bare wildcard "*"\n' "$file" "$grant_key"
     failures=$((failures + 1))
   done < <(printf '%s\n' "$fm" | wildcard_tool_grants)
+
+  if ! paths_error="$(node "$SCRIPT_ROOT/scripts/validate-skill-paths.mjs" "$file" 2>&1)"; then
+    printf 'FAIL  %s\n      > paths-globs-valid: %s\n' "$file" "$paths_error"
+    failures=$((failures + 1))
+  fi
 done < <(find plugins -name SKILL.md -not -path '*/in-progress/*' | sort)
 
 echo ""

--- a/scripts/path-briefs.test.mjs
+++ b/scripts/path-briefs.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { matchPathBriefs, parseSkillPaths } from "./lib/path-briefs.mjs";
+
+test("parseSkillPaths reads an ordered block glob list", () => {
+  const source = `---
+name: guard
+description: Guard a source surface.
+paths:
+  - apps/dev/**/*.ts
+  - packages/shared/*.ts
+---
+Brief body.
+`;
+
+  assert.deepEqual(parseSkillPaths(source), [
+    "apps/dev/**/*.ts",
+    "packages/shared/*.ts",
+  ]);
+});
+
+test("parseSkillPaths reads inline lists and quoted globs", () => {
+  const source = `---
+name: guard
+description: Guard a source surface.
+paths: ["apps/{dev,memory}/**/*.ts", plugins/*/SKILL.md]
+---
+`;
+
+  assert.deepEqual(parseSkillPaths(source), [
+    "apps/{dev,memory}/**/*.ts",
+    "plugins/*/SKILL.md",
+  ]);
+});
+
+test("parseSkillPaths rejects malformed or repository-escaping globs", () => {
+  for (const glob of [
+    "apps/[broken.ts",
+    "apps/[].ts",
+    "apps/*.{ts}",
+    "apps/**broken/*.ts",
+    "../secrets/**",
+    "/tmp/**",
+  ]) {
+    const source = `---
+name: guard
+description: Guard a source surface.
+paths:
+  - ${glob}
+---
+`;
+    assert.throws(() => parseSkillPaths(source), /invalid paths glob/);
+  }
+});
+
+test("parseSkillPaths rejects a paths scalar instead of silently disabling the brief", () => {
+  assert.throws(
+    () => parseSkillPaths(`---
+name: guard
+description: Guard a source surface.
+paths: apps/dev/**
+---
+`),
+    /paths must be a non-empty glob list/,
+  );
+});
+
+test("matchPathBriefs returns matching declarations in source order", () => {
+  const briefs = [
+    { name: "typescript", paths: ["apps/**/[a-z]*.{ts,tsx}"] },
+    { name: "skill-doc", paths: ["**/SKILL.md"] },
+    { name: "dev-config", paths: ["apps/dev/src/config?.ts"] },
+  ];
+
+  assert.deepEqual(
+    matchPathBriefs(briefs, "apps\\dev\\src\\config1.ts").map((brief) => brief.name),
+    ["typescript", "dev-config"],
+  );
+  assert.deepEqual(
+    matchPathBriefs(briefs, "plugins/dev/skills/afk/SKILL.md").map((brief) => brief.name),
+    ["skill-doc"],
+  );
+  assert.deepEqual(matchPathBriefs(briefs, "apps/dev/src/1.ts"), []);
+});

--- a/scripts/test-lint-skill-frontmatter.sh
+++ b/scripts/test-lint-skill-frontmatter.sh
@@ -58,6 +58,8 @@ assert_grep "violating/description" /tmp/.skill-frontmatter-violating "empty-des
 assert_grep "violating/description-rule" /tmp/.skill-frontmatter-violating "description-non-empty"
 assert_grep "violating/wildcard" /tmp/.skill-frontmatter-violating "wildcard-tools/SKILL.md"
 assert_grep "violating/wildcard-rule" /tmp/.skill-frontmatter-violating "no-wildcard-tool-grant"
+assert_grep "violating/paths" /tmp/.skill-frontmatter-violating "malformed-paths/SKILL.md"
+assert_grep "violating/paths-rule" /tmp/.skill-frontmatter-violating "paths-globs-valid"
 
 rm -f /tmp/.skill-frontmatter-compliant /tmp/.skill-frontmatter-violating
 

--- a/scripts/test-validate-marketplace-manifests.sh
+++ b/scripts/test-validate-marketplace-manifests.sh
@@ -102,6 +102,17 @@ plugin_set_mismatch() {
   mv "$1/marketplace2.tmp" "$1/.gemini-plugin/marketplace.json"
 }
 
+malformed_skill_paths() {
+  printf '%s\n' \
+    '---' \
+    'name: do-thing' \
+    'description: Exercise the malformed marketplace path-brief fixture.' \
+    'paths:' \
+    '  - apps/dev/[broken.ts' \
+    '---' \
+    > "$1/plugins/alpha/skills/core/do-thing/SKILL.md"
+}
+
 expect_pass basic
 expect_fail missing-plugin-dir       "plugin directory not found"       missing_plugin_dir
 expect_fail missing-plugin-manifest  "plugin manifest not found"        missing_plugin_manifest
@@ -109,6 +120,7 @@ expect_fail malformed-manifest       "malformed plugin manifest"        malforme
 expect_fail missing-required-field   "missing required field"           missing_manifest_field
 expect_fail skill-without-skill-md   "skill directory missing SKILL.md" skill_without_skill_md
 expect_fail plugin-set-mismatch      "marketplace plugin set mismatch"  plugin_set_mismatch
+expect_fail malformed-skill-paths    "invalid paths glob"               malformed_skill_paths
 
 if [ "$fail_count" -ne 0 ]; then
   printf '\n%d failed, %d passed\n' "$fail_count" "$pass_count" >&2

--- a/scripts/validate-marketplace-manifests.sh
+++ b/scripts/validate-marketplace-manifests.sh
@@ -3,7 +3,8 @@
 
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$SCRIPT_ROOT"
 
 usage() {
   cat <<'EOF'
@@ -16,6 +17,7 @@ Validates:
   - Every listed plugin has well-formed Claude and Codex plugin manifests.
   - Required plugin manifest fields are present.
   - Every skills/<bucket>/<skill>/ directory contains SKILL.md.
+  - Every SKILL.md paths field contains valid repository-relative globs.
 EOF
 }
 
@@ -135,6 +137,9 @@ validate_skill_dirs() {
   while IFS= read -r -d '' skill_dir; do
     [ -f "$skill_dir/SKILL.md" ] \
       || fail "$plugin: skill directory missing SKILL.md: $skill_dir"
+    if ! paths_error="$(node "$SCRIPT_ROOT/scripts/validate-skill-paths.mjs" "$skill_dir/SKILL.md" 2>&1)"; then
+      fail "$plugin: invalid SKILL.md paths: $paths_error"
+    fi
   done < <(find "$skills_dir" -mindepth 2 -maxdepth 2 -type d \
     -not -path '*/_*' \
     -print0 | sort -z)

--- a/scripts/validate-skill-paths.mjs
+++ b/scripts/validate-skill-paths.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+import { parseSkillPaths } from "./lib/path-briefs.mjs";
+
+let failed = false;
+for (const file of process.argv.slice(2)) {
+  try {
+    parseSkillPaths(await readFile(file, "utf8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${file}: ${message}\n`);
+    failed = true;
+  }
+}
+
+process.exitCode = failed ? 1 : 0;


### PR DESCRIPTION
Automated AFK landing for #3833. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3833

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789251783&installation_model_id=20659&pr_number=3860&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3860&signature=7b13e4bce389d1e9173d1cc33c575f49446860baa82446e01ef02afde27b3bd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->