### PR TITLE
fix: #3838 Path brief injection on the Claude Code host

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -32,6 +32,12 @@
       "moveKey": "24cdd7f5b667"
     },
     {
+      "id": "apps/dev/src/core/path-brief-hook.ts#json-parse-file-read#05d430724ad8",
+      "classification": "external",
+      "reason": "Claude plugin manifests are JSON by host contract.",
+      "moveKey": "f632cd5f3c50"
+    },
+    {
       "id": "apps/dev/src/core/toon-version.ts#json-parse-file-read#155234ba4b8b",
       "classification": "external",
       "reason": "package.json is ecosystem JSON.",

--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -14,6 +14,7 @@ import { monitorCommand } from "./commands/monitor.js";
 import { runCommand } from "./commands/run.js";
 import { reapCommand } from "./commands/reap.js";
 import { orphanBranchesCommand } from "./commands/orphan-branches.js";
+import { pathBriefCommand } from "./commands/path-brief.js";
 import { redDoctorCommand } from "./commands/red-doctor.js";
 import { worktreeCommand } from "./commands/worktree.js";
 import { redactSweepCommand } from "./commands/redact-sweep.js";
@@ -48,6 +49,7 @@ export type CliCommand =
   | "weekly-review"
   | "reap"
   | "orphan-branches"
+  | "path-brief"
   | "red-doctor"
   | "worktree"
   | "redact-sweep"
@@ -99,6 +101,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     "weekly-review": {},
     reap: {},
     "orphan-branches": {},
+    "path-brief": {},
     "red-doctor": {},
     worktree: {},
     "redact-sweep": {},
@@ -252,6 +255,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "weekly-review") return activityReviewCommand("weekly", parsed.args);
   if (parsed.command === "reap") return reapCommand(parsed.args);
   if (parsed.command === "orphan-branches") return orphanBranchesCommand(parsed.args);
+  if (parsed.command === "path-brief") return pathBriefCommand(parsed.args);
   if (parsed.command === "red-doctor") return redDoctorCommand(parsed.args);
   if (parsed.command === "worktree") return worktreeCommand(parsed.args);
   if (parsed.command === "redact-sweep") return redactSweepCommand(parsed.args);

