### PR TITLE
merge: #3385 Implement redskilled GitHub credential-profile backends

### DIFF
--- a/.changeset/redskilled-github-credential-profiles.md
+++ b/.changeset/redskilled-github-credential-profiles.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": minor
+---
+
+Add daemon-owned named personal and GitHub App credential profiles with tracked Project bindings, rotation-safe resolution, isolated gateway state, and typed secret-free ACP refusals.

--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -360,43 +360,46 @@ operator-owned.
 
 ## Which identity pays
 
-The host authenticates as a **person** by default: `REDSKILLED_HOST_TOKEN`,
-`GITHUB_TOKEN`, `GH_TOKEN`, or the tracker CLI's own credential, in that order.
-That personal token spends ONE bucket for the whole machine — the queue poll,
-every Worker's reads, and the operator's own commands draw from the same
-5,000/hour.
+Each Project binds to one named, daemon-owned credential profile. The implicit
+profile is `personal`, preserving the existing precedence:
+`REDSKILLED_HOST_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN`, then `gh auth token`.
+The daemon re-runs that lookup when a Project asks for GitHub access; it never
+copies the credential into Project config, an ACP/MCP request, or a Worker.
 
-An operator may additionally declare a **GitHub App**, which carries its own
-bucket, states its permissions instead of inheriting everything its owner can
-do, and is revocable without touching a person's account:
+Named backends live only in the host's `~/.red/config.yaml`:
 
+```yaml
+plugins:
+  dev:
+    redskilled:
+      github_profiles:
+        personal:
+          kind: personal
+        engineering:
+          kind: github-app
+          app_id: "4575633"
+          installation_id: "153309957"
+          private_key: ~/.red/redskilled/credentials/engineering.pem
 ```
-RED_GITHUB_APP_ID=<app id>
-RED_GITHUB_APP_INSTALLATION=<installation id>
-RED_GITHUB_APP_KEY=<absolute path to the App's .pem>
+
+A tracked Project selects only the public name:
+
+```yaml
+plugins:
+  dev:
+    github:
+      credential_profile: engineering
 ```
 
-All three are required together. A partial declaration is refused rather than
-falling back quietly, because a silent fallback would restore the shared bucket
-the App was adopted to end.
+The App's PEM stays daemon-local. `redskilled` reads it and mints a fresh
+installation credential at use, so key and installation-token rotation do not
+expose material downstream. Several profiles may coexist; cache entries,
+in-flight reads, returned budget facts, and authorization decisions are keyed by
+profile as well as Project.
 
-**The App does not replace the person — it is routed to, per repository.** An
-installation covers an ACCOUNT while the daemon is host-global, so the operator
-is routinely working in a repository the App was never installed on: a personal
-repo, another organisation, a fork. Those requests go out on the personal token,
-which remains the floor. Coverage is asked once per repository and remembered
-under the host state root, so the question costs one request rather than one per
-client. When coverage cannot be established at all — offline, unreadable key,
-GitHub refusing — the personal token answers and the recorded reason says
-*unknown* rather than *not installed*, so an outage never masquerades as a
-verdict.
-
-**Two identities keep two balances, and the two are never summed.** Five
-thousand App requests cannot pay for a repository the App does not cover, so a
-combined figure would report headroom that the next request cannot spend. Each
-identity's balance is stored under its own name (`balance.toon` for the person,
-`balance-app-<installation>.toon` for the App), a per-project surface shows the
-bucket that pays for THAT repository, and the host view shows both side by side.
+Profiles are fail-closed. An unknown name, missing or invalid credential, or
+scope mismatch returns a typed, secret-free ACP refusal. An explicitly selected
+App never falls back to `personal`; fix its installation or permissions instead.
 
 ## Provisioning
 

--- a/apps/redskilled/src/acp-github.ts
+++ b/apps/redskilled/src/acp-github.ts
@@ -6,6 +6,7 @@ import {
   type RedskilledGithubRead,
 } from "./github-gateway.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
+import { RedskilledGithubCredentialProfileError } from "./github-credential-profiles.js";
 
 type GithubReadParams = { readonly read: RedskilledGithubRead };
 
@@ -16,31 +17,46 @@ export function bindAcpProjectGithubRead(
 ) {
   return async ({ params: { read } }: { readonly params: GithubReadParams }) => {
     const project = projectForConnection();
-    const selection = gateway?.credentialForProject({
-      projectId: project.projectId,
-      projectLabel: project.projectLabel,
-      workspacePath: project.workspacePath,
-    });
-    if (gateway == null || selection == null) {
-      throw RequestError.invalidRequest("this Project has no daemon-owned GitHub credential profile");
-    }
     try {
-      return await gateway.gateway.forProject({
+      const selection = await gateway?.credentialForProject({
         projectId: project.projectId,
         projectLabel: project.projectLabel,
         workspacePath: project.workspacePath,
-        credentialProfile: selection.profile,
-      }, selection.credential).read(read);
-    } catch (error) {
-      if (!(error instanceof GithubBackpressureError)) throw error;
-      throw new RequestError(-32001, error.message, {
-        version: 1,
-        kind: "github-backpressure",
-        project_id: project.projectId,
-        credential_profile: selection.profile,
-        retry_at: error.fact.retry_at,
-        fact: error.fact,
       });
+      if (gateway == null || selection == null) {
+        throw RequestError.authRequired(
+          {
+            version: 1,
+            kind: "github-credential-profile",
+            reason: "missing-credentials",
+            credential_profile: "personal",
+          },
+          "this Project has no resolvable daemon-owned GitHub credential profile",
+        );
+      }
+      try {
+        return await gateway.gateway.forProject({
+          projectId: project.projectId,
+          projectLabel: project.projectLabel,
+          workspacePath: project.workspacePath,
+          credentialProfile: selection.profile,
+        }, selection.credential).read(read);
+      } catch (error) {
+        if (!(error instanceof GithubBackpressureError)) throw error;
+        throw new RequestError(-32001, error.message, {
+          version: 1,
+          kind: "github-backpressure",
+          project_id: project.projectId,
+          credential_profile: selection.profile,
+          retry_at: error.fact.retry_at,
+          fact: error.fact,
+        });
+      }
+    } catch (error) {
+      if (error instanceof RedskilledGithubCredentialProfileError) {
+        throw RequestError.authRequired(error.refusal, error.message);
+      }
+      throw error;
     }
   };
 }

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -499,7 +499,12 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       githubAttribution,
     );
     const resolvedGithubBalance = resolveServeGithubBalance(values);
-    const githubGateway = resolveServeGithubGateway(resolveRedskilledHostToken(process.env, readTrackerCliToken));
+    const githubGateway = resolveServeGithubGateway({
+      profiles: hostConfig.githubProfiles,
+      resolvePersonal: () => resolveRedskilledHostToken(process.env, readTrackerCliToken),
+      env: process.env,
+      homeDir: homedir(),
+    });
     // An App's ceiling is measured separately because two buckets summed into one document make
     // the last writer the displayed truth for a ceiling the next request may
     // not draw from.
@@ -553,7 +558,7 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
         // is `unknown`, never a full budget, because a full budget is the one
         // answer that admits every call.
         ...(githubBalance == null ? {} : { githubBalance }),
-        ...(githubGateway == null ? {} : { githubGateway }),
+        githubGateway,
         ...(values["demand-ms"] == null ? {} : { demandMs: values["demand-ms"] }),
       });
     } catch (error) {

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -483,11 +483,9 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       hostConfig,
       redskilledHomeDir(homedir()),
     );
