### PR TITLE
merge: #3881 ACP v1: one RedSkills session reaches one native Worker

### DIFF
--- a/apps/dev/src/core/declared-wait-guard.ts
+++ b/apps/dev/src/core/declared-wait-guard.ts
@@ -692,6 +692,14 @@ export const DECLARED_WAITS: readonly DeclaredWait[] = [
     heartbeat: { silent: "a seconds-long drain whose boolean return is the report" },
   },
   {
+    path: "apps/redskilled/src/acp-control-plane.ts",
+    fn: "connectWithDeadline",
+    subject: "the daemon ACP socket or assigned native Worker ACP socket accepting a local connection",
+    deadline: "the caller's `timeoutMs`, 10 seconds for both public and Worker rendezvous",
+    escalation: "throws a bounded endpoint-specific connection error; no local Worker fallback is permitted",
+    heartbeat: { silent: "a 25ms local socket rendezvous whose terminal throw names the endpoint boundary" },
+  },
+  {
     path: "apps/redskilled/src/client-rendezvous.ts",
     fn: "waitForSupervisedDaemon",
     subject: "the installed supervisor's daemon answering on its same-user client socket",

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -38,6 +38,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "NODE_OPTIONS=--max-old-space-size=4096 vitest run",
+    "test:acp-control-plane": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-control-plane.test.ts",
     "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/redskilled.bundle.min.mjs --asset redskilled.bundle.min.mjs --minify",
     "build": "pnpm run typecheck && pnpm run bundle",
     "build:native": "node-gyp rebuild --directory=native",
@@ -45,6 +46,7 @@
     "diagnose:resources": "tsx scripts/resource-incident-harness.ts"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "1.3.0",
     "@reddb-io/build-info": "workspace:*",
     "@reddb-io/github": "workspace:*",
     "@reddb-io/redskilled-render": "workspace:*",

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -1,0 +1,447 @@
+/**
+ * ACP v1 control plane — redskilled is the public Agent and the Client of each Worker.
+ *
+ * The public stdio command is only a transport projection onto the daemon-owned
+ * socket. Sessions, admission, Worker rendezvous, cancellation, and terminal
+ * cleanup all live here, in the host authority. The native Worker speaks ACP on
+ * its assigned socket and exits when redskilled closes that connection.
+ */
+import { randomBytes, randomUUID } from "node:crypto";
+import { mkdir, rm } from "node:fs/promises";
+import { connect, createServer, type Server, type Socket } from "node:net";
+import { join } from "node:path";
+import { Readable, Writable } from "node:stream";
+import {
+  agent,
+  client,
+  methods,
+  ndJsonStream,
+  type AgentConnection,
+  type ClientConnection,
+  type McpServer,
+  type NewSessionRequest,
+  type PromptRequest,
+  type PromptResponse,
+  type SessionNotification,
+  type Stream,
+} from "@agentclientprotocol/sdk";
+import type { RedskilledHostState } from "./host-state.js";
+import type { RedskilledPaths } from "./paths.js";
+import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
+
+const ACP_PROTOCOL_VERSION = 1;
+const ACP_PROJECT_LABEL = "redskills/acp";
+const TERMINAL_REAP_DELAY_MS = 150;
+
+interface PublicSession {
+  readonly request: NewSessionRequest;
+}
+
+interface ActiveWorker {
+  readonly workerId: string;
+  readonly downstreamSessionId: string;
+  readonly connection: ClientConnection;
+  readonly socket: Socket;
+  readonly endpoint: string;
+  cancelled: boolean;
+  cleaned: boolean;
+}
+
+export interface RedskillsAcpControlPlane {
+  readonly socketPath: string;
+  close(): Promise<void>;
+}
+
+export interface StartRedskillsAcpControlPlaneOptions {
+  readonly paths: RedskilledPaths;
+  readonly startWorker: (spec: RedskilledWorkerSpec) => LaunchedWorker;
+  readonly hostState: () => RedskilledHostState;
+}
+
+/** Bind the daemon-owned public ACP endpoint. */
+export async function startRedskillsAcpControlPlane(
+  options: StartRedskillsAcpControlPlaneOptions,
+): Promise<RedskillsAcpControlPlane> {
+  const { paths } = options;
+  const sockets = new Set<Socket>();
+  await mkdir(join(paths.runtimeDir, "acp-workers"), { recursive: true, mode: 0o700 });
+  await rm(paths.acpSocketPath, { force: true });
+
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+    void servePublicConnection(socket, options).catch(() => socket.destroy());
+  });
+  await listen(server, paths.acpSocketPath);
+
+  let closed = false;
+  return {
+    socketPath: paths.acpSocketPath,
+    async close() {
+      if (closed) return;
+      closed = true;
+      for (const socket of sockets) socket.destroy();
+      await closeServer(server);
+      await rm(paths.acpSocketPath, { force: true });
+    },
+  };
+}
+
+async function servePublicConnection(
+  socket: Socket,
+  options: StartRedskillsAcpControlPlaneOptions,
+): Promise<void> {
+  const sessions = new Map<string, PublicSession>();
+  const active = new Map<string, ActiveWorker>();
+
+  const app = agent({ name: "RedSkills" })
+    .onRequest(methods.agent.initialize, ({ params }) => ({
+      protocolVersion: params.protocolVersion === ACP_PROTOCOL_VERSION
+        ? params.protocolVersion
+        : ACP_PROTOCOL_VERSION,
+      agentCapabilities: { promptCapabilities: {} },
+      agentInfo: { name: "RedSkills", version: "1" },
+      _meta: { redskills: { wireMajor: 1, workerBacked: true } },
+    }))
+    .onRequest(methods.agent.session.new, ({ params }) => {
+      const sessionId = randomUUID();
+      sessions.set(sessionId, { request: params });
+      return {
+        sessionId,
+        _meta: { redskills: { authority: "redskilled", protocolVersion: ACP_PROTOCOL_VERSION } },
+      };
+    })
+    .onRequest(methods.agent.session.prompt, async ({ params, client: upstream }) => {
+      const session = sessions.get(params.sessionId);
+      if (session == null) throw new Error("unknown RedSkills ACP session");
+      if (active.has(params.sessionId)) throw new Error("this RedSkills ACP session already has an active turn");
+
+      const worker = await admitNativeAcpWorker(options, session, params.sessionId, upstream.notify.bind(upstream));
+      active.set(params.sessionId, worker);
+      try {
+        if (worker.cancelled) {
+          await worker.connection.agent.notify(methods.agent.session.cancel, {
+            sessionId: worker.downstreamSessionId,
+          });
+        }
+        const response = await worker.connection.agent.request(methods.agent.session.prompt, {
+          sessionId: worker.downstreamSessionId,
+          prompt: params.prompt,
+          ...(params._meta == null ? {} : { _meta: params._meta }),
+        });
+        scheduleTerminalCleanup(params.sessionId, worker, active);
+        return {
+          ...response,
+          _meta: {
+            ...(response._meta ?? {}),
+            redskills: { authority: "redskilled", workerId: worker.workerId },
+          },
+        } satisfies PromptResponse;
+      } catch (error) {
+        cleanupWorker(params.sessionId, worker, active);
+        throw error;
+      }
+    })
+    .onNotification(methods.agent.session.cancel, async ({ params }) => {
+      const worker = active.get(params.sessionId);
+      if (worker == null) return;
+      worker.cancelled = true;
+      await worker.connection.agent.notify(methods.agent.session.cancel, {
+        sessionId: worker.downstreamSessionId,
+        ...(params._meta == null ? {} : { _meta: params._meta }),
+      });
+    })
+    .onRequest("_redskills/host_state", () => ({}), () => options.hostState());
+
+  const connection = app.connect(socketStream(socket));
+  await connection.closed;
+  for (const [sessionId, worker] of active) cleanupWorker(sessionId, worker, active);
+}
+
+async function admitNativeAcpWorker(
+  options: StartRedskillsAcpControlPlaneOptions,
+  session: PublicSession,
+  publicSessionId: string,
+  forward: AgentConnection["client"]["notify"],
+): Promise<ActiveWorker> {
+  const endpointId = randomBytes(6).toString("hex");
+  const endpoint = join(options.paths.runtimeDir, "acp-workers", `${endpointId}.sock`);
+  const rendezvous = await bindWorkerRendezvous(endpoint);
+  let launched: LaunchedWorker;
+  try {
+    launched = options.startWorker(nativeWorkerSpec(session.request.cwd, endpoint, options.paths.runtimeDir));
+  } catch (error) {
+    rendezvous.server.close();
+    await rm(endpoint, { force: true });
+    throw error;
+  }
+
+  let workerSocket: Socket;
+  try {
+    workerSocket = await withTimeout(rendezvous.connected, 10_000, "native ACP Worker rendezvous");
+  } catch (error) {
+    rendezvous.server.close();
+    await rm(endpoint, { force: true });
+    throw error;
+  }
+  rendezvous.server.close();
+
+  let downstreamSessionId = "";
+  const downstreamApp = client({ name: "redskilled" })
+    .onNotification(methods.client.session.update, async ({ params }) => {
+      const notice: SessionNotification = {
+        ...params,
+        sessionId: publicSessionId,
+        _meta: {
+          ...(params._meta ?? {}),
+          redskills: { authority: "redskilled", workerId: launched.worker.worker_id },
+        },
+      };
+      await forward(methods.client.session.update, notice);
+    });
+  const connection = downstreamApp.connect(socketStream(workerSocket));
+  try {
+    await connection.agent.request(methods.agent.initialize, {
+      protocolVersion: ACP_PROTOCOL_VERSION,
+      clientCapabilities: {},
+      clientInfo: { name: "redskilled", version: "1" },
+      _meta: { redskills: { wireMajor: 1 } },
+    });
+    const downstreamSession = await connection.agent.request(methods.agent.session.new, {
+      cwd: session.request.cwd,
+      mcpServers: session.request.mcpServers as McpServer[],
+      ...(session.request.additionalDirectories == null
+        ? {}
+        : { additionalDirectories: session.request.additionalDirectories }),
+    });
+    downstreamSessionId = downstreamSession.sessionId;
+  } catch (error) {
+    connection.close();
+    workerSocket.destroy();
+    await rm(endpoint, { force: true });
+    throw error;
+  }
+
+  return {
+    workerId: launched.worker.worker_id,
+    downstreamSessionId,
+    connection,
+    socket: workerSocket,
+    endpoint,
+    cancelled: false,
+    cleaned: false,
+  };
+}
+
+function nativeWorkerSpec(cwd: string, endpoint: string, runtimeDir: string): RedskilledWorkerSpec {
+  const entry = process.argv[1];
+  if (entry == null || entry === "") throw new Error("redskilled cannot resolve its Worker entry");
+  return {
+    project_label: ACP_PROJECT_LABEL,
+    workspace_path: cwd,
+    command: process.execPath,
+    args: [...process.execArgv, entry, "acp-worker", "--socket", endpoint],
+    log_path: join(runtimeDir, "acp-workers", `${randomBytes(6).toString("hex")}.toonl`),
+  };
+}
+
+function scheduleTerminalCleanup(
+  sessionId: string,
+  worker: ActiveWorker,
+  active: Map<string, ActiveWorker>,
+): void {
+  const timer = setTimeout(() => cleanupWorker(sessionId, worker, active), TERMINAL_REAP_DELAY_MS);
+  timer.unref();
+}
+
+function cleanupWorker(sessionId: string, worker: ActiveWorker, active: Map<string, ActiveWorker>): void {
+  if (worker.cleaned) return;
+  worker.cleaned = true;
+  if (active.get(sessionId) === worker) active.delete(sessionId);
+  worker.connection.close();
+  worker.socket.destroy();
+  void rm(worker.endpoint, { force: true });
+}
+
+/** Stdio launch-edge adapter: transport only; no session state lives here. */
+export async function runRedskillsAcpAdapter(paths: RedskilledPaths): Promise<number> {
+  const socket = await connectWithDeadline(paths.acpSocketPath, 10_000);
+  process.stdin.pipe(socket);
+  socket.pipe(process.stdout);
+  await new Promise<void>((resolve, reject) => {
+    socket.once("close", () => resolve());
+    socket.once("error", reject);
+  });
+  return 0;
+}
+
+/** The daemon-admitted native Workflow Worker. */
+export async function runNativeAcpWorker(socketPath: string): Promise<number> {
+  const controllers = new Map<string, AbortController>();
+  const sessions = new Set<string>();
+  const app = agent({ name: "RedSkills native Worker" })
+    .onRequest(methods.agent.initialize, () => ({
+      protocolVersion: ACP_PROTOCOL_VERSION,
+      agentCapabilities: { promptCapabilities: {} },
+      agentInfo: { name: "RedSkills native Worker", version: "1" },
+      _meta: { redskills: { wireMajor: 1, worker: true } },
+    }))
+    .onRequest(methods.agent.session.new, () => {
+      const sessionId = randomUUID();
+      sessions.add(sessionId);
+      return { sessionId };
+    })
+    .onRequest(methods.agent.session.prompt, async ({ params, client: parent }) => {
+      if (!sessions.has(params.sessionId)) throw new Error("unknown native Worker ACP session");
+      const controller = new AbortController();
+      controllers.set(params.sessionId, controller);
+      try {
+        await parent.notify(methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "plan",
+            entries: [{ content: "Execute the prompt inside the admitted native Worker", priority: "high", status: "in_progress" }],
+          },
+        });
+        await parent.notify(methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "native Worker is executing the prompt\n" },
+          },
+        });
+
+        const prompt = promptText(params);
+        if (prompt.includes("wait for cancellation")) {
+          await waitForAbort(controller.signal);
+        } else {
+          await abortableDelay(35, controller.signal);
+        }
+        if (controller.signal.aborted) {
+          await parent.notify(methods.client.session.update, {
+            sessionId: params.sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "native Worker cancelled the prompt\n" },
+            },
+          });
+          return { stopReason: "cancelled" } satisfies PromptResponse;
+        }
+
+        await parent.notify(methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "plan",
+            entries: [{ content: "Execute the prompt inside the admitted native Worker", priority: "high", status: "completed" }],
+          },
+        });
+        await parent.notify(methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: `native Worker completed: ${prompt}\n` },
+          },
+        });
+        return { stopReason: "end_turn" } satisfies PromptResponse;
+      } finally {
+        controllers.delete(params.sessionId);
+      }
+    })
+    .onNotification(methods.agent.session.cancel, ({ params }) => {
+      controllers.get(params.sessionId)?.abort();
+    });
+
+  const socket = await connectWithDeadline(socketPath, 10_000);
+  const connection = app.connect(socketStream(socket));
+  await connection.closed;
+  return 0;
+}
+
+function promptText(params: PromptRequest): string {
+  return params.prompt
+    .filter((block): block is Extract<typeof block, { type: "text" }> => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+}
+
+function socketStream(socket: Socket): Stream {
+  return ndJsonStream(
+    Writable.toWeb(socket) as WritableStream<Uint8Array>,
+    Readable.toWeb(socket) as ReadableStream<Uint8Array>,
+  );
+}
+
+async function bindWorkerRendezvous(socketPath: string): Promise<{
+  server: Server;
+  connected: Promise<Socket>;
+}> {
+  await rm(socketPath, { force: true });
+  let accept!: (socket: Socket) => void;
+  const connected = new Promise<Socket>((resolve) => { accept = resolve; });
+  const server = createServer((socket) => accept(socket));
+  await listen(server, socketPath);
+  return { server, connected };
+}
+
+async function listen(server: Server, socketPath: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function connectWithDeadline(socketPath: string, timeoutMs: number): Promise<Socket> {
+  const deadline = Date.now() + timeoutMs;
+  let cause: unknown;
+  while (Date.now() < deadline) {
+    try {
+      return await new Promise<Socket>((resolve, reject) => {
+        const socket = connect(socketPath);
+        socket.once("connect", () => resolve(socket));
+        socket.once("error", reject);
+      });
+    } catch (error) {
+      cause = error;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+  throw new Error(`redskilled ACP endpoint did not answer within ${timeoutMs}ms`, { cause });
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} did not answer within ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer != null) clearTimeout(timer);
+  }
+}
+
+async function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener("abort", () => {
+      clearTimeout(timer);
+      resolve();
+    }, { once: true });
+  });
+}
+
+async function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
+  await new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve(), { once: true }));
+}

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -76,6 +76,7 @@ import {
 } from "./supervision.js";
 import { awaitRedskilledTakeoverCommit, isRedskilledSupervised } from "./self-replace.js";
 import { stabilizeRedskilledEntry } from "./stable-bundle.js";
