### PR TITLE
merge: #3885 Project drain survives ACP client disconnection

### DIFF
--- a/.changeset/durable-acp-project-control.md
+++ b/.changeset/durable-acp-project-control.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Keep ACP Project drain and stop state across client disconnects and daemon replacement.

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -44,6 +44,16 @@ import {
 import type { RedskilledHostState } from "./host-state.js";
 import type { RedskilledPaths } from "./paths.js";
 import {
+  applyProjectControl,
+  coreProjectOperation,
+  notifyV1ProjectControl,
+  PROJECT_CONTROL_METHODS,
+  projectControlSnapshot,
+  runV2ProjectControlTurn,
+  type ProjectControlOperation,
+  type ProjectControlState,
+} from "./project-control.js";
+import {
   ensureAcpProjectWorkspace,
   resolveAcpProjectIdentity,
   type AcpProjectIdentity,
@@ -53,26 +63,6 @@ import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
 
 export { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "./acp-compat.js";
 const TERMINAL_REAP_DELAY_MS = 150;
-const PROJECT_CONTROL_METHODS = [
-  "_redskills/project_drain",
-  "_redskills/project_stop",
-  "_redskills/project_status",
-] as const;
-
-type ProjectControlOperation = "drain" | "stop";
-type ProjectDrainIntent = "inactive" | "draining" | "stopped";
-
-interface ProjectControlUpdate {
-  readonly sequence: number;
-  readonly operation: ProjectControlOperation;
-  readonly drain_intent: Exclude<ProjectDrainIntent, "inactive">;
-}
-
-interface ProjectControlState {
-  readonly drainIntent: ProjectDrainIntent;
-  readonly revision: number;
-  readonly updates: readonly ProjectControlUpdate[];
-}
 
 interface PublicSession {
   readonly request: NewSessionRequest;
@@ -360,124 +350,6 @@ async function servePublicConnection(
     .connect(socketStream(socket) as unknown as acpV2.Stream);
   await connection.closed;
   for (const [sessionId, worker] of active) cleanupWorker(sessionId, worker, active);
-}
-
-function projectControlSnapshot(
-  project: AcpProjectWorkspace,
-  projectControls: Map<string, ProjectControlState>,
-) {
-  const control = projectControls.get(project.projectId) ?? {
-    drainIntent: "inactive" as const,
-    revision: 0,
-    updates: [],
-  };
-  return {
-    version: 1 as const,
-    project_id: project.projectId,
-    project_label: project.projectLabel,
-    workspace_path: project.workspacePath,
-    drain_intent: control.drainIntent,
-    revision: control.revision,
-    updates: [...control.updates],
-  };
-}
-
-function applyProjectControl(
-  project: AcpProjectWorkspace,
-  operation: ProjectControlOperation,
-  projectControls: Map<string, ProjectControlState>,
-) {
-  const held = projectControls.get(project.projectId) ?? {
-    drainIntent: "inactive" as const,
-    revision: 0,
-    updates: [],
-  };
-  const requestedIntent = operation === "drain" ? "draining" as const : "stopped" as const;
-  if (held.drainIntent === requestedIntent) return projectControlSnapshot(project, projectControls);
-  const revision = held.revision + 1;
-  projectControls.set(project.projectId, {
-    drainIntent: requestedIntent,
-    revision,
-    updates: [...held.updates, { sequence: revision, operation, drain_intent: requestedIntent }],
-  });
-  return projectControlSnapshot(project, projectControls);
-}
-
-function coreProjectOperation(prompt: unknown): ProjectControlOperation | undefined {
-  const text = promptBlocksText(prompt).trim().toLowerCase();
-  if (text === "/drain" || text === "drain") return "drain";
-  if (text === "/stop" || text === "stop" || text === "/project_stop") return "stop";
-  return undefined;
-}
-
-function promptBlocksText(prompt: unknown): string {
-  if (!Array.isArray(prompt)) return "";
-  return prompt
-    .map((block) => record(block))
-    .filter((block): block is Record<string, unknown> => block?.type === "text" && typeof block.text === "string")
-    .map((block) => block.text as string)
-    .join("\n");
-}
-
-async function notifyV1ProjectControl(
-  upstream: AgentConnection["client"],
-  sessionId: string,
-  operation: ProjectControlOperation,
-  control: ReturnType<typeof projectControlSnapshot>,
-): Promise<void> {
-  await upstream.notify(methods.client.session.update, {
-    sessionId,
-    update: {
-      sessionUpdate: "plan",
-      entries: [{
-        content: `${operation === "drain" ? "Continue" : "Stop"} the Project drain`,
-        priority: "high",
-        status: "completed",
-      }],
-    },
-  });
-  await upstream.notify(methods.client.session.update, {
-    sessionId,
-    update: {
-      sessionUpdate: "agent_message_chunk",
-      content: {
-        type: "text",
-        text: `Project drain intent is ${control.drain_intent} at revision ${control.revision}\n`,
-      },
-    },
-  });
-}
-
-async function runV2ProjectControlTurn(
-  sessions: Map<string, PublicSession>,
-  params: acpV2.PromptRequest,
-  upstream: acpV2.AgentContext,
-  operation: ProjectControlOperation,
-  projectControls: Map<string, ProjectControlState>,
-): Promise<void> {
-  const session = sessions.get(params.sessionId);
-  if (session == null) return;
-  const control = applyProjectControl(session.project, operation, projectControls);
-  await upstream.notify(acpV2.methods.client.session.update, {
-    sessionId: params.sessionId,
-    update: {
-      sessionUpdate: "plan_update",
-      plan: {
-        type: "items",
-        planId: "project-control",
-        entries: [{
-          content: `${operation === "drain" ? "Continue" : "Stop"} the Project drain`,
-          priority: "high",
-          status: "completed",
-        }],
-      },
-    },
-  });
-  await upstream.notify(acpV2.methods.client.session.update, {
-    sessionId: params.sessionId,
-    update: { sessionUpdate: "state_update", state: "idle", stopReason: "end_turn" },
-    _meta: { redskills: { authority: "redskilled", projectControl: control } },
-  });
 }
 
 async function runV2PublicTurn(

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -53,6 +53,26 @@ import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
 
 export { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "./acp-compat.js";
 const TERMINAL_REAP_DELAY_MS = 150;
+const PROJECT_CONTROL_METHODS = [
+  "_redskills/project_drain",
+  "_redskills/project_stop",
+  "_redskills/project_status",
+] as const;
+
+type ProjectControlOperation = "drain" | "stop";
+type ProjectDrainIntent = "inactive" | "draining" | "stopped";
+
+interface ProjectControlUpdate {
+  readonly sequence: number;
+  readonly operation: ProjectControlOperation;
+  readonly drain_intent: Exclude<ProjectDrainIntent, "inactive">;
+}
+
+interface ProjectControlState {
+  readonly drainIntent: ProjectDrainIntent;
+  readonly revision: number;
+  readonly updates: readonly ProjectControlUpdate[];
+}
 
 interface PublicSession {
   readonly request: NewSessionRequest;
@@ -87,6 +107,10 @@ export async function startRedskillsAcpControlPlane(
   const { paths } = options;
   const sockets = new Set<Socket>();
   const projects = new Map<string, Promise<AcpProjectWorkspace>>();
+  // Project control belongs to the daemon endpoint, not to any ACP connection.
+  // Closing the client therefore drops observation only; drain intent remains
+  // until the shared reducer receives an explicit stop.
+  const projectControls = new Map<string, ProjectControlState>();
   const workspaceFor = (identity: AcpProjectIdentity): Promise<AcpProjectWorkspace> => {
     const held = projects.get(identity.projectId);
     if (held != null) return held;
@@ -104,7 +128,7 @@ export async function startRedskillsAcpControlPlane(
   const server = createServer((socket) => {
     sockets.add(socket);
     socket.once("close", () => sockets.delete(socket));
-    void servePublicConnection(socket, options, workspaceFor).catch(() => socket.destroy());
+    void servePublicConnection(socket, options, workspaceFor, projectControls).catch(() => socket.destroy());
   });
   await listen(server, paths.acpSocketPath);
 
@@ -125,6 +149,7 @@ async function servePublicConnection(
   socket: Socket,
   options: StartRedskillsAcpControlPlaneOptions,
   workspaceFor: (identity: AcpProjectIdentity) => Promise<AcpProjectWorkspace>,
+  projectControls: Map<string, ProjectControlState>,
 ): Promise<void> {
   const sessions = new Map<string, PublicSession>();
   const active = new Map<string, ActiveWorker>();
@@ -144,6 +169,17 @@ async function servePublicConnection(
     return projectState(options.hostState(), connectionProject);
   };
 
+  const scopedProject = (): AcpProjectWorkspace => {
+    if (connectionProject == null) {
+      throw RequestError.invalidRequest("a Project session must bind this ACP connection before control can be used");
+    }
+    return connectionProject;
+  };
+  const readProjectControl = () => projectControlSnapshot(scopedProject(), projectControls);
+  const mutateProjectControl = (operation: ProjectControlOperation) =>
+    applyProjectControl(scopedProject(), operation, projectControls);
+  const emptyParams = () => ({});
+
   const v1App = agent({ name: "RedSkills" })
     .onRequest(methods.agent.initialize, ({ params }) => {
       requireCompatibleWireMajor(params._meta);
@@ -153,7 +189,13 @@ async function servePublicConnection(
           : ACP_PROTOCOL_VERSION,
         agentCapabilities: { promptCapabilities: {} },
         agentInfo: { name: "RedSkills", version: "1" },
-        _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR, workerBacked: true } },
+        _meta: {
+          redskills: {
+            wireMajor: REDSKILLS_WIRE_MAJOR,
+            workerBacked: true,
+            projectControl: { version: 1, methods: PROJECT_CONTROL_METHODS },
+          },
+        },
       };
     })
     .onRequest(methods.agent.session.new, async ({ params }) => {
@@ -180,6 +222,16 @@ async function servePublicConnection(
       const session = sessions.get(params.sessionId);
       if (session == null) throw new Error("unknown RedSkills ACP session");
       if (active.has(params.sessionId)) throw new Error("this RedSkills ACP session already has an active turn");
+
+      const controlOperation = coreProjectOperation(params.prompt);
+      if (controlOperation != null) {
+        const control = applyProjectControl(session.project, controlOperation, projectControls);
+        await notifyV1ProjectControl(upstream, params.sessionId, controlOperation, control);
+        return {
+          stopReason: "end_turn",
+          _meta: { redskills: { authority: "redskilled", projectControl: control } },
+        } satisfies PromptResponse;
+      }
 
       const worker = await admitNativeAcpWorker(options, session, params.sessionId, upstream.notify.bind(upstream));
       active.set(params.sessionId, worker);
@@ -218,7 +270,10 @@ async function servePublicConnection(
     })
     // Compatibility spelling, but deliberately a Project projection. Ordinary
     // ACP socket access is not an administrative capability.
-    .onRequest("_redskills/host_state", () => ({}), scopedState);
+    .onRequest("_redskills/host_state", emptyParams, scopedState)
+    .onRequest(PROJECT_CONTROL_METHODS[0], emptyParams, () => mutateProjectControl("drain"))
+    .onRequest(PROJECT_CONTROL_METHODS[1], emptyParams, () => mutateProjectControl("stop"))
+    .onRequest(PROJECT_CONTROL_METHODS[2], emptyParams, readProjectControl);
 
   const v2Turns = new Map<string, Promise<void>>();
   const v2App = acpV2.agent({ name: "RedSkills" })
@@ -234,6 +289,7 @@ async function servePublicConnection(
             wireMajor: REDSKILLS_WIRE_MAJOR,
             workerBacked: true,
             acpDraftRevision: ACP_V2_DRAFT_REVISION,
+            projectControl: { version: 1, methods: PROJECT_CONTROL_METHODS },
           },
         },
       };
@@ -274,8 +330,11 @@ async function servePublicConnection(
       }
 
       const accepted = new Promise<void>((resolve) => setTimeout(resolve, 0));
+      const controlOperation = coreProjectOperation(params.prompt);
       const turn = accepted
-        .then(() => runV2PublicTurn(options, sessions, active, params, upstream))
+        .then(() => controlOperation == null
+          ? runV2PublicTurn(options, sessions, active, params, upstream)
+          : runV2ProjectControlTurn(sessions, params, upstream, controlOperation, projectControls))
         .catch(() => {})
         .finally(() => v2Turns.delete(params.sessionId));
       v2Turns.set(params.sessionId, turn);
@@ -290,7 +349,10 @@ async function servePublicConnection(
         ...(params._meta == null ? {} : { _meta: params._meta }),
       });
     })
-    .onRequest("_redskills/host_state", () => ({}), scopedState);
+    .onRequest("_redskills/host_state", emptyParams, scopedState)
+    .onRequest(PROJECT_CONTROL_METHODS[0], emptyParams, () => mutateProjectControl("drain"))
+    .onRequest(PROJECT_CONTROL_METHODS[1], emptyParams, () => mutateProjectControl("stop"))
+    .onRequest(PROJECT_CONTROL_METHODS[2], emptyParams, readProjectControl);
 
   const connection = acpV2.agentProtocolRouter()
     .withV1(v1App)
@@ -298,6 +360,124 @@ async function servePublicConnection(
     .connect(socketStream(socket) as unknown as acpV2.Stream);
   await connection.closed;
   for (const [sessionId, worker] of active) cleanupWorker(sessionId, worker, active);
+}
+
+function projectControlSnapshot(
+  project: AcpProjectWorkspace,
+  projectControls: Map<string, ProjectControlState>,
+) {
+  const control = projectControls.get(project.projectId) ?? {
+    drainIntent: "inactive" as const,
+    revision: 0,
+    updates: [],
+  };
+  return {
+    version: 1 as const,
+    project_id: project.projectId,
+    project_label: project.projectLabel,
+    workspace_path: project.workspacePath,
+    drain_intent: control.drainIntent,
+    revision: control.revision,
+    updates: [...control.updates],
+  };
+}
+
+function applyProjectControl(
+  project: AcpProjectWorkspace,
+  operation: ProjectControlOperation,
+  projectControls: Map<string, ProjectControlState>,
+) {
+  const held = projectControls.get(project.projectId) ?? {
+    drainIntent: "inactive" as const,
+    revision: 0,
+    updates: [],
+  };
+  const requestedIntent = operation === "drain" ? "draining" as const : "stopped" as const;
+  if (held.drainIntent === requestedIntent) return projectControlSnapshot(project, projectControls);
+  const revision = held.revision + 1;
+  projectControls.set(project.projectId, {
+    drainIntent: requestedIntent,
+    revision,
+    updates: [...held.updates, { sequence: revision, operation, drain_intent: requestedIntent }],
+  });
+  return projectControlSnapshot(project, projectControls);
+}
+
+function coreProjectOperation(prompt: unknown): ProjectControlOperation | undefined {
+  const text = promptBlocksText(prompt).trim().toLowerCase();
+  if (text === "/drain" || text === "drain") return "drain";
+  if (text === "/stop" || text === "stop" || text === "/project_stop") return "stop";
+  return undefined;
+}
+
+function promptBlocksText(prompt: unknown): string {
+  if (!Array.isArray(prompt)) return "";
+  return prompt
+    .map((block) => record(block))
+    .filter((block): block is Record<string, unknown> => block?.type === "text" && typeof block.text === "string")
+    .map((block) => block.text as string)
+    .join("\n");
+}
+
+async function notifyV1ProjectControl(
+  upstream: AgentConnection["client"],
+  sessionId: string,
+  operation: ProjectControlOperation,
+  control: ReturnType<typeof projectControlSnapshot>,
+): Promise<void> {
+  await upstream.notify(methods.client.session.update, {
+    sessionId,
+    update: {
+      sessionUpdate: "plan",
+      entries: [{
+        content: `${operation === "drain" ? "Continue" : "Stop"} the Project drain`,
+        priority: "high",
+        status: "completed",
+      }],
+    },
+  });
+  await upstream.notify(methods.client.session.update, {
+    sessionId,
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: `Project drain intent is ${control.drain_intent} at revision ${control.revision}\n`,
+      },
+    },
+  });
+}
+
+async function runV2ProjectControlTurn(
+  sessions: Map<string, PublicSession>,
+  params: acpV2.PromptRequest,
+  upstream: acpV2.AgentContext,
+  operation: ProjectControlOperation,
+  projectControls: Map<string, ProjectControlState>,
+): Promise<void> {
+  const session = sessions.get(params.sessionId);
+  if (session == null) return;
+  const control = applyProjectControl(session.project, operation, projectControls);
+  await upstream.notify(acpV2.methods.client.session.update, {
+    sessionId: params.sessionId,
+    update: {
+      sessionUpdate: "plan_update",
+      plan: {
+        type: "items",
+        planId: "project-control",
+        entries: [{
+          content: `${operation === "drain" ? "Continue" : "Stop"} the Project drain`,
+          priority: "high",
+          status: "completed",
+        }],
+      },
+    },
+  });
+  await upstream.notify(acpV2.methods.client.session.update, {
+    sessionId: params.sessionId,
+    update: { sessionUpdate: "state_update", state: "idle", stopReason: "end_turn" },
+    _meta: { redskills: { authority: "redskilled", projectControl: control } },
+  });
 }
 
 async function runV2PublicTurn(

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -46,9 +46,11 @@ import type { RedskilledPaths } from "./paths.js";
 import {
   applyProjectControl,
   coreProjectOperation,
+  createProjectControlStore,
   notifyV1ProjectControl,
   PROJECT_CONTROL_METHODS,
   projectControlSnapshot,
+  projectControlStorePath,
   runV2ProjectControlTurn,
   type ProjectControlOperation,
   type ProjectControlState,
@@ -100,7 +102,9 @@ export async function startRedskillsAcpControlPlane(
   // Project control belongs to the daemon endpoint, not to any ACP connection.
   // Closing the client therefore drops observation only; drain intent remains
   // until the shared reducer receives an explicit stop.
-  const projectControls = new Map<string, ProjectControlState>();
+  const projectControlStore = createProjectControlStore(projectControlStorePath(paths.registrationIntentPath));
+  const projectControls = await projectControlStore.read();
+  const persistProjectControls = projectControlStore.replace.bind(projectControlStore);
   const workspaceFor = (identity: AcpProjectIdentity): Promise<AcpProjectWorkspace> => {
     const held = projects.get(identity.projectId);
     if (held != null) return held;
@@ -118,7 +122,13 @@ export async function startRedskillsAcpControlPlane(
   const server = createServer((socket) => {
     sockets.add(socket);
     socket.once("close", () => sockets.delete(socket));
-    void servePublicConnection(socket, options, workspaceFor, projectControls).catch(() => socket.destroy());
+    void servePublicConnection(
+      socket,
+      options,
+      workspaceFor,
+      projectControls,
+      persistProjectControls,
+    ).catch(() => socket.destroy());
   });
   await listen(server, paths.acpSocketPath);
 
@@ -140,6 +150,7 @@ async function servePublicConnection(
   options: StartRedskillsAcpControlPlaneOptions,
   workspaceFor: (identity: AcpProjectIdentity) => Promise<AcpProjectWorkspace>,
   projectControls: Map<string, ProjectControlState>,
+  persistProjectControls: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>,
 ): Promise<void> {
   const sessions = new Map<string, PublicSession>();
   const active = new Map<string, ActiveWorker>();
@@ -167,7 +178,7 @@ async function servePublicConnection(
   };
   const readProjectControl = () => projectControlSnapshot(scopedProject(), projectControls);
   const mutateProjectControl = (operation: ProjectControlOperation) =>
-    applyProjectControl(scopedProject(), operation, projectControls);
+    applyProjectControl(scopedProject(), operation, projectControls, persistProjectControls);
   const emptyParams = () => ({});
 
   const v1App = agent({ name: "RedSkills" })
@@ -215,7 +226,12 @@ async function servePublicConnection(
 
       const controlOperation = coreProjectOperation(params.prompt);
       if (controlOperation != null) {
-        const control = applyProjectControl(session.project, controlOperation, projectControls);
+        const control = await applyProjectControl(
+          session.project,
+          controlOperation,
+          projectControls,
+          persistProjectControls,
+        );
         await notifyV1ProjectControl(upstream, params.sessionId, controlOperation, control);
         return {
           stopReason: "end_turn",
@@ -324,7 +340,14 @@ async function servePublicConnection(
       const turn = accepted
         .then(() => controlOperation == null
           ? runV2PublicTurn(options, sessions, active, params, upstream)
-          : runV2ProjectControlTurn(sessions, params, upstream, controlOperation, projectControls))
+          : runV2ProjectControlTurn(
+            sessions,
+            params,
+            upstream,
+            controlOperation,
+            projectControls,
+            persistProjectControls,
+          ))
         .catch(() => {})
         .finally(() => v2Turns.delete(params.sessionId));
       v2Turns.set(params.sessionId, turn);

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -1,8 +1,12 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import {
   methods,
   type AgentConnection,
 } from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 
 export const PROJECT_CONTROL_METHODS = [
@@ -24,6 +28,19 @@ export interface ProjectControlState {
   readonly drainIntent: ProjectDrainIntent;
   readonly revision: number;
   readonly updates: readonly ProjectControlUpdate[];
+}
+
+interface ProjectControlStoreSnapshot {
+  readonly version: 1;
+  readonly projects: readonly {
+    readonly project_id: string;
+    readonly state: ProjectControlState;
+  }[];
+}
+
+export interface ProjectControlStore {
+  read(): Promise<Map<string, ProjectControlState>>;
+  replace(projects: ReadonlyMap<string, ProjectControlState>): Promise<void>;
 }
 
 interface ProjectControlSession {
@@ -50,10 +67,11 @@ export function projectControlSnapshot(
   };
 }
 
-export function applyProjectControl(
+export async function applyProjectControl(
   project: AcpProjectWorkspace,
   operation: ProjectControlOperation,
   projectControls: Map<string, ProjectControlState>,
+  persist: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>,
 ) {
   const held = projectControls.get(project.projectId) ?? {
     drainIntent: "inactive" as const,
@@ -63,12 +81,55 @@ export function applyProjectControl(
   const requestedIntent = operation === "drain" ? "draining" as const : "stopped" as const;
   if (held.drainIntent === requestedIntent) return projectControlSnapshot(project, projectControls);
   const revision = held.revision + 1;
-  projectControls.set(project.projectId, {
+  const next = new Map(projectControls);
+  next.set(project.projectId, {
     drainIntent: requestedIntent,
     revision,
     updates: [...held.updates, { sequence: revision, operation, drain_intent: requestedIntent }],
   });
+  await persist(next);
+  projectControls.set(project.projectId, next.get(project.projectId)!);
   return projectControlSnapshot(project, projectControls);
+}
+
+export function projectControlStorePath(registrationIntentPath: string): string {
+  return join(dirname(registrationIntentPath), "redskilled.project-control.toon");
+}
+
+export function createProjectControlStore(path: string): ProjectControlStore {
+  let tail: Promise<void> = Promise.resolve();
+
+  return {
+    async read() {
+      await tail;
+      let raw: string;
+      try {
+        raw = await readFile(path, "utf8");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return new Map();
+        throw error;
+      }
+      const parsed = parseStoreSnapshot(raw);
+      if (!isStoreSnapshot(parsed)) return new Map();
+      return new Map(parsed.projects.map(({ project_id, state }) => [project_id, state]));
+    },
+    replace(projects) {
+      const snapshot: ProjectControlStoreSnapshot = {
+        version: 1,
+        projects: [...projects].map(([project_id, state]) => ({ project_id, state })),
+      };
+      tail = tail.then(async () => {
+        await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+        const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+        await writeFile(temporary, `${encode(snapshot as unknown as JsonValue)}\n`, {
+          encoding: "utf8",
+          mode: 0o600,
+        });
+        await rename(temporary, path);
+      });
+      return tail;
+    },
+  };
 }
 
 export function coreProjectOperation(prompt: unknown): ProjectControlOperation | undefined {
@@ -122,10 +183,11 @@ export async function runV2ProjectControlTurn(
   upstream: acpV2.AgentContext,
   operation: ProjectControlOperation,
   projectControls: Map<string, ProjectControlState>,
+  persist: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>,
 ): Promise<void> {
   const session = sessions.get(params.sessionId);
   if (session == null) return;
-  const control = applyProjectControl(session.project, operation, projectControls);
+  const control = await applyProjectControl(session.project, operation, projectControls, persist);
   await upstream.notify(acpV2.methods.client.session.update, {
     sessionId: params.sessionId,
     update: {
@@ -146,6 +208,34 @@ export async function runV2ProjectControlTurn(
     update: { sessionUpdate: "state_update", state: "idle", stopReason: "end_turn" },
     _meta: { redskills: { authority: "redskilled", projectControl: control } },
   });
+}
+
+function parseStoreSnapshot(raw: string): unknown {
+  const body = raw.trim();
+  if (!body) return null;
+  try {
+    return decode(body);
+  } catch {
+    try {
+      return JSON.parse(body) as unknown;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function isStoreSnapshot(value: unknown): value is ProjectControlStoreSnapshot {
+  const snapshot = record(value);
+  return snapshot?.version === 1 &&
+    Array.isArray(snapshot.projects) &&
+    snapshot.projects.every((entry) => {
+      const project = record(entry);
+      const state = record(project?.state);
+      return typeof project?.project_id === "string" &&
+        (state?.drainIntent === "inactive" || state?.drainIntent === "draining" || state?.drainIntent === "stopped") &&
+        typeof state.revision === "number" &&
+        Array.isArray(state.updates);
+    });
 }
 
 function record(value: unknown): Record<string, unknown> | undefined {

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -1,0 +1,155 @@
+import {
+  methods,
+  type AgentConnection,
+} from "@agentclientprotocol/sdk";
+import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
+import type { AcpProjectWorkspace } from "./project-workspace.js";
+
+export const PROJECT_CONTROL_METHODS = [
+  "_redskills/project_drain",
+  "_redskills/project_stop",
+  "_redskills/project_status",
+] as const;
+
+export type ProjectControlOperation = "drain" | "stop";
+type ProjectDrainIntent = "inactive" | "draining" | "stopped";
+
+interface ProjectControlUpdate {
+  readonly sequence: number;
+  readonly operation: ProjectControlOperation;
+  readonly drain_intent: Exclude<ProjectDrainIntent, "inactive">;
+}
+
+export interface ProjectControlState {
+  readonly drainIntent: ProjectDrainIntent;
+  readonly revision: number;
+  readonly updates: readonly ProjectControlUpdate[];
+}
+
+interface ProjectControlSession {
+  readonly project: AcpProjectWorkspace;
+}
+
+export function projectControlSnapshot(
+  project: AcpProjectWorkspace,
+  projectControls: Map<string, ProjectControlState>,
+) {
+  const control = projectControls.get(project.projectId) ?? {
+    drainIntent: "inactive" as const,
+    revision: 0,
+    updates: [],
+  };
+  return {
+    version: 1 as const,
+    project_id: project.projectId,
+    project_label: project.projectLabel,
+    workspace_path: project.workspacePath,
+    drain_intent: control.drainIntent,
+    revision: control.revision,
+    updates: [...control.updates],
+  };
+}
+
+export function applyProjectControl(
+  project: AcpProjectWorkspace,
+  operation: ProjectControlOperation,
+  projectControls: Map<string, ProjectControlState>,
+) {
+  const held = projectControls.get(project.projectId) ?? {
+    drainIntent: "inactive" as const,
+    revision: 0,
+    updates: [],
+  };
+  const requestedIntent = operation === "drain" ? "draining" as const : "stopped" as const;
+  if (held.drainIntent === requestedIntent) return projectControlSnapshot(project, projectControls);
+  const revision = held.revision + 1;
+  projectControls.set(project.projectId, {
+    drainIntent: requestedIntent,
+    revision,
+    updates: [...held.updates, { sequence: revision, operation, drain_intent: requestedIntent }],
+  });
+  return projectControlSnapshot(project, projectControls);
+}
+
+export function coreProjectOperation(prompt: unknown): ProjectControlOperation | undefined {
+  const text = promptBlocksText(prompt).trim().toLowerCase();
+  if (text === "/drain" || text === "drain") return "drain";
+  if (text === "/stop" || text === "stop" || text === "/project_stop") return "stop";
+  return undefined;
+}
+
+function promptBlocksText(prompt: unknown): string {
+  if (!Array.isArray(prompt)) return "";
+  return prompt
+    .map((block) => record(block))
+    .filter((block): block is Record<string, unknown> => block?.type === "text" && typeof block.text === "string")
+    .map((block) => block.text as string)
+    .join("\n");
+}
+
+export async function notifyV1ProjectControl(
+  upstream: AgentConnection["client"],
+  sessionId: string,
+  operation: ProjectControlOperation,
+  control: ReturnType<typeof projectControlSnapshot>,
+): Promise<void> {
+  await upstream.notify(methods.client.session.update, {
+    sessionId,
+    update: {
+      sessionUpdate: "plan",
+      entries: [{
+        content: `${operation === "drain" ? "Continue" : "Stop"} the Project drain`,
+        priority: "high",
+        status: "completed",
+      }],
+    },
+  });
+  await upstream.notify(methods.client.session.update, {
+    sessionId,
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: `Project drain intent is ${control.drain_intent} at revision ${control.revision}\n`,
+      },
+    },
+  });
+}
+
+export async function runV2ProjectControlTurn(
+  sessions: ReadonlyMap<string, ProjectControlSession>,
+  params: acpV2.PromptRequest,
+  upstream: acpV2.AgentContext,
+  operation: ProjectControlOperation,
+  projectControls: Map<string, ProjectControlState>,
+): Promise<void> {
+  const session = sessions.get(params.sessionId);
+  if (session == null) return;
+  const control = applyProjectControl(session.project, operation, projectControls);
+  await upstream.notify(acpV2.methods.client.session.update, {
+    sessionId: params.sessionId,
+    update: {
+      sessionUpdate: "plan_update",
+      plan: {
+        type: "items",
+        planId: "project-control",
+        entries: [{
+          content: `${operation === "drain" ? "Continue" : "Stop"} the Project drain`,
+          priority: "high",
+          status: "completed",
+        }],
+      },
+    },
+  });
+  await upstream.notify(acpV2.methods.client.session.update, {
+    sessionId: params.sessionId,
+    update: { sessionUpdate: "state_update", state: "idle", stopReason: "end_turn" },
+    _meta: { redskills: { authority: "redskilled", projectControl: control } },
+  });
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -259,7 +259,7 @@ describe("the public RedSkills ACP v1 control plane", () => {
       REDSKILLED_SESSION: `test:${root}`,
     };
     const paths = resolveRedskilledPaths({ env, homeDir: root });
-    const daemon = launchCli([
+    let daemon = launchCli([
       "serve",
       "--socket", paths.socketPath,
       "--lease", paths.leasePath,
@@ -303,6 +303,19 @@ describe("the public RedSkills ACP v1 control plane", () => {
 
     first.close();
     firstAdapter.stdin?.end();
+
+    const firstDaemonExit = new Promise<void>((resolve) => daemon.once("exit", () => resolve()));
+    daemon.kill("SIGTERM");
+    await firstDaemonExit;
+    daemon = launchCli([
+      "serve",
+      "--socket", paths.socketPath,
+      "--lease", paths.leasePath,
+      "--events", paths.eventLanePath,
+      "--machine-claim", paths.machineClaimPath,
+      "--idle-ms", "60000",
+    ], env, ["ignore", "ignore", "pipe"]);
+    await waitFor(() => socketAnswers(paths.socketPath, 1_000), "replacement redskilled daemon socket");
 
     const secondAdapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
     const second = client({ name: "project-drain-typed" }).connect(childStream(secondAdapter));

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -246,7 +246,137 @@ describe("the public RedSkills ACP v1 control plane", () => {
     renamedAdapter.stdin?.end();
     daemon.kill("SIGTERM");
   }, 30_000);
+
+  it("keeps one governed Project drain alive across clients until an explicit stop", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-acp-project-drain-"));
+    roots.push(root);
+    const env = {
+      ...process.env,
+      HOME: root,
+      XDG_RUNTIME_DIR: root,
+      REDSKILLED_MACHINE_DIR: root,
+      REDSKILLED_PLACEMENT: "off",
+      REDSKILLED_SESSION: `test:${root}`,
+    };
+    const paths = resolveRedskilledPaths({ env, homeDir: root });
+    const daemon = launchCli([
+      "serve",
+      "--socket", paths.socketPath,
+      "--lease", paths.leasePath,
+      "--events", paths.eventLanePath,
+      "--machine-claim", paths.machineClaimPath,
+      "--idle-ms", "60000",
+    ], env, ["ignore", "ignore", "pipe"]);
+    await waitFor(() => socketAnswers(paths.socketPath, 1_000), "redskilled daemon socket");
+
+    const firstAdapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
+    const orderedCoreUpdates: string[] = [];
+    const first = client({ name: "project-drain-core" })
+      .onNotification(methods.client.session.update, ({ params }) => {
+        orderedCoreUpdates.push(params.update.sessionUpdate);
+      })
+      .connect(childStream(firstAdapter));
+    const initialized = await first.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "project-drain-core", version: "1" },
+    });
+    expect(initialized._meta).toMatchObject({
+      redskills: {
+        projectControl: {
+          version: 1,
+          methods: ["_redskills/project_drain", "_redskills/project_stop", "_redskills/project_status"],
+        },
+      },
+    });
+    const firstSession = await first.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
+    const coreDrain = await first.agent.request(methods.agent.session.prompt, {
+      sessionId: firstSession.sessionId,
+      prompt: [{ type: "text", text: "/drain" }],
+    });
+    expect(projectControlMeta(coreDrain._meta)).toMatchObject({
+      drain_intent: "draining",
+      revision: 1,
+      updates: [{ sequence: 1, operation: "drain", drain_intent: "draining" }],
+    });
+    expect(orderedCoreUpdates).toEqual(["plan", "agent_message_chunk"]);
+
+    first.close();
+    firstAdapter.stdin?.end();
+
+    const secondAdapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
+    const second = client({ name: "project-drain-typed" }).connect(childStream(secondAdapter));
+    await second.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "project-drain-typed", version: "1" },
+    });
+    await second.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
+    const observed = await second.agent.request<ProjectControlSnapshot>("_redskills/project_status", {});
+    expect(observed).toEqual(projectControlMeta(coreDrain._meta));
+
+    const stopped = await second.agent.request<ProjectControlSnapshot>("_redskills/project_stop", {});
+    expect(stopped).toMatchObject({
+      drain_intent: "stopped",
+      revision: 2,
+      updates: [
+        { sequence: 1, operation: "drain", drain_intent: "draining" },
+        { sequence: 2, operation: "stop", drain_intent: "stopped" },
+      ],
+    });
+    second.close();
+    secondAdapter.stdin?.end();
+
+    const thirdAdapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
+    const third = client({ name: "project-drain-core-again" }).connect(childStream(thirdAdapter));
+    await third.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "project-drain-core-again", version: "1" },
+    });
+    const thirdSession = await third.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
+    const coreDrainAgain = await third.agent.request(methods.agent.session.prompt, {
+      sessionId: thirdSession.sessionId,
+      prompt: [{ type: "text", text: "/drain" }],
+    });
+    expect(projectControlMeta(coreDrainAgain._meta)).toMatchObject({
+      drain_intent: "draining",
+      revision: 3,
+      updates: [
+        { sequence: 1, operation: "drain", drain_intent: "draining" },
+        { sequence: 2, operation: "stop", drain_intent: "stopped" },
+        { sequence: 3, operation: "drain", drain_intent: "draining" },
+      ],
+    });
+    expect(await third.agent.request<ProjectControlSnapshot>("_redskills/project_status", {}))
+      .toEqual(projectControlMeta(coreDrainAgain._meta));
+
+    third.close();
+    thirdAdapter.stdin?.end();
+    daemon.kill("SIGTERM");
+  }, 30_000);
 });
+
+interface ProjectControlSnapshot {
+  readonly version: 1;
+  readonly project_id: string;
+  readonly project_label: string;
+  readonly workspace_path: string;
+  readonly drain_intent: "inactive" | "draining" | "stopped";
+  readonly revision: number;
+  readonly updates: ReadonlyArray<{
+    readonly sequence: number;
+    readonly operation: "drain" | "stop";
+    readonly drain_intent: "draining" | "stopped";
+  }>;
+}
+
+function projectControlMeta(meta: unknown): ProjectControlSnapshot {
+  const control = (meta as { redskills?: { projectControl?: unknown } } | undefined)
+    ?.redskills?.projectControl;
+  expect(control).toMatchObject({ version: 1, project_id: expect.any(String) });
+  return control as ProjectControlSnapshot;
+}
 
 function projectMeta(meta: unknown): { projectId: string; projectLabel: string; workspacePath: string } {
   const project = (meta as { redskills?: unknown } | undefined)?.redskills as


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3885 -->
🤖 **Re-seed trail** — #3885 on `afk/3885-project-drain-survives-acp-client-discon`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3885; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3885 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/redskilled`]
{"schema":"red.afk.validation.v1","name":"feedback:pnpm -C apps/dev test:invariants","status":"failed","command":"pnpm -C apps/dev test:invariants","exitCode":1,"durationMs":47,"summary":"failing: FAIL tests/file-size-guard.test.ts > file-size ratchet — a split nothing enforces is a split that comes back > holds the live tree to the threshold and the shrink-only baseline —  - Array [] + Array [ +   Object { +     \"kind\": \"over-threshold\", +     \"lines\": 883, +     \"path\": \"apps/redskilled/src/acp-control-plane.ts\", +     \"reason\": \"apps/redskilled/src/acp-control-plane.ts is 883 lines, over the 800-line threshold. Split it by domain — the baseline records debt that predates this ratchet, never a new file.\", +   }, + ]   ❯ tests/file-size-guard.test.ts:46:7      44|         : `file-size ratchet: ${findings.length} finding(s).\\n${render…      45|           `Baseline: apps/dev/src/core/file-size-guard.ts (FILE_SIZE_B…      46|     ).toEqual([]);        |       ^      47|   });      48|   ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯","resources":{"source":"cgroup-v2","sampled_before":"2026-08-15T05:42:55.183Z","sampled_after":"2026-08-15T05:43:42.656Z","memory_current_before_bytes":427638784,"memory_current_after_bytes":432455680,"memory_peak_bytes":1589145600,"memory_max_bytes":2736193536,"cpu_usage_delta_usec":54107141,"cpu_throttled_delta_usec":0,"pids_peak":219,"memory_events_delta":{},"pids_events_delta":{}}}
```

Closes #3885