### PR TITLE
Unbreak main: the VS Code event fixtures were missing pids_peak

### DIFF
--- a/.changeset/vscode-event-fixture.md
+++ b/.changeset/vscode-event-fixture.md
@@ -1,0 +1,16 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Unbreak main: the VS Code event fixtures were missing a field the record gained
+
+`RedskilledHostEvent` gained a required `pids_peak` column, and the two fixtures
+in the VS Code extension's tests never learned about it. Both build the record by
+listing every field and spreading a `Partial` last, so a field the literal does
+not name arrives only from the spread — typed `number | null | undefined` against
+a required `number | null`.
+
+The blast radius was the whole repository, not one package: `typecheck` runs
+across the workspace, so every open pull request failed it, including the Version
+PR whose entire diff is version numbers. Four PRs read as broken when the break
+was on the branch under all of them.

--- a/apps/vscode-extension-red-skills/tests/signals.test.ts
+++ b/apps/vscode-extension-red-skills/tests/signals.test.ts
@@ -57,6 +57,7 @@ function event(overrides: Partial<RedskilledHostEvent>): RedskilledHostEvent {
     systemd_result: null,
     memory_peak_bytes: null,
     memory_swap_peak_bytes: null,
+    pids_peak: null,
     journal_tail: null,
     ...overrides,
   };

--- a/apps/vscode-extension-red-skills/tests/views.test.ts
+++ b/apps/vscode-extension-red-skills/tests/views.test.ts
@@ -108,6 +108,7 @@ describe("the host event view", () => {
     systemd_result: null,
     memory_peak_bytes: null,
     memory_swap_peak_bytes: null,
+    pids_peak: null,
     journal_tail: null,
     ...overrides,
   });


### PR DESCRIPTION
## Main is red, and it reddens everything built on it

Four open pull requests fail their checks right now. The Version PR (`chore(release): 3.18.7`) is among them — **its entire diff is version numbers, and it fails `typecheck`**. That is the tell: the break is not in any of the four, it is on the branch under all of them.

```
tests/signals.test.ts(32,3): error TS2322
  Types of property 'pids_peak' are incompatible.
    Type 'number | null | undefined' is not assignable to type 'number | null'.
```

## Why

`RedskilledHostEvent` gained a required `pids_peak` column in `cae9326c6` (Refs #3802). The VS Code extension has two test fixtures that build the record by **listing every field and spreading a `Partial` last**:

```ts
function event(overrides: Partial<RedskilledHostEvent>): RedskilledHostEvent {
  return { version: 1, /* …29 fields… */, ...overrides };
}
```

A field the literal does not name has the spread as its only source, and `Partial` makes it possibly-`undefined`. So a new required column does not fail where it was added — it fails in whichever fixture forgot to list it, one package away.

## The fix

Name `pids_peak` in both literals, beside `memory_swap_peak_bytes`, so each fixture keeps the record's own field order.

I checked for more than the one TypeScript happened to report first: the type declares **29 required fields**, and diffing them against what each fixture lists shows `pids_peak` is the only one missing.

## Verification

- `pnpm typecheck --force` — 16/16 tasks
- extension suite — 17 files, 206 passed
- `pnpm -C apps/dev test:invariants` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789269054&installation_model_id=20659&pr_number=3870&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3870&signature=ec957970505b482b4fe25e7ec340112b2d80edb9ed95a404e1599e0b0a6e0891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->