### PR TITLE
refactor(redskilled): split acp-control-plane.ts by domain

### DIFF
--- a/.changeset/split-acp-control-plane.md
+++ b/.changeset/split-acp-control-plane.md
@@ -1,0 +1,6 @@
+---
+"@reddb-io/redskilled": patch
+"@reddb-io/dev": patch
+---
+
+Split `acp-control-plane.ts` into compatibility-negotiation and socket-plumbing modules, restoring file-size headroom for the remaining ACP chain. Behavior unchanged.

--- a/apps/dev/src/core/declared-wait-guard.ts
+++ b/apps/dev/src/core/declared-wait-guard.ts
@@ -692,7 +692,7 @@ export const DECLARED_WAITS: readonly DeclaredWait[] = [
     heartbeat: { silent: "a seconds-long drain whose boolean return is the report" },
   },
   {
-    path: "apps/redskilled/src/acp-control-plane.ts",
+    path: "apps/redskilled/src/acp-socket.ts",
     fn: "connectWithDeadline",
     subject: "the daemon ACP socket or assigned native Worker ACP socket accepting a local connection",
     deadline: "the caller's `timeoutMs`, 10 seconds for both public and Worker rendezvous",

--- a/apps/redskilled/src/acp-compat.ts
+++ b/apps/redskilled/src/acp-compat.ts
@@ -1,0 +1,37 @@
+import { RequestError } from "@agentclientprotocol/sdk";
+import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
+
+export const ACP_PROTOCOL_VERSION = 1;
+export const ACP_V2_DRAFT_REVISION = "schema-v2.0.0-alpha.2";
+export const REDSKILLS_WIRE_MAJOR = 1;
+
+export function requireCompatibleWireMajor(meta: unknown, required = false): void {
+  const redskills = record(record(meta)?.redskills);
+  const wireMajor = redskills?.wireMajor;
+  if (wireMajor == null && !required) return;
+  if (wireMajor !== REDSKILLS_WIRE_MAJOR) {
+    const received = typeof wireMajor === "number" ? wireMajor : "omitted";
+    throw RequestError.invalidParams(
+      { redskills: { receivedWireMajor: received, supportedWireMajor: REDSKILLS_WIRE_MAJOR } },
+      `unsupported RedSkills wire major ${received}; expected ${REDSKILLS_WIRE_MAJOR}`,
+    );
+  }
+}
+
+export function requireSupportedV2Revision(meta: acpV2.InitializeRequest["_meta"]): void {
+  const redskills = record(meta?.redskills);
+  const revision = redskills?.acpDraftRevision;
+  if (revision !== ACP_V2_DRAFT_REVISION) {
+    const received = typeof revision === "string" ? revision : "omitted";
+    throw acpV2.RequestError.invalidParams(
+      { redskills: { receivedRevision: received, supportedRevision: ACP_V2_DRAFT_REVISION } },
+      `unsupported ACP v2 draft revision ${received}; expected ${ACP_V2_DRAFT_REVISION}`,
+    );
+  }
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -8,14 +8,12 @@
  */
 import { randomBytes, randomUUID } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
-import { connect, createServer, type Server, type Socket } from "node:net";
+import { createServer, type Socket } from "node:net";
 import { join } from "node:path";
-import { Readable, Writable } from "node:stream";
 import {
   agent,
   client,
   methods,
-  ndJsonStream,
   RequestError,
   type AgentConnection,
   type ClientConnection,
@@ -24,9 +22,25 @@ import {
   type PromptRequest,
   type PromptResponse,
   type SessionNotification,
-  type Stream,
 } from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
+import {
+  ACP_PROTOCOL_VERSION,
+  ACP_V2_DRAFT_REVISION,
+  REDSKILLS_WIRE_MAJOR,
+  requireCompatibleWireMajor,
+  requireSupportedV2Revision,
+} from "./acp-compat.js";
+import {
+  abortableDelay,
+  bindWorkerRendezvous,
+  closeServer,
+  connectWithDeadline,
+  listen,
+  socketStream,
+  waitForAbort,
+  withTimeout,
+} from "./acp-socket.js";
 import type { RedskilledHostState } from "./host-state.js";
 import type { RedskilledPaths } from "./paths.js";
 import {
@@ -37,9 +51,7 @@ import {
 } from "./project-workspace.js";
 import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
 
-const ACP_PROTOCOL_VERSION = 1;
-export const ACP_V2_DRAFT_REVISION = "schema-v2.0.0-alpha.2";
-export const REDSKILLS_WIRE_MAJOR = 1;
+export { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "./acp-compat.js";
 const TERMINAL_REAP_DELAY_MS = 150;
 
 interface PublicSession {
@@ -288,31 +300,6 @@ async function servePublicConnection(
   for (const [sessionId, worker] of active) cleanupWorker(sessionId, worker, active);
 }
 
-function requireCompatibleWireMajor(meta: unknown, required = false): void {
-  const redskills = record(record(meta)?.redskills);
-  const wireMajor = redskills?.wireMajor;
-  if (wireMajor == null && !required) return;
-  if (wireMajor !== REDSKILLS_WIRE_MAJOR) {
-    const received = typeof wireMajor === "number" ? wireMajor : "omitted";
-    throw RequestError.invalidParams(
-      { redskills: { receivedWireMajor: received, supportedWireMajor: REDSKILLS_WIRE_MAJOR } },
-      `unsupported RedSkills wire major ${received}; expected ${REDSKILLS_WIRE_MAJOR}`,
-    );
-  }
-}
-
-function requireSupportedV2Revision(meta: acpV2.InitializeRequest["_meta"]): void {
-  const redskills = record(meta?.redskills);
-  const revision = redskills?.acpDraftRevision;
-  if (revision !== ACP_V2_DRAFT_REVISION) {
-    const received = typeof revision === "string" ? revision : "omitted";
-    throw acpV2.RequestError.invalidParams(
-      { redskills: { receivedRevision: received, supportedRevision: ACP_V2_DRAFT_REVISION } },
-      `unsupported ACP v2 draft revision ${received}; expected ${ACP_V2_DRAFT_REVISION}`,
-    );
-  }
-}
-
 async function runV2PublicTurn(
   options: StartRedskillsAcpControlPlaneOptions,
   sessions: Map<string, PublicSession>,
@@ -387,12 +374,6 @@ function translateV1UpdateToV2(
     };
   }
   return undefined;
-}
-
-function record(value: unknown): Record<string, unknown> | undefined {
-  return value != null && typeof value === "object" && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : undefined;
 }
 
 async function admitNativeAcpWorker(
@@ -618,86 +599,4 @@ function promptText(params: PromptRequest): string {
     .filter((block): block is Extract<typeof block, { type: "text" }> => block.type === "text")
     .map((block) => block.text)
     .join("\n");
-}
-
-function socketStream(socket: Socket): Stream {
-  return ndJsonStream(
-    Writable.toWeb(socket) as WritableStream<Uint8Array>,
-    Readable.toWeb(socket) as ReadableStream<Uint8Array>,
-  );
-}
-
-async function bindWorkerRendezvous(socketPath: string): Promise<{
-  server: Server;
-  connected: Promise<Socket>;
-}> {
-  await rm(socketPath, { force: true });
-  let accept!: (socket: Socket) => void;
-  const connected = new Promise<Socket>((resolve) => { accept = resolve; });
-  const server = createServer((socket) => accept(socket));
-  await listen(server, socketPath);
-  return { server, connected };
-}
-
-async function listen(server: Server, socketPath: string): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(socketPath, () => {
-      server.off("error", reject);
-      resolve();
-    });
-  });
-}
-
-async function closeServer(server: Server): Promise<void> {
-  if (!server.listening) return;
-  await new Promise<void>((resolve) => server.close(() => resolve()));
-}
-
-async function connectWithDeadline(socketPath: string, timeoutMs: number): Promise<Socket> {
-  const deadline = Date.now() + timeoutMs;
-  let cause: unknown;
-  while (Date.now() < deadline) {
-    try {
-      return await new Promise<Socket>((resolve, reject) => {
-        const socket = connect(socketPath);
-        socket.once("connect", () => resolve(socket));
-        socket.once("error", reject);
-      });
-    } catch (error) {
-      cause = error;
-      await new Promise((resolve) => setTimeout(resolve, 25));
-    }
-  }
-  throw new Error(`redskilled ACP endpoint did not answer within ${timeoutMs}ms`, { cause });
-}
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_, reject) => {
-        timer = setTimeout(() => reject(new Error(`${label} did not answer within ${timeoutMs}ms`)), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer != null) clearTimeout(timer);
-  }
-}
-
-async function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) return;
-  await new Promise<void>((resolve) => {
-    const timer = setTimeout(resolve, ms);
-    signal.addEventListener("abort", () => {
-      clearTimeout(timer);
-      resolve();
-    }, { once: true });
-  });
-}
-
-async function waitForAbort(signal: AbortSignal): Promise<void> {
-  if (signal.aborted) return;
-  await new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve(), { once: true }));
 }

