### PR TITLE
fix: #3911 redskilled provisions the five supported ACP Agents

### DIFF
--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./acp-agent-catalog": "./src/acp-agent-catalog.ts",
     "./cli": "./src/cli.ts",
     "./client": "./src/client.ts",
     "./daemon": "./src/daemon.ts",
@@ -39,6 +40,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "NODE_OPTIONS=--max-old-space-size=4096 vitest run",
+    "test:acp-agent-catalog": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-agent-catalog.test.ts",
     "test:acp-conformance": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-conformance.test.ts",
     "test:acp-control-plane": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-control-plane.test.ts",
     "test:github-gateway": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/github-gateway.test.ts",

--- a/apps/redskilled/src/acp-agent-catalog.ts
+++ b/apps/redskilled/src/acp-agent-catalog.ts
@@ -1,0 +1,403 @@
+/**
+ * Host-scoped ACP Agent catalog.
+ *
+ * redskilled owns discovery, adapter updates, integrity checks and capability
+ * admission. A Worker receives only the selected stdio endpoint; package pins,
+ * download locations, host credentials and fallback policy stay on this side
+ * of the daemon boundary.
+ */
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
+
+export const ACP_AGENT_IDS = ["redcode", "claude-code", "codex", "pi", "opencode"] as const;
+export type AcpAgentId = typeof ACP_AGENT_IDS[number];
+
+export const ACP_AGENT_REQUIRED_CAPABILITIES = [
+  "session/new",
+  "session/prompt",
+  "session/cancel",
+] as const;
+
+export interface AcpAdapterArtifact {
+  readonly package: string;
+  readonly version: string;
+  /** npm Subresource Integrity, pinned with the package version. */
+  readonly integrity: `sha512-${string}`;
+  /** Entrypoint inside the unpacked npm artifact. */
+  readonly entrypoint: string;
+}
+
+export interface NativeAcpAgentDescriptor {
+  readonly id: AcpAgentId;
+  readonly label: string;
+  readonly kind: "native";
+  /** Native ACP argv; the first element is the executable. */
+  readonly command: readonly [string, ...string[]];
+}
+
+export interface AdapterAcpAgentDescriptor {
+  readonly id: AcpAgentId;
+  readonly label: string;
+  readonly kind: "adapter";
+  readonly artifact: AcpAdapterArtifact;
+}
+
+export type AcpAgentDescriptor = NativeAcpAgentDescriptor | AdapterAcpAgentDescriptor;
+
+/**
+ * The only first-class child Agents. Adapter versions and npm SRI values are
+ * deliberately exact: changing either is a reviewed catalog update.
+ */
+export const ACP_AGENT_CATALOG: readonly AcpAgentDescriptor[] = [
+  { id: "redcode", label: "Redcode", kind: "native", command: ["redcode", "acp"] },
+  {
+    id: "claude-code",
+    label: "Claude Code",
+    kind: "adapter",
+    artifact: {
+      package: "@zed-industries/claude-code-acp",
+      version: "0.16.2",
+      integrity: "sha512-D8BJe6CCD49RtNFbZYPsfZOpQI8Z/EzhyYC9zAGMwN/HVunEtVY2sXqYl1iDSkkayzhqABfaDkDZfeqDM1T/aA==",
+      entrypoint: "package/dist/index.js",
+    },
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    kind: "adapter",
+    artifact: {
+      package: "@zed-industries/codex-acp",
+      version: "0.16.0",
+      integrity: "sha512-XKzqztT5R8Wg1BVFnk6/U4JVx5GNUaZgxpf9gP2Cw6BsknvJWh3aefcAGZQljgdMivRqczjNKYL4F6H65dc5vA==",
+      entrypoint: "package/bin/codex-acp.js",
+    },
+  },
+  {
+    id: "pi",
+    label: "Pi",
+    kind: "adapter",
+    artifact: {
+      package: "pi-acp",
+      version: "0.0.33",
+      integrity: "sha512-vX9kY1tK14E72G4dBAx+RGCk/k7XPjTHls6dLUxA8WSkBav6B6JHuSBv3eusp50LCR/GTRsR2kIKsG0Z5jANzw==",
+      entrypoint: "package/dist/index.js",
+    },
+  },
+  { id: "opencode", label: "OpenCode", kind: "native", command: ["opencode", "acp"] },
+] as const;
+
+/** Credential-free launch projection handed to a Worker. */
+export interface AcpEndpoint {
+  readonly agent: AcpAgentId;
+  readonly transport: "stdio";
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+export interface AcpAgentProbeResult {
+  readonly protocolVersion: number;
+  readonly capabilities: readonly string[];
+}
+
+export interface AcpAgentProvisionReceipt {
+  readonly id: AcpAgentId;
+  readonly status: "healthy" | "unavailable";
+  readonly version: string;
+  readonly endpoint?: AcpEndpoint;
+  /** True when a rejected update left an older healthy activation selected. */
+  readonly preserved?: boolean;
+  readonly warning?: string;
+  readonly reason?: string;
+}
+
+export class AcpAgentUnavailableError extends Error {
+  constructor(
+    readonly agent: AcpAgentId,
+    reason: string,
+  ) {
+    super(
+      `ACP Agent ${agent} is not available: ${reason}. ` +
+      `Run redskilled ACP Agent provisioning for ${agent}; redskilled will not substitute another Agent.`,
+    );
+    this.name = "AcpAgentUnavailableError";
+  }
+}
+
+export interface AcpAgentCatalogOptions {
+  /** Host-owned catalog root, normally beneath the redskilled home. */
+  readonly root?: string;
+  readonly descriptors?: readonly AcpAgentDescriptor[];
+  /** External network edge. It is called only by redskilled provisioning. */
+  readonly fetchArtifact?: (artifact: AcpAdapterArtifact) => Promise<Uint8Array>;
+  /**
+   * External package-manager edge. It must unpack/install into `stage` only;
+   * activation remains this module's atomic responsibility.
+   */
+  readonly installArtifact?: (
+    bytes: Uint8Array,
+    stage: string,
+    descriptor: AdapterAcpAgentDescriptor,
+  ) => Promise<void>;
+  /** ACP initialize/session capability probe at the process boundary. */
+  readonly probe: (endpoint: AcpEndpoint) => Promise<AcpAgentProbeResult>;
+  readonly nodePath?: string;
+}
+
+export class AcpAgentCatalog {
+  readonly #root: string;
+  readonly #descriptors: readonly AcpAgentDescriptor[];
+  readonly #fetchArtifact: (artifact: AcpAdapterArtifact) => Promise<Uint8Array>;
+  readonly #installArtifact?: AcpAgentCatalogOptions["installArtifact"];
+  readonly #probe: AcpAgentCatalogOptions["probe"];
+  readonly #nodePath: string;
+
+  constructor(options: AcpAgentCatalogOptions) {
+    this.#root = options.root ?? redskilledAcpAgentCatalogRoot();
+    this.#descriptors = options.descriptors ?? ACP_AGENT_CATALOG;
+    this.#fetchArtifact = options.fetchArtifact ?? fetchNpmArtifact;
+    this.#installArtifact = options.installArtifact;
+    this.#probe = options.probe;
+    this.#nodePath = options.nodePath ?? process.execPath;
+    assertDescriptors(this.#descriptors);
+  }
+
+  async provisionAll(): Promise<readonly AcpAgentProvisionReceipt[]> {
+    const receipts: AcpAgentProvisionReceipt[] = [];
+    for (const descriptor of this.#descriptors) receipts.push(await this.provision(descriptor.id));
+    return receipts;
+  }
+
+  async provision(id: AcpAgentId): Promise<AcpAgentProvisionReceipt> {
+    const descriptor = this.#descriptor(id);
+    if (descriptor.kind === "native") {
+      const endpoint = nativeEndpoint(descriptor);
+      try {
+        await this.#requireHealthy(endpoint);
+        return { id, status: "healthy", version: "native", endpoint };
+      } catch (error) {
+        return { id, status: "unavailable", version: "native", reason: messageOf(error) };
+      }
+    }
+    return this.#provisionAdapter(descriptor);
+  }
+
+  /** Resolve exactly the requested Agent. This function never has fallback semantics. */
+  async resolveForWorker(id: AcpAgentId): Promise<AcpEndpoint> {
+    const descriptor = this.#descriptor(id);
+    const endpoint = descriptor.kind === "native"
+      ? nativeEndpoint(descriptor)
+      : await this.#activeAdapterEndpoint(descriptor);
+    try {
+      await this.#requireHealthy(endpoint);
+      return endpoint;
+    } catch (error) {
+      throw new AcpAgentUnavailableError(id, messageOf(error));
+    }
+  }
+
+  async #provisionAdapter(descriptor: AdapterAcpAgentDescriptor): Promise<AcpAgentProvisionReceipt> {
+    const activeBefore = await this.#readActiveEndpoint(descriptor);
+    const desiredRelease = releaseName(descriptor.artifact);
+    if (activeBefore?.release === desiredRelease) {
+      try {
+        await this.#requireHealthy(activeBefore.endpoint);
+        return {
+          id: descriptor.id,
+          status: "healthy",
+          version: descriptor.artifact.version,
+          endpoint: activeBefore.endpoint,
+        };
+      } catch {
+        // Re-stage the exact pin: the active bytes or their dependencies drifted.
+      }
+    }
+
+    const agentRoot = join(this.#root, descriptor.id);
+    const versionsRoot = join(agentRoot, "versions");
+    const stage = join(agentRoot, ".staging", `${desiredRelease}-${randomUUID()}`);
+    try {
+      if (this.#installArtifact == null) {
+        throw new Error("no host adapter installer is configured");
+      }
+      const bytes = await this.#fetchArtifact(descriptor.artifact);
+      requireIntegrity(bytes, descriptor.artifact.integrity);
+      await mkdir(stage, { recursive: true, mode: 0o700 });
+      await this.#installArtifact(bytes, stage, descriptor);
+      const stagedEndpoint = adapterEndpoint(descriptor, stage, this.#nodePath);
+      await requireFile(join(stage, descriptor.artifact.entrypoint));
+      await this.#requireHealthy(stagedEndpoint);
+
+      await mkdir(versionsRoot, { recursive: true, mode: 0o700 });
+      const releasePath = join(versionsRoot, desiredRelease);
+      await rm(releasePath, { recursive: true, force: true });
+      await rename(stage, releasePath);
+      await activate(agentRoot, desiredRelease);
+      const endpoint = adapterEndpoint(descriptor, releasePath, this.#nodePath);
+      return { id: descriptor.id, status: "healthy", version: descriptor.artifact.version, endpoint };
+    } catch (error) {
+      await rm(stage, { recursive: true, force: true }).catch(() => undefined);
+      const warning = `pinned update ${descriptor.artifact.version} rejected: ${messageOf(error)}`;
+      if (activeBefore != null) {
+        try {
+          await this.#requireHealthy(activeBefore.endpoint);
+          return {
+            id: descriptor.id,
+            status: "healthy",
+            version: versionFromRelease(activeBefore.release),
+            endpoint: activeBefore.endpoint,
+            preserved: true,
+            warning,
+          };
+        } catch {
+          // The prior activation exists but no longer satisfies the baseline.
+        }
+      }
+      return {
+        id: descriptor.id,
+        status: "unavailable",
+        version: descriptor.artifact.version,
+        reason: warning,
+      };
+    }
+  }
+
+  async #activeAdapterEndpoint(descriptor: AdapterAcpAgentDescriptor): Promise<AcpEndpoint> {
+    const active = await this.#readActiveEndpoint(descriptor);
+    if (active == null) {
+      throw new AcpAgentUnavailableError(descriptor.id, "no healthy pinned adapter is active");
+    }
+    return active.endpoint;
+  }
+
+  async #readActiveEndpoint(
+    descriptor: AdapterAcpAgentDescriptor,
+  ): Promise<{ readonly release: string; readonly endpoint: AcpEndpoint } | undefined> {
+    const agentRoot = join(this.#root, descriptor.id);
+    const release = await readFile(join(agentRoot, "active"), "utf8").catch(() => undefined);
+    if (release == null) return undefined;
+    const trimmed = release.trim();
+    if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) return undefined;
+    const releasePath = join(agentRoot, "versions", trimmed);
+    try {
+      await requireFile(join(releasePath, descriptor.artifact.entrypoint));
+    } catch {
+      return undefined;
+    }
+    return { release: trimmed, endpoint: adapterEndpoint(descriptor, releasePath, this.#nodePath) };
+  }
+
+  async #requireHealthy(endpoint: AcpEndpoint): Promise<void> {
+    const result = await this.#probe(endpoint);
+    if (result.protocolVersion !== 1) {
+      throw new Error(`ACP protocol v1 baseline unavailable (reported ${result.protocolVersion})`);
+    }
+    const capabilities = new Set(result.capabilities);
+    const missing = ACP_AGENT_REQUIRED_CAPABILITIES.filter((capability) => !capabilities.has(capability));
+    if (missing.length > 0) throw new Error(`missing ACP baseline capabilities: ${missing.join(", ")}`);
+  }
+
+  #descriptor(id: AcpAgentId): AcpAgentDescriptor {
+    const descriptor = this.#descriptors.find((candidate) => candidate.id === id);
+    if (descriptor == null) throw new AcpAgentUnavailableError(id, "it is not configured in the host catalog");
+    return descriptor;
+  }
+}
+
+/** Canonical host-owned catalog location; no repository path participates. */
+export function redskilledAcpAgentCatalogRoot(homeDir: string = homedir()): string {
+  return join(redskilledHomeDir(homeDir), "acp-agents");
+}
+
+function nativeEndpoint(descriptor: NativeAcpAgentDescriptor): AcpEndpoint {
+  return {
+    agent: descriptor.id,
+    transport: "stdio",
+    command: descriptor.command[0],
+    args: descriptor.command.slice(1),
+  };
+}
+
+function adapterEndpoint(
+  descriptor: AdapterAcpAgentDescriptor,
+  releasePath: string,
+  nodePath: string,
+): AcpEndpoint {
+  return {
+    agent: descriptor.id,
+    transport: "stdio",
+    command: nodePath,
+    args: [join(releasePath, descriptor.artifact.entrypoint)],
+  };
+}
+
+function releaseName(artifact: AcpAdapterArtifact): string {
+  const pin = createHash("sha256").update(artifact.integrity).digest("hex").slice(0, 12);
+  return `${artifact.version}--${pin}`;
+}
+
+function versionFromRelease(release: string): string {
+  return release.split("--", 1)[0] ?? release;
+}
+
+function requireIntegrity(bytes: Uint8Array, integrity: string): void {
+  const [algorithm, expectedText, extra] = integrity.split("-");
+  if (algorithm !== "sha512" || expectedText == null || expectedText.length === 0 || extra != null) {
+    throw new Error(`unsupported adapter integrity ${integrity}`);
+  }
+  const actual = createHash("sha512").update(bytes).digest();
+  const expected = Buffer.from(expectedText, "base64");
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+    throw new Error("adapter artifact integrity mismatch");
+  }
+}
+
+async function requireFile(path: string): Promise<void> {
+  const facts = await stat(path);
+  if (!facts.isFile()) throw new Error(`adapter entrypoint is not a file: ${basename(path)}`);
+}
+
+/** Atomic single-value pointer: structured activation metadata is not written as JSON. */
+async function activate(agentRoot: string, release: string): Promise<void> {
+  await mkdir(agentRoot, { recursive: true, mode: 0o700 });
+  const target = join(agentRoot, "active");
+  const temporary = join(dirname(target), `.active-${randomUUID()}`);
+  await writeFile(temporary, `${release}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+  try {
+    await rename(temporary, target);
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function fetchNpmArtifact(artifact: AcpAdapterArtifact): Promise<Uint8Array> {
+  const encodedPackage = encodeURIComponent(artifact.package).replace("%2F", "%2f");
+  const packageBase = artifact.package.split("/").at(-1);
+  const url = `https://registry.npmjs.org/${encodedPackage}/-/${packageBase}-${artifact.version}.tgz`;
+  const response = await fetch(url, { redirect: "error" });
+  if (!response.ok) throw new Error(`adapter registry returned HTTP ${response.status}`);
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+function assertDescriptors(descriptors: readonly AcpAgentDescriptor[]): void {
+  const seen = new Set<AcpAgentId>();
+  for (const descriptor of descriptors) {
+    if (seen.has(descriptor.id)) throw new Error(`duplicate ACP Agent descriptor: ${descriptor.id}`);
+    seen.add(descriptor.id);
+    if (descriptor.kind === "adapter") {
+      if (!/^\d+\.\d+\.\d+$/.test(descriptor.artifact.version)) {
+        throw new Error(`ACP adapter ${descriptor.id} must use an exact semantic version`);
+      }
+      if (descriptor.artifact.entrypoint.startsWith("/") || descriptor.artifact.entrypoint.includes("..")) {
+        throw new Error(`ACP adapter ${descriptor.id} has an unsafe entrypoint`);
+      }
+    }
+  }
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/redskilled/tests/acp-agent-catalog.test.ts
+++ b/apps/redskilled/tests/acp-agent-catalog.test.ts
@@ -1,0 +1,194 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ACP_AGENT_CATALOG,
+  ACP_AGENT_IDS,
+  ACP_AGENT_REQUIRED_CAPABILITIES,
+  AcpAgentCatalog,
+  AcpAgentUnavailableError,
+  type AcpAgentDescriptor,
+  type AcpEndpoint,
+} from "../src/acp-agent-catalog.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("the host-scoped ACP Agent catalog", () => {
+  it("pins the five supported Agents and keeps adapters outside the native boundary", () => {
+    expect(ACP_AGENT_IDS).toEqual(["redcode", "claude-code", "codex", "pi", "opencode"]);
+    expect(ACP_AGENT_CATALOG.map(({ id, kind }) => ({ id, kind }))).toEqual([
+      { id: "redcode", kind: "native" },
+      { id: "claude-code", kind: "adapter" },
+      { id: "codex", kind: "adapter" },
+      { id: "pi", kind: "adapter" },
+      { id: "opencode", kind: "native" },
+    ]);
+
+    expect(ACP_AGENT_CATALOG.filter((agent) => agent.kind === "native").map((agent) => agent.command)).toEqual([
+      ["redcode", "acp"],
+      ["opencode", "acp"],
+    ]);
+    for (const descriptor of ACP_AGENT_CATALOG.filter((agent) => agent.kind === "adapter")) {
+      expect(descriptor.artifact.version).toMatch(/^\d+\.\d+\.\d+$/);
+      expect(descriptor.artifact.integrity).toMatch(/^sha512-[A-Za-z0-9+/]+={0,2}$/);
+      expect(descriptor.artifact.package).not.toContain("@latest");
+    }
+  });
+
+  it("provisions every Agent only after the shared capability probe passes", async () => {
+    const root = await temporaryRoot();
+    const installed: string[] = [];
+    const catalog = new AcpAgentCatalog({
+      root,
+      fetchArtifact: async (artifact) => bytesFor(artifact.package, artifact.version),
+      installArtifact: async (_bytes, stage, descriptor) => {
+        installed.push(descriptor.id);
+        const entry = join(stage, descriptor.artifact.entrypoint);
+        await mkdir(join(entry, ".."), { recursive: true });
+        await writeFile(entry, "healthy adapter", "utf8");
+      },
+      probe: healthyProbe,
+      descriptors: descriptorsWithFixtureIntegrity(),
+    });
+
+    const result = await catalog.provisionAll();
+
+    expect(result.map(({ id, status }) => ({ id, status }))).toEqual(
+      ACP_AGENT_IDS.map((id) => ({ id, status: "healthy" })),
+    );
+    expect(installed).toEqual(["claude-code", "codex", "pi"]);
+    for (const id of ACP_AGENT_IDS) {
+      expect(await catalog.resolveForWorker(id)).toMatchObject({ agent: id, transport: "stdio" });
+    }
+  });
+
+  it("keeps the last healthy adapter active when a pinned update fails integrity", async () => {
+    const root = await temporaryRoot();
+    const initial = adapterDescriptor("pi", "1.0.0", bytesFor("pi-acp", "1.0.0"));
+    const first = catalogFor(root, initial, bytesFor("pi-acp", "1.0.0"));
+    await expect(first.provision("pi")).resolves.toMatchObject({ status: "healthy", version: "1.0.0" });
+    const prior = await first.resolveForWorker("pi");
+
+    const corrupt = adapterDescriptor("pi", "2.0.0", bytesFor("pi-acp", "2.0.0"));
+    const update = catalogFor(root, corrupt, Buffer.from("substituted bytes"));
+    const receipt = await update.provision("pi");
+
+    expect(receipt).toMatchObject({ status: "healthy", version: "1.0.0", preserved: true });
+    expect(receipt.warning).toMatch(/integrity/i);
+    expect(await update.resolveForWorker("pi")).toEqual(prior);
+  });
+
+  it("keeps the last healthy adapter active when an update misses a baseline capability", async () => {
+    const root = await temporaryRoot();
+    const initialBytes = bytesFor("pi-acp", "1.0.0");
+    const initial = adapterDescriptor("pi", "1.0.0", initialBytes);
+    const first = catalogFor(root, initial, initialBytes);
+    await first.provision("pi");
+
+    const updateBytes = bytesFor("pi-acp", "2.0.0");
+    const update = adapterDescriptor("pi", "2.0.0", updateBytes);
+    const catalog = catalogFor(root, update, updateBytes, async (endpoint) => ({
+      protocolVersion: 1,
+      capabilities: endpoint.args.some((arg) => arg.includes("2.0.0"))
+        ? ["session/new", "session/prompt"]
+        : ACP_AGENT_REQUIRED_CAPABILITIES,
+    }));
+
+    await expect(catalog.provision("pi")).resolves.toMatchObject({
+      status: "healthy",
+      version: "1.0.0",
+      preserved: true,
+      warning: expect.stringMatching(/session\/cancel/),
+    });
+  });
+
+  it("refuses an unavailable selection without routing to another Agent or leaking auth", async () => {
+    const root = await temporaryRoot();
+    const catalog = new AcpAgentCatalog({
+      root,
+      probe: async () => {
+        throw new Error("command not found");
+      },
+      descriptors: ACP_AGENT_CATALOG,
+    });
+
+    await expect(catalog.resolveForWorker("redcode")).rejects.toEqual(expect.objectContaining({
+      name: "AcpAgentUnavailableError",
+      agent: "redcode",
+      message: expect.stringMatching(/redcode.*not available.*provision/i),
+    } satisfies Partial<AcpAgentUnavailableError>));
+    await expect(catalog.resolveForWorker("opencode")).rejects.toMatchObject({ agent: "opencode" });
+
+    const endpoint = await new AcpAgentCatalog({ root, probe: healthyProbe }).resolveForWorker("redcode");
+    expect(endpoint).toEqual({ agent: "redcode", transport: "stdio", command: "redcode", args: ["acp"] });
+    expect(JSON.stringify(endpoint)).not.toMatch(/token|secret|api.?key|auth/i);
+  });
+});
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-acp-agent-catalog-"));
+  roots.push(root);
+  return root;
+}
+
+function bytesFor(packageName: string, version: string): Buffer {
+  return Buffer.from(`${packageName}@${version}`);
+}
+
+function integrityOf(bytes: Uint8Array): `sha512-${string}` {
+  return `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
+}
+
+function descriptorsWithFixtureIntegrity(): readonly AcpAgentDescriptor[] {
+  return ACP_AGENT_CATALOG.map((descriptor) => descriptor.kind === "native" ? descriptor : ({
+    ...descriptor,
+    artifact: {
+      ...descriptor.artifact,
+      integrity: integrityOf(bytesFor(descriptor.artifact.package, descriptor.artifact.version)),
+    },
+  }));
+}
+
+function adapterDescriptor(id: "pi", version: string, bytes: Uint8Array): AcpAgentDescriptor {
+  return {
+    id,
+    label: "Pi",
+    kind: "adapter",
+    artifact: {
+      package: "pi-acp",
+      version,
+      integrity: integrityOf(bytes),
+      entrypoint: "package/dist/index.js",
+    },
+  };
+}
+
+function catalogFor(
+  root: string,
+  descriptor: AcpAgentDescriptor,
+  fetched: Uint8Array,
+  probe: (endpoint: AcpEndpoint) => Promise<{ protocolVersion: number; capabilities: readonly string[] }> = healthyProbe,
+): AcpAgentCatalog {
+  return new AcpAgentCatalog({
+    root,
+    descriptors: [descriptor],
+    fetchArtifact: async () => fetched,
+    installArtifact: async (_bytes, stage, selected) => {
+      if (selected.kind !== "adapter") throw new Error("expected an adapter");
+      const entry = join(stage, selected.artifact.entrypoint);
+      await mkdir(join(entry, ".."), { recursive: true });
+      await writeFile(entry, "adapter", "utf8");
+    },
+    probe,
+  });
+}
+
+async function healthyProbe(): Promise<{ protocolVersion: number; capabilities: readonly string[] }> {
+  return { protocolVersion: 1, capabilities: ACP_AGENT_REQUIRED_CAPABILITIES };
+}


### PR DESCRIPTION
Automated AFK landing for #3911. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3911

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789426271&installation_model_id=20659&pr_number=3922&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3922&signature=09bef6cb5757950691aaaf0a8dc67e8d83080ba4addcd5269c549a4f49274ae0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->