### PR TITLE
fix: #3835 Budget grace in the daemon: signal, deadline, unconditional kill

### DIFF
--- a/apps/redskilled/src/daemon/budget-grace.ts
+++ b/apps/redskilled/src/daemon/budget-grace.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from "node:child_process";
+import type { RedskilledWorkerView } from "../host-state.js";
+
+export const DEFAULT_REDSKILLED_BUDGET_GRACE_MS = 30_000;
+export const REDSKILLED_BUDGET_GRACE_SIGNAL: NodeJS.Signals = "SIGUSR2";
+
+/** Delivers the checkpoint signal; delivery is deliberately not an acknowledgement. */
+export type RedskilledBudgetGraceSignal = (worker: RedskilledWorkerView) => boolean;
+
+export interface RedskilledBudgetGraceRuntime {
+  begin(worker: RedskilledWorkerView, detail: string): Promise<boolean>;
+  workerExited(workerId: string): void;
+  stop(): void;
+}
+
+interface BudgetGraceRuntimeOptions {
+  readonly graceMs: number;
+  readonly signal: RedskilledBudgetGraceSignal;
+  readonly held: (workerId: string) => boolean;
+  readonly kill: (worker: RedskilledWorkerView, detail: string) => void | Promise<void>;
+  readonly record: (
+    kind: "worker-budget-verdict" | "worker-budget-grace",
+    worker: RedskilledWorkerView,
+    detail: string,
+  ) => void;
+}
+
+/** One fixed daemon-policy window per Worker, cancelled only by observed exit. */
+export function createBudgetGraceRuntime(options: BudgetGraceRuntimeOptions): RedskilledBudgetGraceRuntime {
+  const deadlines = new Map<string, NodeJS.Timeout>();
+
+  function workerExited(workerId: string): void {
+    const deadline = deadlines.get(workerId);
+    if (deadline != null) clearTimeout(deadline);
+    deadlines.delete(workerId);
+  }
+
+  return {
+    async begin(worker, detail) {
+      if (deadlines.has(worker.worker_id)) return false;
+      options.record("worker-budget-verdict", worker, detail);
+      try { options.signal(worker); } catch {}
+      options.record(
+        "worker-budget-grace",
+        worker,
+        `${detail}; checkpoint window ${Math.max(0, options.graceMs)}ms`,
+      );
+      if (options.graceMs <= 0) {
+        if (options.held(worker.worker_id)) await options.kill(worker, detail);
+        return true;
+      }
+      const deadline = setTimeout(() => {
+        deadlines.delete(worker.worker_id);
+        if (options.held(worker.worker_id)) void options.kill(worker, detail);
+      }, options.graceMs);
+      deadline.unref();
+      deadlines.set(worker.worker_id, deadline);
+      return true;
+    },
+    workerExited,
+    stop() {
+      for (const deadline of deadlines.values()) clearTimeout(deadline);
+      deadlines.clear();
+    },
+  };
+}
+
+/** Signal the unit when there is one; otherwise signal the detached Worker tree. */
+export function signalWorkerForBudgetGrace(worker: RedskilledWorkerView): boolean {
+  if (worker.unit != null && worker.unit !== "") {
+    const sent = spawnSync(
+      "systemctl",
+      ["--user", "kill", `--signal=${REDSKILLED_BUDGET_GRACE_SIGNAL}`, "--kill-whom=all", worker.unit],
+      { stdio: "ignore" },
+    );
+    return sent.error == null && sent.status === 0;
+  }
+  try {
+    process.kill(-(worker.pgid ?? worker.pid), REDSKILLED_BUDGET_GRACE_SIGNAL);
+    return true;
+  } catch {
+    try { process.kill(worker.pid, REDSKILLED_BUDGET_GRACE_SIGNAL); return true; } catch { return false; }
+  }
+}

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -6,6 +6,7 @@ import { isPidAlive } from "@reddb-io/shared/resident-core.js";
 import { planRegistrationBootRecovery, recordDaemonBootRecovery } from "./boot-recovery.js";
 import { bindExclusive, handleSocket, probeSocketOwnership } from "./socket.js";
 import { createWorkerTeardownLedger } from "./worker-teardown.js";