--- a/apps/dev/src/commands/path-brief.ts
+++ b/apps/dev/src/commands/path-brief.ts
@@ -1,0 +1,33 @@
+import { injectClaudePathBriefs } from "../core/path-brief-hook.js";
+
+function pluginRootFromArgs(args: readonly string[]): string | undefined {
+  const index = args.indexOf("--plugin-root");
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/** Claude PostToolUse adapter for first-touch path brief delivery. */
+export async function pathBriefCommand(args: readonly string[]): Promise<number> {
+  const pluginRoot = pluginRootFromArgs(args);
+  if (!pluginRoot) {
+    process.stdout.write("{}\n");
+    return 0;
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(await readStdin());
+  } catch {
+    process.stdout.write("{}\n");
+    return 0;
+  }
+
+  const output = await injectClaudePathBriefs(payload as Parameters<typeof injectClaudePathBriefs>[0], { pluginRoot });
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+  return 0;
+}

--- a/apps/dev/src/core/path-brief-hook.ts
+++ b/apps/dev/src/core/path-brief-hook.ts
@@ -1,0 +1,144 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve } from "node:path";
+
+// The skill-format parser is deliberately JavaScript: the repository's shell
+// validators execute it directly with Node, while esbuild includes the same
+// source in the dev runtime bundle.
+// @ts-expect-error The canonical JavaScript parser has no separate declaration file.
+import { matchPathBriefs, parseSkillPaths } from "../../../../scripts/lib/path-briefs.mjs";
+
+interface ClaudeEditPayload {
+  readonly session_id?: unknown;
+  readonly cwd?: unknown;
+  readonly tool_name?: unknown;
+  readonly tool_input?: { readonly file_path?: unknown };
+}
+
+interface PathBriefOptions {
+  readonly pluginRoot: string;
+  readonly repoRoot?: string;
+  readonly stateRoot?: string;
+}
+
+interface PathBriefDeclaration {
+  readonly id: string;
+  readonly name: string;
+  readonly paths: readonly string[];
+  readonly body: string;
+}
+
+export interface ClaudePathBriefOutput {
+  readonly hookSpecificOutput?: {
+    readonly hookEventName: "PostToolUse";
+    readonly additionalContext: string;
+  };
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function skillBody(source: string): string {
+  const lines = source.split(/\r?\n/);
+  if (lines[0] !== "---") return source.trim();
+  const end = lines.indexOf("---", 1);
+  return end === -1 ? "" : lines.slice(end + 1).join("\n").trim();
+}
+
+function skillName(source: string): string | undefined {
+  const lines = source.split(/\r?\n/);
+  if (lines[0] !== "---") return undefined;
+  const end = lines.indexOf("---", 1);
+  if (end === -1) return undefined;
+  const declaration = lines.slice(1, end).find((line) => /^name:\s*\S/.test(line));
+  return declaration?.replace(/^name:\s*/, "").trim().replace(/^(["'])(.*)\1$/, "$2");
+}
+
+async function declaredSkills(pluginRoot: string): Promise<PathBriefDeclaration[]> {
+  const manifestPath = join(pluginRoot, ".claude-plugin", "plugin.json");
+  let manifest: { skills?: unknown };
+  try {
+    manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { skills?: unknown };
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(manifest.skills)) return [];
+
+  const declarations: PathBriefDeclaration[] = [];
+  for (const entry of manifest.skills) {
+    if (typeof entry !== "string") continue;
+    const declaredPath = resolve(pluginRoot, entry);
+    const skillPath = declaredPath.endsWith("SKILL.md") ? declaredPath : join(declaredPath, "SKILL.md");
+    if (relative(pluginRoot, skillPath).startsWith("..")) continue;
+    try {
+      const source = await readFile(skillPath, "utf8");
+      const paths = parseSkillPaths(source) as string[];
+      const name = skillName(source);
+      const body = skillBody(source);
+      if (paths.length > 0 && name && body) {
+        declarations.push({ id: relative(pluginRoot, skillPath), name, paths, body });
+      }
+    } catch {
+      // Invalid skill metadata is rejected by the repository validation gate.
+      // A hook hot path remains fail-open so an edit is never blocked by it.
+    }
+  }
+  return declarations;
+}
+
+function editedRepoPath(payload: ClaudeEditPayload, repoRoot: string): string | undefined {
+  if (payload.tool_name !== "Edit" && payload.tool_name !== "Write") return undefined;
+  const filePath = stringField(payload.tool_input?.file_path);
+  if (!filePath) return undefined;
+  const candidate = relative(repoRoot, isAbsolute(filePath) ? filePath : resolve(repoRoot, filePath));
+  if (candidate === "" || candidate === ".." || candidate.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`)) {
+    return undefined;
+  }
+  return candidate;
+}
+
+async function claimBrief(stateRoot: string, sessionId: string, briefId: string): Promise<boolean> {
+  const sessionRoot = join(stateRoot, digest(sessionId));
+  await mkdir(sessionRoot, { recursive: true });
+  try {
+    await mkdir(join(sessionRoot, digest(briefId)));
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+    throw error;
+  }
+}
+
+/** Resolve and claim Claude Code path briefs for one PostToolUse edit event. */
+export async function injectClaudePathBriefs(
+  payload: ClaudeEditPayload,
+  options: PathBriefOptions,
+): Promise<ClaudePathBriefOutput> {
+  const sessionId = stringField(payload.session_id);
+  const repoRoot = stringField(payload.cwd) ?? options.repoRoot;
+  if (!sessionId || !repoRoot) return {};
+  const filePath = editedRepoPath(payload, repoRoot);
+  if (!filePath) return {};
+
+  const briefs = await declaredSkills(options.pluginRoot);
+  const matches = matchPathBriefs(briefs, filePath) as PathBriefDeclaration[];
+  const newlyClaimed: PathBriefDeclaration[] = [];
+  const stateRoot = options.stateRoot ?? join(tmpdir(), "red-skills-path-briefs");
+  for (const brief of matches) {
+    if (await claimBrief(stateRoot, sessionId, `${options.pluginRoot}:${brief.id}`)) newlyClaimed.push(brief);
+  }
+  if (newlyClaimed.length === 0) return {};
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: newlyClaimed.map((brief) => `# Path brief: ${brief.name}\n\n${brief.body}`).join("\n\n"),
+    },
+  };
+}

--- a/apps/dev/tests/path-brief-hook.test.ts
+++ b/apps/dev/tests/path-brief-hook.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { injectClaudePathBriefs } from "../src/core/path-brief-hook.js";
+
+const sandboxes: string[] = [];
+
+async function fixture(): Promise<{ pluginRoot: string; repoRoot: string; stateRoot: string }> {
+  const root = await mkdtemp(join(tmpdir(), "path-brief-hook-"));
+  sandboxes.push(root);
+  const pluginRoot = join(root, "plugin");
+  const repoRoot = join(root, "repo");
+  const stateRoot = join(root, "state");
+  await mkdir(join(pluginRoot, ".claude-plugin"), { recursive: true });
+  await mkdir(join(pluginRoot, "skills", "guard"), { recursive: true });
+  await mkdir(join(repoRoot, "src"), { recursive: true });
+  await writeFile(
+    join(pluginRoot, ".claude-plugin", "plugin.json"),
+    JSON.stringify({ skills: ["./skills/guard"] }),
+  );
+  await writeFile(
+    join(pluginRoot, "skills", "guard", "SKILL.md"),
+    `---
+name: guarded-source
+description: Keep guarded source safe.
+paths:
+  - src/**/*.ts
+---
+Keep the guarded source invariant intact.
+`,
+  );
+  return { pluginRoot, repoRoot, stateRoot };
+}
+
+afterEach(async () => {
+  await Promise.all(sandboxes.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("Claude path brief injection", () => {
+  it("injects a matching skill brief exactly once per session", async () => {
+    const options = await fixture();
+    const payload = {
+      session_id: "session-one",
+      cwd: options.repoRoot,
+      tool_name: "Edit",
+      tool_input: { file_path: join(options.repoRoot, "src", "feature", "thing.ts") },
+    };
+
+    const first = await injectClaudePathBriefs(payload, options);
+    const second = await injectClaudePathBriefs(payload, options);
+
+    expect(first).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: "# Path brief: guarded-source\n\nKeep the guarded source invariant intact.",
+      },
+    });
+    expect(second).toEqual({});
+  });
+
+  it("injects nothing when the session never touches a guarded path", async () => {
+    const options = await fixture();
+
+    await expect(
+      injectClaudePathBriefs(
+        {
+          session_id: "session-untouched",
+          cwd: options.repoRoot,
+          tool_name: "Write",
+          tool_input: { file_path: join(options.repoRoot, "docs", "notes.md") },
+        },
+        options,
+      ),
+    ).resolves.toEqual({});
+  });
+});

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -174,6 +174,9 @@ or a blocking 0–1 floor) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` inner-agent GitHub reads (explicit `gh api` REST forms for issues, pull
 requests, and check runs) -> `plugins/dev/skills/engineering/afk/AGENT-PROMPT.md`;
+Claude path briefs (automatic first-touch injection from a skill's `paths:`
+frontmatter, once per session per skill) -> `scripts/lib/path-briefs.mjs`,
+`apps/dev/src/core/path-brief-hook.ts`, and `plugins/dev/hooks/claude.hooks.json`;
 `/afk` task-class runner routes (`plugins.dev.afk.routes.{validate,simple,complex,think}`),
 their override precedence, and `/red-setup` interview ->
 `plugins/dev/skills/engineering/red-setup/INTERVIEW.md` and

--- a/plugins/dev/hooks/claude.hooks.json
+++ b/plugins/dev/hooks/claude.hooks.json
@@ -55,6 +55,15 @@
             "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; hook=\"${CLAUDE_PLUGIN_ROOT}/hooks/rsp-hook.sh\"; if [ -x \"$hook\" ]; then timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-3s}\" \"$hook\" claude-post-exec <\"$tmp\" || true; else exit 0; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; root=\"${CLAUDE_PLUGIN_ROOT}\"; out=\"\"; for f in \"$root/hooks/red-fetch.mjs\" \"$root/dist/red-fetch.mjs\" \"$root/../../dist/red-fetch.mjs\"; do [ -f \"$f\" ] && { out=\"$(timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-3s}\" node \"$f\" run dev path-brief --plugin-root \"$root\" <\"$tmp\" 2>/dev/null)\"; break; }; done; if [ -n \"$out\" ]; then printf \"%s\" \"$out\"; else printf \"{}\"; fi'"
+          }
+        ]
       }
     ]
   }

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -174,6 +174,9 @@ or a blocking 0–1 floor) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` inner-agent GitHub reads (explicit `gh api` REST forms for issues, pull
 requests, and check runs) -> `plugins/dev/skills/engineering/afk/AGENT-PROMPT.md`;
+Claude path briefs (automatic first-touch injection from a skill's `paths:`
+frontmatter, once per session per skill) -> `scripts/lib/path-briefs.mjs`,
+`apps/dev/src/core/path-brief-hook.ts`, and `plugins/dev/hooks/claude.hooks.json`;
 `/afk` task-class runner routes (`plugins.dev.afk.routes.{validate,simple,complex,think}`),
 their override precedence, and `/red-setup` interview ->
 `plugins/dev/skills/engineering/red-setup/INTERVIEW.md` and


### PR DESCRIPTION
Automated AFK landing for #3838. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3838

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789255002&installation_model_id=20659&pr_number=3866&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3866&signature=6caab43cb0089ee3d2196dd1e6823b3014c33fc8af377b28f2525cb88e42e9a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->