-    // The daemon's own black box (Spec #3022, slice #3023). The event lane already
-    // carries `daemon-stop` for the stop this process CHOSE; this record carries
-    // the death it did not — a signal, an uncaught error — in the one shape every
-    // worker and launcher writes, on a lane that outlives the runtime directory
-    // the event lane lives in.
+    // The daemon's own black box (Spec #3022, slice #3023). The event lane carries
+    // chosen stops; this records unchosen deaths in the shared launcher/worker shape,
+    // on a lane that outlives the runtime directory containing the event lane.
     const hostStateRoot = join(redskilledHomeDir(homedir()), "state");
     const githubAttribution = createGithubAttributionLedger({
       path: join(hostStateRoot, "github", "spend.toonl"),
@@ -502,12 +500,9 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
     const githubGateway = resolveServeGithubGateway({
       profiles: hostConfig.githubProfiles,
       resolvePersonal: () => resolveRedskilledHostToken(process.env, readTrackerCliToken),
-      env: process.env,
-      homeDir: homedir(),
+      env: process.env, homeDir: homedir(),
     });
-    // An App's ceiling is measured separately because two buckets summed into one document make
-    // the last writer the displayed truth for a ceiling the next request may
-    // not draw from.
+    // App ceilings stay separate: summing buckets lets the last writer misstate the next request.
     const githubBalance = resolveServeGithubBalanceRegistration(
       resolvedGithubBalance,
       await readRedskilledHostGithubApp(),

--- a/apps/redskilled/src/github-companions.ts
+++ b/apps/redskilled/src/github-companions.ts
@@ -33,25 +33,39 @@ import {
   createRedskilledGithubUpstream,
   type RedskilledGithubGatewayRegistration,
 } from "./github-gateway.js";
+import {
+  createRedskilledGithubCredentialProfileResolver,
+  type RedskilledGithubCredentialProfiles,
+} from "./github-credential-profiles.js";
 
-/** Bind the host's personal credential to the daemon gateway, never to a client. */
+export interface ResolveServeGithubGatewayOptions {
+  readonly profiles?: RedskilledGithubCredentialProfiles;
+  readonly resolvePersonal: () => { readonly token: string } | null;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly homeDir?: string;
+}
+
+/** Bind named daemon-owned credentials to the gateway, never to a client. */
 export function resolveServeGithubGateway(
-  host: { readonly token: string } | null,
-  env: NodeJS.ProcessEnv = process.env,
-): RedskilledGithubGatewayRegistration | undefined {
-  if (host == null) return undefined;
+  options: ResolveServeGithubGatewayOptions,
+): RedskilledGithubGatewayRegistration {
+  const env = options.env ?? process.env;
+  const fetchImpl = createTimedGithubFetch();
   const gateway = createRedskilledGithubGateway({
     upstream: createRedskilledGithubUpstream({
       ...(env.GITHUB_API_URL ? { origin: env.GITHUB_API_URL } : {}),
       ...(env.GITHUB_GRAPHQL_URL ? { graphqlEndpoint: env.GITHUB_GRAPHQL_URL } : {}),
-      fetchImpl: createTimedGithubFetch(),
+      fetchImpl,
     }),
   });
   return {
     gateway,
-    credentialForProject: () => ({
-      profile: "host-personal",
-      credential: { secret: host.token },
+    credentialForProject: createRedskilledGithubCredentialProfileResolver({
+      profiles: options.profiles ?? {},
+      resolvePersonal: options.resolvePersonal,
+      ...(options.homeDir == null ? {} : { homeDir: options.homeDir }),
+      ...(env.GITHUB_API_URL ? { origin: env.GITHUB_API_URL } : {}),
+      fetchImpl,
     }),
   };
 }

--- a/apps/redskilled/src/github-credential-profiles.ts
+++ b/apps/redskilled/src/github-credential-profiles.ts
@@ -133,11 +133,26 @@ export async function readProjectGithubCredentialProfile(workspacePath: string):
     );
   }
 
-  const github = mappingAt(document, ["plugins", "dev", "github"]);
-  const forbidden = Object.keys(github).find((key) => PROJECT_CREDENTIAL_KEY.test(key));
-  if (forbidden != null) {
+  const dev = mappingAt(document, ["plugins", "dev"]);
+  if (dev.github == null) return DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE;
+  if (!isMapping(dev.github)) {
+    throw new RedskilledGithubCredentialProfileError(
+      "invalid-project-binding",
+      DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE,
+    );
+  }
+  const github = dev.github;
+  const extra = Object.keys(github).find((key) => key !== "credential_profile");
+  const forbidden = extra != null && PROJECT_CREDENTIAL_KEY.test(extra);
+  if (forbidden) {
     throw new RedskilledGithubCredentialProfileError(
       "project-credential-forbidden",
+      profileScalar(github.credential_profile) ?? DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE,
+    );
+  }
+  if (extra != null) {
+    throw new RedskilledGithubCredentialProfileError(
+      "invalid-project-binding",
       profileScalar(github.credential_profile) ?? DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE,
     );
   }

--- a/apps/redskilled/src/github-credential-profiles.ts
+++ b/apps/redskilled/src/github-credential-profiles.ts
@@ -1,0 +1,211 @@
+/**
+ * Daemon-owned GitHub credential profiles.
+ *
+ * Project config contains one public profile name. Host config contains the
+ * backend declaration, while credential material is resolved only at the
+ * authenticated upstream edge and is never returned to ACP clients or Workers.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { mintGithubInstallationToken, type GithubAppCredential } from "@reddb-io/github";
+import { parse } from "yaml";
+import type {
+  RedskilledGithubCredentialSelection,
+  RedskilledGithubProjectAuthority,
+} from "./github-gateway.js";
+
+export const DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE = "personal";
+
+export type RedskilledGithubCredentialProfileDeclaration =
+  | { readonly kind: "personal" }
+  | {
+      readonly kind: "github-app";
+      readonly appId?: string;
+      readonly installationId?: string;
+      readonly privateKeyPath?: string;
+    };
+
+export type RedskilledGithubCredentialProfiles = Readonly<
+  Record<string, RedskilledGithubCredentialProfileDeclaration>
+>;
+
+export type RedskilledGithubCredentialProfileRefusalReason =
+  | "unknown-profile"
+  | "missing-credentials"
+  | "invalid-credentials"
+  | "scope-incompatible"
+  | "invalid-project-binding"
+  | "project-credential-forbidden";
+
+export interface RedskilledGithubCredentialProfileRefusal {
+  readonly version: 1;
+  readonly kind: "github-credential-profile";
+  readonly reason: RedskilledGithubCredentialProfileRefusalReason;
+  readonly credential_profile: string;
+}
+
+/** A public, typed, deliberately secret-free credential refusal. */
+export class RedskilledGithubCredentialProfileError extends Error {
+  readonly refusal: RedskilledGithubCredentialProfileRefusal;
+
+  constructor(reason: RedskilledGithubCredentialProfileRefusalReason, profile: string) {
+    const safeProfile = publishableProfile(profile)
+      ? profile
+      : DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE;
+    super(credentialRefusalMessage(reason, safeProfile));
+    this.name = "RedskilledGithubCredentialProfileError";
+    this.refusal = {
+      version: 1,
+      kind: "github-credential-profile",
+      reason,
+      credential_profile: safeProfile,
+    };
+  }
+}
+
+export interface CreateRedskilledGithubCredentialProfileResolverOptions {
+  readonly profiles: RedskilledGithubCredentialProfiles;
+  readonly resolvePersonal: () => { readonly token: string } | null;
+  readonly homeDir?: string;
+  readonly origin?: string;
+  readonly fetchImpl?: typeof fetch;
+  readonly mintInstallationToken?: (app: GithubAppCredential) => Promise<string>;
+  readonly readProjectProfile?: (workspacePath: string) => Promise<string>;
+}
+
+/**
+ * Resolve one Project's named profile on every request.
+ *
+ * Re-reading both Project config and the backend credential is intentional:
+ * tracked bindings and daemon-local credentials can rotate without restarting
+ * the daemon, and an App installation token is never retained past one ask.
+ */
+export function createRedskilledGithubCredentialProfileResolver(
+  options: CreateRedskilledGithubCredentialProfileResolverOptions,
+): (
+  project: Omit<RedskilledGithubProjectAuthority, "credentialProfile">,
+) => Promise<RedskilledGithubCredentialSelection> {
+  const readProfile = options.readProjectProfile ?? readProjectGithubCredentialProfile;
+  const mint = options.mintInstallationToken ?? ((app: GithubAppCredential) =>
+    mintGithubInstallationToken(app, {
+      ...(options.origin == null ? {} : { origin: options.origin }),
+      ...(options.fetchImpl == null ? {} : { fetchImpl: options.fetchImpl }),
+    }));
+
+  return async (project) => {
+    const profile = await readProfile(project.workspacePath);
+    const declaration = options.profiles[profile] ??
+      (profile === DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE
+        ? { kind: "personal" as const }
+        : undefined);
+    if (declaration == null) throw new RedskilledGithubCredentialProfileError("unknown-profile", profile);
+
+    if (declaration.kind === "personal") {
+      const personal = options.resolvePersonal();
+      const secret = personal?.token.trim() ?? "";
+      if (secret === "") throw new RedskilledGithubCredentialProfileError("missing-credentials", profile);
+      return { profile, credential: { secret } };
+    }
+
+    const app = githubAppCredential(declaration, profile, options.homeDir);
+    try {
+      const secret = (await mint(app)).trim();
+      if (secret === "") throw new Error("empty installation credential");
+      return { profile, credential: { secret } };
+    } catch {
+      throw new RedskilledGithubCredentialProfileError("invalid-credentials", profile);
+    }
+  };
+}
+
+/** Read only the public profile binding from tracked Project config. */
+export async function readProjectGithubCredentialProfile(workspacePath: string): Promise<string> {
+  let document: unknown;
+  try {
+    document = parse(await readFile(join(workspacePath, ".red", "config.yaml"), "utf8")) as unknown;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE;
+    }
+    throw new RedskilledGithubCredentialProfileError(
+      "invalid-project-binding",
+      DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE,
+    );
+  }
+
+  const github = mappingAt(document, ["plugins", "dev", "github"]);
+  const forbidden = Object.keys(github).find((key) => PROJECT_CREDENTIAL_KEY.test(key));
+  if (forbidden != null) {
+    throw new RedskilledGithubCredentialProfileError(
+      "project-credential-forbidden",
+      profileScalar(github.credential_profile) ?? DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE,
+    );
+  }
+  if (github.credential_profile == null) return DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE;
+  const profile = profileScalar(github.credential_profile);
+  if (profile == null || !publishableProfile(profile)) {
+    throw new RedskilledGithubCredentialProfileError(
+      "invalid-project-binding",
+      DEFAULT_REDSKILLED_GITHUB_CREDENTIAL_PROFILE,
+    );
+  }
+  return profile;
+}
+
+/** Turn an upstream authorization failure into the same typed ACP-safe shape. */
+export function githubCredentialScopeRefusal(profile: string): RedskilledGithubCredentialProfileError {
+  return new RedskilledGithubCredentialProfileError("scope-incompatible", profile);
+}
+
+function githubAppCredential(
+  declaration: Extract<RedskilledGithubCredentialProfileDeclaration, { kind: "github-app" }>,
+  profile: string,
+  homeDir: string | undefined,
+): GithubAppCredential {
+  const appId = declaration.appId?.trim() ?? "";
+  const installationId = declaration.installationId?.trim() ?? "";
+  const statedPath = declaration.privateKeyPath?.trim() ?? "";
+  if (appId === "" || installationId === "" || statedPath === "") {
+    throw new RedskilledGithubCredentialProfileError("missing-credentials", profile);
+  }
+  const privateKeyPath = statedPath.startsWith("~/") && homeDir != null
+    ? join(homeDir, statedPath.slice(2))
+    : statedPath;
+  return { appId, installationId, privateKeyPath };
+}
+
+function profileScalar(value: unknown): string | null {
+  return typeof value === "string" ? value.trim() : null;
+}
+
+function mappingAt(value: unknown, path: readonly string[]): Readonly<Record<string, unknown>> {
+  let current = value;
+  for (const key of path) {
+    if (!isMapping(current)) return {};
+    current = current[key];
+  }
+  return isMapping(current) ? current : {};
+}
+
+function isMapping(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function publishableProfile(value: string): boolean {
+  return /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(value);
+}
+
+const PROJECT_CREDENTIAL_KEY = /^(?:token|secret|credential|pem|private[_-]?key|app_id|installation_id)$/i;
+
+function credentialRefusalMessage(
+  reason: RedskilledGithubCredentialProfileRefusalReason,
+  profile: string,
+): string {
+  const named = `GitHub credential profile ${JSON.stringify(profile)}`;
+  if (reason === "unknown-profile") return `${named} is not declared by redskilled host config`;
+  if (reason === "missing-credentials") return `${named} has no resolvable daemon-owned credentials`;
+  if (reason === "invalid-credentials") return `${named} could not resolve valid daemon-owned credentials`;
+  if (reason === "scope-incompatible") return `${named} is not authorized for this Project request`;
+  if (reason === "project-credential-forbidden") return "Project config may select a GitHub credential profile but may not contain credential material";
+  return "Project config has an invalid GitHub credential profile binding";
+}

--- a/apps/redskilled/src/github-gateway.ts
+++ b/apps/redskilled/src/github-gateway.ts
@@ -15,6 +15,10 @@ import {
   type GithubLimitFact,
 } from "@reddb-io/github";
 import { execFile } from "node:child_process";
+import {
+  RedskilledGithubCredentialProfileError,
+  githubCredentialScopeRefusal,
+} from "./github-credential-profiles.js";
 
 export const REDSKILLED_GITHUB_READ_METHOD = "_redskills/github_read";
 
@@ -99,7 +103,7 @@ export interface RedskilledGithubGatewayRegistration {
   readonly gateway: RedskilledGithubGateway;
   readonly credentialForProject: (
     project: Omit<RedskilledGithubProjectAuthority, "credentialProfile">,
-  ) => RedskilledGithubCredentialSelection | null;
+  ) => RedskilledGithubCredentialSelection | null | Promise<RedskilledGithubCredentialSelection | null>;
 }
 
 export interface CreateRedskilledGithubGatewayOptions {
@@ -228,7 +232,7 @@ export function createRedskilledGithubUpstream(
       });
       if (!response.ok) {
         const pool = input.read.path.replace(/^\/+/, "").startsWith("search/") ? "search" : "rest";
-        throw upstreamRefusal("REST", pool, response, clock());
+        throw upstreamRefusal("REST", pool, response, clock(), input.project.credentialProfile);
       }
       return {
         value: await responseValue(response),
@@ -245,11 +249,16 @@ export function createRedskilledGithubUpstream(
       headers: { ...githubHeaders(input.credential.secret), "content-type": "application/json" },
       body: JSON.stringify({ query }),
     });
-    if (!response.ok) throw upstreamRefusal("GraphQL", "graphql", response, clock());
+    if (!response.ok) {
+      throw upstreamRefusal("GraphQL", "graphql", response, clock(), input.project.credentialProfile);
+    }
     const body = await response.json() as {
       readonly data?: { readonly repository?: unknown; readonly rateLimit?: unknown };
       readonly errors?: readonly unknown[];
     };
+    if (body.errors?.some(isGithubScopeError)) {
+      throw githubCredentialScopeRefusal(input.project.credentialProfile);
+    }
     if (body.errors != null && body.errors.length > 0) {
       throw new Error("redskilled GitHub GraphQL read was refused upstream");
     }
@@ -436,15 +445,27 @@ function upstreamRefusal(
   pool: "rest" | "graphql" | "search",
   response: Response,
   now: string,
+  profile: string,
 ): Error {
   const observed = {
     status: response.status,
     response: { headers: Object.fromEntries(response.headers.entries()) },
   };
   const fact = classifyGithubLimit(observed, pool, Date.parse(now));
-  return fact === null
-    ? new Error(`redskilled GitHub ${surface} read failed with status ${response.status}`)
-    : new GithubBackpressureError(fact);
+  if (fact != null) return new GithubBackpressureError(fact);
+  if (response.status === 401) {
+    return new RedskilledGithubCredentialProfileError("invalid-credentials", profile);
+  }
+  if (response.status === 403) return githubCredentialScopeRefusal(profile);
+  return new Error(`redskilled GitHub ${surface} read failed with status ${response.status}`);
+}
+
+function isGithubScopeError(value: unknown): boolean {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return record.type === "FORBIDDEN" || record.extensions != null &&
+    typeof record.extensions === "object" &&
+    (record.extensions as Record<string, unknown>).type === "FORBIDDEN";
 }
 
 async function fetchCanonicalRepository(input: RedskilledGithubUpstreamInput): Promise<unknown> {

--- a/apps/redskilled/src/host-config.ts
+++ b/apps/redskilled/src/host-config.ts
@@ -26,6 +26,10 @@ import {
 } from "./event-lane.js";
 import type { RedskilledLaunchTemplate } from "./launch-template.js";
 import type { RedskilledHostEventSinks } from "./host-event-sink.js";
+import type {
+  RedskilledGithubCredentialProfileDeclaration,
+  RedskilledGithubCredentialProfiles,
+} from "./github-credential-profiles.js";
 
 export const REDSKILLED_IDLE_MS_ENV = "REDSKILLED_IDLE_MS";
 export const REDSKILLED_HOST_CONFIG_PATH = ".red/config.yaml";
@@ -39,6 +43,16 @@ export interface RedskilledHostConfig {
   readonly hooks?: Partial<Record<RedskilledPublicHostEventKind, RedskilledLaunchTemplate>>;
   /** Public Worker lifecycle changes also surfaced through the native desktop sink. */
   readonly notifications?: readonly RedskilledPublicHostEventKind[];
+  /** Named daemon-owned GitHub authentication backends. */
+  readonly githubProfiles?: RedskilledGithubCredentialProfiles;
+}
+
+/** A credential backend declaration that must fail closed at daemon boot. */
+export class RedskilledGithubProfileConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RedskilledGithubProfileConfigError";
+  }
 }
 
 export interface RedskilledHostSettingFlags {
@@ -120,13 +134,73 @@ export async function readRedskilledHostConfig(
       ...scalarAt(redskilled, "idle_ms", "idleMs"),
       ...hooksAt(redskilled),
       ...notificationsAt(redskilled),
+      ...githubProfilesAt(redskilled),
     };
   } catch (error) {
+    if (error instanceof RedskilledGithubProfileConfigError) throw error;
     // The same resilience rule as malformed ceiling values: report the broken
     // declaration, but do not turn a typo into a host-wide outage.
     warn(`redskilled: malformed host config ${JSON.stringify(path)}; using environment and defaults instead: ${errorMessage(error)}`);
     return {};
   }
+}
+
+function githubProfilesAt(
+  redskilled: Readonly<Record<string, unknown>>,
+): Pick<RedskilledHostConfig, "githubProfiles"> | Record<never, never> {
+  if (redskilled.github_profiles == null) return {};
+  if (!isMapping(redskilled.github_profiles)) {
+    throw new RedskilledGithubProfileConfigError("github_profiles must be a map keyed by profile name");
+  }
+  const profiles: Record<string, RedskilledGithubCredentialProfileDeclaration> = {};
+  for (const [name, value] of Object.entries(redskilled.github_profiles)) {
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(name)) {
+      throw new RedskilledGithubProfileConfigError("a GitHub credential profile has an invalid public name");
+    }
+    if (!isMapping(value)) {
+      throw new RedskilledGithubProfileConfigError(`GitHub credential profile ${JSON.stringify(name)} must be a map`);
+    }
+    if (value.kind === "personal") {
+      if (Object.keys(value).some((key) => /^(?:token|secret|credential)$/i.test(key))) {
+        throw new RedskilledGithubProfileConfigError(
+          `personal GitHub credential profile ${JSON.stringify(name)} resolves from the daemon environment or gh auth and may not store a token`,
+        );
+      }
+      profiles[name] = { kind: "personal" };
+      continue;
+    }
+    if (value.kind === "github-app") {
+      const appId = optionalScalar(value.app_id, name, "app_id");
+      const installationId = optionalScalar(value.installation_id, name, "installation_id");
+      const privateKeyPath = optionalScalar(value.private_key, name, "private_key");
+      if (privateKeyPath?.includes("-----BEGIN")) {
+        throw new RedskilledGithubProfileConfigError(
+          `GitHub App credential profile ${JSON.stringify(name)} must name a daemon-local PEM path, not PEM content`,
+        );
+      }
+      profiles[name] = {
+        kind: "github-app",
+        ...(appId == null ? {} : { appId }),
+        ...(installationId == null ? {} : { installationId }),
+        ...(privateKeyPath == null ? {} : { privateKeyPath }),
+      };
+      continue;
+    }
+    throw new RedskilledGithubProfileConfigError(
+      `GitHub credential profile ${JSON.stringify(name)} has unknown backend kind ${JSON.stringify(value.kind)}`,
+    );
+  }
+  return { githubProfiles: profiles };
+}
+
+function optionalScalar(value: unknown, profile: string, field: string): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "string" && typeof value !== "number") {
+    throw new RedskilledGithubProfileConfigError(
+      `GitHub credential profile ${JSON.stringify(profile)} ${field} must be a scalar`,
+    );
+  }
+  return String(value).trim();
 }
 
 /** Resolve every daemon-owned setting under one explicit precedence table. */

