### PR TITLE
fix: #3841 Path brief projection: Codex and OpenCode hosts

### DIFF
--- a/apps/dev/src/core/path-brief-hook.ts
+++ b/apps/dev/src/core/path-brief-hook.ts
@@ -13,7 +13,14 @@ interface ClaudeEditPayload {
   readonly session_id?: unknown;
   readonly cwd?: unknown;
   readonly tool_name?: unknown;
-  readonly tool_input?: { readonly file_path?: unknown };
+  readonly tool_input?: {
+    readonly file_path?: unknown;
+    readonly input?: unknown;
+    readonly patch?: unknown;
+    readonly paths?: unknown;
+    readonly files?: unknown;
+    readonly changes?: unknown;
+  };
 }
 
 interface PathBriefOptions {
@@ -92,15 +99,41 @@ async function declaredSkills(pluginRoot: string): Promise<PathBriefDeclaration[
   return declarations;
 }
 
-function editedRepoPath(payload: ClaudeEditPayload, repoRoot: string): string | undefined {
-  if (payload.tool_name !== "Edit" && payload.tool_name !== "Write") return undefined;
-  const filePath = stringField(payload.tool_input?.file_path);
-  if (!filePath) return undefined;
+function repoPath(filePath: string, repoRoot: string): string | undefined {
   const candidate = relative(repoRoot, isAbsolute(filePath) ? filePath : resolve(repoRoot, filePath));
   if (candidate === "" || candidate === ".." || candidate.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`)) {
     return undefined;
   }
   return candidate;
+}
+
+function patchPaths(input: ClaudeEditPayload["tool_input"]): string[] {
+  if (!input) return [];
+  const paths: string[] = [];
+  const envelope = stringField(input.input) ?? stringField(input.patch);
+  if (envelope) {
+    const pattern = /^\*\*\*\s+(?:Add|Update|Delete)\s+File:\s*(.+?)\s*$/gim;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(envelope)) !== null) paths.push(match[1]);
+  }
+  const list = input.paths ?? input.files;
+  if (Array.isArray(list)) {
+    for (const path of list) if (typeof path === "string" && path.trim()) paths.push(path);
+  }
+  if (input.changes && typeof input.changes === "object" && !Array.isArray(input.changes)) {
+    paths.push(...Object.keys(input.changes));
+  }
+  return paths;
+}
+
+function editedRepoPaths(payload: ClaudeEditPayload, repoRoot: string): string[] {
+  const tool = stringField(payload.tool_name)?.toLowerCase();
+  const rawPaths = tool === "edit" || tool === "write"
+    ? [stringField(payload.tool_input?.file_path)]
+    : tool === "apply_patch"
+      ? patchPaths(payload.tool_input)
+      : [];
+  return [...new Set(rawPaths.flatMap((path) => path ? [repoPath(path, repoRoot)] : []).filter((path): path is string => Boolean(path)))];
 }
 
 async function claimBrief(stateRoot: string, sessionId: string, briefId: string): Promise<boolean> {
@@ -115,19 +148,22 @@ async function claimBrief(stateRoot: string, sessionId: string, briefId: string)
   }
 }
 
-/** Resolve and claim Claude Code path briefs for one PostToolUse edit event. */
-export async function injectClaudePathBriefs(
+/** Resolve and claim path briefs for one host-projected PostToolUse edit event. */
+export async function injectPathBriefs(
   payload: ClaudeEditPayload,
   options: PathBriefOptions,
 ): Promise<ClaudePathBriefOutput> {
   const sessionId = stringField(payload.session_id);
   const repoRoot = stringField(payload.cwd) ?? options.repoRoot;
   if (!sessionId || !repoRoot) return {};
-  const filePath = editedRepoPath(payload, repoRoot);
-  if (!filePath) return {};
+  const filePaths = editedRepoPaths(payload, repoRoot);
+  if (filePaths.length === 0) return {};
 
   const briefs = await declaredSkills(options.pluginRoot);
-  const matches = matchPathBriefs(briefs, filePath) as PathBriefDeclaration[];
+  const matches = [...new Map(
+    filePaths.flatMap((filePath) => matchPathBriefs(briefs, filePath) as PathBriefDeclaration[])
+      .map((brief) => [brief.id, brief]),
+  ).values()];
   const newlyClaimed: PathBriefDeclaration[] = [];
   const stateRoot = options.stateRoot ?? join(tmpdir(), "red-skills-path-briefs");
   for (const brief of matches) {
@@ -142,3 +178,6 @@ export async function injectClaudePathBriefs(
     },
   };
 }
+
+/** Compatibility name retained for the original Claude Code adapter. */
+export const injectClaudePathBriefs = injectPathBriefs;

--- a/apps/dev/tests/path-brief-hook.test.ts
+++ b/apps/dev/tests/path-brief-hook.test.ts
@@ -75,4 +75,27 @@ describe("Claude path brief injection", () => {
       ),
     ).resolves.toEqual({});
   });
+
+  it("injects the same skill exactly once for a Codex apply_patch touch", async () => {
+    const options = await fixture();
+    const payload = {
+      session_id: "codex-session",
+      cwd: options.repoRoot,
+      tool_name: "apply_patch",
+      tool_input: {
+        input: "*** Begin Patch\n*** Update File: src/feature/thing.ts\n@@\n+changed\n*** End Patch",
+      },
+    };
+
+    const first = await injectClaudePathBriefs(payload, options);
+    const second = await injectClaudePathBriefs(payload, options);
+
+    expect(first).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: "# Path brief: guarded-source\n\nKeep the guarded source invariant intact.",
+      },
+    });
+    expect(second).toEqual({});
+  });
 });

--- a/apps/dev/tests/path-brief-host-parity.test.ts
+++ b/apps/dev/tests/path-brief-host-parity.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { injectPathBriefs } from "../src/core/path-brief-hook.js";
+
+const sandboxes: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(sandboxes.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("path brief host parity", () => {
+  it("injects the same paths skill on each host's simulated first touch", async () => {
+    const root = await mkdtemp(join(tmpdir(), "path-brief-host-parity-"));
+    sandboxes.push(root);
+    const pluginRoot = join(root, "plugin");
+    const repoRoot = join(root, "repo");
+    await mkdir(join(pluginRoot, ".claude-plugin"), { recursive: true });
+    await mkdir(join(pluginRoot, "skills", "guard"), { recursive: true });
+    await mkdir(join(repoRoot, "src"), { recursive: true });
+    await writeFile(
+      join(pluginRoot, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ skills: ["./skills/guard"] }),
+    );
+    await writeFile(
+      join(pluginRoot, "skills", "guard", "SKILL.md"),
+      "---\nname: parity-guard\ndescription: Guard parity.\npaths:\n  - src/**/*.ts\n---\nKeep host behavior identical.\n",
+    );
+
+    const hosts = [
+      {
+        name: "Claude Code",
+        payload: { tool_name: "Edit", tool_input: { file_path: "src/feature.ts" } },
+      },
+      {
+        name: "Codex",
+        payload: {
+          tool_name: "apply_patch",
+          tool_input: { input: "*** Begin Patch\n*** Update File: src/feature.ts\n@@\n+change\n*** End Patch" },
+        },
+      },
+      {
+        name: "OpenCode",
+        payload: { tool_name: "write", tool_input: { file_path: "src/feature.ts" } },
+      },
+    ] as const;
+
+    for (const host of hosts) {
+      const options = { pluginRoot, repoRoot, stateRoot: join(root, "state", host.name) };
+      const payload = { ...host.payload, session_id: `${host.name}-session`, cwd: repoRoot };
+      const first = await injectPathBriefs(payload, options);
+      const second = await injectPathBriefs(payload, options);
+
+      expect(first, host.name).toEqual({
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext: "# Path brief: parity-guard\n\nKeep host behavior identical.",
+        },
+      });
+      expect(second, host.name).toEqual({});
+    }
+  });
+});

--- a/apps/opencode-host/src/hooks-to-events.ts
+++ b/apps/opencode-host/src/hooks-to-events.ts
@@ -387,6 +387,7 @@ function toolExecuteAfterTemplate(input: {
       hookGroups: input.hookGroups,
       toolExpression: "input.tool",
       payloadExpression: "__payload",
+      contextSink: 'output.output = [__ctx, output.output].filter(Boolean).join("\\n\\n")',
     }),
     "    },",
     "  };",

--- a/apps/opencode-host/tests/path-brief-projection.test.ts
+++ b/apps/opencode-host/tests/path-brief-projection.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { planPluginHooks } from "../src/hooks-to-events.js";
+
+const REPO = new URL("../../..", import.meta.url).pathname;
+const PLUGINS_ROOT = `${REPO}plugins`;
+
+describe("path brief host projection", () => {
+  it("projects the edit hook through Codex and OpenCode from the shipped manifests", () => {
+    const codexManifest = JSON.parse(
+      readFileSync(`${PLUGINS_ROOT}/dev/hooks/codex.hooks.json`, "utf8"),
+    ) as {
+      hooks: { PostToolUse: Array<{ matcher?: string; hooks: Array<{ command: string }> }> };
+    };
+    const codexPathBriefs = codexManifest.hooks.PostToolUse
+      .filter((group) => group.hooks.some((hook) => hook.command.includes(" path-brief ")))
+      .map((group) => ({
+        matcher: group.matcher,
+        pluginRoot: group.hooks[0]?.command.includes("CODEX_PLUGIN_ROOT") ? "CODEX_PLUGIN_ROOT" : "missing",
+        invocation: group.hooks[0]?.command.includes('run dev path-brief --plugin-root "$root"')
+          ? 'run dev path-brief --plugin-root "$root"'
+          : "missing",
+      }));
+
+    const openCodePostTool = planPluginHooks(PLUGINS_ROOT, "dev")
+      .find((plan) => plan.sourceEvent === "PostToolUse")!;
+    const openCodePathBrief = {
+      sourceEvent: openCodePostTool.sourceEvent,
+      opencodeEvent: openCodePostTool.opencodeEvent,
+      target: openCodePostTool.target,
+      applyPatchMatcher: openCodePostTool.source.includes("/^(apply_patch)$/i.test(input.tool)"),
+      editWriteMatcher: openCodePostTool.source.includes("/^(Edit|Write)$/i.test(input.tool)"),
+      projectedCommands: openCodePostTool.source.match(/run dev path-brief/g)?.length ?? 0,
+      injectsContext: openCodePostTool.source.includes(
+        'output.output = [__ctx, output.output].filter(Boolean).join("\\n\\n")',
+      ),
+    };
+
+    expect({ codexPathBriefs, openCodePathBrief }).toMatchInlineSnapshot(`
+      {
+        "codexPathBriefs": [
+          {
+            "invocation": "run dev path-brief --plugin-root \"$root\"",
+            "matcher": "apply_patch",
+            "pluginRoot": "CODEX_PLUGIN_ROOT",
+          },
+        ],
+        "openCodePathBrief": {
+          "applyPatchMatcher": true,
+          "editWriteMatcher": true,
+          "injectsContext": true,
+          "opencodeEvent": "tool.execute.after",
+          "projectedCommands": 2,
+          "sourceEvent": "PostToolUse",
+          "target": "plugin/post-tool-use.ts",
+        },
+      }
+    `);
+  });
+});

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -174,9 +174,11 @@ or a blocking 0–1 floor) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` inner-agent GitHub reads (explicit `gh api` REST forms for issues, pull
 requests, and check runs) -> `plugins/dev/skills/engineering/afk/AGENT-PROMPT.md`;
-Claude path briefs (automatic first-touch injection from a skill's `paths:`
-frontmatter, once per session per skill) -> `scripts/lib/path-briefs.mjs`,
-`apps/dev/src/core/path-brief-hook.ts`, and `plugins/dev/hooks/claude.hooks.json`;
+Path briefs across Claude Code, Codex, and OpenCode (automatic first-touch
+injection from a skill's `paths:` frontmatter, once per session per skill) ->
+`scripts/lib/path-briefs.mjs`, `apps/dev/src/core/path-brief-hook.ts`,
+`plugins/dev/hooks/{claude,codex}.hooks.json`, and
+`apps/opencode-host/src/hooks-to-events.ts`;
 `/afk` task-class runner routes (`plugins.dev.afk.routes.{validate,simple,complex,think}`),
 their override precedence, and `/red-setup` interview ->
 `plugins/dev/skills/engineering/red-setup/INTERVIEW.md` and

--- a/plugins/dev/hooks/codex.hooks.json
+++ b/plugins/dev/hooks/codex.hooks.json
@@ -48,6 +48,15 @@
             "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; hook=\"${CODEX_PLUGIN_ROOT}/hooks/rsp-hook.sh\"; if [ -x \"$hook\" ]; then timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-3s}\" \"$hook\" codex-post-exec <\"$tmp\" || true; else exit 0; fi'"
           }
         ]
+      },
+      {
+        "matcher": "apply_patch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; root=\"${CODEX_PLUGIN_ROOT}\"; out=\"\"; for f in \"$root/hooks/red-fetch.mjs\" \"$root/dist/red-fetch.mjs\" \"$root/../../dist/red-fetch.mjs\"; do [ -f \"$f\" ] && { out=\"$(timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-3s}\" node \"$f\" run dev path-brief --plugin-root \"$root\" <\"$tmp\" 2>/dev/null)\"; break; }; done; if [ -n \"$out\" ]; then printf \"%s\" \"$out\"; else printf \"{}\"; fi'"
+          }
+        ]
       }
     ]
   }

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -174,9 +174,11 @@ or a blocking 0–1 floor) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` inner-agent GitHub reads (explicit `gh api` REST forms for issues, pull
 requests, and check runs) -> `plugins/dev/skills/engineering/afk/AGENT-PROMPT.md`;
-Claude path briefs (automatic first-touch injection from a skill's `paths:`
-frontmatter, once per session per skill) -> `scripts/lib/path-briefs.mjs`,
-`apps/dev/src/core/path-brief-hook.ts`, and `plugins/dev/hooks/claude.hooks.json`;
+Path briefs across Claude Code, Codex, and OpenCode (automatic first-touch
+injection from a skill's `paths:` frontmatter, once per session per skill) ->
+`scripts/lib/path-briefs.mjs`, `apps/dev/src/core/path-brief-hook.ts`,
+`plugins/dev/hooks/{claude,codex}.hooks.json`, and
+`apps/opencode-host/src/hooks-to-events.ts`;
 `/afk` task-class runner routes (`plugins.dev.afk.routes.{validate,simple,complex,think}`),
 their override precedence, and `/red-setup` interview ->
 `plugins/dev/skills/engineering/red-setup/INTERVIEW.md` and


### PR DESCRIPTION
Automated AFK landing for #3841. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3841

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789255853&installation_model_id=20659&pr_number=3868&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3868&signature=82f3b4e1c23bb944519c5fc20900d9f1de27dfcc12742ce6a84e3b38fec66f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->