--- a/apps/redskilled/src/acp-socket.ts
+++ b/apps/redskilled/src/acp-socket.ts
@@ -1,0 +1,86 @@
+import { rm } from "node:fs/promises";
+import { connect, createServer, type Server, type Socket } from "node:net";
+import { Readable, Writable } from "node:stream";
+import { ndJsonStream, type Stream } from "@agentclientprotocol/sdk";
+
+export function socketStream(socket: Socket): Stream {
+  return ndJsonStream(
+    Writable.toWeb(socket) as WritableStream<Uint8Array>,
+    Readable.toWeb(socket) as ReadableStream<Uint8Array>,
+  );
+}
+
+export async function bindWorkerRendezvous(socketPath: string): Promise<{
+  server: Server;
+  connected: Promise<Socket>;
+}> {
+  await rm(socketPath, { force: true });
+  let accept!: (socket: Socket) => void;
+  const connected = new Promise<Socket>((resolve) => { accept = resolve; });
+  const server = createServer((socket) => accept(socket));
+  await listen(server, socketPath);
+  return { server, connected };
+}
+
+export async function listen(server: Server, socketPath: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+export async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+export async function connectWithDeadline(socketPath: string, timeoutMs: number): Promise<Socket> {
+  const deadline = Date.now() + timeoutMs;
+  let cause: unknown;
+  while (Date.now() < deadline) {
+    try {
+      return await new Promise<Socket>((resolve, reject) => {
+        const socket = connect(socketPath);
+        socket.once("connect", () => resolve(socket));
+        socket.once("error", reject);
+      });
+    } catch (error) {
+      cause = error;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+  throw new Error(`redskilled ACP endpoint did not answer within ${timeoutMs}ms`, { cause });
+}
+
+export async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} did not answer within ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer != null) clearTimeout(timer);
+  }
+}
+
+export async function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener("abort", () => {
+      clearTimeout(timer);
+      resolve();
+    }, { once: true });
+  });
+}
+
+export async function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
+  await new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve(), { once: true }));
+}