--- a/apps/redskilled/src/host-config.ts
+++ b/apps/redskilled/src/host-config.ts
@@ -161,15 +161,22 @@ function githubProfilesAt(
       throw new RedskilledGithubProfileConfigError(`GitHub credential profile ${JSON.stringify(name)} must be a map`);
     }
     if (value.kind === "personal") {
-      if (Object.keys(value).some((key) => /^(?:token|secret|credential)$/i.test(key))) {
+      if (Object.keys(value).some((key) => key !== "kind")) {
         throw new RedskilledGithubProfileConfigError(
-          `personal GitHub credential profile ${JSON.stringify(name)} resolves from the daemon environment or gh auth and may not store a token`,
+          `personal GitHub credential profile ${JSON.stringify(name)} resolves from the daemon environment or gh auth and accepts only kind`,
         );
       }
       profiles[name] = { kind: "personal" };
       continue;
     }
     if (value.kind === "github-app") {
+      const extra = Object.keys(value).find((key) =>
+        !["kind", "app_id", "installation_id", "private_key"].includes(key));
+      if (extra != null) {
+        throw new RedskilledGithubProfileConfigError(
+          `GitHub App credential profile ${JSON.stringify(name)} has unsupported field ${JSON.stringify(extra)}`,
+        );
+      }
       const appId = optionalScalar(value.app_id, name, "app_id");
       const installationId = optionalScalar(value.installation_id, name, "installation_id");
       const privateKeyPath = optionalScalar(value.private_key, name, "private_key");

--- a/apps/redskilled/src/provision.ts
+++ b/apps/redskilled/src/provision.ts
@@ -79,6 +79,14 @@ plugins:
       #     argv: [/usr/local/bin/redwall, refresh]
       # notifications:
       #   - worker-death
+      # github_profiles:
+      #   personal:
+      #     kind: personal
+      #   engineering:
+      #     kind: github-app
+      #     app_id: "4575633"
+      #     installation_id: "153309957"
+      #     private_key: ~/.red/redskilled/credentials/engineering.pem
 `;
 
 /**

--- a/apps/redskilled/tests/acp-github-credentials.test.ts
+++ b/apps/redskilled/tests/acp-github-credentials.test.ts
@@ -1,0 +1,66 @@
+import { RequestError } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import { bindAcpProjectGithubRead } from "../src/acp-github.js";
+import { RedskilledGithubCredentialProfileError } from "../src/github-credential-profiles.js";
+import { createRedskilledGithubGateway, createRedskilledGithubUpstream } from "../src/github-gateway.js";
+
+const PROJECT = {
+  projectId: "github:101",
+  projectLabel: "acme/widgets",
+  checkoutRoot: "/client/widgets",
+  workspacePath: "/daemon/widgets",
+};
+
+describe("ACP GitHub credential refusals", () => {
+  it("carries a missing profile as typed secret-free ACP error data", async () => {
+    const read = bindAcpProjectGithubRead({
+      gateway: createRedskilledGithubGateway({
+        upstream: async () => ({ value: {}, budget: null }),
+      }),
+      credentialForProject: async () => {
+        throw new RedskilledGithubCredentialProfileError("missing-credentials", "engineering");
+      },
+    }, () => PROJECT);
+
+    const error = await read({ params: { read: { kind: "rest", path: "issues/1" } } })
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(RequestError);
+    expect((error as RequestError).data).toEqual({
+      version: 1,
+      kind: "github-credential-profile",
+      reason: "missing-credentials",
+      credential_profile: "engineering",
+    });
+    expect(JSON.stringify((error as RequestError).data)).not.toMatch(/token|secret|private.key/i);
+  });
+
+  it("turns an upstream scope mismatch into the same typed refusal without fallback", async () => {
+    let upstreamCalls = 0;
+    const read = bindAcpProjectGithubRead({
+      gateway: createRedskilledGithubGateway({
+        upstream: createRedskilledGithubUpstream({
+          fetchImpl: async () => {
+            upstreamCalls += 1;
+            return new Response("forbidden", { status: 403 });
+          },
+        }),
+      }),
+      credentialForProject: async () => ({
+        profile: "engineering",
+        credential: { secret: "installation-secret" },
+      }),
+    }, () => PROJECT);
+
+    const error = await read({ params: { read: { kind: "rest", path: "issues/1" } } })
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(RequestError);
+    expect((error as RequestError).data).toEqual({
+      version: 1,
+      kind: "github-credential-profile",
+      reason: "scope-incompatible",
+      credential_profile: "engineering",
+    });
+    expect(upstreamCalls).toBe(1);
+    expect(JSON.stringify(error)).not.toContain("installation-secret");
+  });
+});

--- a/apps/redskilled/tests/github-credential-profiles.test.ts
+++ b/apps/redskilled/tests/github-credential-profiles.test.ts
@@ -1,0 +1,171 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  RedskilledGithubCredentialProfileError,
+  createRedskilledGithubCredentialProfileResolver,
+  readProjectGithubCredentialProfile,
+} from "../src/github-credential-profiles.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function workspace(config?: readonly string[]): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-profile-"));
+  roots.push(root);
+  if (config != null) {
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), [...config, ""].join("\n"));
+  }
+  return root;
+}
+
+function project(workspacePath: string) {
+  return { projectId: "github:101", projectLabel: "acme/widgets", workspacePath };
+}
+
+describe("daemon-owned GitHub credential profiles", () => {
+  it("uses the compatibility personal profile when Project config has no binding and re-resolves rotation", async () => {
+    const workspacePath = await workspace();
+    const tokens = ["personal-one", "personal-two"];
+    const resolve = createRedskilledGithubCredentialProfileResolver({
+      profiles: {},
+      resolvePersonal: () => {
+        const token = tokens.shift();
+        return token == null ? null : { token };
+      },
+    });
+
+    await expect(resolve(project(workspacePath))).resolves.toEqual({
+      profile: "personal",
+      credential: { secret: "personal-one" },
+    });
+    await expect(resolve(project(workspacePath))).resolves.toEqual({
+      profile: "personal",
+      credential: { secret: "personal-two" },
+    });
+  });
+
+  it("binds Projects to independent named profiles and mints a fresh App installation credential", async () => {
+    const engineering = await workspace([
+      "plugins:",
+      "  dev:",
+      "    github:",
+      "      credential_profile: engineering",
+    ]);
+    const release = await workspace([
+      "plugins:",
+      "  dev:",
+      "    github:",
+      "      credential_profile: release",
+    ]);
+    const minted: string[] = [];
+    const resolve = createRedskilledGithubCredentialProfileResolver({
+      profiles: {
+        engineering: {
+          kind: "github-app",
+          appId: "1",
+          installationId: "11",
+          privateKeyPath: "~/.red/redskilled/credentials/engineering.pem",
+        },
+        release: {
+          kind: "github-app",
+          appId: "2",
+          installationId: "22",
+          privateKeyPath: "/credentials/release.pem",
+        },
+      },
+      homeDir: "/daemon-home",
+      resolvePersonal: () => ({ token: "must not fall back" }),
+      mintInstallationToken: async (app) => {
+        minted.push(`${app.appId}:${app.installationId}:${app.privateKeyPath}`);
+        return `installation-${minted.length}`;
+      },
+    });
+
+    await expect(resolve(project(engineering))).resolves.toEqual({
+      profile: "engineering",
+      credential: { secret: "installation-1" },
+    });
+    await expect(resolve(project(release))).resolves.toEqual({
+      profile: "release",
+      credential: { secret: "installation-2" },
+    });
+    await expect(resolve(project(engineering))).resolves.toEqual({
+      profile: "engineering",
+      credential: { secret: "installation-3" },
+    });
+    expect(minted).toEqual([
+      "1:11:/daemon-home/.red/redskilled/credentials/engineering.pem",
+      "2:22:/credentials/release.pem",
+      "1:11:/daemon-home/.red/redskilled/credentials/engineering.pem",
+    ]);
+  });
+
+  it("refuses an unknown binding without falling back to personal credentials", async () => {
+    const workspacePath = await workspace([
+      "plugins:",
+      "  dev:",
+      "    github:",
+      "      credential_profile: missing",
+    ]);
+    let personalCalls = 0;
+    const resolve = createRedskilledGithubCredentialProfileResolver({
+      profiles: {},
+      resolvePersonal: () => {
+        personalCalls += 1;
+        return { token: "fallback" };
+      },
+    });
+
+    const refusal = await resolve(project(workspacePath)).catch((error: unknown) => error);
+    expect(refusal).toBeInstanceOf(RedskilledGithubCredentialProfileError);
+    expect((refusal as RedskilledGithubCredentialProfileError).refusal).toEqual({
+      version: 1,
+      kind: "github-credential-profile",
+      reason: "unknown-profile",
+      credential_profile: "missing",
+    });
+    expect(personalCalls).toBe(0);
+  });
+
+  it("refuses Project-owned credentials and reports no secret material", async () => {
+    const workspacePath = await workspace([
+      "plugins:",
+      "  dev:",
+      "    github:",
+      "      credential_profile: personal",
+      "      token: project-secret",
+      "      private_key: |",
+      "        -----BEGIN PRIVATE KEY-----",
+      "        project-pem",
+      "        -----END PRIVATE KEY-----",
+    ]);
+
+    const refusal = await readProjectGithubCredentialProfile(workspacePath).catch((error: unknown) => error);
+    expect(refusal).toBeInstanceOf(RedskilledGithubCredentialProfileError);
+    expect((refusal as RedskilledGithubCredentialProfileError).refusal.reason).toBe("project-credential-forbidden");
+    expect(JSON.stringify((refusal as RedskilledGithubCredentialProfileError).refusal)).not.toMatch(/project-secret|project-pem|BEGIN/);
+  });
+
+  it("returns a typed secret-free refusal when personal credentials are missing", async () => {
+    const workspacePath = await workspace();
+    const resolve = createRedskilledGithubCredentialProfileResolver({
+      profiles: {},
+      resolvePersonal: () => null,
+    });
+
+    const refusal = await resolve(project(workspacePath)).catch((error: unknown) => error);
+    expect(refusal).toBeInstanceOf(RedskilledGithubCredentialProfileError);
+    expect((refusal as RedskilledGithubCredentialProfileError).refusal).toEqual({
+      version: 1,
+      kind: "github-credential-profile",
+      reason: "missing-credentials",
+      credential_profile: "personal",
+    });
+  });
+});

--- a/apps/redskilled/tests/host-config.test.ts
+++ b/apps/redskilled/tests/host-config.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/admission.js";
 import {
   REDSKILLED_IDLE_MS_ENV,
+  RedskilledGithubProfileConfigError,
   readRedskilledHostConfig,
   resolveRedskilledHostEventSinks,
   resolveRedskilledHostSettings,
@@ -66,6 +67,54 @@ describe("the daemon-owned host config", () => {
       },
       notifications: ["worker-death", "worker-budget-kill"],
     });
+  });
+
+  it("reads several named personal and GitHub App credential profiles", async () => {
+    const home = await fakeHome();
+    await mkdir(join(home, ".red"), { recursive: true });
+    await writeFile(join(home, ".red", "config.yaml"), [
+      "plugins:",
+      "  dev:",
+      "    redskilled:",
+      "      github_profiles:",
+      "        personal:",
+      "          kind: personal",
+      "        engineering:",
+      "          kind: github-app",
+      "          app_id: '4575633'",
+      "          installation_id: '153309957'",
+      "          private_key: ~/.red/redskilled/credentials/engineering.pem",
+      "",
+    ].join("\n"));
+
+    await expect(readRedskilledHostConfig(home)).resolves.toMatchObject({
+      githubProfiles: {
+        personal: { kind: "personal" },
+        engineering: {
+          kind: "github-app",
+          appId: "4575633",
+          installationId: "153309957",
+          privateKeyPath: "~/.red/redskilled/credentials/engineering.pem",
+        },
+      },
+    });
+  });
+
+  it("rejects unknown credential profile backend kinds instead of ignoring them", async () => {
+    const home = await fakeHome();
+    await mkdir(join(home, ".red"), { recursive: true });
+    await writeFile(join(home, ".red", "config.yaml"), [
+      "plugins:",
+      "  dev:",
+      "    redskilled:",
+      "      github_profiles:",
+      "        hosted:",
+      "          kind: hosted-broker",
+      "",
+    ].join("\n"));
+
+    await expect(readRedskilledHostConfig(home)).rejects.toBeInstanceOf(RedskilledGithubProfileConfigError);
+    await expect(readRedskilledHostConfig(home)).rejects.toThrow(/hosted-broker/);
   });
 
   it("is created only through provisioning and is never overwritten", async () => {

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -56,7 +56,9 @@ back into `/start`, `/to-spec`, `/to-tickets`, `/afk`, or `/hitl`.
 - **Host daemon status, provisioning, policy, or lifecycle** -> `/redskilled`.
   It reads the daemon's socket, version, registrations, Workers, ceilings, and
   setting origins; provisions the daemon-owned home; edits host policy; and
-  restarts through the survival-reporting stop path. `/dashboard` stays the
+  configures named personal or GitHub App credential backends. A Project may
+  select one public profile name in tracked config, while every token, App fact,
+  and PEM path stays on the `/redskilled` host-policy route. `/dashboard` stays the
   route for this repository's queue health, while `/red-statusline` owns the
   one-line host adapter.
 - **"What is the Worker on issue N doing, or why did it never start?"** ->

--- a/packaging/pi/dev/skills/engineering/redskilled/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/redskilled/SKILL.md
@@ -70,18 +70,23 @@ Treat `redskilled` as the per-machine process authority: it owns Worker birth, d
    Keep these keys in the home config only: a project's `.red/config.yaml` may
    ask for Workers, but it may not redefine the machine's limit.
 
-   **The App is a payer, never an author.** An operator who wants automation off
-   their personal rate limit declares a GitHub App in the SAME host file, because
-   one machine has one App and one private key — a repository never declares it:
+   **Credentials are named daemon-owned profiles.** The compatibility profile
+   is `personal`; it resolves `REDSKILLED_HOST_TOKEN`, `GITHUB_TOKEN`,
+   `GH_TOKEN`, then `gh auth token`. An operator may declare several personal or
+   bring-your-own App profiles in the SAME host file:
 
    ```yaml
    plugins:
      dev:
        redskilled:
-         github_app:
-           app_id: "4575633"
-           installation_id: "153309957"
-           private_key: ~/.red/redskilled/credentials/github-app.pem
+         github_profiles:
+           personal:
+             kind: personal
+           engineering:
+             kind: github-app
+             app_id: "4575633"
+             installation_id: "153309957"
+             private_key: ~/.red/redskilled/credentials/engineering.pem
    ```
 
    Walk the operator through it in this order, and stop at the first step that
@@ -99,22 +104,27 @@ Treat `redskilled` as the per-machine process authority: it owns Worker birth, d
    4. **Read the installation id back** rather than transcribing it: the App's
       own installations listing names it, and a wrong id fails as an
       authentication error far from its cause.
-   5. **Declare the block** above, all three keys together. A partial block is
-      REFUSED rather than ignored, because a silent fallback restores the shared
-      personal bucket the App was adopted to end.
+   5. **Declare the profile** above, all three App keys together. A partial
+      profile is refused when selected.
+   6. **Bind the tracked Project** by placing only the public name in its
+      `.red/config.yaml`:
 
-   Then say what changes and what does not. The App pays for READS — the queue
-   poll, issue listings, timelines, trust lookups — on its own bucket, per
-   repository it covers. Everything else is unchanged: **writes still go out as
-   the operator**, because comments, labels and pull requests are made through
-   the `gh` CLI with the operator's own credential, and commits are made by
-   local `git` with the operator's name and email. The App credential must never
-   be exported as `GH_TOKEN` or `GITHUB_TOKEN` — that would hand the CLI a bot
-   identity and sign the operator's work with it.
+      ```yaml
+      plugins:
+        dev:
+          github:
+            credential_profile: engineering
+      ```
 
-   A repository outside the installation keeps using the operator's token. That
-   is the ordinary case, not a fault: the daemon is host-scoped and the operator
-   works in personal repositories, other organisations and forks.
+   Never place a token, PEM, App id, installation id, or private-key path in
+   Project config. `redskilled` re-resolves personal credentials and reads the
+   daemon-local PEM when used, then mints the App installation credential
+   internally. ACP clients, MCP clients, and Workers receive none of it.
+
+   An explicit profile is fail-closed. Unknown profiles, missing or invalid
+   credentials, and scope mismatches return typed secret-free ACP refusals; an
+   App profile never falls back to `personal`. Several profiles may coexist,
+   with separate cache, budget, and authorization domains.
 
 4. **Restart and adopt — only once a verb is actually needed** (read *The daemon
    upgrades itself* below before this step; a daemon that merely trails the
@@ -328,11 +338,11 @@ and lifecycle. `/red-setup` is per-repository: it is the only authority allowed
 to create a checkout's `.red/` and enable plugins there. Route repository setup
 to `/red-setup`; route host daemon operation here.
 
-**The GitHub credential is machine-scoped, so it is configured here.** One host
-has one App, one private key and one installation; a repository has none of
-those and must never declare them. A `/red-setup` run that meets an operator
-wanting automation off their personal rate limit routes them to this skill
-rather than writing credentials into a checkout.
+**GitHub credential backends are machine-scoped, so they are configured here.**
+A Project may select one public profile name in tracked config, but it has none
+of the profile's token, PEM, App id, installation id, or private-key path. A
+`/red-setup` run that meets an operator wanting a new backend routes them to this
+skill rather than writing credential material into a checkout.
 
 The debug entry is scoped the same way — it explains one Worker's process life
 from the daemon's and the Worker's own records. Queue health across the backlog

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -56,7 +56,9 @@ back into `/start`, `/to-spec`, `/to-tickets`, `/afk`, or `/hitl`.
 - **Host daemon status, provisioning, policy, or lifecycle** -> `/redskilled`.
   It reads the daemon's socket, version, registrations, Workers, ceilings, and
   setting origins; provisions the daemon-owned home; edits host policy; and
-  restarts through the survival-reporting stop path. `/dashboard` stays the
+  configures named personal or GitHub App credential backends. A Project may
+  select one public profile name in tracked config, while every token, App fact,
+  and PEM path stays on the `/redskilled` host-policy route. `/dashboard` stays the
   route for this repository's queue health, while `/red-statusline` owns the
   one-line host adapter.
 - **"What is the Worker on issue N doing, or why did it never start?"** ->

--- a/plugins/dev/skills/engineering/redskilled/SKILL.md
+++ b/plugins/dev/skills/engineering/redskilled/SKILL.md
@@ -70,18 +70,23 @@ Treat `redskilled` as the per-machine process authority: it owns Worker birth, d
    Keep these keys in the home config only: a project's `.red/config.yaml` may
    ask for Workers, but it may not redefine the machine's limit.
 
-   **The App is a payer, never an author.** An operator who wants automation off
-   their personal rate limit declares a GitHub App in the SAME host file, because
-   one machine has one App and one private key — a repository never declares it:
+   **Credentials are named daemon-owned profiles.** The compatibility profile
+   is `personal`; it resolves `REDSKILLED_HOST_TOKEN`, `GITHUB_TOKEN`,
+   `GH_TOKEN`, then `gh auth token`. An operator may declare several personal or
+   bring-your-own App profiles in the SAME host file:
 
    ```yaml
    plugins:
      dev:
        redskilled:
-         github_app:
-           app_id: "4575633"
-           installation_id: "153309957"
-           private_key: ~/.red/redskilled/credentials/github-app.pem
+         github_profiles:
+           personal:
+             kind: personal
+           engineering:
+             kind: github-app
+             app_id: "4575633"
+             installation_id: "153309957"
+             private_key: ~/.red/redskilled/credentials/engineering.pem
    ```
 
    Walk the operator through it in this order, and stop at the first step that
@@ -99,22 +104,27 @@ Treat `redskilled` as the per-machine process authority: it owns Worker birth, d
    4. **Read the installation id back** rather than transcribing it: the App's
       own installations listing names it, and a wrong id fails as an
       authentication error far from its cause.
-   5. **Declare the block** above, all three keys together. A partial block is
-      REFUSED rather than ignored, because a silent fallback restores the shared
-      personal bucket the App was adopted to end.
+   5. **Declare the profile** above, all three App keys together. A partial
+      profile is refused when selected.
+   6. **Bind the tracked Project** by placing only the public name in its
+      `.red/config.yaml`:
 
-   Then say what changes and what does not. The App pays for READS — the queue
-   poll, issue listings, timelines, trust lookups — on its own bucket, per
-   repository it covers. Everything else is unchanged: **writes still go out as
-   the operator**, because comments, labels and pull requests are made through
-   the `gh` CLI with the operator's own credential, and commits are made by
-   local `git` with the operator's name and email. The App credential must never
-   be exported as `GH_TOKEN` or `GITHUB_TOKEN` — that would hand the CLI a bot
-   identity and sign the operator's work with it.
+      ```yaml
+      plugins:
+        dev:
+          github:
+            credential_profile: engineering
+      ```
 
-   A repository outside the installation keeps using the operator's token. That
-   is the ordinary case, not a fault: the daemon is host-scoped and the operator
-   works in personal repositories, other organisations and forks.
+   Never place a token, PEM, App id, installation id, or private-key path in
+   Project config. `redskilled` re-resolves personal credentials and reads the
+   daemon-local PEM when used, then mints the App installation credential
+   internally. ACP clients, MCP clients, and Workers receive none of it.
+
+   An explicit profile is fail-closed. Unknown profiles, missing or invalid
+   credentials, and scope mismatches return typed secret-free ACP refusals; an
+   App profile never falls back to `personal`. Several profiles may coexist,
+   with separate cache, budget, and authorization domains.
 
 4. **Restart and adopt — only once a verb is actually needed** (read *The daemon
    upgrades itself* below before this step; a daemon that merely trails the
@@ -328,11 +338,11 @@ and lifecycle. `/red-setup` is per-repository: it is the only authority allowed
 to create a checkout's `.red/` and enable plugins there. Route repository setup
 to `/red-setup`; route host daemon operation here.
 
-**The GitHub credential is machine-scoped, so it is configured here.** One host
-has one App, one private key and one installation; a repository has none of
-those and must never declare them. A `/red-setup` run that meets an operator
-wanting automation off their personal rate limit routes them to this skill
-rather than writing credentials into a checkout.
+**GitHub credential backends are machine-scoped, so they are configured here.**
+A Project may select one public profile name in tracked config, but it has none
+of the profile's token, PEM, App id, installation id, or private-key path. A
+`/red-setup` run that meets an operator wanting a new backend routes them to this
+skill rather than writing credential material into a checkout.
 
 The debug entry is scoped the same way — it explains one Worker's process life
 from the daemon's and the Worker's own records. Queue health across the backlog


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3385 -->
🤖 **Re-seed trail** — #3385 on `afk/3385-implement-redskilled-github-credential-p`, lane `/afk`.

Rounds spent: 3/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3385; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

Closes #3385