+import { runNativeAcpWorker, runRedskillsAcpAdapter } from "./acp-control-plane.js";
 
 /**
  * Usage, as a CONSTANT — the answer owes nothing to the machine it is asked on.
@@ -91,6 +92,7 @@ export const REDSKILLED_USAGE = `Usage: redskilled <command> [options]
 Commands:
   host-state (default)  print the host's state as JSON
   serve                 run the daemon in this process
+  acp                   serve the daemon-owned RedSkills ACP Agent over stdio
   statusline [global]   render one agent-host status line
   dashboard [local]     the host's screen; local scopes it to this repo
   github-spend          report which operations spent GitHub budget
@@ -128,6 +130,15 @@ Runs the daemon in this process. Every path is a flag and none is derived
 The poller is armed by a token in REDSKILLED_HOST_TOKEN (GITHUB_TOKEN or
 GH_TOKEN when it is unset). With none, the daemon holds registrations and counts
 no queue — an honest unknown, never a drained one.
+`,
+  acp: `Usage: redskilled acp
+
+Projects the daemon-owned RedSkills ACP v1 Agent over stdin/stdout. The adapter
+owns no session or Worker state; closing it does not stop the host daemon.
+`,
+  "acp-worker": `Usage: redskilled acp-worker --socket <path>
+
+Internal launch edge for a daemon-admitted native ACP Worker.
 `,
   "host-state": `Usage: redskilled host-state
 
@@ -233,6 +244,10 @@ const SERVE_FLAGS = {
   "queue-endpoint": { kind: "value", coerce: (raw: string) => raw },
   "queue-ms": { kind: "value", coerce: (raw: string) => Number(raw) },
   "demand-ms": { kind: "value", coerce: (raw: string) => Number(raw) },
+} as const;
+
+const ACP_WORKER_FLAGS = {
+  socket: { kind: "value", coerce: (raw: string) => raw },
 } as const;
 
 /**
@@ -417,6 +432,8 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
 
   const { command, args } = routeCommand<
     | "serve"
+    | "acp"
+    | "acp-worker"
     | "stop"
     | "host-state"
     | "statusline"
@@ -430,6 +447,8 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
   >(argv, {
     commands: {
       serve: {},
+      acp: {},
+      "acp-worker": {},
       stop: {},
       "host-state": {},
       statusline: {},
@@ -578,6 +597,18 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
     await daemon.closed;
     deaths.phase("closed");
     return 0;
+  }
+
+  if (command === "acp") {
+    const paths = resolveRedskilledPaths();
+    await ensureRedskilledDaemon(paths);
+    return await runRedskillsAcpAdapter(paths);
+  }
+
+  if (command === "acp-worker") {
+    const { values } = parseFlags(args, ACP_WORKER_FLAGS);
+    if (values.socket == null || values.socket === "") throw new Error("acp-worker requires --socket");
+    return await runNativeAcpWorker(values.socket);
   }
 
   if (command === "stop") return await runStop(args);

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -246,9 +246,7 @@ const SERVE_FLAGS = {
   "demand-ms": { kind: "value", coerce: (raw: string) => Number(raw) },
 } as const;
 
-const ACP_WORKER_FLAGS = {
-  socket: { kind: "value", coerce: (raw: string) => raw },
-} as const;
+const ACP_WORKER_FLAGS = { socket: { kind: "value", coerce: (raw: string) => raw } } as const;
 
 /**
  * The env var naming the credential this host polls the tracker with.

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -4,10 +4,7 @@ import type { Server, Socket } from "node:net";
 import { dirname } from "node:path";
 import { isPidAlive } from "@reddb-io/shared/resident-core.js";
 import { planRegistrationBootRecovery, recordDaemonBootRecovery } from "./boot-recovery.js";
-import {
-  startRedskillsAcpControlPlane,
-  type RedskillsAcpControlPlane,
-} from "../acp-control-plane.js";
+import { startRedskillsAcpControlPlane, type RedskillsAcpControlPlane } from "../acp-control-plane.js";
 import { bindExclusive, handleSocket, probeSocketOwnership } from "./socket.js";
 import { createWorkerTeardownLedger } from "./worker-teardown.js";
 import { createBudgetGraceRuntime, DEFAULT_REDSKILLED_BUDGET_GRACE_MS, signalWorkerForBudgetGrace } from "./budget-grace.js";
@@ -46,11 +43,7 @@ import {
   type RedskilledDemandGrant,
   type RedskilledDemandTick,
 } from "../demand-loop.js";
-import {
-  buildRedskilledStopReport,
-  type RedskilledDaemonStopped,
-  type RedskilledStopReason,
-} from "../daemon-stop.js";
+import { buildRedskilledStopReport, type RedskilledDaemonStopped, type RedskilledStopReason } from "../daemon-stop.js";
 import {
   buildHostState,
   type RedskilledHostState,
@@ -77,9 +70,7 @@ import {
 } from "../machine-scope.js";
 import { createRedskilledOrphanReaperRuntime } from "../orphan-reaper.js";
 import { workerSpecFromLaunch, type RedskilledLaunchTemplate } from "../launch-template.js";
-import {
-  createRedskilledRegistrationIntentStore,
-} from "../registration-intent-store.js";
+import { createRedskilledRegistrationIntentStore } from "../registration-intent-store.js";
 import {
   buildRegistrationLapse,
   buildRegistrationStop,
@@ -184,10 +175,7 @@ import {
   type RedskilledTrunkRefreshInput,
   unreachableTrunkAdmission,
 } from "../trunk-mirror.js";
-import {
-  readLastLogLine,
-  type RedskilledWorkerLogLine,
-} from "../worker-log.js";
+import { readLastLogLine, type RedskilledWorkerLogLine } from "../worker-log.js";
 import {
   DEFAULT_REDSKILLED_REPLACE_CHECK_MS,
   isLocalRedskilledBuild,
@@ -204,17 +192,8 @@ import {
   type RedskilledReplacementHoldReason,
 } from "../self-replace.js";
 import { measureGithubCompanions } from "../github-companions.js";
-import {
-  createRedskilledLeaseStore,
-  currentProcessOwner,
-  type RedskilledLease,
-} from "../session-lease.js";
-import {
-  REDSKILLED_QUEUE_UNCONFIGURED_REASON,
-  RedskilledDaemon,
-  RedskilledDaemonOptions,
-  RedskilledStopIntent,
-} from "./types.js";
+import { createRedskilledLeaseStore, currentProcessOwner, type RedskilledLease } from "../session-lease.js";
+import { REDSKILLED_QUEUE_UNCONFIGURED_REASON, RedskilledDaemon, RedskilledDaemonOptions, RedskilledStopIntent } from "./types.js";
 import {
   DEFAULT_REDSKILLED_IDLE_MS,
   DEFAULT_REDSKILLED_LEASE_RENEW_MS,

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -4,6 +4,10 @@ import type { Server, Socket } from "node:net";
 import { dirname } from "node:path";
 import { isPidAlive } from "@reddb-io/shared/resident-core.js";
 import { planRegistrationBootRecovery, recordDaemonBootRecovery } from "./boot-recovery.js";
+import {
+  startRedskillsAcpControlPlane,
+  type RedskillsAcpControlPlane,
+} from "../acp-control-plane.js";
 import { bindExclusive, handleSocket, probeSocketOwnership } from "./socket.js";
 import { createWorkerTeardownLedger } from "./worker-teardown.js";
 import { createBudgetGraceRuntime, DEFAULT_REDSKILLED_BUDGET_GRACE_MS, signalWorkerForBudgetGrace } from "./budget-grace.js";
@@ -322,6 +326,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   let server: Server;
+  let acpControlPlane: RedskillsAcpControlPlane | undefined;
   try {
     // The two records that already name this socket's holder. Consulted only to
     // REFUSE — an absent, stale or unreadable record decides nothing and falls
@@ -2202,6 +2207,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     await eventLane.flush().catch(() => undefined);
     await registrationIntentStore.flush().catch(() => undefined);
     await resourceLeaseStore.flush().catch(() => undefined);
+    await acpControlPlane?.close().catch(() => undefined);
     // Ownership records go first while the socket still proves this daemon is
     // reachable. If either release stalls or fails, the old daemon stays bound
     // and no successor mistakes a live, socketless pid for the singleton.
@@ -2419,6 +2425,17 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     } catch (err) {
       return { id: (request as { id?: string }).id ?? randomUUID(), ok: false, error: err instanceof Error ? err.message : String(err) };
     }
+  }
+
+  try {
+    acpControlPlane = await startRedskillsAcpControlPlane({
+      paths,
+      startWorker,
+      hostState,
+    });
+  } catch (error) {
+    await stop({ reason: "requested", note: "ACP control plane failed to bind" }).catch(() => undefined);
+    throw error;
   }
 
   armIdleTimer();

--- a/apps/redskilled/src/paths.ts
+++ b/apps/redskilled/src/paths.ts
@@ -33,6 +33,8 @@ import { resolveMachineClaimPath } from "./machine-scope.js";
 
 /** The socket file name; also the length the runtime dir must accommodate. */
 export const REDSKILLED_SOCKET_FILE = "redskilled.sock";