--- a/apps/redskilled/tests/acp-control-plane-layout.test.ts
+++ b/apps/redskilled/tests/acp-control-plane-layout.test.ts
@@ -1,0 +1,26 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sourceRoot = join(__dirname, "..", "src");
+
+describe("the ACP control-plane module boundary", () => {
+  it("keeps the public control plane at or below its headroom target", async () => {
+    const source = await readFile(join(sourceRoot, "acp-control-plane.ts"), "utf8");
+
+    expect(source.split("\n").length - 1).toBeLessThanOrEqual(700);
+  });
+
+  it("keeps compatibility negotiation and socket plumbing in domain modules", async () => {
+    const [controlPlane, compatibility, socket] = await Promise.all([
+      readFile(join(sourceRoot, "acp-control-plane.ts"), "utf8"),
+      readFile(join(sourceRoot, "acp-compat.ts"), "utf8"),
+      readFile(join(sourceRoot, "acp-socket.ts"), "utf8"),
+    ]);
+
+    expect(controlPlane).toContain('from "./acp-compat.js"');
+    expect(controlPlane).toContain('from "./acp-socket.js"');
+    expect(compatibility).toContain("requireCompatibleWireMajor");
+    expect(socket).toContain("connectWithDeadline");
+  });
+});


### PR DESCRIPTION
Closes #3908.

Splits `apps/redskilled/src/acp-control-plane.ts` by domain so the remaining Spec #3880 chain has room to land in it. No behavior change — the existing suites are the proof.

## Result

| file | lines |
| --- | ---: |
| `acp-control-plane.ts` | 703 → **602** |
| `acp-compat.ts` (new) | 37 |
| `acp-socket.ts` (new) | 86 |

That restores ~200 lines of headroom under the 800-line ratchet. The Ticket asked for ≤700; this lands at 602.

## Why this Ticket existed

`acp-control-plane.ts` is the file every remaining ACP ticket lands in, and it sat 97 lines from the threshold. #3885 alone pushed it to 883 and was parked `blocked:validation` after burning four re-seed rounds fighting the guard. #3886 through #3897 queued up behind the same wall, so twelve tickets were each about to pay for a split that only needed doing once.

The guard forbids the escape hatch explicitly — *"the baseline records debt that predates this ratchet, never a new file"* — so `FILE_SIZE_BASELINE` is untouched.

## Notes on provenance

The AFK Worker produced the five refactor commits and then stopped without opening a PR (`orphaned work: 5 commits ahead of the base, no open pull request`). This PR adopts that branch and adds the one thing it was missing: a changeset. Without it the `scope` gate refuses any `apps/` change, which is the same failure that had #3900 red earlier today.

Two things the Worker got right beyond the brief: it pinned the new module boundary with `acp-control-plane-layout.test.ts`, and it registered the extracted socket wait in `DECLARED_WAITS` rather than leaving an undeclared poll behind.

## Verification

- `pnpm -C apps/dev test:invariants` — 17 files, 206 tests, exit 0, `file-size-guard` clean
- `pnpm typecheck` — 16/16 successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789400610&installation_model_id=20659&pr_number=3909&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3909&signature=f8dfd605a89b0f80d24430a38f3f0efdb2b462f2e9b595cd7114313ab7e0ea19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->