+import { createBudgetGraceRuntime, DEFAULT_REDSKILLED_BUDGET_GRACE_MS, signalWorkerForBudgetGrace } from "./budget-grace.js";
 import { RedskilledAlreadyRunningError } from "./errors.js";
 import {
   appendRedskilledMetricObservation,
@@ -350,6 +351,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const stopProbe = options.stopWorker ?? stopWorker;
   /** Exactly-once Worker teardown: a second ask joins the stop already in flight. */
   const endWorkerOnce = createWorkerTeardownLedger(stopProbe);
+  const budgetGraceMs = options.budgetGraceMs ?? DEFAULT_REDSKILLED_BUDGET_GRACE_MS;
   const unitInventory = options.unitInventory ??
     (() =>
       maySweepMachine(paths.machineClaimPath, paths.machineClaimPathOfThisHost)
@@ -1191,6 +1193,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
    * note alive and leak a little memory per death.
    */
   function forgetWorker(workerId: string): void {
+    budgetGrace.workerExited(workerId);
     workers.delete(workerId);
     reattached.delete(workerId);
     logLines.delete(workerId);
@@ -1740,21 +1743,19 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       forgetWorker(worker.worker_id); record("worker-death", worker, detail); await eventLane.flush(); armIdleTimer();
     },
   });
+  const budgetGrace = createBudgetGraceRuntime({
+    graceMs: budgetGraceMs,
+    signal: options.signalWorkerForBudgetGrace ?? signalWorkerForBudgetGrace,
+    held: (workerId) => workers.has(workerId),
+    kill: async (worker, detail) => { await endWorkerOnce(worker, () => {
+      forgetWorker(worker.worker_id); record("worker-budget-kill", worker, detail); armIdleTimer();
+    }); },
+    record: (kind, worker, detail) => record(kind, worker, detail),
+  });
   async function killWorkerOverBudget(workerId: string, detail: string): Promise<boolean> {
     const worker = workers.get(workerId);
     if (!worker) return false;
-    // The kill is recorded either way: a stop the host refused still ends the
-    // daemon's claim on the budget, and a silent failure would leave the
-    // accounting holding room for a Worker nobody is tracking any more. It joins
-    // a teardown already in flight rather than starting a second one, so a floor
-    // tick that lands on a Worker a project is already stopping writes no second
-    // death and gives no second slot back.
-    await endWorkerOnce(worker, () => {
-      forgetWorker(workerId);
-      record("worker-budget-kill", worker, detail);
-      armIdleTimer();
-    });
-    return true;
+    return await budgetGrace.begin(worker, detail);
   }
 
   /** Sample all Workers once, record resources, and enforce memory budgets. */
@@ -2194,6 +2195,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     if (balanceTimer) clearTimeout(balanceTimer);
     if (queueTimer) clearTimeout(queueTimer);
     if (demandTimer) clearInterval(demandTimer);
+    budgetGrace.stop();
     // Every event already handed over reaches the lane before the daemon lets go
     // of the session: a birth still in flight would leave the next daemon with a
     // Worker it holds a budget for and no record of.

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -88,6 +88,7 @@ import type {
 } from "../resource-incidents.js";
 import type { RedskilledResourceLeaseRuntime } from "../resource-lease.js";
 import type { RedskilledResourceLeaseStore } from "../resource-lease-store.js";
