### PR TITLE
fix: #3842 ACP budget grace lets a Worker checkpoint and terminate

### DIFF
--- a/apps/dev/tests/budget-grace-disposition.test.ts
+++ b/apps/dev/tests/budget-grace-disposition.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { extractPendingHitlDecision } from "../src/core/hitl-decision-extraction.js";
+import { formatCurrentBlocker, upsertCurrentBlocker } from "../src/core/blocker-state.js";
+import { blockerForFailure } from "../src/core/process-issue/terminal.js";
+import { isRequeueComplete, planRequeue } from "../src/core/requeue.js";
+
+describe("Budget grace disposition", () => {
+  it("records the extension decision and clears it through the ordinary human requeue door", () => {
+    const blocker = blockerForFailure("budget-exceeded", {
+      log: "Worker checkpointed recoverable local work before its Budget grace expired.",
+    });
+    expect(blocker).toMatchObject({ status: "blocked", kind: "budget" });
+    const body = upsertCurrentBlocker("## Summary\nContinue bounded work.", blocker!);
+
+    expect(extractPendingHitlDecision({ number: 3842, title: "Budget grace", body, comments: [] })).toMatchObject({
+      kind: "pending-decision",
+      source: "current-blocker",
+      prompt: expect.stringContaining("larger budget"),
+    });
+    expect(isRequeueComplete(body, ["ready-for-agent"])).toBe(false);
+
+    const requeue = planRequeue({
+      authority: "human",
+      body,
+      labels: ["ready-for-human", "blocked:budget"],
+      guidance: "Extend the next Worker's budget and continue from the published checkpoint.",
+    });
+
+    expect(requeue.requeueable).toBe(true);
+    expect(requeue.body).not.toContain(formatCurrentBlocker(blocker!));
+    expect(requeue.body).not.toContain("<!-- red:blocker-state v1 -->");
+    expect(requeue.removeLabels).toEqual(expect.arrayContaining(["ready-for-human", "blocked:budget"]));
+    expect(requeue.addLabels).toEqual(["ready-for-agent"]);
+    expect(isRequeueComplete(requeue.body, ["ready-for-agent"])).toBe(true);
+  });
+});

