### PR TITLE
merge: #3653 redskilled GitHub gateway owns merge custody and exposes liveness

### DIFF
--- a/.changeset/redskilled-merge-custody.md
+++ b/.changeset/redskilled-merge-custody.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": minor
+---
+
+Keep merge custody and its liveness state in the Project-scoped redskilled GitHub gateway and expose it through ACP.

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -41,8 +41,11 @@ import {
 import {
   REDSKILLED_GITHUB_UPDATE_METHOD,
   bindAcpGithubReaderUpdates,
+  bindAcpProjectGithubCustodyHandoff,
+  bindAcpProjectGithubCustodyStatus,
   bindAcpProjectGithubRead,
   bindAcpProjectGithubWrite,
+  githubCustodyHandoffParams,
   githubReadParams,
   githubWriteParams,
   type AcpGithubUpdateObserver,
@@ -66,6 +69,7 @@ import {
 } from "./acp-retake-evidence.js";
 import type { RedskilledHostState } from "./host-state.js";
 import {
+  REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD,
   REDSKILLED_GITHUB_READ_METHOD,
   REDSKILLED_GITHUB_WRITE_METHOD,
   type RedskilledGithubGatewayRegistration,
@@ -223,7 +227,6 @@ async function servePublicConnection(
     }
     return connectionProject;
   };
-  const readProjectControl = () => projectControlSnapshot(scopedProject(), projectControls);
   const mutateProjectControl = (operation: ProjectControlOperation) =>
     applyProjectControl(scopedProject(), operation, projectControls, persistProjectControls);
   const readGithub = bindAcpProjectGithubRead(options.githubGateway, scopedProject, (reader) => {
@@ -234,6 +237,13 @@ async function servePublicConnection(
     ));
   });
   const writeGithub = bindAcpProjectGithubWrite(options.githubGateway, scopedProject);
+  const handoffGithubCustody = bindAcpProjectGithubCustodyHandoff(options.githubGateway, scopedProject);
+  const readGithubCustody = bindAcpProjectGithubCustodyStatus(options.githubGateway, scopedProject);
+  const readProjectControl = async () => {
+    const control = projectControlSnapshot(scopedProject(), projectControls);
+    const mergeCustody = await readGithubCustody();
+    return mergeCustody == null ? control : { ...control, merge_custody: mergeCustody };
+  };
   const readProjectBudget = bindAcpProjectGithubBudget(options.githubGateway, scopedProject);
   const readHostBudget = bindAcpHostGithubBudget(options.githubGateway, options.hostAdministration === true);
   const emptyParams = () => ({});
@@ -255,7 +265,11 @@ async function servePublicConnection(
             ...(options.githubGateway == null ? {} : {
               githubGateway: {
                 version: 1,
-                methods: [REDSKILLED_GITHUB_READ_METHOD, REDSKILLED_GITHUB_WRITE_METHOD],
+                methods: [
+                  REDSKILLED_GITHUB_READ_METHOD,
+                  REDSKILLED_GITHUB_WRITE_METHOD,
+                  REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD,
+                ],
                 notifications: [REDSKILLED_GITHUB_UPDATE_METHOD],
               },
               credentialBudgets: {
@@ -385,6 +399,7 @@ async function servePublicConnection(
     .onRequest(PROJECT_CONTROL_METHODS[2], emptyParams, readProjectControl)
     .onRequest(REDSKILLED_GITHUB_READ_METHOD, githubReadParams, readGithub)
     .onRequest(REDSKILLED_GITHUB_WRITE_METHOD, githubWriteParams, writeGithub)
+    .onRequest(REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD, githubCustodyHandoffParams, handoffGithubCustody)
     .onRequest(REDSKILLED_PROJECT_BUDGET_METHOD, emptyBudgetParams, readProjectBudget)
     .onRequest(REDSKILLED_HOST_BUDGET_METHOD, emptyBudgetParams, readHostBudget);
 
@@ -406,7 +421,11 @@ async function servePublicConnection(
             ...(options.githubGateway == null ? {} : {
               githubGateway: {
                 version: 1,
-                methods: [REDSKILLED_GITHUB_READ_METHOD, REDSKILLED_GITHUB_WRITE_METHOD],
+                methods: [
+                  REDSKILLED_GITHUB_READ_METHOD,
+                  REDSKILLED_GITHUB_WRITE_METHOD,
+                  REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD,
+                ],
                 notifications: [REDSKILLED_GITHUB_UPDATE_METHOD],
               },
               credentialBudgets: {
@@ -507,6 +526,7 @@ async function servePublicConnection(
     .onRequest(PROJECT_CONTROL_METHODS[2], emptyParams, readProjectControl)
     .onRequest(REDSKILLED_GITHUB_READ_METHOD, githubReadParams, readGithub)
     .onRequest(REDSKILLED_GITHUB_WRITE_METHOD, githubWriteParams, writeGithub)
+    .onRequest(REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD, githubCustodyHandoffParams, handoffGithubCustody)
     .onRequest(REDSKILLED_PROJECT_BUDGET_METHOD, emptyBudgetParams, readProjectBudget)
     .onRequest(REDSKILLED_HOST_BUDGET_METHOD, emptyBudgetParams, readHostBudget);
 

--- a/apps/redskilled/src/acp-github.ts
+++ b/apps/redskilled/src/acp-github.ts
@@ -3,6 +3,9 @@ import { GithubBackpressureError } from "@reddb-io/github";
 import {
   RedskilledGithubAuthorityError,
   type RedskilledGithubGatewayRegistration,
+  type RedskilledGithubCustodyHandoff,
+  type RedskilledGithubCustodyRecord,
+  type RedskilledGithubCustodyStatus,
   type RedskilledGithubManagedProjectReader,
   type RedskilledGithubRead,
   type RedskilledGithubUpdate,
@@ -13,6 +16,7 @@ import { RedskilledGithubCredentialProfileError } from "./github-credential-prof
 
 type GithubReadParams = { readonly read: RedskilledGithubRead };
 type GithubWriteParams = RedskilledGithubWriteRequest;
+type GithubCustodyHandoffParams = RedskilledGithubCustodyHandoff;
 
 export const REDSKILLED_GITHUB_UPDATE_METHOD = "_redskills/github_update";
 
@@ -164,6 +168,81 @@ export function bindAcpProjectGithubWrite(
   };
 }
 
+/** Transfer a published PR to daemon custody under this connection's Project. */
+export function bindAcpProjectGithubCustodyHandoff(
+  gateway: RedskilledGithubGatewayRegistration | undefined,
+  projectForConnection: () => AcpProjectWorkspace,
+) {
+  return async ({ params }: { readonly params: GithubCustodyHandoffParams }): Promise<RedskilledGithubCustodyRecord> => {
+    const { reader } = await custodyReader(gateway, projectForConnection());
+    return reader.handoffMergeCustody(params);
+  };
+}
+
+/** Read custody through ACP without making the observing client an owner. */
+export function bindAcpProjectGithubCustodyStatus(
+  gateway: RedskilledGithubGatewayRegistration | undefined,
+  projectForConnection: () => AcpProjectWorkspace,
+) {
+  return async (): Promise<RedskilledGithubCustodyStatus | undefined> => {
+    if (gateway == null) return undefined;
+    const project = projectForConnection();
+    const selection = await gateway.credentialForProject({
+      projectId: project.projectId,
+      projectLabel: project.projectLabel,
+      workspacePath: project.workspacePath,
+    });
+    if (selection == null) return undefined;
+    const reader = gateway.gateway.forProject({
+      projectId: project.projectId,
+      projectLabel: project.projectLabel,
+      workspacePath: project.workspacePath,
+      credentialProfile: selection.profile,
+    }, selection.credential);
+    return isCustodyReader(reader) ? reader.mergeCustodyStatus() : undefined;
+  };
+}
+
+async function custodyReader(
+  gateway: RedskilledGithubGatewayRegistration | undefined,
+  project: AcpProjectWorkspace,
+): Promise<{
+  readonly reader: RedskilledGithubManagedProjectReader;
+}> {
+  const selection = await gateway?.credentialForProject({
+    projectId: project.projectId,
+    projectLabel: project.projectLabel,
+    workspacePath: project.workspacePath,
+  });
+  if (gateway == null || selection == null) {
+    throw RequestError.authRequired(
+      {
+        version: 1,
+        kind: "github-credential-profile",
+        reason: "missing-credentials",
+        credential_profile: "personal",
+      },
+      "this Project has no resolvable daemon-owned GitHub credential profile",
+    );
+  }
+  const reader = gateway.gateway.forProject({
+    projectId: project.projectId,
+    projectLabel: project.projectLabel,
+    workspacePath: project.workspacePath,
+    credentialProfile: selection.profile,
+  }, selection.credential);
+  if (!isCustodyReader(reader)) {
+    throw new RedskilledGithubAuthorityError("this GitHub gateway has no durable merge custodian");
+  }
+  return { reader };
+}
+
+function isCustodyReader(value: unknown): value is RedskilledGithubManagedProjectReader {
+  return value != null && typeof value === "object" &&
+    typeof (value as RedskilledGithubManagedProjectReader).handoffMergeCustody === "function" &&
+    typeof (value as RedskilledGithubManagedProjectReader).mergeCustodyStatus === "function";
+}
+
 /** Reject caller-controlled Project, credential, remote, and host authority. */
 export function githubReadParams(value: unknown): GithubReadParams {
   if (value == null || typeof value !== "object" || Array.isArray(value)) {
@@ -196,4 +275,19 @@ export function githubWriteParams(value: unknown): GithubWriteParams {
     throw new RedskilledGithubAuthorityError("a Project GitHub write needs one mutation object");
   }
   return params as unknown as GithubWriteParams;
+}
+
+/** Reject caller-controlled Project and credential authority on custody handoff. */
+export function githubCustodyHandoffParams(value: unknown): GithubCustodyHandoffParams {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new RedskilledGithubAuthorityError("merge custody needs one pull request handoff");
+  }
+  const params = value as Record<string, unknown>;
+  const expected = ["pull_request", "owner_ticket", "branch", "base"];
+  if (Object.keys(params).length !== expected.length || expected.some((key) => !(key in params))) {
+    throw new RedskilledGithubAuthorityError(
+      "a Project merge custody handoff cannot name a Project, credential profile, remote, or host operation",
+    );
+  }
+  return params as unknown as GithubCustodyHandoffParams;
 }

--- a/apps/redskilled/src/github-companions.ts
+++ b/apps/redskilled/src/github-companions.ts
@@ -31,6 +31,7 @@ import type {
 } from "./daemon/types.js";
 import {
   createRedskilledGithubGateway,
+  createRedskilledGithubCustodyUpstream,
   createRedskilledGithubUpstream,
   createRedskilledGithubWriteUpstream,
   type RedskilledGithubGatewayRegistration,
@@ -63,6 +64,14 @@ export function resolveServeGithubGateway(
     }),
     ...(homeDir == null ? {} : {
       outboxPath: join(redskilledHomeDir(homeDir), "state", "github", "outbox.toon"),
+      custodyPath: join(redskilledHomeDir(homeDir), "state", "github", "custody.toon"),
+      custodyTickMs: 30_000,
+      custodyInertMs: 120_000,
+      custodyUpstream: createRedskilledGithubCustodyUpstream({
+        ...(env.GITHUB_API_URL ? { origin: env.GITHUB_API_URL } : {}),
+        ...(env.GITHUB_GRAPHQL_URL ? { graphqlEndpoint: env.GITHUB_GRAPHQL_URL } : {}),
+        fetchImpl,
+      }),
       writeUpstream: createRedskilledGithubWriteUpstream({
         ...(env.GITHUB_API_URL ? { origin: env.GITHUB_API_URL } : {}),
         fetchImpl,

--- a/apps/redskilled/src/github-custody-upstream.ts
+++ b/apps/redskilled/src/github-custody-upstream.ts
@@ -1,0 +1,87 @@
+import type {
+  RedskilledGithubCustodyForgeView,
+  RedskilledGithubCustodyUpstream,
+  RedskilledGithubCustodyUpstreamInput,
+} from "./github-custody.js";
+import { githubHeaders } from "./github-transport.js";
+
+export interface CreateRedskilledGithubCustodyUpstreamOptions {
+  readonly origin?: string;
+  readonly graphqlEndpoint?: string;
+  readonly fetchImpl?: typeof fetch;
+}
+
+/** GitHub's native auto-merge intent is the durable primary merge holder. */
+export function createRedskilledGithubCustodyUpstream(
+  options: CreateRedskilledGithubCustodyUpstreamOptions = {},
+): RedskilledGithubCustodyUpstream {
+  const origin = (options.origin ?? "https://api.github.com").replace(/\/+$/, "");
+  const graphqlEndpoint = options.graphqlEndpoint ?? `${origin}/graphql`;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const observe = async (
+    input: RedskilledGithubCustodyUpstreamInput,
+  ): Promise<RedskilledGithubCustodyForgeView> => {
+    const repository = input.project.projectLabel.split("/").map(encodeURIComponent).join("/");
+    const response = await fetchImpl(`${origin}/repos/${repository}/pulls/${input.pullRequest}`, {
+      method: "GET",
+      headers: githubHeaders(input.credential.secret),
+    });
+    if (!response.ok) throw new Error(`GitHub custody observation failed with HTTP ${response.status}`);
+    return pullRequestView(await response.json());
+  };
+
+  return {
+    observe,
+    async arm(input) {
+      const repository = input.project.projectLabel.split("/").map(encodeURIComponent).join("/");
+      const pull = await fetchImpl(`${origin}/repos/${repository}/pulls/${input.pullRequest}`, {
+        method: "GET",
+        headers: githubHeaders(input.credential.secret),
+      });
+      if (!pull.ok) throw new Error(`GitHub custody arm lookup failed with HTTP ${pull.status}`);
+      const body = await pull.json() as Record<string, unknown>;
+      if (body.merged === true || body.merged_at != null) {
+        return { forge_state: "merged", native_intent: false };
+      }
+      const nodeId = typeof body.node_id === "string" ? body.node_id : "";
+      if (nodeId === "") throw new Error("GitHub custody cannot arm a pull request without a node identity");
+      const response = await fetchImpl(graphqlEndpoint, {
+        method: "POST",
+        headers: { ...githubHeaders(input.credential.secret), "content-type": "application/json" },
+        body: JSON.stringify({
+          query: "mutation($pullRequestId:ID!){enablePullRequestAutoMerge(input:{pullRequestId:$pullRequestId,mergeMethod:MERGE}){pullRequest{id}}}",
+          variables: { pullRequestId: nodeId },
+        }),
+      });
+      if (!response.ok) throw new Error(`GitHub custody arm failed with HTTP ${response.status}`);
+      const answer = await response.json() as { readonly errors?: unknown };
+      if (Array.isArray(answer.errors) && answer.errors.length > 0) {
+        throw new Error("GitHub refused the native merge intent");
+      }
+      const refreshed = await observe(input);
+      if (refreshed.forge_state === "merged" || refreshed.forge_state === "closed") return refreshed;
+      return { ...refreshed, native_intent: true };
+    },
+  };
+}
+
+function pullRequestView(value: unknown): RedskilledGithubCustodyForgeView {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("GitHub custody received an invalid pull request");
+  }
+  const pull = value as Record<string, unknown>;
+  if (pull.merged === true || pull.merged_at != null) {
+    return { forge_state: "merged", native_intent: false };
+  }
+  if (pull.state === "closed") return { forge_state: "closed", native_intent: false };
+  if (pull.state !== "open") throw new Error("GitHub custody received an unknown pull request state");
+  const nativeIntent = pull.auto_merge != null;
+  const mergeableState = typeof pull.mergeable_state === "string" ? pull.mergeable_state.toLowerCase() : "unknown";
+  const forgeState = pull.mergeable === false || ["blocked", "dirty", "behind"].includes(mergeableState)
+    ? "open-blocked" as const
+    : pull.mergeable === true && ["clean", "has_hooks", "unstable"].includes(mergeableState)
+      ? "open-clean" as const
+      : "open-pending" as const;
+  return { forge_state: forgeState, native_intent: nativeIntent };
+}

--- a/apps/redskilled/src/github-custody.ts
+++ b/apps/redskilled/src/github-custody.ts
@@ -1,0 +1,424 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import type {
+  RedskilledGithubCredential,
+  RedskilledGithubProjectAuthority,
+} from "./github-gateway.js";
+
+export type RedskilledGithubForgeState =
+  | "unknown"
+  | "open-clean"
+  | "open-pending"
+  | "open-blocked"
+  | "merged"
+  | "closed"
+  | "unavailable";
+
+export interface RedskilledGithubCustodyHandoff {
+  readonly pull_request: number;
+  readonly owner_ticket: number;
+  readonly branch: string;
+  readonly base: string;
+}
+
+export interface RedskilledGithubCustodyForgeView {
+  readonly forge_state: Exclude<RedskilledGithubForgeState, "unknown" | "unavailable">;
+  readonly native_intent: boolean;
+}
+
+export interface RedskilledGithubCustodyUpstreamInput {
+  readonly project: RedskilledGithubProjectAuthority;
+  readonly credential: RedskilledGithubCredential;
+  readonly pullRequest: number;
+}
+
+export interface RedskilledGithubCustodyUpstream {
+  observe(input: RedskilledGithubCustodyUpstreamInput): Promise<RedskilledGithubCustodyForgeView>;
+  arm(input: RedskilledGithubCustodyUpstreamInput): Promise<RedskilledGithubCustodyForgeView>;
+}
+
+export interface RedskilledGithubCustodyFault {
+  readonly kind: "inert-custodian";
+  readonly threshold_ms: number;
+  readonly age_ms: number;
+}
+
+export interface RedskilledGithubCustodyRecord extends RedskilledGithubCustodyHandoff {
+  readonly project_id: string;
+  readonly project_label: string;
+  readonly workspace_path: string;
+  readonly credential_profile: string;
+  readonly handed_off_at: string;
+  readonly state: "active" | "terminal";
+  readonly last_tick_at: string | null;
+  readonly last_forge_state: RedskilledGithubForgeState;
+  readonly next_action: "observe-forge" | "await-forge" | "retry-forge" | "repair-custodian" | "none";
+  readonly terminal_outcome: "merged" | "closed" | null;
+  readonly fault?: RedskilledGithubCustodyFault;
+}
+
+export interface RedskilledGithubCustodyStatus {
+  readonly version: 1;
+  readonly project_id: string;
+  readonly inert_after_ms: number;
+  readonly records: readonly RedskilledGithubCustodyRecord[];
+}
+
+interface GithubCustodySnapshot {
+  readonly version: 1;
+  readonly records: RedskilledGithubCustodyRecord[];
+}
+
+interface ProjectExecution {
+  readonly project: RedskilledGithubProjectAuthority;
+  readonly credential: RedskilledGithubCredential;
+}
+
+export interface GithubCustodian {
+  register(project: RedskilledGithubProjectAuthority, credential: RedskilledGithubCredential): Promise<void>;
+  handoff(
+    project: RedskilledGithubProjectAuthority,
+    credential: RedskilledGithubCredential,
+    request: RedskilledGithubCustodyHandoff,
+  ): Promise<RedskilledGithubCustodyRecord>;
+  status(
+    project: RedskilledGithubProjectAuthority,
+    credential: RedskilledGithubCredential,
+  ): Promise<RedskilledGithubCustodyStatus>;
+  close(): void;
+}
+
+export interface CreateGithubCustodianOptions {
+  readonly path: string;
+  readonly upstream: RedskilledGithubCustodyUpstream;
+  readonly clock: () => string;
+  readonly tickMs: number;
+  readonly inertMs: number;
+}
+
+/**
+ * One gateway-owned driver for every durable Project/PR obligation.
+ * Connections only register daemon-owned execution authority; disconnecting a
+ * connection never removes it. The host singleton is therefore the sole live
+ * owner while the TOON snapshot lets its replacement recover the obligation.
+ */
+export function createGithubCustodian(options: CreateGithubCustodianOptions): GithubCustodian {
+  let snapshot: GithubCustodySnapshot | undefined;
+  let tail: Promise<unknown> = Promise.resolve();
+  let closed = false;
+  const executions = new Map<string, ProjectExecution>();
+  const timers = new Map<string, NodeJS.Timeout>();
+  const driving = new Set<string>();
+
+  const serialized = <T>(operation: () => Promise<T>): Promise<T> => {
+    const next = tail.then(operation, operation);
+    tail = next.then(() => undefined, () => undefined);
+    return next;
+  };
+
+  const load = async (): Promise<GithubCustodySnapshot> => {
+    if (snapshot != null) return snapshot;
+    try {
+      snapshot = parseSnapshot(decode((await readFile(options.path, "utf8")).trim()));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      snapshot = { version: 1, records: [] };
+    }
+    return snapshot;
+  };
+
+  const persist = async (value: GithubCustodySnapshot): Promise<void> => {
+    await mkdir(dirname(options.path), { recursive: true, mode: 0o700 });
+    const temporary = `${options.path}.${process.pid}.${randomUUID()}.tmp`;
+    await writeFile(temporary, `${encode(value as unknown as JsonValue)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(temporary, options.path);
+  };
+
+  const schedule = (key: string, delay = options.tickMs): void => {
+    if (closed || timers.has(key)) return;
+    const timer = setTimeout(() => {
+      timers.delete(key);
+      void drive(key);
+    }, Math.max(0, delay));
+    timer.unref?.();
+    timers.set(key, timer);
+  };
+
+  const updateRecord = async (
+    key: string,
+    update: (record: RedskilledGithubCustodyRecord) => RedskilledGithubCustodyRecord,
+  ): Promise<RedskilledGithubCustodyRecord | undefined> => serialized(async () => {
+    const current = await load();
+    const index = current.records.findIndex((record) => custodyKey(record.project_id, record.pull_request) === key);
+    if (index < 0) return undefined;
+    const record = update(current.records[index]!);
+    const records = [...current.records];
+    records[index] = record;
+    snapshot = { version: 1, records };
+    await persist(snapshot);
+    return record;
+  });
+
+  const drive = async (key: string): Promise<void> => {
+    if (closed || driving.has(key)) return;
+    const execution = executions.get(key);
+    if (execution == null) return;
+    driving.add(key);
+    try {
+      const tickAt = options.clock();
+      const ticking = await updateRecord(key, (record) => record.state === "terminal" ? record : {
+        ...record,
+        last_tick_at: tickAt,
+        next_action: "observe-forge",
+      });
+      if (ticking == null || ticking.state === "terminal") return;
+      const input = {
+        project: execution.project,
+        credential: execution.credential,
+        pullRequest: ticking.pull_request,
+      };
+      let view = validateForgeView(await options.upstream.observe(input));
+      if (view.forge_state !== "merged" && view.forge_state !== "closed" && !view.native_intent) {
+        view = validateForgeView(await options.upstream.arm(input));
+      }
+      const terminal = view.forge_state === "merged" || view.forge_state === "closed";
+      await updateRecord(key, (record) => ({
+        ...record,
+        state: terminal ? "terminal" : "active",
+        last_forge_state: view.forge_state,
+        next_action: terminal ? "none" : "await-forge",
+        terminal_outcome: view.forge_state === "merged"
+          ? "merged"
+          : view.forge_state === "closed" ? "closed" : null,
+      }));
+      if (!terminal) schedule(key);
+    } catch {
+      await updateRecord(key, (record) => record.state === "terminal" ? record : {
+        ...record,
+        last_forge_state: "unavailable",
+        next_action: "retry-forge",
+      }).catch(() => undefined);
+      schedule(key);
+    } finally {
+      driving.delete(key);
+    }
+  };
+
+  const register = async (
+    project: RedskilledGithubProjectAuthority,
+    credential: RedskilledGithubCredential,
+  ): Promise<void> => {
+    const current = await serialized(load);
+    for (const record of current.records) {
+      if (record.project_id !== project.projectId || record.state === "terminal") continue;
+      const key = custodyKey(record.project_id, record.pull_request);
+      executions.set(key, { project, credential });
+      schedule(key, 0);
+    }
+  };
+
+  return {
+    register,
+    async handoff(project, credential, request) {
+      const valid = validateHandoff(request);
+      await register(project, credential);
+      const record = await serialized(async () => {
+        const current = await load();
+        const key = custodyKey(project.projectId, valid.pull_request);
+        const existing = current.records.find((candidate) =>
+          custodyKey(candidate.project_id, candidate.pull_request) === key);
+        if (existing != null) {
+          if (
+            existing.owner_ticket !== valid.owner_ticket || existing.branch !== valid.branch ||
+            existing.base !== valid.base || existing.credential_profile !== project.credentialProfile
+          ) {
+            throw new Error("one pull request cannot have two merge custody owners");
+          }
+          return existing;
+        }
+        const next: RedskilledGithubCustodyRecord = {
+          ...valid,
+          project_id: project.projectId,
+          project_label: project.projectLabel,
+          workspace_path: project.workspacePath,
+          credential_profile: project.credentialProfile,
+          handed_off_at: options.clock(),
+          state: "active",
+          last_tick_at: null,
+          last_forge_state: "unknown",
+          next_action: "observe-forge",
+          terminal_outcome: null,
+        };
+        snapshot = { version: 1, records: [...current.records, next] };
+        await persist(snapshot);
+        return next;
+      });
+      const key = custodyKey(project.projectId, valid.pull_request);
+      executions.set(key, { project, credential });
+      if (record.state !== "terminal") schedule(key, 0);
+      return publicRecord(record, options.clock(), options.inertMs);
+    },
+    async status(project, credential) {
+      await register(project, credential);
+      const current = await serialized(load);
+      const now = options.clock();
+      return {
+        version: 1,
+        project_id: project.projectId,
+        inert_after_ms: options.inertMs,
+        records: current.records
+          .filter((record) => record.project_id === project.projectId)
+          .sort((left, right) => left.pull_request - right.pull_request)
+          .map((record) => publicRecord(record, now, options.inertMs)),
+      };
+    },
+    close() {
+      closed = true;
+      for (const timer of timers.values()) clearTimeout(timer);
+      timers.clear();
+      executions.clear();
+    },
+  };
+}
+
+function publicRecord(
+  record: RedskilledGithubCustodyRecord,
+  now: string,
+  inertMs: number,
+): RedskilledGithubCustodyRecord {
+  if (record.state === "terminal") return withoutFault(record);
+  const lastActivity = record.last_tick_at ?? record.handed_off_at;
+  const age = Date.parse(now) - Date.parse(lastActivity);
+  if (!Number.isFinite(age) || age <= inertMs) return withoutFault(record);
+  return {
+    ...record,
+    next_action: "repair-custodian",
+    fault: { kind: "inert-custodian", threshold_ms: inertMs, age_ms: Math.max(0, age) },
+  };
+}
+
+function withoutFault(record: RedskilledGithubCustodyRecord): RedskilledGithubCustodyRecord {
+  const { fault: _fault, ...answer } = record;
+  return answer;
+}
+
+function custodyKey(projectId: string, pullRequest: number): string {
+  return `${projectId}:${pullRequest}`;
+}
+
+function validateHandoff(value: RedskilledGithubCustodyHandoff): RedskilledGithubCustodyHandoff {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("merge custody needs one pull request handoff");
+  }
+  if (!Number.isSafeInteger(value.pull_request) || value.pull_request <= 0) {
+    throw new Error("merge custody needs one positive pull request number");
+  }
+  if (!Number.isSafeInteger(value.owner_ticket) || value.owner_ticket <= 0) {
+    throw new Error("merge custody needs one positive owner Ticket number");
+  }
+  return {
+    pull_request: value.pull_request,
+    owner_ticket: value.owner_ticket,
+    branch: branch(value.branch, "branch"),
+    base: branch(value.base, "base"),
+  };
+}
+
+function branch(value: unknown, label: string): string {
+  const name = typeof value === "string" ? value.trim() : "";
+  if (
+    name === "" || !/^[A-Za-z0-9][A-Za-z0-9._\/-]*$/.test(name) || name.includes("..") ||
+    name.includes("//") || name.endsWith(".") || name.endsWith("/") || name.includes("@{")
+  ) {
+    throw new Error(`merge custody needs one ordinary ${label}`);
+  }
+  return name;
+}
+
+function validateForgeView(value: RedskilledGithubCustodyForgeView): RedskilledGithubCustodyForgeView {
+  if (
+    value == null || typeof value !== "object" ||
+    !["open-clean", "open-pending", "open-blocked", "merged", "closed"].includes(value.forge_state) ||
+    typeof value.native_intent !== "boolean"
+  ) {
+    throw new Error("the GitHub custody upstream returned an invalid forge view");
+  }
+  return value;
+}
+
+function parseSnapshot(value: unknown): GithubCustodySnapshot {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("redskilled GitHub custody is not a snapshot");
+  }
+  const root = value as Record<string, unknown>;
+  if (root.version !== 1 || !Array.isArray(root.records)) {
+    throw new Error("redskilled GitHub custody has an unsupported version");
+  }
+  return { version: 1, records: root.records.map(parseRecord) };
+}
+
+function parseRecord(value: unknown): RedskilledGithubCustodyRecord {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("redskilled GitHub custody contains an invalid record");
+  }
+  const record = value as Record<string, unknown>;
+  const request = validateHandoff({
+    pull_request: record.pull_request as number,
+    owner_ticket: record.owner_ticket as number,
+    branch: record.branch as string,
+    base: record.base as string,
+  });
+  const state = record.state === "active" || record.state === "terminal" ? record.state : invalidState();
+  const forge = typeof record.last_forge_state === "string" && [
+    "unknown", "open-clean", "open-pending", "open-blocked", "merged", "closed", "unavailable",
+  ].includes(record.last_forge_state)
+    ? record.last_forge_state as RedskilledGithubForgeState
+    : invalidForgeState();
+  const terminal = record.terminal_outcome === null || record.terminal_outcome === "merged" || record.terminal_outcome === "closed"
+    ? record.terminal_outcome
+    : invalidTerminal();
+  return {
+    ...request,
+    project_id: scalar(record.project_id),
+    project_label: scalar(record.project_label),
+    workspace_path: scalar(record.workspace_path),
+    credential_profile: scalar(record.credential_profile),
+    handed_off_at: scalar(record.handed_off_at),
+    state,
+    last_tick_at: record.last_tick_at === null ? null : scalar(record.last_tick_at),
+    last_forge_state: forge,
+    next_action: nextAction(record.next_action),
+    terminal_outcome: terminal,
+  };
+}
+
+function scalar(value: unknown): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error("redskilled GitHub custody contains an invalid scalar");
+  }
+  return value;
+}
+
+function nextAction(value: unknown): RedskilledGithubCustodyRecord["next_action"] {
+  if (["observe-forge", "await-forge", "retry-forge", "repair-custodian", "none"].includes(String(value))) {
+    return value as RedskilledGithubCustodyRecord["next_action"];
+  }
+  throw new Error("redskilled GitHub custody contains an invalid next action");
+}
+
+function invalidState(): never {
+  throw new Error("redskilled GitHub custody contains an invalid state");
+}
+
+function invalidForgeState(): never {
+  throw new Error("redskilled GitHub custody contains an invalid forge state");
+}
+
+function invalidTerminal(): never {
+  throw new Error("redskilled GitHub custody contains an invalid terminal outcome");
+}

--- a/apps/redskilled/src/github-gateway.ts
+++ b/apps/redskilled/src/github-gateway.ts
@@ -53,6 +53,14 @@ import {
   validateWriteRequest,
 } from "./github-outbox.js";
 import {
+  createGithubCustodian,
+  type GithubCustodian,
+  type RedskilledGithubCustodyHandoff,
+  type RedskilledGithubCustodyRecord,
+  type RedskilledGithubCustodyStatus,
+  type RedskilledGithubCustodyUpstream,
+} from "./github-custody.js";
+import {
   githubHeaders,
   githubUpstreamRefusal,
   responseValue,
@@ -75,6 +83,17 @@ export {
 
 export const REDSKILLED_GITHUB_READ_METHOD = "_redskills/github_read";
 export const REDSKILLED_GITHUB_WRITE_METHOD = "_redskills/github_write";
+export const REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD = "_redskills/github_custody_handoff";
+
+export type {
+  RedskilledGithubCustodyFault,
+  RedskilledGithubCustodyForgeView,
+  RedskilledGithubCustodyHandoff,
+  RedskilledGithubCustodyRecord,
+  RedskilledGithubCustodyStatus,
+  RedskilledGithubCustodyUpstream,
+  RedskilledGithubCustodyUpstreamInput,
+} from "./github-custody.js";
 
 export interface RedskilledGithubProjectAuthority {
   readonly projectId: string;
@@ -153,6 +172,10 @@ export interface RedskilledGithubManagedProjectReader extends RedskilledGithubPr
   wake(signal: RedskilledGithubWake): Promise<number>;
   /** Observe ordered updates derived only from completed authoritative refreshes. */
   subscribe(observer: (update: RedskilledGithubUpdate) => void): () => void;
+  /** Transfer one published PR to the daemon; caller lifetime ends here. */
+  handoffMergeCustody(request: RedskilledGithubCustodyHandoff): Promise<RedskilledGithubCustodyRecord>;
+  /** Project-scoped liveness and terminal facts for every accepted handoff. */
+  mergeCustodyStatus(): Promise<RedskilledGithubCustodyStatus>;
 }
 
 export interface RedskilledGithubGateway {
@@ -203,6 +226,11 @@ export interface CreateRedskilledGithubGatewayOptions {
   /** Durable host-state snapshot. Required before this gateway accepts writes. */
   readonly outboxPath?: string;
   readonly writeUpstream?: RedskilledGithubWriteUpstream;
+  /** Durable host-state snapshot for merge obligations accepted by this gateway. */
+  readonly custodyPath?: string;
+  readonly custodyUpstream?: RedskilledGithubCustodyUpstream;
+  readonly custodyTickMs?: number;
+  readonly custodyInertMs?: number;
   readonly clock?: () => string;
   readonly freshMs?: number;
   readonly capacity?: number;
@@ -393,6 +421,15 @@ export function createRedskilledGithubGateway(
   const outbox = options.outboxPath == null || options.writeUpstream == null
     ? null
     : createGithubOutbox(options.outboxPath, options.writeUpstream, clock);
+  const custodian = options.custodyPath == null || options.custodyUpstream == null
+    ? null
+    : createGithubCustodian({
+        path: options.custodyPath,
+        upstream: options.custodyUpstream,
+        clock,
+        tickMs: Math.max(1, options.custodyTickMs ?? refreshMs),
+        inertMs: Math.max(1, options.custodyInertMs ?? Math.max(refreshMs * 3, 60_000)),
+      });
 
   return {
     forProject(authority, credential) {
@@ -412,6 +449,12 @@ export function createRedskilledGithubGateway(
           throw new RedskilledGithubAuthorityError("this GitHub gateway has no durable write outbox");
         }
         return outbox;
+      };
+      const requireCustodian = (): GithubCustodian => {
+        if (custodian == null) {
+          throw new RedskilledGithubAuthorityError("this GitHub gateway has no durable merge custodian");
+        }
+        return custodian;
       };
       return {
         async read(request) {
@@ -481,6 +524,12 @@ export function createRedskilledGithubGateway(
         resumeWrites() {
           return requireOutbox().resume(project, credential);
         },
+        handoffMergeCustody(request) {
+          return requireCustodian().handoff(project, credential, request);
+        },
+        mergeCustodyStatus() {
+          return requireCustodian().status(project, credential);
+        },
       };
     },
     projectBudget(authority) {
@@ -516,6 +565,7 @@ export function createRedskilledGithubGateway(
       states.clear();
       observers.clear();
       seenWakes.clear();
+      custodian?.close();
     },
   };
 }

--- a/apps/redskilled/src/github-gateway.ts
+++ b/apps/redskilled/src/github-gateway.ts
@@ -15,7 +15,6 @@ import {
   type GithubCacheOutcome,
   type GithubLimitFact,
 } from "@reddb-io/github";
-import { execFile } from "node:child_process";
 import { isDeepStrictEqual } from "node:util";
 import {
   githubCredentialScopeRefusal,
@@ -69,6 +68,7 @@ import {
   githubUpstreamRefusal,
   responseValue,
 } from "./github-transport.js";
+import { fetchCanonicalRepository } from "./github-repository-fetch.js";
 import {
   type RedskilledGithubWriteAnswer,
   type RedskilledGithubWriteRequest,
@@ -801,25 +801,4 @@ function isGithubScopeError(value: unknown): boolean {
   return record.type === "FORBIDDEN" || record.extensions != null &&
     typeof record.extensions === "object" &&
     (record.extensions as Record<string, unknown>).type === "FORBIDDEN";
-}
-
-async function fetchCanonicalRepository(input: RedskilledGithubUpstreamInput): Promise<unknown> {
-  if (input.read.kind !== "repository-fetch") throw new Error("repository fetch received a non-fetch read");
-  const authorization = Buffer.from(`x-access-token:${input.credential.secret}`, "utf8").toString("base64");
-  const args = ["fetch", "--no-tags", "origin", ...(input.read.ref == null ? [] : [input.read.ref])];
-  await new Promise<void>((resolve, reject) => {
-    execFile("git", args, {
-      cwd: input.project.workspacePath,
-      env: {
-        ...process.env,
-        GIT_CONFIG_COUNT: "1",
-        GIT_CONFIG_KEY_0: "http.extraHeader",
-        GIT_CONFIG_VALUE_0: `Authorization: Basic ${authorization}`,
-        GIT_TERMINAL_PROMPT: "0",
-      },
-      windowsHide: true,
-      timeout: 60_000,
-    }, (error) => error == null ? resolve() : reject(new Error("redskilled repository fetch failed", { cause: error })));
-  });
-  return { fetched: true, ref: input.read.ref ?? null };
 }

--- a/apps/redskilled/src/github-gateway.ts
+++ b/apps/redskilled/src/github-gateway.ts
@@ -60,6 +60,10 @@ import {
   type RedskilledGithubCustodyStatus,
   type RedskilledGithubCustodyUpstream,
 } from "./github-custody.js";
+export {
+  createRedskilledGithubCustodyUpstream,
+  type CreateRedskilledGithubCustodyUpstreamOptions,
+} from "./github-custody-upstream.js";
 import {
   githubHeaders,
   githubUpstreamRefusal,

--- a/apps/redskilled/src/github-gateway.ts
+++ b/apps/redskilled/src/github-gateway.ts
@@ -1,11 +1,6 @@
 /**
- * Project-scoped GitHub reads owned by the redskilled daemon.
- *
- * A caller receives a reader already bound to one Project and one named
- * daemon-owned credential profile. It can describe a read, but it cannot name a
- * credential, a second Project, a repository remote, or a host operation. The
- * gateway therefore has one place to coalesce demand and one place to enforce
- * the authority boundary before any authenticated transport is reached.
+ * Project-scoped GitHub reads, coalescing, and authority enforcement owned by
+ * redskilled. Callers receive readers bound to one Project and credential.
  */
 import {
   DEFAULT_GITHUB_CACHE_CAPACITY,

--- a/apps/redskilled/src/github-repository-fetch.ts
+++ b/apps/redskilled/src/github-repository-fetch.ts
@@ -1,0 +1,24 @@
+import { execFile } from "node:child_process";
+import type { RedskilledGithubUpstreamInput } from "./github-gateway.js";
+
+/** Fetch one canonical ref without exposing the daemon-owned credential. */
+export async function fetchCanonicalRepository(input: RedskilledGithubUpstreamInput): Promise<unknown> {
+  if (input.read.kind !== "repository-fetch") throw new Error("repository fetch received a non-fetch read");
+  const authorization = Buffer.from(`x-access-token:${input.credential.secret}`, "utf8").toString("base64");
+  const args = ["fetch", "--no-tags", "origin", ...(input.read.ref == null ? [] : [input.read.ref])];
+  await new Promise<void>((resolve, reject) => {
+    execFile("git", args, {
+      cwd: input.project.workspacePath,
+      env: {
+        ...process.env,
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: "http.extraHeader",
+        GIT_CONFIG_VALUE_0: `Authorization: Basic ${authorization}`,
+        GIT_TERMINAL_PROMPT: "0",
+      },
+      windowsHide: true,
+      timeout: 60_000,
+    }, (error) => error == null ? resolve() : reject(new Error("redskilled repository fetch failed", { cause: error })));
+  });
+  return { fetched: true, ref: input.read.ref ?? null };
+}

--- a/apps/redskilled/tests/github-custody.test.ts
+++ b/apps/redskilled/tests/github-custody.test.ts
@@ -1,0 +1,211 @@
+import { execFileSync } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { client, methods, type ClientConnection } from "@agentclientprotocol/sdk";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD,
+  createRedskilledGithubGateway,
+  type RedskilledGithubCustodyStatus,
+} from "../src/github-gateway.js";
+import { startRedskillsAcpControlPlane } from "../src/acp-control-plane.js";
+import { socketStream } from "../src/acp-socket.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("redskilled GitHub merge custody", () => {
+  it("finishes a clean pull request after every handing-off client disconnects", async () => {
+    const root = await fixtureRoot("redskilled-github-custody-");
+    const checkout = join(root, "checkout");
+    execFileSync("git", ["init", checkout], { stdio: "ignore" });
+    execFileSync("git", ["remote", "add", "origin", "https://github.com/acme/widgets.git"], {
+      cwd: checkout,
+      stdio: "ignore",
+    });
+    const identity = await identityFixture();
+    const previousApi = process.env.GITHUB_API_URL;
+    process.env.GITHUB_API_URL = identity.origin;
+
+    let nativeIntent = false;
+    let merged = false;
+    let armCalls = 0;
+    let finish!: () => void;
+    const terminal = new Promise<void>((resolve) => { finish = resolve; });
+    const gateway = createRedskilledGithubGateway({
+      upstream: async () => ({ value: {}, budget: null }),
+      outboxPath: join(root, "github-outbox.toon"),
+      custodyPath: join(root, "github-custody.toon"),
+      custodyTickMs: 1,
+      writeUpstream: async ({ write }) => write.kind === "pull-request" ? { number: 73 } : {},
+      custodyUpstream: {
+        async observe() {
+          if (nativeIntent) {
+            merged = true;
+            finish();
+          }
+          return merged
+            ? { forge_state: "merged", native_intent: false }
+            : { forge_state: "open-clean", native_intent: nativeIntent };
+        },
+        async arm() {
+          armCalls += 1;
+          nativeIntent = true;
+          return { forge_state: "open-pending", native_intent: true };
+        },
+      },
+    });
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const control = await startRedskillsAcpControlPlane({
+      paths,
+      startWorker: () => { throw new Error("merge custody must not birth a client-owned Worker"); },
+      hostState: () => ({ workers: [] }) as never,
+      githubGateway: {
+        gateway,
+        credentialForProject: () => ({ profile: "engineering", credential: { secret: "fixture" } }),
+      },
+    });
+    let handingOff: ClientConnection | undefined;
+    let observer: ClientConnection | undefined;
+    try {
+      handingOff = await connectProjectClient(control.socketPath, checkout, "worker");
+      await expect(handingOff.agent.request("_redskills/github_write", {
+        idempotency_key: "worker-pr-3653",
+        write: {
+          kind: "pull-request",
+          head: "worker/3653",
+          base: "main",
+          title: "Publish Worker result",
+          body: "Closes #3653",
+        },
+      })).resolves.toMatchObject({ state: "published", value: { number: 73 } });
+      await expect(handingOff.agent.request(REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD, {
+        pull_request: 73,
+        owner_ticket: 3653,
+        branch: "worker/3653",
+        base: "main",
+      })).resolves.toMatchObject({ pull_request: 73, state: "active" });
+
+      handingOff.close();
+      handingOff = undefined;
+      await terminal;
+
+      observer = await connectProjectClient(control.socketPath, checkout, "observer");
+      const status = await observer.agent.request<{
+        merge_custody: RedskilledGithubCustodyStatus;
+      }>("_redskills/project_status", {});
+      expect(status.merge_custody.records).toEqual([
+        expect.objectContaining({
+          pull_request: 73,
+          last_tick_at: expect.any(String),
+          last_forge_state: "merged",
+          next_action: "none",
+          terminal_outcome: "merged",
+        }),
+      ]);
+      expect(armCalls).toBe(1);
+    } finally {
+      handingOff?.close();
+      observer?.close();
+      await control.close();
+      gateway.close();
+      await identity.close();
+      if (previousApi == null) delete process.env.GITHUB_API_URL;
+      else process.env.GITHUB_API_URL = previousApi;
+    }
+  });
+
+  it("deduplicates recovered publication custody and exposes a bounded inert fault", async () => {
+    const root = await fixtureRoot("redskilled-github-custody-recovery-");
+    let now = "2026-08-15T20:00:00.000Z";
+    let releases = 0;
+    const gateway = createRedskilledGithubGateway({
+      upstream: async () => ({ value: {}, budget: null }),
+      outboxPath: join(root, "github-outbox.toon"),
+      custodyPath: join(root, "github-custody.toon"),
+      custodyTickMs: 60_000,
+      custodyInertMs: 1_000,
+      clock: () => now,
+      writeUpstream: async () => ({ number: 73 }),
+      custodyUpstream: {
+        async observe() {
+          releases += 1;
+          return { forge_state: "open-pending", native_intent: true };
+        },
+        async arm() {
+          throw new Error("an already armed pull request must not be armed twice");
+        },
+      },
+    });
+    const project = gateway.forProject({
+      projectId: "github:101",
+      projectLabel: "acme/widgets",
+      workspacePath: join(root, "workspace"),
+      credentialProfile: "engineering",
+    }, { secret: "fixture" });
+    const request = {
+      pull_request: 73,
+      owner_ticket: 3653,
+      branch: "worker/3653",
+      base: "main",
+    } as const;
+
+    await Promise.all([project.handoffMergeCustody(request), project.handoffMergeCustody(request)]);
+    await project.resumeWrites();
+    expect((await project.mergeCustodyStatus()).records).toHaveLength(1);
+
+    now = "2026-08-15T20:00:02.000Z";
+    expect((await project.mergeCustodyStatus()).records[0]).toMatchObject({
+      pull_request: 73,
+      next_action: "repair-custodian",
+      fault: { kind: "inert-custodian", threshold_ms: 1_000 },
+    });
+    expect(releases).toBeLessThanOrEqual(1);
+    gateway.close();
+  });
+});
+
+async function fixtureRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+async function identityFixture(): Promise<{ readonly origin: string; close(): Promise<void> }> {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ id: 101, full_name: "acme/widgets" }));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (address == null || typeof address === "string") throw new Error("identity fixture did not bind TCP");
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+async function connectProjectClient(socketPath: string, checkout: string, name: string): Promise<ClientConnection> {
+  const socket = connect(socketPath);
+  await once(socket, "connect");
+  const connection = client({ name }).connect(socketStream(socket));
+  await connection.agent.request(methods.agent.initialize, {
+    protocolVersion: 1,
+    clientCapabilities: {},
+    clientInfo: { name, version: "1" },
+  });
+  await connection.agent.request(methods.agent.session.new, { cwd: checkout, mcpServers: [] });
+  return connection;
+}

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -164,7 +164,10 @@ structured `project_reset` repair) ->
 Worker GitHub publication (credential-free Workers request authenticated fetch,
 push, pull-request, and Issue operations through project-scoped ACP; redskilled
 serializes mutations through its durable outbox, so there is no direct `gh` or
-authenticated Git fallback route) ->
+authenticated Git fallback route; after publication, the Worker hands a pull
+request to `_redskills/github_custody_handoff` and ends, while the gateway keeps
+the single durable owner and `_redskills/project_status` exposes its last tick,
+forge state, next action, terminal outcome, or bounded inert-custodian fault) ->
 `apps/redskilled/src/github-gateway.ts` and `apps/redskilled/src/acp-github.ts`;
 Castle resident lifecycle (one project identity across Worktrees, versioned
 wire, spawn/handover/idle rules, matching proxy/resident artifacts, bounded
@@ -201,8 +204,8 @@ required contexts, and harmless strict-base lag) ->
 `plugins/dev/skills/engineering/red-setup/INTERVIEW.md`,
 `plugins/dev/skills/engineering/red-setup/config-template.yaml`, and
 `plugins/dev/skills/engineering/red-setup/WORKFLOWS.md`;
-`/afk` ADR 0136 ownership (Landing hands native intent to the Queue Custodian
-and ends, Verdict has no classification hook, and the Park exposes one
+`/afk` ADR 0136 ownership (Landing hands native intent to redskilled's
+gateway-owned Queue Custodian and ends, Verdict has no classification hook, and the Park exposes one
 authority-parameterized requeue door whose HITL repair projects labels from the
 authoritative blocker body) ->
 `plugins/dev/skills/engineering/afk/SKILL.md` and

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -164,7 +164,10 @@ structured `project_reset` repair) ->
 Worker GitHub publication (credential-free Workers request authenticated fetch,
 push, pull-request, and Issue operations through project-scoped ACP; redskilled
 serializes mutations through its durable outbox, so there is no direct `gh` or
-authenticated Git fallback route) ->
+authenticated Git fallback route; after publication, the Worker hands a pull
+request to `_redskills/github_custody_handoff` and ends, while the gateway keeps
+the single durable owner and `_redskills/project_status` exposes its last tick,
+forge state, next action, terminal outcome, or bounded inert-custodian fault) ->
 `apps/redskilled/src/github-gateway.ts` and `apps/redskilled/src/acp-github.ts`;
 Castle resident lifecycle (one project identity across Worktrees, versioned
 wire, spawn/handover/idle rules, matching proxy/resident artifacts, bounded
@@ -201,8 +204,8 @@ required contexts, and harmless strict-base lag) ->
 `plugins/dev/skills/engineering/red-setup/INTERVIEW.md`,
 `plugins/dev/skills/engineering/red-setup/config-template.yaml`, and
 `plugins/dev/skills/engineering/red-setup/WORKFLOWS.md`;
-`/afk` ADR 0136 ownership (Landing hands native intent to the Queue Custodian
-and ends, Verdict has no classification hook, and the Park exposes one
+`/afk` ADR 0136 ownership (Landing hands native intent to redskilled's
+gateway-owned Queue Custodian and ends, Verdict has no classification hook, and the Park exposes one
 authority-parameterized requeue door whose HITL repair projects labels from the
 authoritative blocker body) ->
 `plugins/dev/skills/engineering/afk/SKILL.md` and


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3653 -->
🤖 **Re-seed trail** — #3653 on `afk/3653-redskilled-github-gateway-owns-merge-cus`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3653; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3653 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/dev`, `apps/redskilled`]
{"schema":"red.afk.validation.v1","name":"feedback:pnpm -C apps/dev test:invariants","status":"failed","command":"pnpm -C apps/dev test:invariants","exitCode":1,"durationMs":66,"summary":"failing: FAIL tests/file-size-guard.test.ts > file-size ratchet — a split nothing enforces is a split that comes back > holds the live tree to the threshold and the shrink-only baseline —  - Array [] + Array [ +   Object { +     \"kind\": \"over-threshold\", +     \"lines\": 825, +     \"path\": \"apps/redskilled/src/github-gateway.ts\", +     \"reason\": \"apps/redskilled/src/github-gateway.ts is 825 lines, over the 800-line threshold. Split it by domain — the baseline records debt that predates this ratchet, never a new file.\", +   }, + ]   ❯ tests/file-size-guard.test.ts:46:7      44|         : `file-size ratchet: ${findings.length} finding(s).\\n${render…      45|           `Baseline: apps/dev/src/core/file-size-guard.ts (FILE_SIZE_B…      46|     ).toEqual([]);        |       ^      47|   });      48|   ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯","resources":{"source":"cgroup-v2","sampled_before":"2026-08-15T22:50:53.949Z","sampled_after":"2026-08-15T22:51:36.034Z","memory_current_before_bytes":253857792,"memory_current_after_bytes":259260416,"memory_peak_bytes":1408643072,"memory_max_bytes":2736193536,"cpu_usage_delta_usec":48122371,"cpu_throttled_delta_usec":0,"pids_peak":227,"memory_events_delta":{},"pids_events_delta":{}}}
Verdict: mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted.
```

Closes #3653