### PR TITLE
fix: #3884 Client checkouts resolve one canonical Project workspace

### DIFF
--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -29,16 +29,22 @@ import {
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import type { RedskilledHostState } from "./host-state.js";
 import type { RedskilledPaths } from "./paths.js";
+import {
+  ensureAcpProjectWorkspace,
+  resolveAcpProjectIdentity,
+  type AcpProjectIdentity,
+  type AcpProjectWorkspace,
+} from "./project-workspace.js";
 import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
 
 const ACP_PROTOCOL_VERSION = 1;
 export const ACP_V2_DRAFT_REVISION = "schema-v2.0.0-alpha.2";
 export const REDSKILLS_WIRE_MAJOR = 1;
-const ACP_PROJECT_LABEL = "redskills/acp";
 const TERMINAL_REAP_DELAY_MS = 150;
 
 interface PublicSession {
   readonly request: NewSessionRequest;
+  readonly project: AcpProjectWorkspace;
 }
 
 interface ActiveWorker {
@@ -68,13 +74,25 @@ export async function startRedskillsAcpControlPlane(
 ): Promise<RedskillsAcpControlPlane> {
   const { paths } = options;
   const sockets = new Set<Socket>();
+  const projects = new Map<string, Promise<AcpProjectWorkspace>>();
+  const workspaceFor = (identity: AcpProjectIdentity): Promise<AcpProjectWorkspace> => {
+    const held = projects.get(identity.projectId);
+    if (held != null) return held;
+    const pending = ensureAcpProjectWorkspace(identity, paths.projectWorkspaceRoot)
+      .catch((error) => {
+        projects.delete(identity.projectId);
+        throw error;
+      });
+    projects.set(identity.projectId, pending);
+    return pending;
+  };
   await mkdir(join(paths.runtimeDir, "acp-workers"), { recursive: true, mode: 0o700 });
   await rm(paths.acpSocketPath, { force: true });
 
   const server = createServer((socket) => {
     sockets.add(socket);
     socket.once("close", () => sockets.delete(socket));
-    void servePublicConnection(socket, options).catch(() => socket.destroy());
+    void servePublicConnection(socket, options, workspaceFor).catch(() => socket.destroy());
   });
   await listen(server, paths.acpSocketPath);
 
@@ -94,9 +112,25 @@ export async function startRedskillsAcpControlPlane(
 async function servePublicConnection(
   socket: Socket,
   options: StartRedskillsAcpControlPlaneOptions,
+  workspaceFor: (identity: AcpProjectIdentity) => Promise<AcpProjectWorkspace>,
 ): Promise<void> {
   const sessions = new Map<string, PublicSession>();
   const active = new Map<string, ActiveWorker>();
+  let connectionProject: AcpProjectWorkspace | undefined;
+
+  const bindProject = async (cwd: string, incompatible: () => Error): Promise<AcpProjectWorkspace> => {
+    const identity = await resolveAcpProjectIdentity(cwd);
+    if (connectionProject != null && connectionProject.projectId !== identity.projectId) throw incompatible();
+    connectionProject ??= await workspaceFor(identity);
+    return connectionProject;
+  };
+
+  const scopedState = () => {
+    if (connectionProject == null) {
+      throw RequestError.invalidRequest("a Project session must bind this ACP connection before state can be read");
+    }
+    return projectState(options.hostState(), connectionProject);
+  };
 
   const v1App = agent({ name: "RedSkills" })
     .onRequest(methods.agent.initialize, ({ params }) => {
@@ -110,12 +144,24 @@ async function servePublicConnection(
         _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR, workerBacked: true } },
       };
     })
-    .onRequest(methods.agent.session.new, ({ params }) => {
+    .onRequest(methods.agent.session.new, async ({ params }) => {
+      const project = await bindProject(params.cwd, () => RequestError.invalidParams(
+        {},
+        "this project-scoped ACP connection cannot address a different Project",
+      ));
       const sessionId = randomUUID();
-      sessions.set(sessionId, { request: params });
+      sessions.set(sessionId, { request: params, project });
       return {
         sessionId,
-        _meta: { redskills: { authority: "redskilled", protocolVersion: ACP_PROTOCOL_VERSION } },
+        _meta: {
+          redskills: {
+            authority: "redskilled",
+            protocolVersion: ACP_PROTOCOL_VERSION,
+            projectId: project.projectId,
+            projectLabel: project.projectLabel,
+            workspacePath: project.workspacePath,
+          },
+        },
       };
     })
     .onRequest(methods.agent.session.prompt, async ({ params, client: upstream }) => {
@@ -158,7 +204,9 @@ async function servePublicConnection(
         ...(params._meta == null ? {} : { _meta: params._meta }),
       });
     })
-    .onRequest("_redskills/host_state", () => ({}), () => options.hostState());
+    // Compatibility spelling, but deliberately a Project projection. Ordinary
+    // ACP socket access is not an administrative capability.
+    .onRequest("_redskills/host_state", () => ({}), scopedState);
 
   const v2Turns = new Map<string, Promise<void>>();
   const v2App = acpV2.agent({ name: "RedSkills" })
@@ -178,7 +226,10 @@ async function servePublicConnection(
         },
       };
     })
-    .onRequest(acpV2.methods.agent.session.new, ({ params }) => {
+    .onRequest(acpV2.methods.agent.session.new, async ({ params }) => {
+      const project = await bindProject(params.cwd, () => acpV2.RequestError.invalidParams(
+        "this project-scoped ACP connection cannot address a different Project",
+      ));
       const sessionId = randomUUID();
       sessions.set(sessionId, {
         request: {
@@ -188,6 +239,7 @@ async function servePublicConnection(
             ? {}
             : { additionalDirectories: params.additionalDirectories }),
         },
+        project,
       });
       return {
         sessionId,
@@ -196,6 +248,9 @@ async function servePublicConnection(
             authority: "redskilled",
             protocolVersion: acpV2.PROTOCOL_VERSION,
             acpDraftRevision: ACP_V2_DRAFT_REVISION,
+            projectId: project.projectId,
+            projectLabel: project.projectLabel,
+            workspacePath: project.workspacePath,
           },
         },
       };
@@ -223,7 +278,7 @@ async function servePublicConnection(
         ...(params._meta == null ? {} : { _meta: params._meta }),
       });
     })
-    .onRequest("_redskills/host_state", () => ({}), () => options.hostState());
+    .onRequest("_redskills/host_state", () => ({}), scopedState);
 
   const connection = acpV2.agentProtocolRouter()
     .withV1(v1App)
@@ -351,7 +406,7 @@ async function admitNativeAcpWorker(
   const rendezvous = await bindWorkerRendezvous(endpoint);
   let launched: LaunchedWorker;
   try {
-    launched = options.startWorker(nativeWorkerSpec(session.request.cwd, endpoint, options.paths.runtimeDir));
+    launched = options.startWorker(nativeWorkerSpec(session.project, endpoint, options.paths.runtimeDir));
   } catch (error) {
     rendezvous.server.close();
     await rm(endpoint, { force: true });
@@ -391,7 +446,7 @@ async function admitNativeAcpWorker(
     });
     requireCompatibleWireMajor(initialized._meta, true);
     const downstreamSession = await connection.agent.request(methods.agent.session.new, {
-      cwd: session.request.cwd,
+      cwd: session.project.workspacePath,
       mcpServers: session.request.mcpServers as McpServer[],
       ...(session.request.additionalDirectories == null
         ? {}
@@ -416,15 +471,28 @@ async function admitNativeAcpWorker(
   };
 }
 
-function nativeWorkerSpec(cwd: string, endpoint: string, runtimeDir: string): RedskilledWorkerSpec {
+function nativeWorkerSpec(
+  project: AcpProjectWorkspace,
+  endpoint: string,
+  runtimeDir: string,
+): RedskilledWorkerSpec {
   const entry = process.argv[1];
   if (entry == null || entry === "") throw new Error("redskilled cannot resolve its Worker entry");
   return {
-    project_label: ACP_PROJECT_LABEL,
-    workspace_path: cwd,
+    project_label: project.projectLabel,
+    workspace_path: project.workspacePath,
     command: process.execPath,
     args: [...process.execArgv, entry, "acp-worker", "--socket", endpoint],
     log_path: join(runtimeDir, "acp-workers", `${randomBytes(6).toString("hex")}.toonl`),
+  };
+}
+
+function projectState(host: RedskilledHostState, project: AcpProjectWorkspace) {
+  return {
+    project_id: project.projectId,
+    project_label: project.projectLabel,
+    workspace_path: project.workspacePath,
+    workers: host.workers.filter((worker) => worker.project_label === project.projectLabel),
   };
 }
 

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -479,7 +479,9 @@ function nativeWorkerSpec(
   const entry = process.argv[1];
   if (entry == null || entry === "") throw new Error("redskilled cannot resolve its Worker entry");
   return {
-    project_label: project.projectLabel,
+    // The host's authority key must survive a repository rename. The current
+    // GitHub full name remains display metadata on the public session.
+    project_label: project.projectId,
     workspace_path: project.workspacePath,
     command: process.execPath,
     args: [...process.execArgv, entry, "acp-worker", "--socket", endpoint],
@@ -492,7 +494,7 @@ function projectState(host: RedskilledHostState, project: AcpProjectWorkspace) {
     project_id: project.projectId,
     project_label: project.projectLabel,
     workspace_path: project.workspacePath,
-    workers: host.workers.filter((worker) => worker.project_label === project.projectLabel),
+    workers: host.workers.filter((worker) => worker.project_label === project.projectId),
   };
 }
 

--- a/apps/redskilled/src/paths.ts
+++ b/apps/redskilled/src/paths.ts
@@ -62,6 +62,8 @@ export interface RedskilledPaths {
   readonly registrationIntentPath: string;
   /** Generic host-resource leases retained across daemon handover. */
   readonly resourceLeasePath: string;
+  /** Daemon-managed canonical Project workspaces, keyed below this directory by stable identity. */
+  readonly projectWorkspaceRoot: string;
   /** The canonical claim path resolved for this host and resolver environment. */
   readonly machineClaimPathOfThisHost: string;
   /**
@@ -151,6 +153,7 @@ export function resolveRedskilledPaths(options: ResolveRedskilledPathsOptions = 
     // and its successor used the uid fallback (or vice versa).
     registrationIntentPath: join(redskilledHomeDir(homeDir), "redskilled.registrations.toon"),
     resourceLeasePath: join(redskilledHomeDir(homeDir), "redskilled.resources.toon"),
+    projectWorkspaceRoot: join(redskilledHomeDir(homeDir), "projects"),
     machineClaimPathOfThisHost,
     machineClaimPath: options.machineClaimPath ?? machineClaimPathOfThisHost,
   };

--- a/apps/redskilled/src/project-workspace.ts
+++ b/apps/redskilled/src/project-workspace.ts
@@ -1,0 +1,175 @@
+/**
+ * Resolve a client checkout to daemon-owned Project state.
+ *
+ * A checkout path is evidence, never an execution root. GitHub's numeric
+ * repository id is stable across clones, moves, and repository renames, so it
+ * is the Project key. The checkout only seeds the canonical workspace from its
+ * committed HEAD; uncommitted and untracked editor state cannot cross that
+ * clone boundary.
+ */
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rename, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  repoSlugFromRemoteUrl,
+  resolveProjectIdentity,
+} from "@reddb-io/shared/project-identity.js";
+
+const GIT_TIMEOUT_MS = 10_000;
+const GITHUB_TIMEOUT_MS = 5_000;
+
+export interface AcpProjectIdentity {
+  readonly projectId: string;
+  readonly projectLabel: string;
+  readonly checkoutRoot: string;
+}
+
+export interface AcpProjectWorkspace extends AcpProjectIdentity {
+  readonly workspacePath: string;
+}
+
+export interface ResolveAcpProjectIdentityOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly fetchImpl?: typeof fetch;
+}
+
+/** Resolve identity without creating Project state, so authority can be checked first. */
+export async function resolveAcpProjectIdentity(
+  cwd: string,
+  options: ResolveAcpProjectIdentityOptions = {},
+): Promise<AcpProjectIdentity> {
+  const checkoutRoot = await gitOutput(cwd, ["rev-parse", "--show-toplevel"]) ?? cwd;
+  const gitCommonDir = await gitOutput(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+  const remoteUrl = await gitOutput(cwd, ["remote", "get-url", "origin"]);
+  const remoteSlug = repoSlugFromRemoteUrl(remoteUrl);
+  const github = remoteSlug == null
+    ? undefined
+    : await readGithubRepository(remoteSlug, remoteUrl, options).catch(() => undefined);
+  if (github != null) {
+    return {
+      projectId: `github:${github.id}`,
+      projectLabel: github.fullName,
+      checkoutRoot,
+    };
+  }
+
+  // Non-GitHub directories remain usable by generic ACP clients. This fallback
+  // is deliberately named as local/remote evidence; it never masquerades as an
+  // immutable GitHub identity.
+  const fallback = resolveProjectIdentity({
+    checkoutPath: checkoutRoot,
+    ...(gitCommonDir == null ? {} : { gitCommonDir }),
+    ...(remoteUrl == null ? {} : { remoteUrl }),
+  });
+  return {
+    projectId: remoteSlug == null ? `local:${fallback.hash}` : `remote:${remoteSlug}`,
+    projectLabel: fallback.name,
+    checkoutRoot,
+  };
+}
+
+/** Materialize (or reuse) the one clean execution workspace for a Project. */
+export async function ensureAcpProjectWorkspace(
+  identity: AcpProjectIdentity,
+  workspaceRoot: string,
+): Promise<AcpProjectWorkspace> {
+  const projectDir = join(workspaceRoot, projectDirectory(identity.projectId));
+  const workspacePath = join(projectDir, "workspace");
+  if (await exists(workspacePath)) return { ...identity, workspacePath };
+
+  await mkdir(projectDir, { recursive: true, mode: 0o700 });
+  if (await gitOutput(identity.checkoutRoot, ["rev-parse", "--is-inside-work-tree"]) === "true") {
+    const staging = await mkdtemp(join(projectDir, "seed-"));
+    const candidate = join(staging, "workspace");
+    try {
+      await gitOutput(projectDir, [
+        "clone",
+        "--no-hardlinks",
+        "--quiet",
+        "--",
+        identity.checkoutRoot,
+        candidate,
+      ], true);
+      try {
+        await rename(candidate, workspacePath);
+      } catch (error) {
+        if (!(await exists(workspacePath))) throw error;
+      }
+    } finally {
+      await rm(staging, { recursive: true, force: true });
+    }
+  } else {
+    await mkdir(workspacePath, { recursive: true, mode: 0o700 });
+  }
+  return { ...identity, workspacePath };
+}
+
+interface GithubRepositoryAnswer {
+  readonly id: string;
+  readonly fullName: string;
+}
+
+async function readGithubRepository(
+  slug: string,
+  remoteUrl: string | undefined,
+  options: ResolveAcpProjectIdentityOptions,
+): Promise<GithubRepositoryAnswer | undefined> {
+  const env = options.env ?? process.env;
+  const configuredOrigin = env.GITHUB_API_URL?.trim();
+  const isGithubRemote = /(^|[.@/:])github\.com(?=[:/])/i.test(remoteUrl ?? "");
+  const token = (env.REDSKILLED_HOST_TOKEN ?? env.GITHUB_TOKEN ?? env.GH_TOKEN ?? "").trim();
+  if (!configuredOrigin && !isGithubRemote && token === "") return undefined;
+
+  const origin = (configuredOrigin || "https://api.github.com").replace(/\/+$/, "");
+  const route = slug.split("/").map(encodeURIComponent).join("/");
+  const response = await (options.fetchImpl ?? fetch)(`${origin}/repos/${route}`, {
+    headers: {
+      accept: "application/vnd.github+json",
+      ...(token === "" ? {} : { authorization: `Bearer ${token}` }),
+    },
+    signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
+  });
+  if (!response.ok) return undefined;
+  const body = await response.json() as { id?: unknown; full_name?: unknown };
+  if ((typeof body.id !== "number" && typeof body.id !== "string") || typeof body.full_name !== "string") {
+    return undefined;
+  }
+  const id = String(body.id).trim();
+  const fullName = body.full_name.trim();
+  return id === "" || fullName === "" ? undefined : { id, fullName };
+}
+
+function projectDirectory(projectId: string): string {
+  const readable = projectId.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "project";
+  const hash = createHash("sha256").update(projectId).digest("hex").slice(0, 8);
+  return `${readable}-${hash}`;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function gitOutput(cwd: string, args: readonly string[], required = false): Promise<string | undefined> {
+  return await new Promise<string | undefined>((resolve, reject) => {
+    execFile("git", [...args], {
+      cwd,
+      encoding: "utf8",
+      timeout: GIT_TIMEOUT_MS,
+      windowsHide: true,
+    }, (error, stdout) => {
+      if (error != null) {
+        if (required) reject(error);
+        else resolve(undefined);
+        return;
+      }
+      const value = stdout.trim();
+      resolve(value === "" ? undefined : value);
+    });
+  });
+}

--- a/apps/redskilled/tests/acp-conformance.test.ts
+++ b/apps/redskilled/tests/acp-conformance.test.ts
@@ -3,7 +3,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { Readable, Writable } from "node:stream";
 import * as acpV1 from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
@@ -79,7 +79,7 @@ describe("the maintained ACP adapters", () => {
     expect(client.updates.at(-1)).toMatchObject({ kind: "terminal", stopReason: "end_turn" });
 
     const firstBirth = await waitForEvent(runtime.paths.eventLanePath, "worker-birth");
-    expect(firstBirth.project_label).toBe("redskills/acp");
+    expect(firstBirth.project_label).toBe(basename(runtime.root));
     expect(firstBirth.pid).toBeGreaterThan(0);
     const liveAfterTerminal = await client.hostState();
     expect(liveAfterTerminal.workers.map((worker) => worker.worker_id)).toContain(firstBirth.worker_id);

--- a/apps/redskilled/tests/acp-conformance.test.ts
+++ b/apps/redskilled/tests/acp-conformance.test.ts
@@ -3,7 +3,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { Readable, Writable } from "node:stream";
 import * as acpV1 from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
@@ -79,7 +79,7 @@ describe("the maintained ACP adapters", () => {
     expect(client.updates.at(-1)).toMatchObject({ kind: "terminal", stopReason: "end_turn" });
 
     const firstBirth = await waitForEvent(runtime.paths.eventLanePath, "worker-birth");
-    expect(firstBirth.project_label).toBe(basename(runtime.root));
+    expect(firstBirth.project_label).toMatch(/^local:[0-9a-f]{8}$/);
     expect(firstBirth.pid).toBeGreaterThan(0);
     const liveAfterTerminal = await client.hostState();
     expect(liveAfterTerminal.workers.map((worker) => worker.worker_id)).toContain(firstBirth.worker_id);

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -73,6 +73,7 @@ describe("the public RedSkills ACP v1 control plane", () => {
     expect(initialized.agentInfo?.name).toBe("RedSkills");
 
     const session = await connection.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
+    const project = projectMeta(session._meta);
     const completed = await connection.agent.request(methods.agent.session.prompt, {
       sessionId: session.sessionId,
       prompt: [{ type: "text", text: "complete the native tracer" }],
@@ -86,7 +87,8 @@ describe("the public RedSkills ACP v1 control plane", () => {
     )).toBe(true);
 
     const firstBirth = await waitForEvent(paths.eventLanePath, "worker-birth");
-    expect(firstBirth.project_label).toBe("redskills/acp");
+    expect(firstBirth.project_label).toBe(project.projectLabel);
+    expect(firstBirth.workspace_path).toBe(project.workspacePath);
     expect(firstBirth.pid).toBeGreaterThan(0);
     const liveAfterTerminal = await connection.agent.request<{ workers: Array<{ worker_id: string }> }>(
       "_redskills/host_state",

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -87,7 +87,7 @@ describe("the public RedSkills ACP v1 control plane", () => {
     )).toBe(true);
 
     const firstBirth = await waitForEvent(paths.eventLanePath, "worker-birth");
-    expect(firstBirth.project_label).toBe(project.projectLabel);
+    expect(firstBirth.project_label).toBe(project.projectId);
     expect(firstBirth.workspace_path).toBe(project.workspacePath);
     expect(firstBirth.pid).toBeGreaterThan(0);
     const liveAfterTerminal = await connection.agent.request<{ workers: Array<{ worker_id: string }> }>(
@@ -191,6 +191,18 @@ describe("the public RedSkills ACP v1 control plane", () => {
     expect(firstProject.workspacePath).not.toBe(firstCheckout);
     expect(await readFile(join(firstProject.workspacePath, "tracked.txt"), "utf8")).toBe("committed\n");
     await expect(readFile(join(firstProject.workspacePath, "untracked.txt"), "utf8")).rejects.toThrow();
+    await first.agent.request(methods.agent.session.prompt, {
+      sessionId: firstSession.sessionId,
+      prompt: [{ type: "text", text: "observe the canonical Project" }],
+    });
+    const projectBirth = await waitForEvent(paths.eventLanePath, "worker-birth");
+    expect(projectBirth.project_label).toBe(firstProject.projectId);
+    expect(projectBirth.workspace_path).toBe(firstProject.workspacePath);
+    const liveScoped = await first.agent.request<{ workers: Array<{ project_label: string }> }>(
+      "_redskills/host_state",
+      {},
+    );
+    expect(liveScoped.workers.map((worker) => worker.project_label)).toEqual([firstProject.projectId]);
 
     const secondAdapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
     const second = client({ name: "project-client-b" }).connect(childStream(secondAdapter));
@@ -226,12 +238,6 @@ describe("the public RedSkills ACP v1 control plane", () => {
       code: -32602,
       message: expect.stringMatching(/different Project/),
     });
-    const scoped = await first.agent.request<{ workers: Array<{ project_label: string }> }>(
-      "_redskills/host_state",
-      {},
-    );
-    expect(scoped.workers.every((worker) => worker.project_label === firstProject.projectLabel)).toBe(true);
-
     first.close();
     second.close();
     renamed.close();

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -1,6 +1,8 @@
-import { spawn, type ChildProcess } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
 import { createRequire } from "node:module";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { Readable, Writable } from "node:stream";
@@ -21,11 +23,13 @@ const tsxLoader = require_.resolve("tsx");
 const cliEntry = resolve(__dirname, "..", "src", "cli.ts");
 const children: ChildProcess[] = [];
 const roots: string[] = [];
+const servers: Server[] = [];
 
 afterEach(async () => {
   for (const child of children.splice(0)) {
     if (child.exitCode == null && child.signalCode == null) child.kill("SIGKILL");
   }
+  for (const server of servers.splice(0)) await new Promise<void>((resolve) => server.close(() => resolve()));
   for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
 });
 
@@ -115,7 +119,146 @@ describe("the public RedSkills ACP v1 control plane", () => {
     adapter.stdin?.end();
     daemon.kill("SIGTERM");
   }, 30_000);
+
+  it("maps clones and a rename to one clean canonical Project workspace and bounds client authority", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-acp-project-"));
+    roots.push(root);
+    const remote = join(root, "acme", "widgets.git");
+    const firstCheckout = join(root, "client-a");
+    const secondCheckout = join(root, "client-b");
+    git(root, "init", "--bare", remote);
+    git(root, "clone", remote, firstCheckout);
+    git(firstCheckout, "config", "user.email", "fixture@example.invalid");
+    git(firstCheckout, "config", "user.name", "Fixture");
+    await writeFile(join(firstCheckout, "tracked.txt"), "committed\n");
+    git(firstCheckout, "add", "tracked.txt");
+    git(firstCheckout, "commit", "-m", "fixture");
+    git(firstCheckout, "push", "origin", "HEAD");
+    git(root, "clone", remote, secondCheckout);
+    await writeFile(join(firstCheckout, "tracked.txt"), "dirty editor state\n");
+    await writeFile(join(firstCheckout, "untracked.txt"), "must not cross\n");
+
+    const github = createServer((request, response) => {
+      const other = request.url?.endsWith("/acme/other") === true;
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        id: other ? 9002 : 9001,
+        node_id: other ? "R_other" : "R_widgets",
+        full_name: other ? "acme/other" : "acme/renamed-widgets",
+      }));
+    });
+    servers.push(github);
+    await new Promise<void>((resolve) => github.listen(0, "127.0.0.1", resolve));
+    const githubOrigin = `http://127.0.0.1:${(github.address() as AddressInfo).port}`;
+
+    const env = {
+      ...process.env,
+      HOME: root,
+      XDG_RUNTIME_DIR: root,
+      REDSKILLED_MACHINE_DIR: root,
+      REDSKILLED_PLACEMENT: "off",
+      REDSKILLED_SESSION: `test:${root}`,
+      REDSKILLED_HOST_TOKEN: "fixture-token",
+      GITHUB_API_URL: githubOrigin,
+    };
+    const paths = resolveRedskilledPaths({ env, homeDir: root });
+    const daemon = launchCli([
+      "serve",
+      "--socket", paths.socketPath,
+      "--lease", paths.leasePath,
+      "--events", paths.eventLanePath,
+      "--machine-claim", paths.machineClaimPath,
+      "--idle-ms", "60000",
+    ], env, ["ignore", "ignore", "pipe"]);
+    await waitFor(() => socketAnswers(paths.socketPath, 1_000), "redskilled daemon socket");
+
+    const firstAdapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
+    const first = client({ name: "project-client-a" }).connect(childStream(firstAdapter));
+    await first.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "project-client-a", version: "1" },
+    });
+    const firstSession = await first.agent.request(methods.agent.session.new, {
+      cwd: firstCheckout,
+      mcpServers: [],
+    });
+    const firstProject = projectMeta(firstSession._meta);
+    expect(firstProject.projectId).toBe("github:9001");
+    expect(firstProject.projectLabel).toBe("acme/renamed-widgets");
+    expect(firstProject.workspacePath).not.toBe(firstCheckout);
+    expect(await readFile(join(firstProject.workspacePath, "tracked.txt"), "utf8")).toBe("committed\n");
+    await expect(readFile(join(firstProject.workspacePath, "untracked.txt"), "utf8")).rejects.toThrow();
+
+    const secondAdapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
+    const second = client({ name: "project-client-b" }).connect(childStream(secondAdapter));
+    await second.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "project-client-b", version: "1" },
+    });
+    const secondSession = await second.agent.request(methods.agent.session.new, {
+      cwd: secondCheckout,
+      mcpServers: [],
+    });
+    expect(projectMeta(secondSession._meta)).toEqual(firstProject);
+
+    git(secondCheckout, "remote", "set-url", "origin", "https://github.invalid/acme/renamed-widgets.git");
+    const renamedAdapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
+    const renamed = client({ name: "project-client-renamed" }).connect(childStream(renamedAdapter));
+    await renamed.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "project-client-renamed", version: "1" },
+    });
+    const renamedSession = await renamed.agent.request(methods.agent.session.new, {
+      cwd: secondCheckout,
+      mcpServers: [],
+    });
+    expect(projectMeta(renamedSession._meta)).toEqual(firstProject);
+
+    const other = join(root, "other");
+    git(root, "init", other);
+    git(other, "remote", "add", "origin", "https://github.invalid/acme/other.git");
+    await expect(first.agent.request(methods.agent.session.new, { cwd: other, mcpServers: [] })).rejects.toMatchObject({
+      code: -32602,
+      message: expect.stringMatching(/different Project/),
+    });
+    const scoped = await first.agent.request<{ workers: Array<{ project_label: string }> }>(
+      "_redskills/host_state",
+      {},
+    );
+    expect(scoped.workers.every((worker) => worker.project_label === firstProject.projectLabel)).toBe(true);
+
+    first.close();
+    second.close();
+    renamed.close();
+    firstAdapter.stdin?.end();
+    secondAdapter.stdin?.end();
+    renamedAdapter.stdin?.end();
+    daemon.kill("SIGTERM");
+  }, 30_000);
 });
+
+function projectMeta(meta: unknown): { projectId: string; projectLabel: string; workspacePath: string } {
+  const project = (meta as { redskills?: unknown } | undefined)?.redskills as
+    | { projectId?: unknown; projectLabel?: unknown; workspacePath?: unknown }
+    | undefined;
+  expect(project).toMatchObject({
+    projectId: expect.any(String),
+    projectLabel: expect.any(String),
+    workspacePath: expect.any(String),
+  });
+  return {
+    projectId: project!.projectId as string,
+    projectLabel: project!.projectLabel as string,
+    workspacePath: project!.workspacePath as string,
+  };
+}
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
 
 function launchCli(
   args: readonly string[],


### PR DESCRIPTION
Automated AFK landing for #3884. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3884

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789363230&installation_model_id=20659&pr_number=3904&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3904&signature=abb0b8b4b49d88dc81bc35993dc027a45ed40aec2550e735f21c5501797bb417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->