### PR TITLE
merge: #3862 Hook protocol failures are never classified as merge conflicts

### DIFF
--- a/.changeset/honest-hook-contract-failures.md
+++ b/.changeset/honest-hook-contract-failures.md
@@ -1,0 +1,4 @@
+---
+"@reddb-io/dev": patch
+---
+Classify pre-merge hook output protocol violations as bounded validation failures and identify the offending hook in operator summaries.

--- a/apps/dev/src/core/process-issue/hook-landing-failure.ts
+++ b/apps/dev/src/core/process-issue/hook-landing-failure.ts
@@ -1,0 +1,55 @@
+import type { HookDispatchResult } from "../hook-dispatcher.js";
+import type { HookName } from "../hook-config.js";
+import { ensureRemoteWorkVisible, terminalFailure, type StageCommon } from "./terminal.js";
+import type { ProcessIssueResult } from "./types.js";
+
+export interface HookAbortDetail {
+  name: HookName;
+  command?: string;
+  rc: number;
+  stdoutProtocolViolation: boolean;
+}
+
+/** Preserve the command-level cause that Landing's boolean hook port omits. */
+export function hookAbortDetail(name: HookName, result: HookDispatchResult): HookAbortDetail | undefined {
+  if (!result.aborted) return undefined;
+  const failed = result.executions.at(-1);
+  return {
+    name,
+    command: failed?.command,
+    rc: result.rc,
+    // A dispatcher parse failure reports EX_DATAERR while the hook process
+    // itself succeeded. A real hook that exits 65 retains execution rc=65.
+    stdoutProtocolViolation: result.rc === 65 && failed?.rc === 0,
+  };
+}
+
+/** Route a pre_merge hook refusal as bounded policy, never as branch conflict. */
+export async function hookAbortedLanding(
+  common: StageCommon,
+  lastAbort: HookAbortDetail | undefined,
+): Promise<ProcessIssueResult> {
+  const hook = lastAbort?.name === "pre_merge" ? lastAbort : undefined;
+  const command = hook?.command ? ` \`${hook.command}\`` : "";
+  const summary = hook?.stdoutProtocolViolation
+    ? `pre_merge hook${command} violated the hook stdout protocol: invalid structured stdout (expected empty stdout or a JSON object).`
+    : `pre_merge hook${command} aborted the landing${hook ? ` (rc=${hook.rc})` : ""}.`;
+  const visiblePr = await ensureRemoteWorkVisible(common);
+  const notes = visiblePr === undefined
+    ? summary
+    : `${summary} The completed worker branch remains visible in PR #${visiblePr}; do not re-run the implementation.`;
+  common.deps.recordWorkerEvent?.("worker.blocked", {
+    outcome: "hook-aborted",
+    reason: hook?.stdoutProtocolViolation ? "hook-stdout-protocol" : "pre_merge-abort",
+    hook: "pre_merge",
+  });
+  return terminalFailure(
+    common,
+    "hook-aborted",
+    hook?.stdoutProtocolViolation
+      ? "pre_merge hook: invalid structured stdout"
+      : "pre_merge hook: landing aborted",
+    { notes },
+    { notes },
+  );
+}

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -182,9 +182,8 @@ import {
 import { abortAfterClaim, claimLost, emitBackpressureReview, emitDone, handoffForManualLanding, handoffForReview, hookContext, isRunnerRecoverableOutcome, landLockBackoff, mergeFailed, ciBlocked, prLandingBlocked, trunkDivergedBlocked, onErrorContext, parseHookEnv, postAttemptContext, recordOutcomeBestEffort, releaseOwnedClaim, runCascadeRebase, runCloseCascade, runnerRecoverable, terminalFailure, writeValidationSidecar, type StageCommon } from "./terminal.js";
 import { reportValidationEvidenceInconsistency } from "./validation-park.js";
 import { setupFailureExcerpt } from "./setup-failure.js";
-
-/** Recorded when the forge refused the merge and the PR state did not explain it
- * (#2807). It says the cause is unknown rather than inventing a probable one. */
+import { hookAbortDetail, hookAbortedLanding, type HookAbortDetail } from "./hook-landing-failure.js";
+/** A forge refusal with no observed cause (#2807), without inventing a probable one. */
 const MERGE_REJECTION_UNEXPLAINED =
   "the open PR merge was rejected by GitHub and the PR state did not explain the refusal";
 /** The `next:` step for a rejected merge. It points at the recorded reason
@@ -200,6 +199,7 @@ export async function processIssue(
   const hooksFired: HookName[] = [];
   const startedEpoch = deps.nowEpoch();
   const resolved: ResolvedHooks = resolveHooks(deps.hooks.config, deps.hooks.resolveOptions);
+  let lastHookAbort: HookAbortDetail | undefined;
   let ownsCommentClaim = false;
   const releaseClaim = async () => {
     if (ownsCommentClaim) {
@@ -220,15 +220,15 @@ export async function processIssue(
       env: deps.hooks.env ?? {},
       log: (line) => deps.appendIterLog(line),
     });
+    lastHookAbort = hookAbortDetail(name, result);
     if (name === "pre_worktree" && !result.aborted) {
       const parsed = parseHookEnv(result.context);
       if (parsed) agentEnv = parsed;
     }
     return result;
   };
-  const fireHook = async (name: HookName, context: string): Promise<boolean> => {
-    return !(await fireHookCtx(name, context)).aborted;
-  };
+  const fireHook = async (name: HookName, context: string): Promise<boolean> =>
+    !(await fireHookCtx(name, context)).aborted;
   /** Withdraw from the issue, naming the cause. Every exit routes through here
    * so no withdrawal is anonymous: the sweep deletes this worker's workspace on
    * a claim-lost, so the account has to reach the durable lane (#3156). */
@@ -2166,6 +2166,7 @@ export async function processIssue(
     if (landing.reason === "land-lock-timeout") {
       return await landLockBackoff(common);
     }
+    if (landing.reason === "pre_merge-abort") return await hookAbortedLanding(common, lastHookAbort);
     if (landing.reason === "infra") {
       const reason = landing.infraReason ?? "landing infrastructure precondition failed";
       return await terminalFailure(

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -2039,17 +2039,22 @@ describe("processIssue — daemon-granted fork point (ADR 0138)", () => {
   });
 });
 
-describe("processIssue — pre_merge hook abort (primary checkout untouched, #2628)", () => {
-  it("pre_merge abort: push happened but no integration ran, routes to merge-conflict", async () => {
-    // Pins AC1/AC2 from #2628: pre_merge fires after the attempt push but before
-    // any integration command. An abort must leave the primary checkout untouched —
-    // Landing runs entirely inside its isolated worktree; no primary snapshot commit
-    // is created. The lifecycle routes the abort to merge-conflict, not a hard error.
-    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true, abortHook: "pre_merge" });
+describe("processIssue — pre_merge hook contract", () => {
+  it("zero-exit invalid stdout parks as bounded policy failure and names the violation", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    deps.hooks.config["afk.hooks.pre_merge"] = "scripts/afk-pre-merge.sh";
+    deps.hooks.exec = async () => ({ code: 0, stdout: "human-readable report" });
     const result = await processIssue(deps, input);
 
-    // pre_merge-abort feeds mergeFailed → merge-conflict outcome.
-    expect(result.outcome).toBe("merge-conflict");
+    expect(result.outcome).toBe("hook-aborted");
+    expect(trace.labelEdits.at(-1)).toMatchObject({
+      add: ["ready-for-human", "blocked:policy"],
+    });
+    expect(trace.labelEdits.at(-1)?.add).not.toContain("blocked:merge-conflict");
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+    expect(trace.envelopeBodies.at(-1)).toContain("pre_merge hook `scripts/afk-pre-merge.sh`");
+    expect(trace.envelopeBodies.at(-1)).toContain("invalid structured stdout");
+    expect(trace.envelopeBodies.at(-1)).not.toContain("merge-conflict");
     // The attempt was pushed (push precedes the hook) — the remote ref exists.
     expect(trace.pushedAttempt).toHaveLength(1);
     // No merge or integration command ran after the abort. The park does run
@@ -2063,6 +2068,22 @@ describe("processIssue — pre_merge hook abort (primary checkout untouched, #26
     // pre_merge fired; post_merge did not — no integration ran.
     expect(result.hooksFired).toContain("pre_merge");
     expect(result.hooksFired).not.toContain("post_merge");
+  });
+
+  it.each([
+    ["empty stdout", ""],
+    ["structured stdout", '{"landing":"allowed"}'],
+  ])("preserves success for %s", async (_case, stdout) => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    deps.hooks.config["afk.hooks.pre_merge"] = "scripts/afk-pre-merge.sh";
+    deps.hooks.exec = async () => ({ code: 0, stdout });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.closed).toEqual([9]);
+    expect(result.hooksFired).toContain("pre_merge");
+    expect(result.hooksFired).toContain("post_merge");
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #3862. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3862

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789350349&installation_model_id=20659&pr_number=3900&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3900&signature=6687e375cbd1cc1021854004f14f1676bb4e631fcbf0802cfeefbc165681d98b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->