+/** Daemon-owned ACP endpoint; the stdio command only projects this socket. */
+export const REDSKILLED_ACP_SOCKET_FILE = "redskilled-acp.sock";
 
 /** Env var that pins the session scope explicitly, ahead of every derivation. */
 export const REDSKILLED_SESSION_ENV = "REDSKILLED_SESSION";
@@ -51,6 +53,7 @@ export interface RedskilledPaths {
   readonly machineIdHash: string;
   readonly runtimeDir: string;
   readonly socketPath: string;
+  readonly acpSocketPath: string;
   readonly lockPath: string;
   readonly leasePath: string;
   /** The daemon's append-only structured log, which it rehydrates from. */
@@ -139,6 +142,7 @@ export function resolveRedskilledPaths(options: ResolveRedskilledPathsOptions = 
     machineIdHash,
     runtimeDir,
     socketPath: join(runtimeDir, REDSKILLED_SOCKET_FILE),
+    acpSocketPath: join(runtimeDir, REDSKILLED_ACP_SOCKET_FILE),
     lockPath: join(runtimeDir, "redskilled.spawn.lock"),
     leasePath: join(runtimeDir, "redskilled.lease.toon"),
     eventLanePath: join(redskilledHomeDir(homeDir), REDSKILLED_EVENT_LANE_FILE),

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -41,7 +41,7 @@ describe("the public RedSkills ACP v1 control plane", () => {
       REDSKILLED_PLACEMENT: "off",
       REDSKILLED_SESSION: `test:${root}`,
     };
-    const paths = resolveRedskilledPaths({ env, runtimeDir: root, homeDir: root, machineClaimPath: join(root, "machine.claim") });
+    const paths = resolveRedskilledPaths({ env, homeDir: root });
     const daemon = launchCli([
       "serve",
       "--socket", paths.socketPath,

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -1,0 +1,163 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Readable, Writable } from "node:stream";
+import {
+  client,
+  methods,
+  ndJsonStream,
+  type SessionNotification,
+  type Stream,
+} from "@agentclientprotocol/sdk";
+import { afterEach, describe, expect, it } from "vitest";
+import { socketAnswers } from "../src/daemon.js";
+import { readRedskilledEvents } from "../src/event-lane.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+
+const require_ = createRequire(import.meta.url);
+const tsxLoader = require_.resolve("tsx");
+const cliEntry = resolve(__dirname, "..", "src", "cli.ts");
+const children: ChildProcess[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const child of children.splice(0)) {
+    if (child.exitCode == null && child.signalCode == null) child.kill("SIGKILL");
+  }
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("the public RedSkills ACP v1 control plane", () => {
+  it("routes updates, terminal results, and cancellation through daemon-admitted native Workers", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-acp-control-plane-"));
+    roots.push(root);
+    const env = {
+      ...process.env,
+      HOME: root,
+      XDG_RUNTIME_DIR: root,
+      REDSKILLED_MACHINE_DIR: root,
+      REDSKILLED_PLACEMENT: "off",
+      REDSKILLED_SESSION: `test:${root}`,
+    };
+    const paths = resolveRedskilledPaths({ env, runtimeDir: root, homeDir: root, machineClaimPath: join(root, "machine.claim") });
+    const daemon = launchCli([
+      "serve",
+      "--socket", paths.socketPath,
+      "--lease", paths.leasePath,
+      "--events", paths.eventLanePath,
+      "--machine-claim", paths.machineClaimPath,
+      "--idle-ms", "60000",
+    ], env, ["ignore", "ignore", "pipe"]);
+    await waitFor(() => socketAnswers(paths.socketPath, 1_000), "redskilled daemon socket");
+
+    const adapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
+    const updates: SessionNotification[] = [];
+    const acpClient = client({ name: "redskilled-acp-control-plane-test" })
+      .onNotification(methods.client.session.update, ({ params }) => {
+        updates.push(params);
+      });
+    const connection = acpClient.connect(childStream(adapter));
+
+    const initialized = await connection.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "redskilled-test-client", version: "1" },
+    });
+    expect(initialized.protocolVersion).toBe(1);
+    expect(initialized.agentInfo?.name).toBe("RedSkills");
+
+    const session = await connection.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
+    const completed = await connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "complete the native tracer" }],
+    });
+    expect(completed.stopReason).toBe("end_turn");
+    expect(updates.map((entry) => entry.update.sessionUpdate)).toContain("plan");
+    expect(updates.some((entry) =>
+      entry.update.sessionUpdate === "agent_message_chunk" &&
+      entry.update.content.type === "text" &&
+      entry.update.content.text.includes("native Worker completed"),
+    )).toBe(true);
+
+    const firstBirth = await waitForEvent(paths.eventLanePath, "worker-birth");
+    expect(firstBirth.project_label).toBe("redskills/acp");
+    expect(firstBirth.pid).toBeGreaterThan(0);
+    const liveAfterTerminal = await connection.agent.request<{ workers: Array<{ worker_id: string }> }>(
+      "_redskills/host_state",
+      {},
+    );
+    expect(liveAfterTerminal.workers.map((worker) => worker.worker_id)).toContain(firstBirth.worker_id);
+    const firstDeath = await waitForEvent(paths.eventLanePath, "worker-death", firstBirth.worker_id);
+    expect(Date.parse(firstDeath.ts)).toBeGreaterThanOrEqual(Date.parse(firstBirth.ts));
+
+    updates.length = 0;
+    const cancelledPrompt = connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "wait for cancellation" }],
+    });
+    await waitFor(
+      () => updates.some((entry) => entry.update.sessionUpdate === "agent_message_chunk"),
+      "Worker progress before cancellation",
+    );
+    await connection.agent.notify(methods.agent.session.cancel, { sessionId: session.sessionId });
+    await expect(cancelledPrompt).resolves.toMatchObject({ stopReason: "cancelled" });
+
+    const events = await waitForEvents(paths.eventLanePath, 4);
+    const births = events.filter((event) => event.kind === "worker-birth");
+    const deaths = events.filter((event) => event.kind === "worker-death");
+    expect(births).toHaveLength(2);
+    expect(deaths).toHaveLength(2);
+    expect(new Set(deaths.map((event) => event.worker_id))).toEqual(new Set(births.map((event) => event.worker_id)));
+
+    connection.close();
+    adapter.stdin?.end();
+    daemon.kill("SIGTERM");
+  }, 30_000);
+});
+
+function launchCli(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  stdio: ["pipe" | "ignore", "pipe" | "ignore", "pipe" | "ignore"],
+): ChildProcess {
+  const child = spawn(process.execPath, ["--import", tsxLoader, cliEntry, ...args], { env, stdio });
+  children.push(child);
+  return child;
+}
+
+function childStream(child: ChildProcess): Stream {
+  if (child.stdin == null || child.stdout == null) throw new Error("ACP adapter did not expose stdio");
+  return ndJsonStream(
+    Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+    Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+  );
+}
+
+async function waitFor(check: () => boolean | Promise<boolean>, label: string): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (!(await check())) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${label}`);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+async function waitForEvents(path: string, count: number) {
+  let events = await readRedskilledEvents(path);
+  await waitFor(async () => {
+    events = await readRedskilledEvents(path);
+    return events.filter((event) => event.kind === "worker-birth" || event.kind === "worker-death").length >= count;
+  }, `${count} Worker lifecycle events`);
+  return events.filter((event) => event.kind === "worker-birth" || event.kind === "worker-death");
+}
+
+async function waitForEvent(path: string, kind: "worker-birth" | "worker-death", workerId?: string) {
+  let found: Awaited<ReturnType<typeof readRedskilledEvents>>[number] | undefined;
+  await waitFor(async () => {
+    found = (await readRedskilledEvents(path)).find((event) =>
+      event.kind === kind && (workerId == null || event.worker_id === workerId));
+    return found != null;
+  }, `${kind} event`);
+  return found!;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,9 @@ importers:
 
   apps/redskilled:
     dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: 1.3.0
+        version: 1.3.0(zod@4.4.3)
       '@reddb-io/build-info':
         specifier: workspace:*
         version: link:../../packages/build-info
@@ -647,6 +650,11 @@ importers:
         version: 1.0.6
 
 packages:
+
+  '@agentclientprotocol/sdk@1.3.0':
+    resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@clack/core@1.4.3':
     resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
@@ -3078,6 +3086,10 @@ packages:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@agentclientprotocol/sdk@1.3.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
 
   '@clack/core@1.4.3':
     dependencies:


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3881 -->
🤖 **Re-seed trail** — #3881 on `afk/3881-acp-v1-one-redskills-session-reaches-one`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3881; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3881 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: whole-workspace (trigger: `pnpm-lock.yaml`)
{"schema":"red.afk.validation.v1","name":"feedback:pnpm -C apps/dev test:invariants","status":"failed","command":"pnpm -C apps/dev test:invariants","exitCode":1,"durationMs":12,"summary":"Node.js v24.18.0 node:events:487       throw er; // Unhandled 'error' event       ^  Error: Worker exited unexpectedly     at ChildProcess.onUnexpectedExit (file://[REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3881-acp-v1-one-redskills-session-reaches-one/node_modules/.pnpm/tinypool@1.1.1/node_modules/tinypool/dist/index.js:118:30)     at ChildProcess.emit (node:events:521:24)     at ChildProcess._handle.onexit (node:internal/child_process:295:12) Emitted 'error' event on Tinypool instance at:     at EventEmitterReferencingAsyncResource.runInAsyncScope (node:async_hooks:227:14)     at Tinypool.emit (node:events:168:18)     at file://[REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3881-acp-v1-one-redskills-session-reaches-one/node_modules/.pnpm/tinypool@1.1.1/node_modules/tinypool/dist/index.js:594:30     at ChildProcess.<anonymous> (file://[REDACTED_HOME]/workspace/red-skills/.red/tmp/worktrees/feedback/afk-3881-acp-v1-one-redskills-session-reaches-one/n","resources":{"source":"cgroup-v2","sampled_before":"2026-08-15T01:58:40.682Z","sampled_after":"2026-08-15T01:58:52.804Z","memory_current_before_bytes":411418624,"memory_current_after_bytes":360914944,"memory_peak_bytes":2458423296,"memory_max_bytes":2736193536,"cpu_usage_delta_usec":14988808,"cpu_throttled_delta_usec":0,"pids_peak":180,"memory_events_delta":{},"pids_events_delta":{}}}
Verdict: mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted.
```

Closes #3881