### PR TITLE
fix: #3882 ACP v2 runs the shared RedSkills session corpus

### DIFF
--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -38,6 +38,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "NODE_OPTIONS=--max-old-space-size=4096 vitest run",
+    "test:acp-conformance": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-conformance.test.ts",
     "test:acp-control-plane": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-control-plane.test.ts",
     "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/redskilled.bundle.min.mjs --asset redskilled.bundle.min.mjs --minify",
     "build": "pnpm run typecheck && pnpm run bundle",

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -1,5 +1,5 @@
 /**
- * ACP v1 control plane — redskilled is the public Agent and the Client of each Worker.
+ * ACP v1/v2 control plane — redskilled is the public Agent and the Client of each Worker.
  *
  * The public stdio command is only a transport projection onto the daemon-owned
  * socket. Sessions, admission, Worker rendezvous, cancellation, and terminal
@@ -25,11 +25,13 @@ import {
   type SessionNotification,
   type Stream,
 } from "@agentclientprotocol/sdk";
+import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import type { RedskilledHostState } from "./host-state.js";
 import type { RedskilledPaths } from "./paths.js";
 import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
 
 const ACP_PROTOCOL_VERSION = 1;
+export const ACP_V2_DRAFT_REVISION = "schema-v2.0.0-alpha.2";
 const ACP_PROJECT_LABEL = "redskills/acp";
 const TERMINAL_REAP_DELAY_MS = 150;
 
@@ -94,7 +96,7 @@ async function servePublicConnection(
   const sessions = new Map<string, PublicSession>();
   const active = new Map<string, ActiveWorker>();
 
-  const app = agent({ name: "RedSkills" })
+  const v1App = agent({ name: "RedSkills" })
     .onRequest(methods.agent.initialize, ({ params }) => ({
       protocolVersion: params.protocolVersion === ACP_PROTOCOL_VERSION
         ? params.protocolVersion
@@ -153,9 +155,170 @@ async function servePublicConnection(
     })
     .onRequest("_redskills/host_state", () => ({}), () => options.hostState());
 
-  const connection = app.connect(socketStream(socket));
+  const v2Turns = new Map<string, Promise<void>>();
+  const v2App = acpV2.agent({ name: "RedSkills" })
+    .onRequest(acpV2.methods.agent.initialize, ({ params }) => {
+      requireSupportedV2Revision(params._meta);
+      return {
+        protocolVersion: acpV2.PROTOCOL_VERSION,
+        info: { name: "RedSkills", version: "1" },
+        capabilities: { session: {} },
+        _meta: {
+          redskills: {
+            wireMajor: 1,
+            workerBacked: true,
+            acpDraftRevision: ACP_V2_DRAFT_REVISION,
+          },
+        },
+      };
+    })
+    .onRequest(acpV2.methods.agent.session.new, ({ params }) => {
+      const sessionId = randomUUID();
+      sessions.set(sessionId, {
+        request: {
+          cwd: params.cwd,
+          mcpServers: (params.mcpServers ?? []) as unknown as McpServer[],
+          ...(params.additionalDirectories == null
+            ? {}
+            : { additionalDirectories: params.additionalDirectories }),
+        },
+      });
+      return {
+        sessionId,
+        _meta: {
+          redskills: {
+            authority: "redskilled",
+            protocolVersion: acpV2.PROTOCOL_VERSION,
+            acpDraftRevision: ACP_V2_DRAFT_REVISION,
+          },
+        },
+      };
+    })
+    .onRequest(acpV2.methods.agent.session.prompt, ({ params, client: upstream }) => {
+      if (!sessions.has(params.sessionId)) throw acpV2.RequestError.invalidParams("unknown RedSkills ACP session");
+      if (active.has(params.sessionId) || v2Turns.has(params.sessionId)) {
+        throw acpV2.RequestError.invalidRequest("this RedSkills ACP session already has an active turn");
+      }
+
+      const accepted = new Promise<void>((resolve) => setTimeout(resolve, 0));
+      const turn = accepted
+        .then(() => runV2PublicTurn(options, sessions, active, params, upstream))
+        .catch(() => {})
+        .finally(() => v2Turns.delete(params.sessionId));
+      v2Turns.set(params.sessionId, turn);
+      return {};
+    })
+    .onNotification(acpV2.methods.agent.session.cancel, async ({ params }) => {
+      const worker = active.get(params.sessionId);
+      if (worker == null) return;
+      worker.cancelled = true;
+      await worker.connection.agent.notify(methods.agent.session.cancel, {
+        sessionId: worker.downstreamSessionId,
+        ...(params._meta == null ? {} : { _meta: params._meta }),
+      });
+    })
+    .onRequest("_redskills/host_state", () => ({}), () => options.hostState());
+
+  const connection = acpV2.agentProtocolRouter()
+    .withV1(v1App)
+    .withV2(v2App)
+    .connect(socketStream(socket) as unknown as acpV2.Stream);
   await connection.closed;
   for (const [sessionId, worker] of active) cleanupWorker(sessionId, worker, active);
+}
+
+function requireSupportedV2Revision(meta: acpV2.InitializeRequest["_meta"]): void {
+  const redskills = record(meta?.redskills);
+  const revision = redskills?.acpDraftRevision;
+  if (revision !== ACP_V2_DRAFT_REVISION) {
+    const received = typeof revision === "string" ? revision : "omitted";
+    throw acpV2.RequestError.invalidParams(
+      { redskills: { receivedRevision: received, supportedRevision: ACP_V2_DRAFT_REVISION } },
+      `unsupported ACP v2 draft revision ${received}; expected ${ACP_V2_DRAFT_REVISION}`,
+    );
+  }
+}
+
+async function runV2PublicTurn(
+  options: StartRedskillsAcpControlPlaneOptions,
+  sessions: Map<string, PublicSession>,
+  active: Map<string, ActiveWorker>,
+  params: acpV2.PromptRequest,
+  upstream: acpV2.AgentContext,
+): Promise<void> {
+  const session = sessions.get(params.sessionId);
+  if (session == null) return;
+  const messageId = randomUUID();
+  await upstream.notify(acpV2.methods.client.session.update, {
+    sessionId: params.sessionId,
+    update: { sessionUpdate: "state_update", state: "running" },
+  });
+
+  let worker: ActiveWorker | undefined;
+  try {
+    worker = await admitNativeAcpWorker(options, session, params.sessionId, async (
+      _method: typeof methods.client.session.update,
+      notice: SessionNotification,
+    ) => {
+      const update = translateV1UpdateToV2(notice.update, messageId);
+      if (update == null) return;
+      await upstream.notify(acpV2.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update,
+        _meta: notice._meta,
+      });
+    });
+    active.set(params.sessionId, worker);
+    const response = await worker.connection.agent.request(methods.agent.session.prompt, {
+      sessionId: worker.downstreamSessionId,
+      prompt: params.prompt as unknown as PromptRequest["prompt"],
+      ...(params._meta == null ? {} : { _meta: params._meta }),
+    });
+    scheduleTerminalCleanup(params.sessionId, worker, active);
+    await upstream.notify(acpV2.methods.client.session.update, {
+      sessionId: params.sessionId,
+      update: { sessionUpdate: "state_update", state: "idle", stopReason: response.stopReason },
+      _meta: { redskills: { authority: "redskilled", workerId: worker.workerId } },
+    });
+  } catch (error) {
+    if (worker != null) cleanupWorker(params.sessionId, worker, active);
+    await upstream.notify(acpV2.methods.client.session.update, {
+      sessionId: params.sessionId,
+      update: { sessionUpdate: "state_update", state: "idle", stopReason: "refusal" },
+      _meta: {
+        redskills: {
+          authority: "redskilled",
+          detail: error instanceof Error ? error.message : String(error),
+        },
+      },
+    });
+  }
+}
+
+function translateV1UpdateToV2(
+  update: SessionNotification["update"],
+  messageId: string,
+): acpV2.SessionUpdate | undefined {
+  if (update.sessionUpdate === "plan") {
+    return {
+      sessionUpdate: "plan_update",
+      plan: { type: "items", planId: "primary", entries: update.entries },
+    };
+  }
+  if (update.sessionUpdate === "agent_message_chunk") {
+    return {
+      sessionUpdate: "agent_message_chunk",
+      messageId,
+      content: update.content as acpV2.ContentBlock,
+    };
+  }
+  return undefined;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
 }
 
 async function admitNativeAcpWorker(

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -133,7 +133,7 @@ no queue — an honest unknown, never a drained one.
 `,
   acp: `Usage: redskilled acp
 
-Projects the daemon-owned RedSkills ACP v1 Agent over stdin/stdout. The adapter
+Projects the RedSkills ACP v1/v2 Agent; v2 requires schema-v2.0.0-alpha.2. The adapter
 owns no session or Worker state; closing it does not stop the host daemon.
 `,
   "acp-worker": `Usage: redskilled acp-worker --socket <path>

--- a/apps/redskilled/tests/acp-conformance.test.ts
+++ b/apps/redskilled/tests/acp-conformance.test.ts
@@ -1,0 +1,347 @@
+import { createHash } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { Readable, Writable } from "node:stream";
+import * as acpV1 from "@agentclientprotocol/sdk";
+import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
+import { afterEach, describe, expect, it } from "vitest";
+import { ACP_V2_DRAFT_REVISION } from "../src/acp-control-plane.js";
+import { readRedskilledHostState } from "../src/client.js";
+import { socketAnswers } from "../src/daemon.js";
+import { readRedskilledEvents } from "../src/event-lane.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+
+const require_ = createRequire(import.meta.url);
+const tsxLoader = require_.resolve("tsx");
+const cliEntry = resolve(__dirname, "..", "src", "cli.ts");
+const children: ChildProcess[] = [];
+const roots: string[] = [];
+
+interface NormalizedUpdate {
+  readonly kind: "plan" | "message" | "terminal";
+  readonly text?: string;
+  readonly stopReason?: string;
+}
+
+interface CorpusClient {
+  readonly updates: NormalizedUpdate[];
+  initialize(): Promise<void>;
+  newSession(cwd: string): Promise<string>;
+  prompt(sessionId: string, text: string): Promise<void>;
+  cancel(sessionId: string): Promise<void>;
+  hostState(): Promise<{ workers: Array<{ worker_id: string }> }>;
+  close(): void;
+}
+
+interface SupportedAdapter {
+  readonly label: string;
+  connect(child: ChildProcess): CorpusClient;
+}
+
+afterEach(async () => {
+  for (const child of children.splice(0)) {
+    if (child.exitCode == null && child.signalCode == null) child.kill("SIGKILL");
+  }
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("the maintained ACP adapters", () => {
+  it.each([
+    { label: "ACP v1", connect: connectV1 },
+    { label: `ACP v2 ${ACP_V2_DRAFT_REVISION}`, connect: connectV2 },
+  ] satisfies SupportedAdapter[])("runs the shared RedSkills session corpus through $label", async (adapter) => {
+    const runtime = await launchDaemon();
+    const stdioAdapter = launchCli(["acp"], runtime.env, ["pipe", "pipe", "pipe"]);
+    const client = adapter.connect(stdioAdapter);
+
+    await client.initialize();
+    const sessionId = await client.newSession(runtime.root);
+    await client.prompt(sessionId, "complete the native tracer");
+
+    expect(client.updates.map((entry) => entry.kind)).toContain("plan");
+    expect(client.updates.some((entry) =>
+      entry.kind === "message" && entry.text?.includes("native Worker completed") === true,
+    )).toBe(true);
+    expect(client.updates.at(-1)).toMatchObject({ kind: "terminal", stopReason: "end_turn" });
+
+    const firstBirth = await waitForEvent(runtime.paths.eventLanePath, "worker-birth");
+    expect(firstBirth.project_label).toBe("redskills/acp");
+    expect(firstBirth.pid).toBeGreaterThan(0);
+    const liveAfterTerminal = await client.hostState();
+    expect(liveAfterTerminal.workers.map((worker) => worker.worker_id)).toContain(firstBirth.worker_id);
+    const firstDeath = await waitForEvent(runtime.paths.eventLanePath, "worker-death", firstBirth.worker_id);
+    expect(Date.parse(firstDeath.ts)).toBeGreaterThanOrEqual(Date.parse(firstBirth.ts));
+
+    client.updates.length = 0;
+    const cancelledPrompt = client.prompt(sessionId, "wait for cancellation");
+    await waitFor(
+      () => client.updates.some((entry) => entry.kind === "message"),
+      "Worker progress before cancellation",
+    );
+    await client.cancel(sessionId);
+    await cancelledPrompt;
+    expect(client.updates.at(-1)).toMatchObject({ kind: "terminal", stopReason: "cancelled" });
+
+    const events = await waitForEvents(runtime.paths.eventLanePath, 4);
+    const births = events.filter((event) => event.kind === "worker-birth");
+    const deaths = events.filter((event) => event.kind === "worker-death");
+    expect(births).toHaveLength(2);
+    expect(deaths).toHaveLength(2);
+    expect(new Set(deaths.map((event) => event.worker_id))).toEqual(new Set(births.map((event) => event.worker_id)));
+
+    client.close();
+    stdioAdapter.stdin?.end();
+    runtime.daemon.kill("SIGTERM");
+  }, 30_000);
+
+  it.each([
+    { label: "omitted", revision: undefined },
+    { label: "unknown", revision: "schema-v2.0.0-alpha.999" },
+  ])("refuses an $label v2 draft revision before creating workflow state", async ({ revision }) => {
+    const runtime = await launchDaemon();
+    const stdioAdapter = launchCli(["acp"], runtime.env, ["pipe", "pipe", "pipe"]);
+    const connection = acpV2.client({ name: "redskilled-v2-negotiation-test" }).connect(childV2Stream(stdioAdapter));
+
+    await expect(connection.agent.request(acpV2.methods.agent.initialize, {
+      protocolVersion: 2,
+      info: { name: "redskilled-test-client", version: "1" },
+      capabilities: {},
+      ...(revision == null ? {} : { _meta: { redskills: { acpDraftRevision: revision } } }),
+    })).rejects.toMatchObject({
+      code: -32602,
+      message: expect.stringMatching(/ACP v2 draft revision/),
+      data: {
+        redskills: {
+          receivedRevision: revision ?? "omitted",
+          supportedRevision: ACP_V2_DRAFT_REVISION,
+        },
+      },
+    });
+
+    expect(await readRedskilledEvents(runtime.paths.eventLanePath)).toEqual([]);
+    const state = await readRedskilledHostState(runtime.paths);
+    expect(state.workers).toEqual([]);
+    expect(state.projects).toEqual([]);
+    expect(state.registrations).toEqual([]);
+    expect((await readdir(runtime.root, { recursive: true })).filter((path) =>
+      /acp.*session|session.*journal/i.test(path),
+    )).toEqual([]);
+
+    connection.close();
+    stdioAdapter.stdin?.end();
+    runtime.daemon.kill("SIGTERM");
+  }, 30_000);
+
+  it("pins the SDK v2 generated schema and types to schema-v2.0.0-alpha.2", async () => {
+    const schemaPath = require_.resolve("@agentclientprotocol/sdk/schema/v2/schema.unstable.json");
+    const sdkRoot = resolve(dirname(schemaPath), "..", "..");
+    const packageJson = JSON.parse(await readFile(join(sdkRoot, "package.json"), "utf8")) as { version?: unknown };
+    const generatedTypes = join(sdkRoot, "dist", "v2", "schema", "types.gen.d.ts");
+
+    expect(packageJson.version).toBe("1.3.0");
+    expect(ACP_V2_DRAFT_REVISION).toBe("schema-v2.0.0-alpha.2");
+    expect({
+      schema: await sha256(schemaPath),
+      generatedTypes: await sha256(generatedTypes),
+    }).toEqual({
+      schema: "e1ef10a309878485fc3be76e64334ba638c6da4517ed585987368f7f8012bc03",
+      generatedTypes: "a02424517cea030423d5a2c8b5740eb29af20721cffe9f0c2959465a7bc9d823",
+    });
+  });
+});
+
+function connectV1(child: ChildProcess): CorpusClient {
+  const updates: NormalizedUpdate[] = [];
+  const app = acpV1.client({ name: "redskilled-acp-v1-conformance" })
+    .onNotification(acpV1.methods.client.session.update, ({ params }) => {
+      if (params.update.sessionUpdate === "plan") updates.push({ kind: "plan" });
+      if (params.update.sessionUpdate === "agent_message_chunk" && params.update.content.type === "text") {
+        updates.push({ kind: "message", text: params.update.content.text });
+      }
+    });
+  const connection = app.connect(childV1Stream(child));
+  return {
+    updates,
+    async initialize() {
+      const response = await connection.agent.request(acpV1.methods.agent.initialize, {
+        protocolVersion: 1,
+        clientCapabilities: {},
+        clientInfo: { name: "redskilled-test-client", version: "1" },
+      });
+      expect(response.protocolVersion).toBe(1);
+      expect(response.agentInfo?.name).toBe("RedSkills");
+    },
+    async newSession(cwd) {
+      return (await connection.agent.request(acpV1.methods.agent.session.new, { cwd, mcpServers: [] })).sessionId;
+    },
+    async prompt(sessionId, text) {
+      const response = await connection.agent.request(acpV1.methods.agent.session.prompt, {
+        sessionId,
+        prompt: [{ type: "text", text }],
+      });
+      updates.push({ kind: "terminal", stopReason: response.stopReason });
+    },
+    async cancel(sessionId) {
+      await connection.agent.notify(acpV1.methods.agent.session.cancel, { sessionId });
+    },
+    hostState() {
+      return connection.agent.request("_redskills/host_state", {});
+    },
+    close() {
+      connection.close();
+    },
+  };
+}
+
+function connectV2(child: ChildProcess): CorpusClient {
+  const updates: NormalizedUpdate[] = [];
+  const app = acpV2.client({ name: "redskilled-acp-v2-conformance" })
+    .onNotification(acpV2.methods.client.session.update, ({ params }) => {
+      const update = params.update;
+      if (update.sessionUpdate === "plan_update") updates.push({ kind: "plan" });
+      if (
+        update.sessionUpdate === "agent_message_chunk" &&
+        update.content != null &&
+        typeof update.content === "object" &&
+        "type" in update.content &&
+        update.content.type === "text" &&
+        "text" in update.content &&
+        typeof update.content.text === "string"
+      ) {
+        updates.push({ kind: "message", text: update.content.text });
+      }
+      if (update.sessionUpdate === "state_update" && update.state === "idle") {
+        updates.push({
+          kind: "terminal",
+          ...(typeof update.stopReason === "string" ? { stopReason: update.stopReason } : {}),
+        });
+      }
+    });
+  const connection = app.connect(childV2Stream(child));
+  return {
+    updates,
+    async initialize() {
+      const response = await connection.agent.request(acpV2.methods.agent.initialize, {
+        protocolVersion: 2,
+        info: { name: "redskilled-test-client", version: "1" },
+        capabilities: {},
+        _meta: { redskills: { acpDraftRevision: ACP_V2_DRAFT_REVISION } },
+      });
+      expect(response.protocolVersion).toBe(2);
+      expect(response.info.name).toBe("RedSkills");
+      expect(response._meta).toMatchObject({ redskills: { acpDraftRevision: ACP_V2_DRAFT_REVISION } });
+    },
+    async newSession(cwd) {
+      return (await connection.agent.request(acpV2.methods.agent.session.new, { cwd, mcpServers: [] })).sessionId;
+    },
+    async prompt(sessionId, text) {
+      const terminalCount = updates.filter((entry) => entry.kind === "terminal").length;
+      await connection.agent.request(acpV2.methods.agent.session.prompt, {
+        sessionId,
+        prompt: [{ type: "text", text }],
+      });
+      await waitFor(
+        () => updates.filter((entry) => entry.kind === "terminal").length > terminalCount,
+        "ACP v2 terminal state",
+      );
+    },
+    async cancel(sessionId) {
+      await connection.agent.notify(acpV2.methods.agent.session.cancel, { sessionId });
+    },
+    hostState() {
+      return connection.agent.request("_redskills/host_state", {});
+    },
+    close() {
+      connection.close();
+    },
+  };
+}
+
+async function launchDaemon(): Promise<{
+  root: string;
+  env: NodeJS.ProcessEnv;
+  paths: RedskilledPaths;
+  daemon: ChildProcess;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-acp-conformance-"));
+  roots.push(root);
+  const env = {
+    ...process.env,
+    HOME: root,
+    XDG_RUNTIME_DIR: root,
+    REDSKILLED_MACHINE_DIR: root,
+    REDSKILLED_PLACEMENT: "off",
+    REDSKILLED_SESSION: `test:${root}`,
+  };
+  const paths = resolveRedskilledPaths({ env, homeDir: root });
+  const daemon = launchCli([
+    "serve",
+    "--socket", paths.socketPath,
+    "--lease", paths.leasePath,
+    "--events", paths.eventLanePath,
+    "--machine-claim", paths.machineClaimPath,
+    "--idle-ms", "60000",
+  ], env, ["ignore", "ignore", "pipe"]);
+  await waitFor(() => socketAnswers(paths.socketPath, 1_000), "redskilled daemon socket");
+  return { root, env, paths, daemon };
+}
+
+function launchCli(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  stdio: ["pipe" | "ignore", "pipe" | "ignore", "pipe" | "ignore"],
+): ChildProcess {
+  const child = spawn(process.execPath, ["--import", tsxLoader, cliEntry, ...args], { env, stdio });
+  children.push(child);
+  return child;
+}
+
+function childV1Stream(child: ChildProcess): acpV1.Stream {
+  if (child.stdin == null || child.stdout == null) throw new Error("ACP adapter did not expose stdio");
+  return acpV1.ndJsonStream(
+    Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+    Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+  );
+}
+
+function childV2Stream(child: ChildProcess): acpV2.Stream {
+  if (child.stdin == null || child.stdout == null) throw new Error("ACP adapter did not expose stdio");
+  return acpV2.ndJsonStream(
+    Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+    Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+  );
+}
+
+async function sha256(path: string): Promise<string> {
+  return createHash("sha256").update(await readFile(path)).digest("hex");
+}
+
+async function waitFor(check: () => boolean | Promise<boolean>, label: string): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (!(await check())) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${label}`);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+async function waitForEvents(path: string, count: number) {
+  let events = await readRedskilledEvents(path);
+  await waitFor(async () => {
+    events = await readRedskilledEvents(path);
+    return events.filter((event) => event.kind === "worker-birth" || event.kind === "worker-death").length >= count;
+  }, `${count} Worker lifecycle events`);
+  return events.filter((event) => event.kind === "worker-birth" || event.kind === "worker-death");
+}
+
+async function waitForEvent(path: string, kind: "worker-birth" | "worker-death", workerId?: string) {
+  let found: Awaited<ReturnType<typeof readRedskilledEvents>>[number] | undefined;
+  await waitFor(async () => {
+    found = (await readRedskilledEvents(path)).find((event) =>
+      event.kind === kind && (workerId == null || event.worker_id === workerId));
+    return found != null;
+  }, `${kind} event`);
+  return found!;
+}


### PR DESCRIPTION
Automated AFK landing for #3882. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3882

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789361156&installation_model_id=20659&pr_number=3902&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3902&signature=ae25c4cd6165408382556bf9c38828af96eb7a8fee5200c757e59774bda3040d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->