### PR TITLE
Activate redskilled project drainage through the canonical MCP path

### DIFF
--- a/.changeset/project-drain-mcp.md
+++ b/.changeset/project-drain-mcp.md
@@ -1,0 +1,6 @@
+---
+"@reddb-io/dev": patch
+"@reddb-io/red-castle": patch
+---
+
+Expose canonical redskilled project activation and drainage through the MCP boundary while keeping Worker birth host-owned.

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ apps/*/out/
 
 # sandcastle runtime scratch (ADR 0033)
 .sandcastle/
+.red/tmp/
+.red/state/

--- a/apps/dev/src/mcp/dependencies.ts
+++ b/apps/dev/src/mcp/dependencies.ts
@@ -51,6 +51,7 @@ import { createDefaultDevAfkMcpOperations } from "./handlers.js";
 import {
   concretizeSelectorUser,
   drain,
+  projectActivation,
   projectResize,
   projectStart,
   projectStatus,
@@ -151,6 +152,7 @@ export function createCastleMcpDependencies(
   readers: CastleMcpReadPorts = {},
 ): CastleMcpDependencies {
   const baseDeps: CastleMcpDependencies = {
+    projectActivation: async () => projectActivation(root),
     projectStatus: () => projectStatus(root),
     drain: (input) => drain(root, input),
     projectStart: (input) => projectStart(root, input),

--- a/apps/dev/src/mcp/project.ts
+++ b/apps/dev/src/mcp/project.ts
@@ -40,9 +40,12 @@ import {
   resolveRepoContext,
 } from "../runtime/wire.js";
 import {
+  auditConfigLoad,
+  getConfig,
   loadConfig,
   readStandingDrain,
   readValidationMoments,
+  resolveTaskRoute,
 } from "../core/config.js";
 import { describeValidationMoments } from "../core/validation-moments.js";
 import {
@@ -51,8 +54,26 @@ import {
   registrationQueryUnexpressedFacets,
 } from "../core/registration-query.js";
 import { resolveRepoSlugForDir } from "@reddb-io/shared/project-identity-resolve.js";
+import { DEFAULT_FLEET_WIDTH, FLEET_WIDTH_CONFIG_KEY } from "@reddb-io/shared/default-fleet-width.js";
 
 import { resolveConfiguredBase } from "./operations.js";
+
+export function projectActivation(root: string) {
+  const config = afkPaths(root).configPath;
+  const audit = auditConfigLoad(config, { warn: () => undefined });
+  const standing = readStandingDrain(audit.values);
+  const configuredTarget = Number.parseInt(getConfig(audit.values, FLEET_WIDTH_CONFIG_KEY), 10);
+  return {
+    eligible: audit.pluginEnabled,
+    project: createRedskilledBirthPort({ root }).projectLabel,
+    runner: standing?.runner ?? resolveTaskRoute(audit.values).runner,
+    target:
+      standing?.target ??
+      (Number.isInteger(configuredTarget) && configuredTarget > 0 ? configuredTarget : DEFAULT_FLEET_WIDTH),
+    standing: standing !== null,
+    config,
+  };
+}
 
 export async function waitStatusImpl(root: string, input: WaitStatusInput): Promise<unknown> {
   const resultFile = join(waitsDir(root), `${input.id}.toon`);
@@ -426,6 +447,16 @@ export async function drain(
   input: ProjectDrainInput,
   options: { readonly standing?: boolean } = {},
 ) {
+  const activation = projectActivation(root);
+  if ((input.runner === undefined || input.target === undefined) && !activation.eligible) {
+    throw new Error(
+      `drain defaults are unavailable because ${activation.config} does not declare plugins.dev.enabled: true`,
+    );
+  }
+  const requested = {
+    runner: input.runner ?? activation.runner,
+    target: input.target ?? activation.target,
+  };
   const port = createRedskilledBirthPort({ root });
   try {
     await port.reach();
@@ -449,7 +480,7 @@ export async function drain(
       lapsed: held == null && state.lapse != null,
       workers: await port.liveWorkers(),
     },
-    input,
+    requested,
   );
 
   if (plan.outcome === "refuse") {

--- a/apps/dev/tests/mcp-project-registration.test.ts
+++ b/apps/dev/tests/mcp-project-registration.test.ts
@@ -133,6 +133,26 @@ async function liveHost(queueDepth?: number): Promise<RedskilledDaemon> {
 }
 
 describe("starting work registers the project", () => {
+  it("previews and applies canonical activation without starting a project process", async () => {
+    const daemon = await liveHost();
+    const root = await project();
+    const deps = createCastleMcpDependencies(root);
+
+    await expect(deps.projectActivation()).resolves.toMatchObject({
+      eligible: true,
+      project: "acme/widgets",
+      runner: "claude",
+      target: 1,
+      standing: false,
+      config: join(root, ".red", "config.yaml"),
+    });
+    await expect(deps.drain({})).resolves.toMatchObject({ outcome: "applied" });
+
+    expect(daemon.registrations()[0]).toMatchObject({ target: 1 });
+    expect(daemon.registrations()[0]?.env.RED_AFK_RUNNER).toBe("claude");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
   it("marks only policy-driven registration as standing", async () => {
     const daemon = await liveHost();
     const root = await project();

--- a/packages/red-castle/src/mcp-server.test.ts
+++ b/packages/red-castle/src/mcp-server.test.ts
@@ -6,6 +6,14 @@ import {
 
 function deps(): CastleMcpDependencies {
   return {
+    projectActivation: vi.fn(async () => ({
+      eligible: true,
+      project: "red-skills",
+      runner: "codex",
+      target: 2,
+      standing: true,
+      config: "/repo/.red/config.yaml",
+    })),
     projectStatus: vi.fn(async () => ({
       validation_schedule: {
         narration: "Validation moments — iteration: skip (undeclared); post_done: skip (undeclared); landing: skip (undeclared)",
@@ -183,6 +191,7 @@ describe("redskilled MCP tools", () => {
     expect(createCastleMcpTools(deps()).map((tool) => tool.name)).toEqual([
       "help",
       "status",
+      "project_activation",
       "project_status",
       "drain",
       "project_start",
@@ -288,6 +297,19 @@ describe("redskilled MCP tools", () => {
     });
   });
 
+  it("previews the canonical project activation without mutating", async () => {
+    const d = deps();
+    const activation = createCastleMcpTools(d).find((candidate) => candidate.name === "project_activation")!;
+    await expect(activation.invoke({})).resolves.toMatchObject({
+      eligible: true,
+      project: "red-skills",
+      runner: "codex",
+      target: 2,
+    });
+    expect(d.projectActivation).toHaveBeenCalledOnce();
+    expect(d.drain).not.toHaveBeenCalled();
+  });
+
   it("ensures a drain through the host adapter", async () => {
     const d = deps();
     const tool = createCastleMcpTools(d).find((candidate) => candidate.name === "drain")!;
@@ -301,6 +323,13 @@ describe("redskilled MCP tools", () => {
       },
     });
     expect(d.drain).toHaveBeenCalledWith({ runner: "codex", target: 2 });
+  });
+
+  it("forwards an empty drain so the project resolves canonical defaults", async () => {
+    const d = deps();
+    const tool = createCastleMcpTools(d).find((candidate) => candidate.name === "drain")!;
+    await tool.invoke({});
+    expect(d.drain).toHaveBeenCalledWith({});
   });
 
   it("resets the named project latch", async () => {

--- a/packages/red-castle/src/mcp-tool-surface.test.ts
+++ b/packages/red-castle/src/mcp-tool-surface.test.ts
@@ -33,6 +33,13 @@ const SURFACE: ReadonlyArray<{
     schema: ["scope", "worker", "live_only", "fields"],
   },
   {
+    name: "project_activation",
+    title: "Preview this project's redskilled activation",
+    description:
+      "READ-ONLY: report whether this project opted into RedSkills and the canonical runner and target a no-argument drain would register.",
+    schema: [],
+  },
+  {
     name: "project_status",
     title: "Deprecated project status alias",
     description:
@@ -43,7 +50,7 @@ const SURFACE: ReadonlyArray<{
     name: "drain",
     title: "Make this project drain",
     description:
-      "MUTATING: ensure the daemon is reachable and this project is registered at the requested runner and target; repeated calls report what was kept.",
+      "MUTATING: ensure the daemon is reachable and this project is registered. Omitted runner and target resolve from this project's canonical RedSkills configuration; repeated calls report what was kept.",
     schema: ["runner", "target"],
   },
   {

--- a/packages/red-castle/src/mcp/project.ts
+++ b/packages/red-castle/src/mcp/project.ts
@@ -40,8 +40,17 @@ export interface ProjectStartInput {
 }
 
 export interface ProjectDrainInput {
+  runner?: string;
+  target?: number;
+}
+
+export interface ProjectActivationOutput {
+  eligible: boolean;
+  project: string;
   runner: string;
   target: number;
+  standing: boolean;
+  config: string;
 }
 
 export interface ProjectResizeInput {
@@ -61,6 +70,7 @@ export interface ProjectResetInput {
 }
 
 export interface ProjectDependencies {
+  projectActivation(): Promise<ProjectActivationOutput>;
   projectStatus(): Promise<ProjectStatusOutput>;
   drain(input: ProjectDrainInput): Promise<unknown>;
   projectStart(input: ProjectStartInput): Promise<unknown>;
@@ -99,6 +109,14 @@ const removedFleetName = z
 export function createProjectTools(deps: ProjectDependencies): CastleMcpTool[] {
   return [
     {
+      name: "project_activation",
+      title: "Preview this project's redskilled activation",
+      description:
+        "READ-ONLY: report whether this project opted into RedSkills and the canonical runner and target a no-argument drain would register.",
+      inputSchema: {},
+      invoke: () => deps.projectActivation(),
+    },
+    {
       name: "project_status",
       title: "Deprecated project status alias",
       description:
@@ -118,10 +136,10 @@ export function createProjectTools(deps: ProjectDependencies): CastleMcpTool[] {
       name: "drain",
       title: "Make this project drain",
       description:
-        "MUTATING: ensure the daemon is reachable and this project is registered at the requested runner and target; repeated calls report what was kept.",
+        "MUTATING: ensure the daemon is reachable and this project is registered. Omitted runner and target resolve from this project's canonical RedSkills configuration; repeated calls report what was kept.",
       inputSchema: {
-        runner: z.string().min(1),
-        target: z.number().int().min(0).default(DEFAULT_FLEET_WIDTH),
+        runner: z.string().min(1).optional(),
+        target: z.number().int().min(0).optional(),
       },
       invoke: async (input) => deps.drain(input as unknown as ProjectDrainInput),
     },

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -104,6 +104,7 @@ that block, startup preserves the explicit-only `drain`/`project_start` behavior
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
+| `project_activation` | read | Report whether this project opted into RedSkills and the canonical runner and target that a no-argument `drain` would register. |
 | `drain` | mutating | Ensure the daemon is reachable and this project is registered at the requested runner and target. Repeated calls succeed with a four-dimension difference report; a runner change is refused with the explicit stop-then-drain repair. |
 | `project_start` | mutating | Register this project with the host daemon — a runner, a target width, and its work policy. It registers; it launches no process of the project's own. |
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -104,6 +104,7 @@ that block, startup preserves the explicit-only `drain`/`project_start` behavior
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
+| `project_activation` | read | Report whether this project opted into RedSkills and the canonical runner and target that a no-argument `drain` would register. |
 | `drain` | mutating | Ensure the daemon is reachable and this project is registered at the requested runner and target. Repeated calls succeed with a four-dimension difference report; a runner change is refused with the explicit stop-then-drain repair. |
 | `project_start` | mutating | Register this project with the host daemon — a runner, a target width, and its work policy. It registers; it launches no process of the project's own. |
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |


### PR DESCRIPTION
## Summary

- expose canonical project activation and drain dependencies through the MCP boundary
- keep Worker birth behind redskilled while project registration remains process-free
- extend MCP surface and registration coverage for the activation path

## Why

These changes were preserved from the primary checkout before updating it to current `origin/main`. The architectural documentation portions were already merged separately; this PR contains only the remaining seven-file implementation and test delta.

## Validation

The patch was mechanically rebased onto current `origin/main` with `git merge-tree` without conflicts. Repository CI remains authoritative.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789348452&installation_model_id=20659&pr_number=3898&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3898&signature=c2fa1749c2b94a24bb636b960e1209009bd47e91c28b836a1af5fd94779bb2f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->