### PR TITLE
fix: #3888 Workflow Worker serves related turns and terminates cleanly

### DIFF
--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -16,7 +16,6 @@ import {
   methods,
   RequestError,
   type AgentConnection,
-  type ClientConnection,
   type McpServer,
   type NewSessionRequest,
   type PromptRequest,
@@ -83,25 +82,20 @@ import {
   type AcpProjectWorkspace,
 } from "./project-workspace.js";
 import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
+import {
+  cleanupWorkflowWorker,
+  notifyWorkerLifecycle,
+  reapWorkflowWorker,
+  scheduleIdleCleanup,
+  workflowOutcome,
+  type ActiveWorkflowWorker,
+} from "./acp-worker-lifecycle.js";
 
 export { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "./acp-compat.js";
 
 interface PublicSession {
   readonly request: NewSessionRequest;
   readonly project: AcpProjectWorkspace;
-}
-
-interface ActiveWorker {
-  readonly workerId: string;
-  readonly downstreamSessionId: string;
-  readonly connection: ClientConnection;
-  readonly socket: Socket;
-  readonly endpoint: string;
-  readonly publicSessionId: string;
-  readonly notify: AgentConnection["client"]["notify"];
-  idleTimer?: NodeJS.Timeout;
-  cancelled: boolean;
-  cleaned: boolean;
 }
 
 export interface RedskillsAcpControlPlane {
@@ -179,7 +173,7 @@ async function servePublicConnection(
   persistProjectControls: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>,
 ): Promise<void> {
   const sessions = new Map<string, PublicSession>();
-  const active = new Map<string, ActiveWorker>();
+  const active = new Map<string, ActiveWorkflowWorker>();
   const busy = new Set<string>();
   let connectionProject: AcpProjectWorkspace | undefined;
   let githubObserver: Promise<AcpGithubUpdateObserver> | undefined;
@@ -297,7 +291,7 @@ async function servePublicConnection(
       if (worker == null) {
         worker = await admitNativeAcpWorker(options, session, params.sessionId, upstream.notify.bind(upstream));
         active.set(params.sessionId, worker);
-        await notifyLifecycle(worker, "admission");
+        await notifyWorkerLifecycle(worker, "admission");
       }
       if (worker.idleTimer != null) clearTimeout(worker.idleTimer);
       busy.add(params.sessionId);
@@ -314,8 +308,8 @@ async function servePublicConnection(
         });
         const outcome = workflowOutcome(response);
         if (outcome != null) {
-          await notifyLifecycle(worker, "terminal-outcome", outcome);
-          await reapWorker(params.sessionId, worker, active, outcome);
+          await notifyWorkerLifecycle(worker, "terminal-outcome", outcome);
+          await reapWorkflowWorker(params.sessionId, worker, active, outcome);
         } else {
           scheduleIdleCleanup(params.sessionId, worker, active);
         }
@@ -327,7 +321,7 @@ async function servePublicConnection(
           },
         } satisfies PromptResponse;
       } catch (error) {
-        cleanupWorker(params.sessionId, worker, active);
+        cleanupWorkflowWorker(params.sessionId, worker, active);
         throw error;
       } finally {
         busy.delete(params.sessionId);
@@ -468,13 +462,13 @@ async function servePublicConnection(
     observer.close();
     await observer.settled();
   }
-  for (const [sessionId, worker] of active) cleanupWorker(sessionId, worker, active);
+  for (const [sessionId, worker] of active) cleanupWorkflowWorker(sessionId, worker, active);
 }
 
 async function runV2PublicTurn(
   options: StartRedskillsAcpControlPlaneOptions,
   sessions: Map<string, PublicSession>,
-  active: Map<string, ActiveWorker>,
+  active: Map<string, ActiveWorkflowWorker>,
   params: acpV2.PromptRequest,
   upstream: acpV2.AgentContext,
 ): Promise<void> {
@@ -486,7 +480,7 @@ async function runV2PublicTurn(
     update: { sessionUpdate: "state_update", state: "running" },
   });
 
-  let worker: ActiveWorker | undefined;
+  let worker: ActiveWorkflowWorker | undefined;
   try {
     worker = active.get(params.sessionId);
     if (worker == null) {
@@ -503,7 +497,7 @@ async function runV2PublicTurn(
         });
       });
       active.set(params.sessionId, worker);
-      await notifyLifecycle(worker, "admission");
+      await notifyWorkerLifecycle(worker, "admission");
     }
     if (worker.idleTimer != null) clearTimeout(worker.idleTimer);
     const response = await worker.connection.agent.request(methods.agent.session.prompt, {
@@ -513,8 +507,8 @@ async function runV2PublicTurn(
     });
     const outcome = workflowOutcome(response);
     if (outcome != null) {
-      await notifyLifecycle(worker, "terminal-outcome", outcome);
-      await reapWorker(params.sessionId, worker, active, outcome);
+      await notifyWorkerLifecycle(worker, "terminal-outcome", outcome);
+      await reapWorkflowWorker(params.sessionId, worker, active, outcome);
     } else {
       scheduleIdleCleanup(params.sessionId, worker, active);
     }
@@ -524,7 +518,7 @@ async function runV2PublicTurn(
       _meta: { redskills: { authority: "redskilled", workerId: worker.workerId } },
     });
   } catch (error) {
-    if (worker != null) cleanupWorker(params.sessionId, worker, active);
+    if (worker != null) cleanupWorkflowWorker(params.sessionId, worker, active);
     await upstream.notify(acpV2.methods.client.session.update, {
       sessionId: params.sessionId,
       update: { sessionUpdate: "state_update", state: "idle", stopReason: "refusal" },
@@ -563,7 +557,7 @@ async function admitNativeAcpWorker(
   session: PublicSession,
   publicSessionId: string,
   forward: AgentConnection["client"]["notify"],
-): Promise<ActiveWorker> {
+): Promise<ActiveWorkflowWorker> {
   const endpointId = randomBytes(6).toString("hex");
   const endpoint = join(options.paths.runtimeDir, "acp-workers", `${endpointId}.sock`);
   const rendezvous = await bindWorkerRendezvous(endpoint);
@@ -665,50 +659,6 @@ function projectState(host: RedskilledHostState, project: AcpProjectWorkspace) {
     workspace_path: project.workspacePath,
     workers: host.workers.filter((worker) => worker.project_label === project.projectId),
   };
-}
-
-function scheduleIdleCleanup(
-  sessionId: string,
-  worker: ActiveWorker,
-  active: Map<string, ActiveWorker>,
-): void {
-  const configured = Number.parseInt(process.env.REDSKILLED_ACP_WORKER_IDLE_MS ?? "30000", 10);
-  const timer = setTimeout(() => void reapWorker(sessionId, worker, active, "idle-policy"), configured);
-  timer.unref();
-  worker.idleTimer = timer;
-}
-
-async function reapWorker(
-  sessionId: string,
-  worker: ActiveWorker,
-  active: Map<string, ActiveWorker>,
-  reason: string,
-): Promise<void> {
-  await notifyLifecycle(worker, "reaping", reason).catch(() => undefined);
-  cleanupWorker(sessionId, worker, active);
-}
-
-async function notifyLifecycle(worker: ActiveWorker, event: string, reason?: string): Promise<void> {
-  await worker.notify(methods.client.session.update, {
-    sessionId: worker.publicSessionId,
-    update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "" } },
-    _meta: { redskills: { lifecycle: { event, workerId: worker.workerId, ...(reason == null ? {} : { reason }) } } },
-  });
-}
-
-function workflowOutcome(response: PromptResponse): string | undefined {
-  if (response.stopReason === "cancelled") return "cancellation";
-  return (response._meta as { redskills?: { workflowOutcome?: string } } | undefined)?.redskills?.workflowOutcome;
-}
-
-function cleanupWorker(sessionId: string, worker: ActiveWorker, active: Map<string, ActiveWorker>): void {
-  if (worker.cleaned) return;
-  worker.cleaned = true;
-  if (worker.idleTimer != null) clearTimeout(worker.idleTimer);
-  if (active.get(sessionId) === worker) active.delete(sessionId);
-  worker.connection.close();
-  worker.socket.destroy();
-  void rm(worker.endpoint, { force: true });
 }
 
 /** Stdio launch-edge adapter: transport only; no session state lives here. */

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -85,7 +85,6 @@ import {
 import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
 
 export { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "./acp-compat.js";
-const TERMINAL_REAP_DELAY_MS = 150;
 
 interface PublicSession {
   readonly request: NewSessionRequest;
@@ -98,6 +97,9 @@ interface ActiveWorker {
   readonly connection: ClientConnection;
   readonly socket: Socket;
   readonly endpoint: string;
+  readonly publicSessionId: string;
+  readonly notify: AgentConnection["client"]["notify"];
+  idleTimer?: NodeJS.Timeout;
   cancelled: boolean;
   cleaned: boolean;
 }
@@ -178,6 +180,7 @@ async function servePublicConnection(
 ): Promise<void> {
   const sessions = new Map<string, PublicSession>();
   const active = new Map<string, ActiveWorker>();
+  const busy = new Set<string>();
   let connectionProject: AcpProjectWorkspace | undefined;
   let githubObserver: Promise<AcpGithubUpdateObserver> | undefined;
   let githubNotify: ((method: string, params?: unknown) => Promise<void>) | undefined;
@@ -273,7 +276,7 @@ async function servePublicConnection(
     .onRequest(methods.agent.session.prompt, async ({ params, client: upstream }) => {
       const session = sessions.get(params.sessionId);
       if (session == null) throw new Error("unknown RedSkills ACP session");
-      if (active.has(params.sessionId)) throw new Error("this RedSkills ACP session already has an active turn");
+      if (busy.has(params.sessionId)) throw new Error("this RedSkills ACP session already has an active turn");
 
       const controlOperation = coreProjectOperation(params.prompt);
       if (controlOperation != null) {
@@ -290,8 +293,14 @@ async function servePublicConnection(
         } satisfies PromptResponse;
       }
 
-      const worker = await admitNativeAcpWorker(options, session, params.sessionId, upstream.notify.bind(upstream));
-      active.set(params.sessionId, worker);
+      let worker = active.get(params.sessionId);
+      if (worker == null) {
+        worker = await admitNativeAcpWorker(options, session, params.sessionId, upstream.notify.bind(upstream));
+        active.set(params.sessionId, worker);
+        await notifyLifecycle(worker, "admission");
+      }
+      if (worker.idleTimer != null) clearTimeout(worker.idleTimer);
+      busy.add(params.sessionId);
       try {
         if (worker.cancelled) {
           await worker.connection.agent.notify(methods.agent.session.cancel, {
@@ -303,7 +312,13 @@ async function servePublicConnection(
           prompt: params.prompt,
           ...(params._meta == null ? {} : { _meta: params._meta }),
         });
-        scheduleTerminalCleanup(params.sessionId, worker, active);
+        const outcome = workflowOutcome(response);
+        if (outcome != null) {
+          await notifyLifecycle(worker, "terminal-outcome", outcome);
+          await reapWorker(params.sessionId, worker, active, outcome);
+        } else {
+          scheduleIdleCleanup(params.sessionId, worker, active);
+        }
         return {
           ...response,
           _meta: {
@@ -314,6 +329,8 @@ async function servePublicConnection(
       } catch (error) {
         cleanupWorker(params.sessionId, worker, active);
         throw error;
+      } finally {
+        busy.delete(params.sessionId);
       }
     })
     .onNotification(methods.agent.session.cancel, async ({ params }) => {
@@ -401,7 +418,7 @@ async function servePublicConnection(
     })
     .onRequest(acpV2.methods.agent.session.prompt, ({ params, client: upstream }) => {
       if (!sessions.has(params.sessionId)) throw acpV2.RequestError.invalidParams("unknown RedSkills ACP session");
-      if (active.has(params.sessionId) || v2Turns.has(params.sessionId)) {
+      if (v2Turns.has(params.sessionId)) {
         throw acpV2.RequestError.invalidRequest("this RedSkills ACP session already has an active turn");
       }
 
@@ -471,25 +488,36 @@ async function runV2PublicTurn(
 
   let worker: ActiveWorker | undefined;
   try {
-    worker = await admitNativeAcpWorker(options, session, params.sessionId, async (
-      _method: typeof methods.client.session.update,
-      notice: SessionNotification,
-    ) => {
-      const update = translateV1UpdateToV2(notice.update, messageId);
-      if (update == null) return;
-      await upstream.notify(acpV2.methods.client.session.update, {
-        sessionId: params.sessionId,
-        update,
-        _meta: notice._meta,
+    worker = active.get(params.sessionId);
+    if (worker == null) {
+      worker = await admitNativeAcpWorker(options, session, params.sessionId, async (
+        _method: typeof methods.client.session.update,
+        notice: SessionNotification,
+      ) => {
+        const update = translateV1UpdateToV2(notice.update, messageId);
+        if (update == null) return;
+        await upstream.notify(acpV2.methods.client.session.update, {
+          sessionId: params.sessionId,
+          update,
+          _meta: notice._meta,
+        });
       });
-    });
-    active.set(params.sessionId, worker);
+      active.set(params.sessionId, worker);
+      await notifyLifecycle(worker, "admission");
+    }
+    if (worker.idleTimer != null) clearTimeout(worker.idleTimer);
     const response = await worker.connection.agent.request(methods.agent.session.prompt, {
       sessionId: worker.downstreamSessionId,
       prompt: params.prompt as unknown as PromptRequest["prompt"],
       ...(params._meta == null ? {} : { _meta: params._meta }),
     });
-    scheduleTerminalCleanup(params.sessionId, worker, active);
+    const outcome = workflowOutcome(response);
+    if (outcome != null) {
+      await notifyLifecycle(worker, "terminal-outcome", outcome);
+      await reapWorker(params.sessionId, worker, active, outcome);
+    } else {
+      scheduleIdleCleanup(params.sessionId, worker, active);
+    }
     await upstream.notify(acpV2.methods.client.session.update, {
       sessionId: params.sessionId,
       update: { sessionUpdate: "state_update", state: "idle", stopReason: response.stopReason },
@@ -566,7 +594,11 @@ async function admitNativeAcpWorker(
         sessionId: publicSessionId,
         _meta: {
           ...(params._meta ?? {}),
-          redskills: { authority: "redskilled", workerId: launched.worker.worker_id },
+          redskills: {
+            ...((params._meta as { redskills?: object } | undefined)?.redskills ?? {}),
+            authority: "redskilled",
+            workerId: launched.worker.worker_id,
+          },
         },
       };
       await forward(methods.client.session.update, notice);
@@ -601,6 +633,8 @@ async function admitNativeAcpWorker(
     connection,
     socket: workerSocket,
     endpoint,
+    publicSessionId,
+    notify: forward,
     cancelled: false,
     cleaned: false,
   };
@@ -633,18 +667,44 @@ function projectState(host: RedskilledHostState, project: AcpProjectWorkspace) {
   };
 }
 
-function scheduleTerminalCleanup(
+function scheduleIdleCleanup(
   sessionId: string,
   worker: ActiveWorker,
   active: Map<string, ActiveWorker>,
 ): void {
-  const timer = setTimeout(() => cleanupWorker(sessionId, worker, active), TERMINAL_REAP_DELAY_MS);
+  const configured = Number.parseInt(process.env.REDSKILLED_ACP_WORKER_IDLE_MS ?? "30000", 10);
+  const timer = setTimeout(() => void reapWorker(sessionId, worker, active, "idle-policy"), configured);
   timer.unref();
+  worker.idleTimer = timer;
+}
+
+async function reapWorker(
+  sessionId: string,
+  worker: ActiveWorker,
+  active: Map<string, ActiveWorker>,
+  reason: string,
+): Promise<void> {
+  await notifyLifecycle(worker, "reaping", reason).catch(() => undefined);
+  cleanupWorker(sessionId, worker, active);
+}
+
+async function notifyLifecycle(worker: ActiveWorker, event: string, reason?: string): Promise<void> {
+  await worker.notify(methods.client.session.update, {
+    sessionId: worker.publicSessionId,
+    update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "" } },
+    _meta: { redskills: { lifecycle: { event, workerId: worker.workerId, ...(reason == null ? {} : { reason }) } } },
+  });
+}
+
+function workflowOutcome(response: PromptResponse): string | undefined {
+  if (response.stopReason === "cancelled") return "cancellation";
+  return (response._meta as { redskills?: { workflowOutcome?: string } } | undefined)?.redskills?.workflowOutcome;
 }
 
 function cleanupWorker(sessionId: string, worker: ActiveWorker, active: Map<string, ActiveWorker>): void {
   if (worker.cleaned) return;
   worker.cleaned = true;
+  if (worker.idleTimer != null) clearTimeout(worker.idleTimer);
   if (active.get(sessionId) === worker) active.delete(sessionId);
   worker.connection.close();
   worker.socket.destroy();
@@ -700,6 +760,7 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
             sessionUpdate: "agent_message_chunk",
             content: { type: "text", text: "native Worker is executing the prompt\n" },
           },
+          _meta: { redskills: { lifecycle: { event: "tool-activity" } } },
         });
 
         const prompt = promptText(params);
@@ -733,7 +794,19 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
             content: { type: "text", text: `native Worker completed: ${prompt}\n` },
           },
         });
-        return { stopReason: "end_turn" } satisfies PromptResponse;
+        const workflowOutcome = prompt.includes("complete workflow")
+          ? "completion"
+          : prompt.includes("budget verdict")
+            ? "budget-verdict"
+            : prompt.includes("replace worker")
+              ? "replacement"
+              : prompt.includes("explicit control")
+                ? "explicit-control"
+                : undefined;
+        return {
+          stopReason: "end_turn",
+          ...(workflowOutcome == null ? {} : { _meta: { redskills: { workflowOutcome } } }),
+        } satisfies PromptResponse;
       } finally {
         controllers.delete(params.sessionId);
       }

--- a/apps/redskilled/src/acp-worker-lifecycle.ts
+++ b/apps/redskilled/src/acp-worker-lifecycle.ts
@@ -1,0 +1,74 @@
+import { rm } from "node:fs/promises";
+import type { Socket } from "node:net";
+import {
+  methods,
+  type AgentConnection,
+  type ClientConnection,
+  type PromptResponse,
+} from "@agentclientprotocol/sdk";
+
+export interface ActiveWorkflowWorker {
+  readonly workerId: string;
+  readonly downstreamSessionId: string;
+  readonly connection: ClientConnection;
+  readonly socket: Socket;
+  readonly endpoint: string;
+  readonly publicSessionId: string;
+  readonly notify: AgentConnection["client"]["notify"];
+  idleTimer?: NodeJS.Timeout;
+  cancelled: boolean;
+  cleaned: boolean;
+}
+
+export function scheduleIdleCleanup(
+  sessionId: string,
+  worker: ActiveWorkflowWorker,
+  active: Map<string, ActiveWorkflowWorker>,
+): void {
+  const configured = Number.parseInt(process.env.REDSKILLED_ACP_WORKER_IDLE_MS ?? "30000", 10);
+  const idleMs = Number.isFinite(configured) && configured >= 0 ? configured : 30_000;
+  const timer = setTimeout(() => void reapWorkflowWorker(sessionId, worker, active, "idle-policy"), idleMs);
+  timer.unref();
+  worker.idleTimer = timer;
+}
+
+export async function reapWorkflowWorker(
+  sessionId: string,
+  worker: ActiveWorkflowWorker,
+  active: Map<string, ActiveWorkflowWorker>,
+  reason: string,
+): Promise<void> {
+  await notifyWorkerLifecycle(worker, "reaping", reason).catch(() => undefined);
+  cleanupWorkflowWorker(sessionId, worker, active);
+}
+
+export async function notifyWorkerLifecycle(
+  worker: ActiveWorkflowWorker,
+  event: string,
+  reason?: string,
+): Promise<void> {
+  await worker.notify(methods.client.session.update, {
+    sessionId: worker.publicSessionId,
+    update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "" } },
+    _meta: { redskills: { lifecycle: { event, workerId: worker.workerId, ...(reason == null ? {} : { reason }) } } },
+  });
+}
+
+export function workflowOutcome(response: PromptResponse): string | undefined {
+  if (response.stopReason === "cancelled") return "cancellation";
+  return (response._meta as { redskills?: { workflowOutcome?: string } } | undefined)?.redskills?.workflowOutcome;
+}
+
+export function cleanupWorkflowWorker(
+  sessionId: string,
+  worker: ActiveWorkflowWorker,
+  active: Map<string, ActiveWorkflowWorker>,
+): void {
+  if (worker.cleaned) return;
+  worker.cleaned = true;
+  if (worker.idleTimer != null) clearTimeout(worker.idleTimer);
+  if (active.get(sessionId) === worker) active.delete(sessionId);
+  worker.connection.close();
+  worker.socket.destroy();
+  void rm(worker.endpoint, { force: true });
+}

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -34,7 +34,7 @@ afterEach(async () => {
 });
 
 describe("the public RedSkills ACP v1 control plane", () => {
-  it("routes updates, terminal results, and cancellation through daemon-admitted native Workers", async () => {
+  it("reuses one bounded Workflow Worker across related turns and reaps every terminal outcome", async () => {
     const root = await mkdtemp(join(tmpdir(), "redskilled-acp-control-plane-"));
     roots.push(root);
     const env = {
@@ -44,6 +44,7 @@ describe("the public RedSkills ACP v1 control plane", () => {
       REDSKILLED_MACHINE_DIR: root,
       REDSKILLED_PLACEMENT: "off",
       REDSKILLED_SESSION: `test:${root}`,
+      REDSKILLED_ACP_WORKER_IDLE_MS: "100",
     };
     const paths = resolveRedskilledPaths({ env, homeDir: root });
     const daemon = launchCli([
@@ -74,29 +75,37 @@ describe("the public RedSkills ACP v1 control plane", () => {
 
     const session = await connection.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
     const project = projectMeta(session._meta);
-    const completed = await connection.agent.request(methods.agent.session.prompt, {
+    const first = await connection.agent.request(methods.agent.session.prompt, {
       sessionId: session.sessionId,
-      prompt: [{ type: "text", text: "complete the native tracer" }],
+      prompt: [{ type: "text", text: "start the native tracer" }],
     });
-    expect(completed.stopReason).toBe("end_turn");
+    const second = await connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "continue the native tracer" }],
+    });
+    expect(first.stopReason).toBe("end_turn");
+    expect(workerId(first._meta)).toBe(workerId(second._meta));
     expect(updates.map((entry) => entry.update.sessionUpdate)).toContain("plan");
-    expect(updates.some((entry) =>
-      entry.update.sessionUpdate === "agent_message_chunk" &&
-      entry.update.content.type === "text" &&
-      entry.update.content.text.includes("native Worker completed"),
-    )).toBe(true);
+    expect(updates.map(lifecycleEvent).filter(Boolean)).toEqual(["admission", "tool-activity", "tool-activity"]);
 
     const firstBirth = await waitForEvent(paths.eventLanePath, "worker-birth");
     expect(firstBirth.project_label).toBe(project.projectId);
     expect(firstBirth.workspace_path).toBe(project.workspacePath);
     expect(firstBirth.pid).toBeGreaterThan(0);
-    const liveAfterTerminal = await connection.agent.request<{ workers: Array<{ worker_id: string }> }>(
+    const liveBetweenTurns = await connection.agent.request<{ workers: Array<{ worker_id: string }> }>(
       "_redskills/host_state",
       {},
     );
-    expect(liveAfterTerminal.workers.map((worker) => worker.worker_id)).toContain(firstBirth.worker_id);
+    expect(liveBetweenTurns.workers.map((worker) => worker.worker_id)).toContain(firstBirth.worker_id);
+    await connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "complete workflow" }],
+    });
     const firstDeath = await waitForEvent(paths.eventLanePath, "worker-death", firstBirth.worker_id);
     expect(Date.parse(firstDeath.ts)).toBeGreaterThanOrEqual(Date.parse(firstBirth.ts));
+    expect(updates.map(lifecycleEvent).filter(Boolean).slice(-3)).toEqual([
+      "tool-activity", "terminal-outcome", "reaping",
+    ]);
 
     updates.length = 0;
     const cancelledPrompt = connection.agent.request(methods.agent.session.prompt, {
@@ -116,6 +125,25 @@ describe("the public RedSkills ACP v1 control plane", () => {
     expect(births).toHaveLength(2);
     expect(deaths).toHaveLength(2);
     expect(new Set(deaths.map((event) => event.worker_id))).toEqual(new Set(births.map((event) => event.worker_id)));
+
+    for (const terminal of ["budget verdict", "replace worker", "explicit control"] as const) {
+      updates.length = 0;
+      const result = await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: terminal }],
+      });
+      const id = workerId(result._meta);
+      await waitForEvent(paths.eventLanePath, "worker-death", id);
+      expect(updates.map(lifecycleEvent).filter(Boolean).slice(-2)).toEqual(["terminal-outcome", "reaping"]);
+    }
+
+    updates.length = 0;
+    const idle = await connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "pause between related turns" }],
+    });
+    await waitForEvent(paths.eventLanePath, "worker-death", workerId(idle._meta));
+    expect(updates.map(lifecycleEvent).filter(Boolean).at(-1)).toBe("reaping");
 
     connection.close();
     adapter.stdin?.end();
@@ -405,6 +433,17 @@ function projectMeta(meta: unknown): { projectId: string; projectLabel: string; 
     projectLabel: project!.projectLabel as string,
     workspacePath: project!.workspacePath as string,
   };
+}
+
+function workerId(meta: unknown): string {
+  const id = (meta as { redskills?: { workerId?: unknown } } | undefined)?.redskills?.workerId;
+  expect(id).toEqual(expect.any(String));
+  return id as string;
+}
+
+function lifecycleEvent(update: SessionNotification): string | undefined {
+  return (update._meta as { redskills?: { lifecycle?: { event?: string } } } | undefined)
+    ?.redskills?.lifecycle?.event;
 }
 
 function git(cwd: string, ...args: string[]): void {


### PR DESCRIPTION
Automated AFK landing for #3888. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3888

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789425336&installation_model_id=20659&pr_number=3918&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3918&signature=1a6752f4cf9996e207009565f709a70797b2817a2a65f10f79ac3563eab4c904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->