+import type { RedskilledBudgetGraceSignal } from "./budget-grace.js";
 export interface RedskilledDaemonOptions {
   readonly paths: RedskilledPaths;
   /** Test seam; production detects the kernel-side topology at daemon start. */
@@ -154,6 +155,10 @@ export interface RedskilledDaemonOptions {
   readonly livenessGraceMs?: number;
   /** How the daemon stops a Worker it is reclaiming a budget from. */
   readonly stopWorker?: RedskilledStopProbe;
+  /** Fixed host-policy checkpoint window before an over-budget Worker is killed. */
+  readonly budgetGraceMs?: number;
+  /** Test seam; production delivers the daemon's Budget grace signal. */
+  readonly signalWorkerForBudgetGrace?: RedskilledBudgetGraceSignal;
   /**
    * How the daemon lists the Worker units this host has active.
    *

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -85,6 +85,8 @@ export type RedskilledWorkerEventKind =
   | "worker-resource"
   | "worker-drift"
   | "worker-heal"
+  | "worker-budget-verdict"
+  | "worker-budget-grace"
   | "worker-death"
   | "worker-budget-kill";
 
@@ -95,6 +97,8 @@ export const REDSKILLED_WORKER_EVENT_KINDS = [
   "worker-resource",
   "worker-drift",
   "worker-heal",
+  "worker-budget-verdict",
+  "worker-budget-grace",
   "worker-death",
   "worker-budget-kill",
 ] as const as readonly [
@@ -104,6 +108,8 @@ export const REDSKILLED_WORKER_EVENT_KINDS = [
   "worker-resource",
   "worker-drift",
   "worker-heal",
+  "worker-budget-verdict",
+  "worker-budget-grace",
   "worker-death",
   "worker-budget-kill",
 ] & {

--- a/apps/redskilled/tests/budget-grace.test.ts
+++ b/apps/redskilled/tests/budget-grace.test.ts
@@ -1,0 +1,139 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { readRedskilledEvents } from "../src/event-lane.js";
+import type { RedskilledWorkerView } from "../src/host-state.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function sessionPaths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-budget-grace-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+function worker(): RedskilledWorkerView {
+  return {
+    worker_id: "wGRACE",
+    project_label: "acme/widgets",
+    pid: 4242,
+    pgid: 4242,
+    started_at: "2026-08-13T20:00:00.000Z",
+    workspace_path: "/tmp/acme/wGRACE",
+    isolated: false,
+    budget: { memory_max: "1G" },
+    warnings: [],
+  };
+}
+
+describe("daemon Budget grace", () => {
+  it("does not kill a Worker that checkpoints and exits inside the window", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const signals: string[] = [];
+    const kills: string[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      idleMs: 60_000,
+      sampleMs: 0,
+      budgetGraceMs: 1_000,
+      signalWorkerForBudgetGrace: (held) => { signals.push(held.worker_id); return true; },
+      stopWorker: (held) => { kills.push(held.worker_id); return true; },
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+
+    expect(await daemon.killWorkerOverBudget("wGRACE", "MemoryMax budget exceeded")).toBe(true);
+    expect(signals).toEqual(["wGRACE"]);
+    expect(daemon.workerCount()).toBe(1);
+
+    daemon.releaseWorker("wGRACE");
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(kills).toEqual([]);
+    expect(daemon.workerCount()).toBe(0);
+  });
+
+  it("kills an overrunning checkpoint exactly at the machine-policy deadline", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const kills: string[] = [];
+    let checkpointStarted = false;
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      idleMs: 60_000,
+      sampleMs: 0,
+      budgetGraceMs: 1_000,
+      signalWorkerForBudgetGrace: () => { checkpointStarted = true; return true; },
+      stopWorker: (held) => { kills.push(held.worker_id); return true; },
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+
+    await daemon.killWorkerOverBudget("wGRACE", "MemoryMax budget exceeded");
+    await vi.advanceTimersByTimeAsync(999);
+    expect(checkpointStarted).toBe(true);
+    expect(kills).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(kills).toEqual(["wGRACE"]);
+    expect(daemon.workerCount()).toBe(0);
+  });
+
+  it("kills at the deadline even when the Worker ignores the signal", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const kills: string[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      idleMs: 60_000,
+      sampleMs: 0,
+      budgetGraceMs: 1_000,
+      signalWorkerForBudgetGrace: () => false,
+      stopWorker: (held) => { kills.push(held.worker_id); return true; },
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+
+    await daemon.killWorkerOverBudget("wGRACE", "MemoryMax budget exceeded");
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(kills).toEqual(["wGRACE"]);
+    expect(daemon.workerCount()).toBe(0);
+  });
+
+  it("records verdict, grace start, and kill as distinct events for one Worker", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({
+      paths,
+      idleMs: 60_000,
+      sampleMs: 0,
+      budgetGraceMs: 1_000,
+      signalWorkerForBudgetGrace: () => true,
+      stopWorker: () => true,
+    });
+    running.push(daemon);
+    daemon.trackWorker(worker());
+
+    await daemon.killWorkerOverBudget("wGRACE", "MemoryMax budget exceeded");
+    await vi.advanceTimersByTimeAsync(1_000);
+    await daemon.flushEvents();
+
+    expect(
+      (await readRedskilledEvents(paths.eventLanePath))
+        .filter((event) => event.worker_id === "wGRACE" && event.kind.startsWith("worker-budget-"))
+        .map((event) => event.kind),
+    ).toEqual(["worker-budget-verdict", "worker-budget-grace", "worker-budget-kill"]);
+  });
+});

--- a/apps/redskilled/tests/daemon-restart.test.ts
+++ b/apps/redskilled/tests/daemon-restart.test.ts
@@ -190,13 +190,15 @@ describe("budget accounting survives the restart", () => {
 });
 
 describe("the host event lane", () => {
-  it("records birth, death and budget-kill, and nothing else", async () => {
+  it("records the full Budget grace sequence between birth and kill", async () => {
     const paths = await sessionPaths();
     const workspace = await scratch("redskilled-workspace-");
     const daemon = await startRedskilledDaemon({
       paths,
       idleMs: 60_000,
       liveness: pidLiveness,
+      budgetGraceMs: 0,
+      signalWorkerForBudgetGrace: () => true,
       stopWorker: () => true,
     });
     running.push(daemon);
@@ -210,8 +212,14 @@ describe("the host event lane", () => {
     await daemon.flushEvents();
 
     const events = await readRedskilledEvents(paths.eventLanePath);
-    expect(events.map((event) => event.event)).toEqual(["worker-birth", "worker-birth", "worker-budget-kill"]);
-    const kill = events[2]!;
+    expect(events.map((event) => event.event)).toEqual([
+      "worker-birth",
+      "worker-birth",
+      "worker-budget-verdict",
+      "worker-budget-grace",
+      "worker-budget-kill",
+    ]);
+    const kill = events[4]!;
     expect(kill.worker_id).toBe(killed.worker.worker_id);
     expect(kill.project_label).toBe("acme/gadgets");
     expect(kill.detail).toBe("host memory high-water mark exceeded");

--- a/apps/redskilled/tests/event-lane-query.test.ts
+++ b/apps/redskilled/tests/event-lane-query.test.ts
@@ -79,6 +79,9 @@ function workerEvent(kind: RecordWorkerEventInput["kind"]): RecordWorkerEventInp
       return { ...common, baseHeadSha: "bbbb2222", baseCommitsAhead: 3 };
     case "worker-heal":
       return { ...common, healKind: "mechanical-regeneration", detail: "generated surfaces regenerated" };
+    case "worker-budget-verdict":
+    case "worker-budget-grace":
+      return { ...common, detail: "MemoryMax budget exceeded" };
     case "worker-death":
       return { ...common, exitCode: 0 };
     case "worker-budget-kill":

--- a/apps/redskilled/tests/memory-floor.test.ts
+++ b/apps/redskilled/tests/memory-floor.test.ts
@@ -137,6 +137,8 @@ describe("the memory floor", () => {
       idleMs: 60_000,
       // Unarmed: this test drives the tick itself, so nothing races it.
       sampleMs: 0,
+      budgetGraceMs: 0,
+      signalWorkerForBudgetGrace: () => true,
       stopWorker: (w) => {
         stopped.push(w.worker_id);
         return true;
@@ -161,6 +163,8 @@ describe("the memory floor", () => {
       paths,
       idleMs: 60_000,
       sampleMs: 0,
+      budgetGraceMs: 0,
+      signalWorkerForBudgetGrace: () => true,
       stopWorker: (w) => {
         stopped.push(w.worker_id);
         return true;
@@ -188,6 +192,8 @@ describe("the memory floor", () => {
       paths,
       idleMs: 60_000,
       sampleMs: 0,
+      budgetGraceMs: 0,
+      signalWorkerForBudgetGrace: () => true,
       stopWorker: () => true,
       treeSampler: () => ({ rss: { "w-1": 3 * 1024 ** 3 }, cpu_seconds: {} }),
     });
@@ -214,6 +220,8 @@ describe("the memory floor", () => {
       paths,
       idleMs: 60_000,
       sampleMs: 0,
+      budgetGraceMs: 0,
+      signalWorkerForBudgetGrace: () => true,
       stopWorker: () => true,
       treeSampler: () => ({ rss: { "w-1": 900 * 1024 * 1024 }, cpu_seconds: {} }),
     });


### PR DESCRIPTION
Automated AFK landing for #3835. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3835

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789254210&installation_model_id=20659&pr_number=3864&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3864&signature=2dcc73751879425008fb151793c4fb733f3561c103df043ef8b22473154036ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->