### PR TITLE
fix: #3391 Implement ACP credential-budget projections for Projects and host administration

### DIFF
--- a/apps/redskilled/src/acp-budget.ts
+++ b/apps/redskilled/src/acp-budget.ts
@@ -1,0 +1,82 @@
+import { RequestError } from "@agentclientprotocol/sdk";
+import {
+  type RedskilledGithubBudgetGateway,
+  type RedskilledGithubGateway,
+  type RedskilledGithubGatewayRegistration,
+  type RedskilledGithubHostBudgetProjection,
+  type RedskilledGithubProjectBudgetProjection,
+} from "./github-gateway.js";
+import type { AcpProjectWorkspace } from "./project-workspace.js";
+import { RedskilledGithubCredentialProfileError } from "./github-credential-profiles.js";
+
+export const REDSKILLED_PROJECT_BUDGET_METHOD = "_redskills/project_budget";
+export const REDSKILLED_HOST_BUDGET_METHOD = "_redskills/host_budgets";
+
+type EmptyParams = Record<string, never>;
+
+/** Project authority can observe only the profile selected by daemon policy. */
+export function bindAcpProjectGithubBudget(
+  registration: RedskilledGithubGatewayRegistration | undefined,
+  projectForConnection: () => AcpProjectWorkspace,
+) {
+  return async (_request: { readonly params: EmptyParams }): Promise<RedskilledGithubProjectBudgetProjection> => {
+    const project = projectForConnection();
+    try {
+      const selection = await registration?.credentialForProject({
+        projectId: project.projectId,
+        projectLabel: project.projectLabel,
+        workspacePath: project.workspacePath,
+      });
+      const budgets = budgetGateway(registration?.gateway);
+      if (selection == null || budgets == null) {
+        throw RequestError.authRequired(
+          { version: 1, kind: "github-credential-profile", reason: "missing-credentials" },
+          "this Project has no observable daemon-owned GitHub credential budget",
+        );
+      }
+      return budgets.projectBudget({
+        projectId: project.projectId,
+        projectLabel: project.projectLabel,
+        workspacePath: project.workspacePath,
+        credentialProfile: selection.profile,
+      });
+    } catch (error) {
+      if (error instanceof RedskilledGithubCredentialProfileError) {
+        throw RequestError.authRequired(error.refusal, error.message);
+      }
+      throw error;
+    }
+  };
+}
+
+/** Host-wide facts require an endpoint explicitly started with administrative authority. */
+export function bindAcpHostGithubBudget(
+  registration: RedskilledGithubGatewayRegistration | undefined,
+  hostAdministration: boolean,
+) {
+  return async (_request: { readonly params: EmptyParams }): Promise<RedskilledGithubHostBudgetProjection> => {
+    if (!hostAdministration) {
+      throw RequestError.invalidRequest(
+        "this project-scoped ACP connection has no host-administrative authority",
+      );
+    }
+    const budgets = budgetGateway(registration?.gateway);
+    if (budgets == null) {
+      throw RequestError.invalidRequest("GitHub credential-budget projection is unavailable");
+    }
+    return budgets.hostBudget();
+  };
+}
+
+/** Both budget methods accept exactly an empty object; authority is never caller-named. */
+export function emptyBudgetParams(value: unknown): EmptyParams {
+  if (value == null || typeof value !== "object" || Array.isArray(value) || Object.keys(value).length !== 0) {
+    throw RequestError.invalidParams({}, "credential-budget requests accept no caller-controlled authority fields");
+  }
+  return {};
+}
+
+function budgetGateway(gateway: RedskilledGithubGateway | undefined): RedskilledGithubBudgetGateway | null {
+  if (gateway == null || !("projectBudget" in gateway) || !("hostBudget" in gateway)) return null;
+  return gateway as RedskilledGithubBudgetGateway;
+}

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -42,6 +42,13 @@ import {
   withTimeout,
 } from "./acp-socket.js";
 import { bindAcpProjectGithubRead, githubReadParams } from "./acp-github.js";
