### PR TITLE
fix: #3883 RedSkills handshake enforces wire-major compatibility

### DIFF
--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -16,6 +16,7 @@ import {
   client,
   methods,
   ndJsonStream,
+  RequestError,
   type AgentConnection,
   type ClientConnection,
   type McpServer,
@@ -32,6 +33,7 @@ import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
 
 const ACP_PROTOCOL_VERSION = 1;
 export const ACP_V2_DRAFT_REVISION = "schema-v2.0.0-alpha.2";
+export const REDSKILLS_WIRE_MAJOR = 1;
 const ACP_PROJECT_LABEL = "redskills/acp";
 const TERMINAL_REAP_DELAY_MS = 150;
 
@@ -97,14 +99,17 @@ async function servePublicConnection(
   const active = new Map<string, ActiveWorker>();
 
   const v1App = agent({ name: "RedSkills" })
-    .onRequest(methods.agent.initialize, ({ params }) => ({
-      protocolVersion: params.protocolVersion === ACP_PROTOCOL_VERSION
-        ? params.protocolVersion
-        : ACP_PROTOCOL_VERSION,
-      agentCapabilities: { promptCapabilities: {} },
-      agentInfo: { name: "RedSkills", version: "1" },
-      _meta: { redskills: { wireMajor: 1, workerBacked: true } },
-    }))
+    .onRequest(methods.agent.initialize, ({ params }) => {
+      requireCompatibleWireMajor(params._meta);
+      return {
+        protocolVersion: params.protocolVersion === ACP_PROTOCOL_VERSION
+          ? params.protocolVersion
+          : ACP_PROTOCOL_VERSION,
+        agentCapabilities: { promptCapabilities: {} },
+        agentInfo: { name: "RedSkills", version: "1" },
+        _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR, workerBacked: true } },
+      };
+    })
     .onRequest(methods.agent.session.new, ({ params }) => {
       const sessionId = randomUUID();
       sessions.set(sessionId, { request: params });
@@ -158,6 +163,7 @@ async function servePublicConnection(
   const v2Turns = new Map<string, Promise<void>>();
   const v2App = acpV2.agent({ name: "RedSkills" })
     .onRequest(acpV2.methods.agent.initialize, ({ params }) => {
+      requireCompatibleWireMajor(params._meta);
       requireSupportedV2Revision(params._meta);
       return {
         protocolVersion: acpV2.PROTOCOL_VERSION,
@@ -165,7 +171,7 @@ async function servePublicConnection(
         capabilities: { session: {} },
         _meta: {
           redskills: {
-            wireMajor: 1,
+            wireMajor: REDSKILLS_WIRE_MAJOR,
             workerBacked: true,
             acpDraftRevision: ACP_V2_DRAFT_REVISION,
           },
@@ -225,6 +231,19 @@ async function servePublicConnection(
     .connect(socketStream(socket) as unknown as acpV2.Stream);
   await connection.closed;
   for (const [sessionId, worker] of active) cleanupWorker(sessionId, worker, active);
+}
+
+function requireCompatibleWireMajor(meta: unknown, required = false): void {
+  const redskills = record(record(meta)?.redskills);
+  const wireMajor = redskills?.wireMajor;
+  if (wireMajor == null && !required) return;
+  if (wireMajor !== REDSKILLS_WIRE_MAJOR) {
+    const received = typeof wireMajor === "number" ? wireMajor : "omitted";
+    throw RequestError.invalidParams(
+      { redskills: { receivedWireMajor: received, supportedWireMajor: REDSKILLS_WIRE_MAJOR } },
+      `unsupported RedSkills wire major ${received}; expected ${REDSKILLS_WIRE_MAJOR}`,
+    );
+  }
 }
 
 function requireSupportedV2Revision(meta: acpV2.InitializeRequest["_meta"]): void {
@@ -364,12 +383,13 @@ async function admitNativeAcpWorker(
     });
   const connection = downstreamApp.connect(socketStream(workerSocket));
   try {
-    await connection.agent.request(methods.agent.initialize, {
+    const initialized = await connection.agent.request(methods.agent.initialize, {
       protocolVersion: ACP_PROTOCOL_VERSION,
       clientCapabilities: {},
       clientInfo: { name: "redskilled", version: "1" },
-      _meta: { redskills: { wireMajor: 1 } },
+      _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR } },
     });
+    requireCompatibleWireMajor(initialized._meta, true);
     const downstreamSession = await connection.agent.request(methods.agent.session.new, {
       cwd: session.request.cwd,
       mcpServers: session.request.mcpServers as McpServer[],
@@ -443,12 +463,15 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
   const controllers = new Map<string, AbortController>();
   const sessions = new Set<string>();
   const app = agent({ name: "RedSkills native Worker" })
-    .onRequest(methods.agent.initialize, () => ({
-      protocolVersion: ACP_PROTOCOL_VERSION,
-      agentCapabilities: { promptCapabilities: {} },
-      agentInfo: { name: "RedSkills native Worker", version: "1" },
-      _meta: { redskills: { wireMajor: 1, worker: true } },
-    }))
+    .onRequest(methods.agent.initialize, ({ params }) => {
+      requireCompatibleWireMajor(params._meta, true);
+      return {
+        protocolVersion: ACP_PROTOCOL_VERSION,
+        agentCapabilities: { promptCapabilities: {} },
+        agentInfo: { name: "RedSkills native Worker", version: "1" },
+        _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR, worker: true } },
+      };
+    })
     .onRequest(methods.agent.session.new, () => {
       const sessionId = randomUUID();
       sessions.add(sessionId);

--- a/apps/redskilled/tests/acp-conformance.test.ts
+++ b/apps/redskilled/tests/acp-conformance.test.ts
@@ -8,7 +8,7 @@ import { Readable, Writable } from "node:stream";
 import * as acpV1 from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import { afterEach, describe, expect, it } from "vitest";
-import { ACP_V2_DRAFT_REVISION } from "../src/acp-control-plane.js";
+import { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "../src/acp-control-plane.js";
 import { readRedskilledHostState } from "../src/client.js";
 import { socketAnswers } from "../src/daemon.js";
 import { readRedskilledEvents } from "../src/event-lane.js";
@@ -38,7 +38,8 @@ interface CorpusClient {
 
 interface SupportedAdapter {
   readonly label: string;
-  connect(child: ChildProcess): CorpusClient;
+  readonly peerVersion: string;
+  connect(child: ChildProcess, peerVersion: string, wireMajor: number): CorpusClient;
 }
 
 afterEach(async () => {
@@ -50,12 +51,22 @@ afterEach(async () => {
 
 describe("the maintained ACP adapters", () => {
   it.each([
-    { label: "ACP v1", connect: connectV1 },
-    { label: `ACP v2 ${ACP_V2_DRAFT_REVISION}`, connect: connectV2 },
-  ] satisfies SupportedAdapter[])("runs the shared RedSkills session corpus through $label", async (adapter) => {
+    { label: "ACP v1 / newer minor component", peerVersion: "1.7.0", connect: connectV1 },
+    { label: "ACP v1 / newer patch component", peerVersion: "1.0.9", connect: connectV1 },
+    {
+      label: `ACP v2 ${ACP_V2_DRAFT_REVISION} / newer minor component`,
+      peerVersion: "1.7.0",
+      connect: connectV2,
+    },
+    {
+      label: `ACP v2 ${ACP_V2_DRAFT_REVISION} / newer patch component`,
+      peerVersion: "1.0.9",
+      connect: connectV2,
+    },
+  ] satisfies SupportedAdapter[])("runs the same-wire-major session corpus through $label", async (adapter) => {
     const runtime = await launchDaemon();
     const stdioAdapter = launchCli(["acp"], runtime.env, ["pipe", "pipe", "pipe"]);
-    const client = adapter.connect(stdioAdapter);
+    const client = adapter.connect(stdioAdapter, adapter.peerVersion, REDSKILLS_WIRE_MAJOR);
 
     await client.initialize();
     const sessionId = await client.newSession(runtime.root);
@@ -91,6 +102,40 @@ describe("the maintained ACP adapters", () => {
     expect(births).toHaveLength(2);
     expect(deaths).toHaveLength(2);
     expect(new Set(deaths.map((event) => event.worker_id))).toEqual(new Set(births.map((event) => event.worker_id)));
+
+    client.close();
+    stdioAdapter.stdin?.end();
+    runtime.daemon.kill("SIGTERM");
+  }, 30_000);
+
+  it.each([
+    { label: "ACP v1", peerVersion: "2.0.0", connect: connectV1 },
+    { label: `ACP v2 ${ACP_V2_DRAFT_REVISION}`, peerVersion: "2.0.0", connect: connectV2 },
+  ] satisfies SupportedAdapter[])("refuses a cross-major $label peer before creating workflow state", async (adapter) => {
+    const runtime = await launchDaemon();
+    const stdioAdapter = launchCli(["acp"], runtime.env, ["pipe", "pipe", "pipe"]);
+    const receivedWireMajor = REDSKILLS_WIRE_MAJOR + 1;
+    const client = adapter.connect(stdioAdapter, adapter.peerVersion, receivedWireMajor);
+
+    await expect(client.initialize()).rejects.toMatchObject({
+      code: -32602,
+      message: expect.stringMatching(/RedSkills wire major/),
+      data: {
+        redskills: {
+          receivedWireMajor,
+          supportedWireMajor: REDSKILLS_WIRE_MAJOR,
+        },
+      },
+    });
+
+    expect(await readRedskilledEvents(runtime.paths.eventLanePath)).toEqual([]);
+    const state = await readRedskilledHostState(runtime.paths);
+    expect(state.workers).toEqual([]);
+    expect(state.projects).toEqual([]);
+    expect(state.registrations).toEqual([]);
+    expect((await readdir(runtime.root, { recursive: true })).filter((path) =>
+      /acp.*session|session.*journal/i.test(path),
+    )).toEqual([]);
 
     client.close();
     stdioAdapter.stdin?.end();
@@ -153,7 +198,7 @@ describe("the maintained ACP adapters", () => {
   });
 });
 
-function connectV1(child: ChildProcess): CorpusClient {
+function connectV1(child: ChildProcess, peerVersion: string, wireMajor: number): CorpusClient {
   const updates: NormalizedUpdate[] = [];
   const app = acpV1.client({ name: "redskilled-acp-v1-conformance" })
     .onNotification(acpV1.methods.client.session.update, ({ params }) => {
@@ -169,10 +214,12 @@ function connectV1(child: ChildProcess): CorpusClient {
       const response = await connection.agent.request(acpV1.methods.agent.initialize, {
         protocolVersion: 1,
         clientCapabilities: {},
-        clientInfo: { name: "redskilled-test-client", version: "1" },
+        clientInfo: { name: "redskilled-test-client", version: peerVersion },
+        _meta: { redskills: { wireMajor } },
       });
       expect(response.protocolVersion).toBe(1);
       expect(response.agentInfo?.name).toBe("RedSkills");
+      expect(response._meta).toMatchObject({ redskills: { wireMajor: REDSKILLS_WIRE_MAJOR } });
     },
     async newSession(cwd) {
       return (await connection.agent.request(acpV1.methods.agent.session.new, { cwd, mcpServers: [] })).sessionId;
@@ -196,7 +243,7 @@ function connectV1(child: ChildProcess): CorpusClient {
   };
 }
 
-function connectV2(child: ChildProcess): CorpusClient {
+function connectV2(child: ChildProcess, peerVersion: string, wireMajor: number): CorpusClient {
   const updates: NormalizedUpdate[] = [];
   const app = acpV2.client({ name: "redskilled-acp-v2-conformance" })
     .onNotification(acpV2.methods.client.session.update, ({ params }) => {
@@ -226,13 +273,18 @@ function connectV2(child: ChildProcess): CorpusClient {
     async initialize() {
       const response = await connection.agent.request(acpV2.methods.agent.initialize, {
         protocolVersion: 2,
-        info: { name: "redskilled-test-client", version: "1" },
+        info: { name: "redskilled-test-client", version: peerVersion },
         capabilities: {},
-        _meta: { redskills: { acpDraftRevision: ACP_V2_DRAFT_REVISION } },
+        _meta: { redskills: { wireMajor, acpDraftRevision: ACP_V2_DRAFT_REVISION } },
       });
       expect(response.protocolVersion).toBe(2);
       expect(response.info.name).toBe("RedSkills");
-      expect(response._meta).toMatchObject({ redskills: { acpDraftRevision: ACP_V2_DRAFT_REVISION } });
+      expect(response._meta).toMatchObject({
+        redskills: {
+          wireMajor: REDSKILLS_WIRE_MAJOR,
+          acpDraftRevision: ACP_V2_DRAFT_REVISION,
+        },
+      });
     },
     async newSession(cwd) {
       return (await connection.agent.request(acpV2.methods.agent.session.new, { cwd, mcpServers: [] })).sessionId;


### PR DESCRIPTION
Automated AFK landing for #3883. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3883

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789362000&installation_model_id=20659&pr_number=3903&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3903&signature=0aa0c0631f20dd924002e88f2e3f2c18a700b376269ba68e38e21d2be27aa269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->