### PR TITLE
ci: stop running disabled expensive suites

### DIFF
--- a/.changeset/quiet-rsp-gates.md
+++ b/.changeset/quiet-rsp-gates.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/rsp": patch
+---
+
+Remove disabled RSP, redskilled, and red-castle test suites from the pull-request merge gate, and make the RSP benchmark manual-only.

--- a/.github/workflows/red-rsp-benchmark-ci.yml
+++ b/.github/workflows/red-rsp-benchmark-ci.yml
@@ -1,15 +1,9 @@
 name: red-rsp-benchmark-ci
 
 on:
-  pull_request:
-    paths:
-      - apps/rsp/**
-      - .github/workflows/red-rsp-benchmark-ci.yml
-  push:
-    # The red-toon-watch rolling PR (GITHUB_TOKEN-authored, never triggers
-    # pull_request workflows) bumps TQ_VERSION here — run on its branch push
-    # so the benchmark check lands on the head SHA.
-    branches: [automation/toon-bump]
+  # RSP is disabled in this repository. Keep the benchmark available only for
+  # an explicit maintainer investigation; it is not a PR or automation gate.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -301,111 +301,6 @@ jobs:
         if: env.RUN_DEV != 'true'
         run: echo "apps/dev is not in the affected cone (scope ${{ needs.scope.outputs.mode }}) — no shard to run."
 
-  # RSP owns the terminal boundary, so its fast fidelity suite and its heavier
-  # subprocess/resident integration suite are both merge requirements. Build
-  # first and smoke the same bundle shipped to users; integration tests then
-  # keep exercising that artifact across the real CLI and resident surfaces.
-  rsp:
-    runs-on: ubuntu-latest
-    needs: scope
-    env:
-      RUN_RSP: ${{ contains(fromJSON(needs.scope.outputs.test_packages), 'apps/rsp') }}
-    steps:
-      - name: Checkout
-        if: env.RUN_RSP == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-
-      - if: env.RUN_RSP == 'true'
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
-
-      - if: env.RUN_RSP == 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: 22
-
-      # The rsp integration suite exercises the XML command boundary through
-      # the real `tq` binary on PATH (structured-boundary.ts shells out to it,
-      # and command-boundary.test.ts asserts tq's canonical ordered tree), so
-      # the pinned binary must exist here exactly as it does on dev machines
-      # (/red-setup) and in the RUN_DEV jobs above. Same pinned installer,
-      # same GitHub-release source, no fallback.
-      - name: Install pinned tq
-        if: env.RUN_RSP == 'true'
-        env:
-          TQ_VERSION: v0.26.2
-        run: |
-          set -euo pipefail
-          tq_root="$RUNNER_TEMP/tq"
-          mkdir -p "$tq_root/bin"
-          base="https://github.com/reddb-io/tq/releases/download/${TQ_VERSION}"
-          scripts/ci-fetch-with-retry.sh "$base/tq-linux-x86_64-static" "$tq_root/bin/tq"
-          scripts/ci-fetch-with-retry.sh "$base/tq-linux-x86_64-static.sha256" "$tq_root/tq.sha256"
-          echo "$(cut -d' ' -f1 "$tq_root/tq.sha256")  $tq_root/bin/tq" | sha256sum -c -
-          chmod +x "$tq_root/bin/tq"
-          echo "$tq_root/bin" >> "$GITHUB_PATH"
-          "$tq_root/bin/tq" --version
-
-      # Unlike the other jobs, this one MUST let the @reddb-io/sdk postinstall
-      # download the `red` binary: the resident tests spawn the built bundle
-      # against the embedded RedDb elision store, and `rsp setup` provisions
-      # through the same binary. With REDDB_SKIP_POSTINSTALL=1 every
-      # built-bundle resident test dies with `reddb: binary "red" not found`.
-      # ...and that download has no retry of its own. GitHub Releases answers 503
-      # under load, which failed this job twice in one evening on a byte nobody
-      # changed — the same lesson the pinned `tq` install above already learned,
-      # applied to the one step that had not. Coverage is not the thing to drop
-      # when the network is the thing that failed.
-      - name: Install workspace dependencies
-        if: env.RUN_RSP == 'true'
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            if pnpm install --frozen-lockfile; then exit 0; fi
-            echo "::warning::dependency install attempt $attempt failed; retrying (the @reddb-io/sdk postinstall downloads the red binary from GitHub Releases)"
-            sleep $((attempt * 20))
-          done
-          pnpm install --frozen-lockfile
-
-      - name: Build distributable RSP bundle
-        if: env.RUN_RSP == 'true'
-        run: pnpm -C apps/rsp build
-
-      - name: Exercise distributable RSP bundle
-        if: env.RUN_RSP == 'true'
-        run: node dist/rsp.bundle.min.mjs --help
-
-      # The resident tests spawn the built bundle, and the bundled sdk cannot
-      # resolve `bin/red` relative to its own package: the bundle lives in
-      # dist/, so the sdk's package-root fallback points at <repo>/bin/red,
-      # which never exists. Production hosts find the binary through the warm
-      # cache (~/.cache/red-skills/bundles/reddb/<version>/red) that
-      # /red-setup provisions; give the runner the same warm cache from the
-      # binary the sdk postinstall just downloaded.
-      - name: Seed RedDb warm cache for resident tests
-        if: env.RUN_RSP == 'true'
-        run: |
-          set -euo pipefail
-          sdk_dir=$(cd apps/rsp/node_modules/@reddb-io/sdk && pwd -P)
-          version=$(node -p "require('$sdk_dir/package.json').version")
-          dest="$HOME/.cache/red-skills/bundles/reddb/$version"
-          mkdir -p "$dest"
-          cp "$sdk_dir/bin/red" "$dest/red"
-          "$dest/red" --version
-
-      - name: Test RSP fidelity and units
-        if: env.RUN_RSP == 'true'
-        run: pnpm -C apps/rsp test
-
-      - name: Test RSP integration
-        if: env.RUN_RSP == 'true'
-        env:
-          NODE_OPTIONS: --unhandled-rejections=strict
-        run: pnpm -C apps/rsp test:integration
-
-      - name: Report narrowed scope
-        if: env.RUN_RSP != 'true'
-        run: echo "apps/rsp is not in the affected cone (scope ${{ needs.scope.outputs.mode }}) — no RSP gate to run."
-
   # The remaining suites are seconds-cheap, so they stay in one job rather than
   # paying a runner's fixed cost each.
   test-packages:
@@ -418,10 +313,8 @@ jobs:
       # apps/dev is deliberately absent: it belongs to the shard matrix, and
       # asking for it here would install a workspace for no step to use.
       RUN_ANY: >-
-        ${{ contains(fromJSON(needs.scope.outputs.test_packages), 'packages/red-castle')
-        || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/opencode-host')
+        ${{ contains(fromJSON(needs.scope.outputs.test_packages), 'apps/opencode-host')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/afk-container')
-        || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/redskilled')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/herdr-plugin-red-skills')
         || contains(fromJSON(needs.scope.outputs.test_packages), 'apps/vscode-extension-red-skills') }}
     steps:
@@ -446,14 +339,6 @@ jobs:
           REDDB_SKIP_POSTINSTALL: "1"
         run: pnpm install --frozen-lockfile
 
-      # The engine's own suite carries the castle-tree transition-API contract
-      # lint (#2666). The root `test` script filters red-castle out, so without
-      # this step that lint would never run and a raw state-role writer could
-      # reach main unseen.
-      - name: Test packages/red-castle
-        if: contains(fromJSON(env.PACKAGES), 'packages/red-castle')
-        run: pnpm -C packages/red-castle test
-
       - name: Test apps/opencode-host
         if: contains(fromJSON(env.PACKAGES), 'apps/opencode-host')
         run: pnpm -C apps/opencode-host test
@@ -461,33 +346,6 @@ jobs:
       - name: Test apps/afk-container
         if: contains(fromJSON(env.PACKAGES), 'apps/afk-container')
         run: pnpm -C apps/afk-container test
-
-      # The vendored herdr plugin (ADR 0131). Its `test` script is the manifest
-      # check and the `node --test` suite in that order, so the manifest a pane
-      # is opened from is validated by the same command as the code behind it.
-      # `tq` is the query surface the /redskilled skill documents an operator
-      # into, and one test runs those exact recipes against a fixture lane — so
-      # the doc and the tool are checked by the same command. It is an external
-      # Rust binary, not a workspace dependency, so CI installs it: the
-      # PREBUILT static binary against its published checksum, never
-      # `cargo install`, which would spend minutes compiling on every run.
-      - name: Install tq (event-lane query recipes)
-        if: contains(fromJSON(env.PACKAGES), 'apps/redskilled')
-        env:
-          TQ_VERSION: v0.28.2
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh release download "$TQ_VERSION" -R reddb-io/toon \
-            -p 'tq-linux-x86_64-static*' -D "$RUNNER_TEMP/tq"
-          cd "$RUNNER_TEMP/tq"
-          awk '{print $1"  tq-linux-x86_64-static"}' tq-linux-x86_64-static.sha256 | sha256sum -c -
-          install -m 0755 tq-linux-x86_64-static "$RUNNER_TEMP/tq/tq"
-          echo "$RUNNER_TEMP/tq" >> "$GITHUB_PATH"
-
-      - name: Test apps/redskilled
-        if: contains(fromJSON(env.PACKAGES), 'apps/redskilled')
-        run: pnpm -C apps/redskilled test
 
       - name: Test apps/herdr-plugin-red-skills
         if: contains(fromJSON(env.PACKAGES), 'apps/herdr-plugin-red-skills')
@@ -513,14 +371,13 @@ jobs:
     # and shrink their own steps, so a docs-only PR reaches this job green.
     if: always()
     runs-on: ubuntu-latest
-    needs: [scope, test-shard, rsp, test-packages]
+    needs: [scope, test-shard, test-packages]
     steps:
       - name: Fail when a test dependency failed or was cancelled
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "scope=${{ needs.scope.result }}"
           echo "test-shard=${{ needs['test-shard'].result }}"
-          echo "rsp=${{ needs.rsp.result }}"
           echo "test-packages=${{ needs['test-packages'].result }}"
           exit 1
 

--- a/apps/rsp/tests/ci-gate.test.ts
+++ b/apps/rsp/tests/ci-gate.test.ts
@@ -17,29 +17,16 @@ function jobBody(source: string, name: string): string {
   return end === -1 ? rest : rest.slice(0, end);
 }
 
-describe("RSP required CI gates (#3625)", () => {
-  it("builds and exercises the distributable before required unit and integration checks", async () => {
+describe("RSP CI posture", () => {
+  it("does not make RSP build, unit, or integration checks merge requirements", async () => {
     const source = await workflow("red-workspace-ci.yml");
-    const rsp = jobBody(source, "rsp");
-
-    expect(rsp).toContain("needs: scope");
-    expect(rsp).toContain("contains(fromJSON(needs.scope.outputs.test_packages), 'apps/rsp')");
-    expect(rsp).not.toMatch(/^ {4}if:/m);
-
-    const build = rsp.indexOf("run: pnpm -C apps/rsp build");
-    const exercise = rsp.indexOf("run: node dist/rsp.bundle.min.mjs --help");
-    const unit = rsp.indexOf("run: pnpm -C apps/rsp test");
-    const integration = rsp.indexOf("run: pnpm -C apps/rsp test:integration");
-
-    expect(build, "missing distributable build").toBeGreaterThanOrEqual(0);
-    expect(exercise, "missing distributable smoke exercise").toBeGreaterThan(build);
-    expect(unit, "missing unit/fidelity gate").toBeGreaterThan(exercise);
-    expect(integration, "missing integration gate").toBeGreaterThan(unit);
-    expect(rsp).toContain("NODE_OPTIONS: --unhandled-rejections=strict");
+    expect(source).not.toMatch(/^  rsp:/m);
+    expect(source).not.toContain("run: pnpm -C apps/rsp test");
+    expect(source).not.toContain("run: pnpm -C apps/rsp test:integration");
 
     const aggregate = jobBody(source, "test");
-    expect(aggregate).toMatch(/needs:\s*\[[^\]]*rsp[^\]]*\]/);
-    expect(aggregate).toContain("rsp=${{ needs.rsp.result }}");
+    expect(aggregate).not.toMatch(/needs:\s*\[[^\]]*rsp[^\]]*\]/);
+    expect(aggregate).not.toContain("rsp=${{ needs.rsp.result }}");
   });
 
   it("keeps unhandled integration errors fatal at the Vitest boundary", async () => {
@@ -47,15 +34,13 @@ describe("RSP required CI gates (#3625)", () => {
     expect(config).toContain("dangerouslyIgnoreUnhandledErrors: false");
   });
 
-  it("runs the deterministic two-axis check only for the RSP surface", async () => {
+  it("keeps the deterministic two-axis check manual-only", async () => {
     const source = await workflow("red-rsp-benchmark-ci.yml");
     const trigger = source.slice(0, source.indexOf("\njobs:"));
 
-    expect(trigger).toContain("- apps/rsp/**");
-    expect(trigger).toContain("- .github/workflows/red-rsp-benchmark-ci.yml");
-    expect(trigger).not.toContain("- apps/**");
-    expect(trigger).not.toContain("- packages/**");
-    expect(trigger).not.toContain("- pnpm-lock.yaml");
+    expect(trigger).toContain("workflow_dispatch:");
+    expect(trigger).not.toContain("pull_request:");
+    expect(trigger).not.toContain("push:");
     expect(source).toContain("run: pnpm -C apps/rsp bench:two-axis:check");
     expect(source).toContain(
       "run: git diff --exit-code -- apps/rsp/bench/results/rsp-two-axis.toon apps/rsp/bench/results/rsp-two-axis.md",

--- a/scripts/test-ci-affected-scope.sh
+++ b/scripts/test-ci-affected-scope.sh
@@ -185,6 +185,21 @@ need(/^ {4}if: always\(\)$/m.test(aggregate), 'test always runs, so it always re
 need(/contains\(needs\.\*\.result, 'failure'\)/.test(aggregate)
   && /contains\(needs\.\*\.result, 'cancelled'\)/.test(aggregate),
   'test fails when any dependency failed or was cancelled');
+
+// These suites are intentionally not merge gates. RSP is disabled in this
+// repository, and the redskilled/red-castle suites are too expensive for the
+// shared package lane.
+need(!/^\s{2}rsp:/m.test(text), 'red-workspace-ci does not define an rsp job');
+const packages = jobBody('test-packages');
+need(!/pnpm -C apps\/redskilled test/.test(packages), 'test-packages does not run apps/redskilled tests');
+need(!/pnpm -C packages\/red-castle test/.test(packages), 'test-packages does not run packages/red-castle tests');
 NODE
+
+benchmark_trigger="$(sed -n '1,/^jobs:/p' .github/workflows/red-rsp-benchmark-ci.yml)"
+grep -q 'workflow_dispatch:' <<<"$benchmark_trigger" || fail "RSP benchmark is manual-only"
+if grep -Eq '^  (pull_request|push):' <<<"$benchmark_trigger"; then
+  fail "RSP benchmark must not run automatically"
+fi
+printf 'PASS: RSP benchmark is manual-only\n'
 
 printf '\nAll CI affected-scope contract checks passed.\n'


### PR DESCRIPTION
## Summary

- remove the RSP job from the pull-request merge gate
- stop running apps/redskilled and packages/red-castle suites in test-packages
- make the separate RSP benchmark workflow manual-only
- ratchet the disabled CI posture in the affected-scope contract

## Validation

- scripts/test-ci-affected-scope.sh
- scripts/test-workflow-security-pins.sh
- scripts/test-workflow-fork-posture.sh
- pnpm -C apps/rsp exec vitest run tests/ci-gate.test.ts
- pnpm -C apps/rsp typecheck
- node scripts/validate-changesets.mjs
- workflow YAML parse

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789322931&installation_model_id=20659&pr_number=3878&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3878&signature=c70f2b517a2b6aee86854a1a14468285f34949315ba58ecd13cf43088deeb642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->