+import {
+  bindAcpHostGithubBudget,
+  bindAcpProjectGithubBudget,
+  emptyBudgetParams,
+  REDSKILLED_HOST_BUDGET_METHOD,
+  REDSKILLED_PROJECT_BUDGET_METHOD,
+} from "./acp-budget.js";
 import type { RedskilledHostState } from "./host-state.js";
 import {
   REDSKILLED_GITHUB_READ_METHOD,
@@ -96,6 +103,8 @@ export interface StartRedskillsAcpControlPlaneOptions {
   readonly startWorker: (spec: RedskilledWorkerSpec) => LaunchedWorker;
   readonly hostState: () => RedskilledHostState;
   readonly githubGateway?: RedskilledGithubGatewayRegistration;
+  /** Explicit endpoint authority; ordinary public/project ACP stays false. */
+  readonly hostAdministration?: boolean;
 }
 
 /** Bind the daemon-owned public ACP endpoint. */
@@ -186,6 +195,8 @@ async function servePublicConnection(
   const mutateProjectControl = (operation: ProjectControlOperation) =>
     applyProjectControl(scopedProject(), operation, projectControls, persistProjectControls);
   const readGithub = bindAcpProjectGithubRead(options.githubGateway, scopedProject);
+  const readProjectBudget = bindAcpProjectGithubBudget(options.githubGateway, scopedProject);
+  const readHostBudget = bindAcpHostGithubBudget(options.githubGateway, options.hostAdministration === true);
   const emptyParams = () => ({});
 
   const v1App = agent({ name: "RedSkills" })
@@ -204,6 +215,13 @@ async function servePublicConnection(
             projectControl: { version: 1, methods: PROJECT_CONTROL_METHODS },
             ...(options.githubGateway == null ? {} : {
               githubGateway: { version: 1, methods: [REDSKILLED_GITHUB_READ_METHOD] },
+              credentialBudgets: {
+                version: 1,
+                methods: [
+                  REDSKILLED_PROJECT_BUDGET_METHOD,
+                  ...(options.hostAdministration === true ? [REDSKILLED_HOST_BUDGET_METHOD] : []),
+                ],
+              },
             }),
           },
         },
@@ -290,7 +308,9 @@ async function servePublicConnection(
     .onRequest(PROJECT_CONTROL_METHODS[0], emptyParams, () => mutateProjectControl("drain"))
     .onRequest(PROJECT_CONTROL_METHODS[1], emptyParams, () => mutateProjectControl("stop"))
     .onRequest(PROJECT_CONTROL_METHODS[2], emptyParams, readProjectControl)
-    .onRequest(REDSKILLED_GITHUB_READ_METHOD, githubReadParams, readGithub);
+    .onRequest(REDSKILLED_GITHUB_READ_METHOD, githubReadParams, readGithub)
+    .onRequest(REDSKILLED_PROJECT_BUDGET_METHOD, emptyBudgetParams, readProjectBudget)
+    .onRequest(REDSKILLED_HOST_BUDGET_METHOD, emptyBudgetParams, readHostBudget);
 
   const v2Turns = new Map<string, Promise<void>>();
   const v2App = acpV2.agent({ name: "RedSkills" })
@@ -309,6 +329,13 @@ async function servePublicConnection(
             projectControl: { version: 1, methods: PROJECT_CONTROL_METHODS },
             ...(options.githubGateway == null ? {} : {
               githubGateway: { version: 1, methods: [REDSKILLED_GITHUB_READ_METHOD] },
+              credentialBudgets: {
+                version: 1,
+                methods: [
+                  REDSKILLED_PROJECT_BUDGET_METHOD,
+                  ...(options.hostAdministration === true ? [REDSKILLED_HOST_BUDGET_METHOD] : []),
+                ],
+              },
             }),
           },
         },
@@ -380,7 +407,9 @@ async function servePublicConnection(
     .onRequest(PROJECT_CONTROL_METHODS[0], emptyParams, () => mutateProjectControl("drain"))
     .onRequest(PROJECT_CONTROL_METHODS[1], emptyParams, () => mutateProjectControl("stop"))
     .onRequest(PROJECT_CONTROL_METHODS[2], emptyParams, readProjectControl)
-    .onRequest(REDSKILLED_GITHUB_READ_METHOD, githubReadParams, readGithub);
+    .onRequest(REDSKILLED_GITHUB_READ_METHOD, githubReadParams, readGithub)
+    .onRequest(REDSKILLED_PROJECT_BUDGET_METHOD, emptyBudgetParams, readProjectBudget)
+    .onRequest(REDSKILLED_HOST_BUDGET_METHOD, emptyBudgetParams, readHostBudget);
 
   const connection = acpV2.agentProtocolRouter()
     .withV1(v1App)

--- a/apps/redskilled/src/github-companions.ts
+++ b/apps/redskilled/src/github-companions.ts
@@ -52,6 +52,7 @@ export function resolveServeGithubGateway(
   const env = options.env ?? process.env;
   const fetchImpl = createTimedGithubFetch();
   const gateway = createRedskilledGithubGateway({
+    configuredProfiles: ["personal", ...Object.keys(options.profiles ?? {})],
     upstream: createRedskilledGithubUpstream({
       ...(env.GITHUB_API_URL ? { origin: env.GITHUB_API_URL } : {}),
       ...(env.GITHUB_GRAPHQL_URL ? { graphqlEndpoint: env.GITHUB_GRAPHQL_URL } : {}),

--- a/apps/redskilled/src/github-gateway.ts
+++ b/apps/redskilled/src/github-gateway.ts
@@ -49,6 +49,66 @@ export interface RedskilledGithubBudgetFacts {
   readonly limit?: number | null;
 }
 
+export type RedskilledGithubBudgetPool = "rest" | "graphql" | "search";
+export type RedskilledGithubBudgetEvidenceState =
+  | "authoritative"
+  | "cached"
+  | "unavailable"
+  | "unknown"
+  | "backpressured";
+
+export interface RedskilledGithubBudgetEvidence {
+  readonly state: RedskilledGithubBudgetEvidenceState;
+  readonly authority: "github" | "redskilled-cache" | "redskilled-gateway";
+  readonly observed_at: string | null;
+  readonly age_ms: number | null;
+  readonly fresh: boolean;
+}
+
+export interface RedskilledGithubBudgetPresentation {
+  readonly warning: "normal" | "warning" | "critical" | "unknown";
+  readonly density: "compact" | "expanded";
+}
+
+export interface RedskilledGithubPoolBudgetProjection {
+  readonly pool: RedskilledGithubBudgetPool;
+  readonly remaining: number | null;
+  readonly used: number | null;
+  readonly limit: number | null;
+  readonly reset_at: string | null;
+  readonly retry_at: string | null;
+  readonly evidence: RedskilledGithubBudgetEvidence;
+  readonly active_backpressure: null | {
+    readonly kind: GithubLimitFact["kind"];
+    readonly pool: GithubLimitFact["pool"];
+    readonly retry_at: string;
+    readonly evidence: GithubLimitFact["evidence"];
+  };
+  readonly presentation: RedskilledGithubBudgetPresentation;
+}
+
+export interface RedskilledGithubProjectBudgetProjection {
+  readonly version: 1;
+  readonly scope: "project";
+  readonly project_id: string;
+  readonly project_label: string;
+  readonly credential_profile: string;
+  readonly pools: readonly RedskilledGithubPoolBudgetProjection[];
+}
+
+export interface RedskilledGithubProfileBudgetProjection {
+  readonly credential_profile: string;
+  readonly project_ids: readonly string[];
+  readonly project_labels: readonly string[];
+  readonly pools: readonly RedskilledGithubPoolBudgetProjection[];
+}
+
+export interface RedskilledGithubHostBudgetProjection {
+  readonly version: 1;
+  readonly scope: "host-administration";
+  readonly profiles: readonly RedskilledGithubProfileBudgetProjection[];
+}
+
 export interface RedskilledGithubUpstreamAnswer {
   readonly value: unknown;
   readonly budget: RedskilledGithubBudgetFacts | null;
@@ -93,6 +153,11 @@ export interface RedskilledGithubGateway {
   ): RedskilledGithubProjectReader;
 }
 
+export interface RedskilledGithubBudgetGateway extends RedskilledGithubGateway {
+  projectBudget(authority: RedskilledGithubProjectAuthority): RedskilledGithubProjectBudgetProjection;
+  hostBudget(): RedskilledGithubHostBudgetProjection;
+}
+
 export interface RedskilledGithubCredentialSelection {
   readonly profile: string;
   readonly credential: RedskilledGithubCredential;
@@ -111,6 +176,8 @@ export interface CreateRedskilledGithubGatewayOptions {
   readonly clock?: () => string;
   readonly freshMs?: number;
   readonly capacity?: number;
+  /** Public profile names from host config; credential declarations stay private. */
+  readonly configuredProfiles?: readonly string[];
 }
 
 export interface CreateRedskilledGithubUpstreamOptions {
@@ -122,6 +189,15 @@ export interface CreateRedskilledGithubUpstreamOptions {
 }
 
 interface KeptGithubAnswer extends RedskilledGithubUpstreamAnswer {}
+
+interface BudgetObservation {
+  readonly facts: RedskilledGithubBudgetFacts | null;
+  readonly state: Exclude<RedskilledGithubBudgetEvidenceState, "unknown">;
+  readonly observedAt: string;
+  readonly backpressure?: GithubLimitFact;
+}
+
+const BUDGET_POOLS = ["rest", "graphql", "search"] as const;
 
 export class RedskilledGithubAuthorityError extends Error {
   constructor(message: string) {
@@ -136,13 +212,24 @@ export class RedskilledGithubAuthorityError extends Error {
  */
 export function createRedskilledGithubGateway(
   options: CreateRedskilledGithubGatewayOptions,
-): RedskilledGithubGateway {
+): RedskilledGithubBudgetGateway {
   const cache = createGithubCache({
     ...(options.freshMs == null ? {} : { freshMs: options.freshMs }),
     ...(options.capacity == null ? {} : { capacity: options.capacity }),
   });
   const clock = options.clock ?? (() => new Date().toISOString());
   const inFlight = new Map<string, Promise<RedskilledGithubReadAnswer>>();
+  const profiles = new Set((options.configuredProfiles ?? []).filter(publishableProfile));
+  const projectsByProfile = new Map<string, Map<string, string>>();
+  const observations = new Map<string, BudgetObservation>();
+
+  const observe = (
+    project: RedskilledGithubProjectAuthority,
+    pool: RedskilledGithubBudgetPool,
+    observation: BudgetObservation,
+  ): void => {
+    observations.set(budgetKey(project.credentialProfile, pool), observation);
+  };
 
   return {
     forProject(authority, credential) {
@@ -152,13 +239,23 @@ export function createRedskilledGithubGateway(
           `credential profile ${JSON.stringify(project.credentialProfile)} has no daemon-owned credential`,
         );
       }
+      profiles.add(project.credentialProfile);
+      const attributed = projectsByProfile.get(project.credentialProfile) ?? new Map<string, string>();
+      attributed.set(project.projectId, project.projectLabel);
+      projectsByProfile.set(project.credentialProfile, attributed);
       return {
         async read(request) {
           const read = validateRead(project, request);
+          const pool = poolForRead(read);
           const key = cacheKey(project, read);
           const now = clock();
           const held = cache.read<KeptGithubAnswer>(key, { now });
           if (held.outcome === "fresh" && held.value != null && held.fetched_at != null && held.age_ms != null) {
+            if (pool != null) observe(project, pool, {
+              facts: held.value.budget,
+              state: "cached",
+              observedAt: held.fetched_at,
+            });
             return publicAnswer(project, held.value, "cache", {
               outcome: held.outcome,
               fetched_at: held.fetched_at,
@@ -172,6 +269,11 @@ export function createRedskilledGithubGateway(
           const fetch = options.upstream({ project, credential, read })
             .then((answer) => {
               const fetchedAt = clock();
+              if (pool != null) observe(project, pool, {
+                facts: answer.budget,
+                state: answer.budget == null ? "unavailable" : "authoritative",
+                observedAt: fetchedAt,
+              });
               cache.put({ key, kind: read.kind, value: answer, fetchedAt });
               const kept = cache.read<KeptGithubAnswer>(key, { now: fetchedAt });
               return publicAnswer(project, answer, "upstream", {
@@ -182,6 +284,12 @@ export function createRedskilledGithubGateway(
               });
             })
             .catch((error: unknown) => {
+              if (pool != null) observe(project, pool, {
+                facts: held.value?.budget ?? null,
+                state: error instanceof GithubBackpressureError ? "backpressured" : "unavailable",
+                observedAt: clock(),
+                ...(error instanceof GithubBackpressureError ? { backpressure: error.fact } : {}),
+              });
               if (
                 error instanceof GithubBackpressureError &&
                 read.kind !== "repository-fetch" &&
@@ -202,7 +310,106 @@ export function createRedskilledGithubGateway(
         },
       };
     },
+    projectBudget(authority) {
+      const project = validateAuthority(authority);
+      return {
+        version: 1,
+        scope: "project",
+        project_id: project.projectId,
+        project_label: project.projectLabel,
+        credential_profile: project.credentialProfile,
+        pools: projectPools(project.credentialProfile, observations, clock()),
+      };
+    },
+    hostBudget() {
+      return {
+        version: 1,
+        scope: "host-administration",
+        profiles: [...profiles].sort().map((profile) => {
+          const attributed = projectsByProfile.get(profile) ?? new Map<string, string>();
+          const projects = [...attributed].sort(([left], [right]) => left.localeCompare(right));
+          return {
+            credential_profile: profile,
+            project_ids: projects.map(([id]) => id),
+            project_labels: projects.map(([, label]) => label),
+            pools: projectPools(profile, observations, clock()),
+          };
+        }),
+      };
+    },
   };
+}
+
+function projectPools(
+  profile: string,
+  observations: ReadonlyMap<string, BudgetObservation>,
+  now: string,
+): RedskilledGithubPoolBudgetProjection[] {
+  return BUDGET_POOLS.map((pool) => budgetProjection(pool, observations.get(budgetKey(profile, pool)), now));
+}
+
+function budgetProjection(
+  pool: RedskilledGithubBudgetPool,
+  observation: BudgetObservation | undefined,
+  now: string,
+): RedskilledGithubPoolBudgetProjection {
+  const facts = observation?.facts ?? null;
+  const remaining = facts?.remaining ?? null;
+  const limit = facts?.limit ?? null;
+  const used = remaining == null || limit == null ? null : Math.max(0, limit - remaining);
+  const ageMs = observation == null ? null : Math.max(0, Date.parse(now) - Date.parse(observation.observedAt));
+  const state = observation?.state ?? "unknown";
+  const warning = budgetWarning(state, remaining, limit);
+  const backpressure = observation?.backpressure;
+  return {
+    pool,
+    remaining,
+    used,
+    limit,
+    reset_at: facts?.reset_at ?? null,
+    retry_at: backpressure?.retry_at ?? null,
+    evidence: {
+      state,
+      authority: state === "authoritative" ? "github" : state === "cached" ? "redskilled-cache" : "redskilled-gateway",
+      observed_at: observation?.observedAt ?? null,
+      age_ms: Number.isFinite(ageMs) ? ageMs : null,
+      fresh: state === "authoritative" || state === "cached",
+    },
+    active_backpressure: backpressure == null ? null : {
+      kind: backpressure.kind,
+      pool: backpressure.pool,
+      retry_at: backpressure.retry_at,
+      evidence: backpressure.evidence,
+    },
+    presentation: { warning, density: warning === "normal" ? "compact" : "expanded" },
+  };
+}
+
+function budgetWarning(
+  state: RedskilledGithubBudgetEvidenceState,
+  remaining: number | null,
+  limit: number | null,
+): RedskilledGithubBudgetPresentation["warning"] {
+  if (state === "backpressured") return "critical";
+  if (state === "unknown" || state === "unavailable" || remaining == null || limit == null || limit <= 0) return "unknown";
+  const share = remaining / limit;
+  if (share <= 0.1) return "critical";
+  if (share <= 0.25) return "warning";
+  return "normal";
+}
+
+function budgetKey(profile: string, pool: RedskilledGithubBudgetPool): string {
+  return `${profile}\u0000${pool}`;
+}
+
+function poolForRead(read: RedskilledGithubRead): RedskilledGithubBudgetPool | null {
+  if (read.kind === "graphql") return "graphql";
+  if (read.kind === "repository-fetch") return null;
+  return read.path.replace(/^\/+/, "").startsWith("search/") ? "search" : "rest";
+}
+
+function publishableProfile(value: string): boolean {
+  return /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(value);
 }
 
 /**
@@ -230,13 +437,13 @@ export function createRedskilledGithubUpstream(
         method: "GET",
         headers: githubHeaders(input.credential.secret),
       });
+      const pool = input.read.path.replace(/^\/+/, "").startsWith("search/") ? "search" : "rest";
       if (!response.ok) {
-        const pool = input.read.path.replace(/^\/+/, "").startsWith("search/") ? "search" : "rest";
         throw upstreamRefusal("REST", pool, response, clock(), input.project.credentialProfile);
       }
       return {
         value: await responseValue(response),
-        budget: budgetFromHeaders("rest", response.headers),
+        budget: budgetFromHeaders(pool, response.headers),
       };
     }
 

--- a/apps/redskilled/tests/acp-budget-authority.test.ts
+++ b/apps/redskilled/tests/acp-budget-authority.test.ts
@@ -1,0 +1,53 @@
+import { RequestError } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import {
+  bindAcpHostGithubBudget,
+  bindAcpProjectGithubBudget,
+} from "../src/acp-budget.js";
+import { createRedskilledGithubGateway } from "../src/github-gateway.js";
+
+const project = {
+  projectId: "github:101",
+  projectLabel: "acme/widgets",
+  checkoutRoot: "/client-checkouts/widgets",
+  workspacePath: "/project-workspaces/widgets",
+};
+
+describe("ACP credential-budget authority", () => {
+  it("binds Project reads to the daemon-selected profile and ignores unrelated profiles", async () => {
+    const budgets = createRedskilledGithubGateway({
+      configuredProfiles: ["engineering", "release"],
+      upstream: async () => ({ value: {}, budget: null }),
+    });
+    const registration = {
+      gateway: budgets,
+      credentialForProject: () => ({ profile: "engineering", credential: { secret: "private-token" } }),
+    };
+    const answer = await bindAcpProjectGithubBudget(registration, () => project)({ params: {} });
+
+    expect(answer.scope).toBe("project");
+    expect(answer.credential_profile).toBe("engineering");
+    expect(JSON.stringify(answer)).not.toContain("release");
+    expect(JSON.stringify(answer)).not.toContain("private-token");
+  });
+
+  it("refuses host projection without explicit administrative authority", async () => {
+    const budgets = createRedskilledGithubGateway({
+      configuredProfiles: ["engineering", "release"],
+      upstream: async () => ({ value: {}, budget: null }),
+    });
+    const projectHandler = bindAcpHostGithubBudget({
+      gateway: budgets,
+      credentialForProject: () => null,
+    }, false);
+    const error = await projectHandler({ params: {} }).then(() => null, (caught: unknown) => caught);
+    expect(error).toBeInstanceOf(RequestError);
+
+    const administrative = await bindAcpHostGithubBudget({
+      gateway: budgets,
+      credentialForProject: () => null,
+    }, true)({ params: {} });
+    expect(administrative.scope).toBe("host-administration");
+    expect(administrative.profiles.map((entry) => entry.credential_profile)).toEqual(["engineering", "release"]);
+  });
+});

--- a/apps/redskilled/tests/acp-budget-projection.test.ts
+++ b/apps/redskilled/tests/acp-budget-projection.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { GithubBackpressureError } from "@reddb-io/github";
+import {
+  createRedskilledGithubGateway,
+  type RedskilledGithubProjectAuthority,
+} from "../src/github-gateway.js";
+
+const PROJECT: RedskilledGithubProjectAuthority = {
+  projectId: "github:101",
+  projectLabel: "acme/widgets",
+  workspacePath: "/project-workspaces/widgets",
+  credentialProfile: "engineering",
+};
+
+describe("ACP credential-budget projections", () => {
+  it("projects one Project's bound profile with authoritative freshness and daemon presentation policy", async () => {
+    let now = "2026-08-15T18:00:00.000Z";
+    const gateway = createRedskilledGithubGateway({
+      configuredProfiles: ["engineering", "release"],
+      clock: () => now,
+      upstream: async () => ({
+        value: { state: "OPEN" },
+        budget: { pool: "rest", remaining: 400, limit: 5_000, reset_at: "2026-08-15T19:00:00.000Z" },
+      }),
+    });
+    await gateway.forProject(PROJECT, { secret: "never-publish-this-token" })
+      .read({ kind: "rest", path: "issues/17" });
+    now = "2026-08-15T18:00:05.000Z";
+
+    const projection = gateway.projectBudget(PROJECT);
+    expect(projection).toMatchObject({
+      version: 1,
+      scope: "project",
+      project_id: "github:101",
+      credential_profile: "engineering",
+    });
+    expect(projection.pools.find((pool) => pool.pool === "rest")).toMatchObject({
+      remaining: 400,
+      used: 4_600,
+      limit: 5_000,
+      evidence: { state: "authoritative", authority: "github", age_ms: 5_000, fresh: true },
+      presentation: { warning: "critical", density: "expanded" },
+    });
+    expect(JSON.stringify(projection)).not.toContain("never-publish-this-token");
+    expect(JSON.stringify(projection)).not.toContain("release");
+  });
+
+  it("separates cached, unavailable, and actively backpressured evidence", async () => {
+    let mode: "ok" | "backpressure" | "unavailable" = "ok";
+    const gateway = createRedskilledGithubGateway({
+      clock: () => "2026-08-15T18:00:00.000Z",
+      upstream: async (input) => {
+        const pool = input.read.kind === "graphql" ? "graphql" : "rest";
+        if (mode === "backpressure") throw new GithubBackpressureError({
+          kind: "primary-rest-exhausted",
+          pool: "rest",
+          retry_at: "2026-08-15T19:00:00.000Z",
+          evidence: "balance",
+          message: "spent",
+        });
+        if (mode === "unavailable") throw new Error("offline");
+        return { value: {}, budget: { pool, remaining: 4_900, limit: 5_000, reset_at: null } };
+      },
+    });
+    const reader = gateway.forProject(PROJECT, { secret: "fixture" });
+    await reader.read({ kind: "rest", path: "issues/1" });
+    await reader.read({ kind: "rest", path: "issues/1" });
+    mode = "backpressure";
+    await reader.read({ kind: "rest", path: "issues/2" }).catch(() => undefined);
+    mode = "unavailable";
+    await reader.read({ kind: "graphql", selection: "id" }).catch(() => undefined);
+
+    const pools = gateway.projectBudget(PROJECT).pools;
+    expect(pools.find((pool) => pool.pool === "rest")?.evidence.state).toBe("backpressured");
+    expect(pools.find((pool) => pool.pool === "graphql")?.evidence.state).toBe("unavailable");
+    expect(pools.find((pool) => pool.pool === "search")?.evidence.state).toBe("unknown");
+  });
+
+  it("gives host administration every configured profile and known Project attribution without secrets", async () => {
+    const gateway = createRedskilledGithubGateway({
+      configuredProfiles: ["engineering", "release"],
+      upstream: async () => ({ value: {}, budget: null }),
+    });
+    gateway.forProject(PROJECT, { secret: "engineering-secret" });
+    gateway.forProject({ ...PROJECT, projectId: "github:202", projectLabel: "acme/release", credentialProfile: "release" }, {
+      secret: "release-secret",
+    });
+
+    const projection = gateway.hostBudget();
+    expect(projection.scope).toBe("host-administration");
+    expect(projection.profiles.map((profile) => profile.credential_profile)).toEqual(["engineering", "release"]);
+    expect(projection.profiles[0]?.project_ids).toEqual(["github:101"]);
+    const publicBytes = JSON.stringify(projection);
+    expect(publicBytes).not.toContain("engineering-secret");
+    expect(publicBytes).not.toContain("release-secret");
+  });
+});

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -152,6 +152,10 @@ The LLM Wiki routes ship with the `memory` plugin as `/memory:wiki-init` and
 `/memory:wiki`, not with `dev`, so they stay out of this inventory.
 
 Capability references registered by owner:
+ACP credential-budget observations (Project clients receive only their bound
+profile; explicit host administration receives all configured profiles and
+pools; warning and density policy stays daemon-owned) -> `/redskilled` and
+`apps/redskilled/src/acp-budget.ts`;
 `redskilled` MCP (the canonical project interface; start with its situational
 `help` tool, while `status {scope: worker | project | host}` provides scoped
 read-only diagnostics, and a visible project `birth_latch` routes through its

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -152,6 +152,10 @@ The LLM Wiki routes ship with the `memory` plugin as `/memory:wiki-init` and
 `/memory:wiki`, not with `dev`, so they stay out of this inventory.
 
 Capability references registered by owner:
+ACP credential-budget observations (Project clients receive only their bound
+profile; explicit host administration receives all configured profiles and
+pools; warning and density policy stays daemon-owned) -> `/redskilled` and
+`apps/redskilled/src/acp-budget.ts`;
 `redskilled` MCP (the canonical project interface; start with its situational
 `help` tool, while `status {scope: worker | project | host}` provides scoped
 read-only diagnostics, and a visible project `birth_latch` routes through its


### PR DESCRIPTION
Automated AFK landing for #3391. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789422405&installation_model_id=20659&pr_number=3915&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3915&signature=74a3285387dd3737b57790ff5c2bcff5acde35cd4901336594aa5e1b94f7d8e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->