--- a/apps/redskilled/src/acp-worker-budget-grace.ts
+++ b/apps/redskilled/src/acp-worker-budget-grace.ts
@@ -1,0 +1,137 @@
+import type { RedskilledGithubWriteRequest } from "./github-write.js";
+
+/** ACP control delivered to a Worker after the daemon records its budget verdict. */
+export const REDSKILLED_WORKER_BUDGET_GRACE_METHOD = "_redskills/worker_budget_grace";
+
+export interface WorkerBudgetGraceControl {
+  readonly version: 1;
+  readonly worker_id: string;
+  readonly detail: string;
+  /** Observability only. The daemon remains the sole deadline and kill authority. */
+  readonly deadline_at: string;
+}
+
+export interface WorkerBudgetGraceCheckpoint {
+  readonly ref: string;
+  readonly sha: string;
+}
+
+export interface WorkerBudgetExtensionBlocker {
+  readonly status: "blocked";
+  readonly kind: "budget";
+  readonly summary: string;
+  readonly next: string;
+}
+
+/** Terminal evidence handed to the Worker's ordinary Envelope writer. */
+export interface WorkerBudgetGraceEnvelope {
+  readonly outcome: "budget-exceeded";
+  readonly worker_id: string;
+  readonly detail: string;
+  readonly deadline_at: string;
+  readonly checkpoint?: WorkerBudgetGraceCheckpoint;
+  readonly publication_requested: boolean;
+  readonly publication_receipt?: unknown;
+  readonly failures: readonly string[];
+  readonly blocker: WorkerBudgetExtensionBlocker;
+}
+
+export interface AcpWorkerBudgetGraceDeps {
+  /** Cancel the Worker's child Agent through its existing ACP connection. */
+  cancelChildAgent(control: WorkerBudgetGraceControl): Promise<void>;
+  /** Commit recoverable local work and return the ref/commit to publish. */
+  checkpointLocalWork(control: WorkerBudgetGraceControl): Promise<WorkerBudgetGraceCheckpoint | null>;
+  /** Ask redskilled's Project-bound GitHub gateway to publish; no credential crosses this seam. */
+  requestPublication(request: RedskilledGithubWriteRequest): Promise<unknown>;
+  writeEnvelope(envelope: WorkerBudgetGraceEnvelope): Promise<void>;
+  /** End the Worker. Deadline expiry may independently kill it at any point. */
+  terminate(): Promise<void> | void;
+}
+
+export interface AcpWorkerBudgetGraceRuntime {
+  receive(control: WorkerBudgetGraceControl): Promise<void>;
+}
+
+const EXTENSION_BLOCKER: WorkerBudgetExtensionBlocker = {
+  status: "blocked",
+  kind: "budget",
+  summary: "The Worker exhausted its resource budget and checkpointed recoverable local work before termination.",
+  next: "Decide whether to requeue with a larger budget, re-scope, or stop.",
+};
+
+/**
+ * Run the Worker's checkpoint-and-die transaction once.
+ *
+ * Each recoverable stage is best-effort so a failed commit or publication does
+ * not suppress the Envelope or turn Budget grace into a live held state. The
+ * daemon's timer is deliberately not mirrored here: it may kill this process
+ * unconditionally while any awaited stage is still running.
+ */
+export function createAcpWorkerBudgetGraceRuntime(
+  deps: AcpWorkerBudgetGraceDeps,
+): AcpWorkerBudgetGraceRuntime {
+  let terminal: Promise<void> | undefined;
+  return {
+    receive(control) {
+      terminal ??= runBudgetGrace(control, deps);
+      return terminal;
+    },
+  };
+}
+
+async function runBudgetGrace(
+  control: WorkerBudgetGraceControl,
+  deps: AcpWorkerBudgetGraceDeps,
+): Promise<void> {
+  const failures: string[] = [];
+  let checkpoint: WorkerBudgetGraceCheckpoint | undefined;
+  let publicationRequested = false;
+  let publicationReceipt: unknown;
+
+  try {
+    await deps.cancelChildAgent(control);
+  } catch (error) {
+    failures.push(`cancellation: ${reason(error)}`);
+  }
+
+  try {
+    checkpoint = (await deps.checkpointLocalWork(control)) ?? undefined;
+  } catch (error) {
+    failures.push(`checkpoint: ${reason(error)}`);
+  }
+
+  if (checkpoint != null) {
+    publicationRequested = true;
+    try {
+      publicationReceipt = await deps.requestPublication({
+        idempotency_key: `worker-budget-grace:${control.worker_id}`,
+        write: { kind: "repository-push", ref: checkpoint.ref, sha: checkpoint.sha },
+      });
+    } catch (error) {
+      failures.push(`publication: ${reason(error)}`);
+    }
+  }
+
+  try {
+    await deps.writeEnvelope({
+      outcome: "budget-exceeded",
+      worker_id: control.worker_id,
+      detail: control.detail,
+      deadline_at: control.deadline_at,
+      ...(checkpoint == null ? {} : { checkpoint }),
+      publication_requested: publicationRequested,
+      ...(publicationReceipt === undefined ? {} : { publication_receipt: publicationReceipt }),
+      failures,
+      blocker: EXTENSION_BLOCKER,
+    });
+  } catch {
+    // The Worker cannot durably report an Envelope-writer failure from inside
+    // that same failed writer. Termination still wins over retaining the slot.
+  } finally {
+    await deps.terminate();
+  }
+}
+
+function reason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/redskilled/tests/acp-worker-budget-grace.test.ts
+++ b/apps/redskilled/tests/acp-worker-budget-grace.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  REDSKILLED_WORKER_BUDGET_GRACE_METHOD,
+  createAcpWorkerBudgetGraceRuntime,
+  type WorkerBudgetGraceEnvelope,
+} from "../src/acp-worker-budget-grace.js";
+
+describe("ACP Worker Budget grace", () => {
+  it("cancels, checkpoints, requests tokenless publication, writes its Envelope, and exits in order", async () => {
+    const order: string[] = [];
+    let envelope: WorkerBudgetGraceEnvelope | undefined;
+    const requestPublication = vi.fn(async () => {
+      order.push("publication");
+      return { publication_id: "queued:worker-budget-grace:wGRACE" };
+    });
+    const runtime = createAcpWorkerBudgetGraceRuntime({
+      cancelChildAgent: async () => { order.push("cancel"); },
+      checkpointLocalWork: async () => {
+        order.push("checkpoint");
+        return { ref: "refs/heads/worker-3842", sha: "a".repeat(40) };
+      },
+      requestPublication,
+      writeEnvelope: async (value) => { order.push("envelope"); envelope = value; },
+      terminate: async () => { order.push("exit"); },
+    });
+
+    expect(REDSKILLED_WORKER_BUDGET_GRACE_METHOD).toBe("_redskills/worker_budget_grace");
+    await runtime.receive({
+      version: 1,
+      worker_id: "wGRACE",
+      detail: "memory budget exceeded",
+      deadline_at: "2026-08-15T23:00:30.000Z",
+    });
+
+    expect(order).toEqual(["cancel", "checkpoint", "publication", "envelope", "exit"]);
+    expect(requestPublication).toHaveBeenCalledWith({
+      idempotency_key: "worker-budget-grace:wGRACE",
+      write: {
+        kind: "repository-push",
+        ref: "refs/heads/worker-3842",
+        sha: "a".repeat(40),
+      },
+    });
+    expect(requestPublication.mock.calls[0]![0]).not.toHaveProperty("credential");
+    expect(requestPublication.mock.calls[0]![0]).not.toHaveProperty("token");
+    expect(envelope).toMatchObject({
+      outcome: "budget-exceeded",
+      worker_id: "wGRACE",
+      publication_requested: true,
+      blocker: {
+        status: "blocked",
+        kind: "budget",
+        next: "Decide whether to requeue with a larger budget, re-scope, or stop.",
+      },
+    });
+  });
+
+  it("attempts the Envelope and exit even when an earlier checkpoint stage overruns or fails", async () => {
+    const order: string[] = [];
+    let envelope: WorkerBudgetGraceEnvelope | undefined;
+    const runtime = createAcpWorkerBudgetGraceRuntime({
+      cancelChildAgent: async () => { order.push("cancel"); },
+      checkpointLocalWork: async () => { order.push("checkpoint"); throw new Error("checkpoint overran"); },
+      requestPublication: async () => { order.push("publication"); return {}; },
+      writeEnvelope: async (value) => { order.push("envelope"); envelope = value; },
+      terminate: async () => { order.push("exit"); },
+    });
+
+    await runtime.receive({
+      version: 1,
+      worker_id: "wOVERRUN",
+      detail: "memory budget exceeded",
+      deadline_at: "2026-08-15T23:00:30.000Z",
+    });
+
+    expect(order).toEqual(["cancel", "checkpoint", "envelope", "exit"]);
+    expect(envelope?.failures).toEqual(["checkpoint: checkpoint overran"]);
+    expect(envelope?.publication_requested).toBe(false);
+  });
+
+  it("coalesces repeated grace controls into one terminal transaction", async () => {
+    const terminate = vi.fn(async () => undefined);
+    const runtime = createAcpWorkerBudgetGraceRuntime({
+      cancelChildAgent: async () => undefined,
+      checkpointLocalWork: async () => null,
+      requestPublication: async () => ({}),
+      writeEnvelope: async () => undefined,
+      terminate,
+    });
+    const control = {
+      version: 1 as const,
+      worker_id: "wONCE",
+      detail: "budget exceeded",
+      deadline_at: "2026-08-15T23:00:30.000Z",
+    };
+
+    await Promise.all([runtime.receive(control), runtime.receive(control)]);
+
+    expect(terminate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/redskilled/tests/acp-worker-budget-grace.test.ts
+++ b/apps/redskilled/tests/acp-worker-budget-grace.test.ts
@@ -9,7 +9,7 @@ describe("ACP Worker Budget grace", () => {
   it("cancels, checkpoints, requests tokenless publication, writes its Envelope, and exits in order", async () => {
     const order: string[] = [];
     let envelope: WorkerBudgetGraceEnvelope | undefined;
-    const requestPublication = vi.fn(async () => {
+    const requestPublication = vi.fn(async (_request: unknown) => {
       order.push("publication");
       return { publication_id: "queued:worker-budget-grace:wGRACE" };
     });


### PR DESCRIPTION
Automated AFK landing for #3842. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3842

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789426167&installation_model_id=20659&pr_number=3921&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3921&signature=2b3b74b7cf32ede38670f7889cd1f6b6b2e20acf08d9450eac1d98aba323f947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->