### PR TITLE
fix: #3889 Worker replacement resumes the daemon-owned ACP session

### DIFF
--- a/apps/redskilled/src/acp-compat.ts
+++ b/apps/redskilled/src/acp-compat.ts
@@ -1,4 +1,4 @@
-import { RequestError } from "@agentclientprotocol/sdk";
+import { RequestError, type SessionNotification } from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 
 export const ACP_PROTOCOL_VERSION = 1;
@@ -28,6 +28,26 @@ export function requireSupportedV2Revision(meta: acpV2.InitializeRequest["_meta"
       `unsupported ACP v2 draft revision ${received}; expected ${ACP_V2_DRAFT_REVISION}`,
     );
   }
+}
+
+export function translateV1SessionUpdateToV2(
+  update: SessionNotification["update"],
+  messageId: string,
+): acpV2.SessionUpdate | undefined {
+  if (update.sessionUpdate === "plan") {
+    return {
+      sessionUpdate: "plan_update",
+      plan: { type: "items", planId: "primary", entries: update.entries },
+    };
+  }
+  if (update.sessionUpdate === "agent_message_chunk") {
+    return {
+      sessionUpdate: "agent_message_chunk",
+      messageId,
+      content: update.content as acpV2.ContentBlock,
+    };
+  }
+  return undefined;
 }
 
 function record(value: unknown): Record<string, unknown> | undefined {

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -29,6 +29,7 @@ import {
   REDSKILLS_WIRE_MAJOR,
   requireCompatibleWireMajor,
   requireSupportedV2Revision,
+  translateV1SessionUpdateToV2,
 } from "./acp-compat.js";
 import {
   abortableDelay,
@@ -56,6 +57,10 @@ import {
   REDSKILLED_HOST_BUDGET_METHOD,
   REDSKILLED_PROJECT_BUDGET_METHOD,
 } from "./acp-budget.js";
+import {
+  acpSessionJournalPath, createAcpSessionJournal, notifySessionRecovery, replacementRecoveryMeta,
+  sessionRecoveryFromMeta, type AcpSessionJournal, type AcpSessionRecoveryCheckpoint,
+} from "./acp-session-journal.js";
 import type { RedskilledHostState } from "./host-state.js";
 import {
   REDSKILLED_GITHUB_READ_METHOD,
@@ -86,6 +91,7 @@ import {
   cleanupWorkflowWorker,
   notifyWorkerLifecycle,
   reapWorkflowWorker,
+  requestWorkflowTurn,
   scheduleIdleCleanup,
   workflowOutcome,
   type ActiveWorkflowWorker,
@@ -125,6 +131,7 @@ export async function startRedskillsAcpControlPlane(
   const projectControlStore = createProjectControlStore(projectControlStorePath(paths.registrationIntentPath));
   const projectControls = await projectControlStore.read();
   const persistProjectControls = projectControlStore.replace.bind(projectControlStore);
+  const sessionJournal = await createAcpSessionJournal(acpSessionJournalPath(paths.registrationIntentPath));
   const workspaceFor = (identity: AcpProjectIdentity): Promise<AcpProjectWorkspace> => {
     const held = projects.get(identity.projectId);
     if (held != null) return held;
@@ -148,6 +155,7 @@ export async function startRedskillsAcpControlPlane(
       workspaceFor,
       projectControls,
       persistProjectControls,
+      sessionJournal,
     ).catch(() => socket.destroy());
   });
   await listen(server, paths.acpSocketPath);
@@ -171,6 +179,7 @@ async function servePublicConnection(
   workspaceFor: (identity: AcpProjectIdentity) => Promise<AcpProjectWorkspace>,
   projectControls: Map<string, ProjectControlState>,
   persistProjectControls: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>,
+  sessionJournal: AcpSessionJournal,
 ): Promise<void> {
   const sessions = new Map<string, PublicSession>();
   const active = new Map<string, ActiveWorkflowWorker>();
@@ -253,6 +262,7 @@ async function servePublicConnection(
       ));
       githubNotify ??= upstream.notify.bind(upstream);
       const sessionId = randomUUID();
+      await sessionJournal.create(sessionId, project);
       sessions.set(sessionId, { request: params, project });
       return {
         sessionId,
@@ -271,6 +281,7 @@ async function servePublicConnection(
       const session = sessions.get(params.sessionId);
       if (session == null) throw new Error("unknown RedSkills ACP session");
       if (busy.has(params.sessionId)) throw new Error("this RedSkills ACP session already has an active turn");
+      await sessionJournal.prompt(params.sessionId, params.prompt);
 
       const controlOperation = coreProjectOperation(params.prompt);
       if (controlOperation != null) {
@@ -287,26 +298,26 @@ async function servePublicConnection(
         } satisfies PromptResponse;
       }
 
-      let worker = active.get(params.sessionId);
-      if (worker == null) {
-        worker = await admitNativeAcpWorker(options, session, params.sessionId, upstream.notify.bind(upstream));
-        active.set(params.sessionId, worker);
-        await notifyWorkerLifecycle(worker, "admission");
-      }
-      if (worker.idleTimer != null) clearTimeout(worker.idleTimer);
       busy.add(params.sessionId);
+      let worker: ActiveWorkflowWorker | undefined;
       try {
-        if (worker.cancelled) {
-          await worker.connection.agent.notify(methods.agent.session.cancel, {
-            sessionId: worker.downstreamSessionId,
-          });
-        }
-        const response = await worker.connection.agent.request(methods.agent.session.prompt, {
-          sessionId: worker.downstreamSessionId,
-          prompt: params.prompt,
-          ...(params._meta == null ? {} : { _meta: params._meta }),
-        });
+        const turn = await requestWorkflowTurn(
+          params.sessionId,
+          active,
+          params,
+          (replacement) => admitNativeAcpWorker(
+            options,
+            sessionJournal,
+            session,
+            params.sessionId,
+            upstream.notify.bind(upstream),
+            replacement,
+          ),
+        );
+        worker = turn.worker;
+        const response = turn.response;
         const outcome = workflowOutcome(response);
+        await sessionJournal.checkpoint(params.sessionId, response, outcome);
         if (outcome != null) {
           await notifyWorkerLifecycle(worker, "terminal-outcome", outcome);
           await reapWorkflowWorker(params.sessionId, worker, active, outcome);
@@ -321,7 +332,7 @@ async function servePublicConnection(
           },
         } satisfies PromptResponse;
       } catch (error) {
-        cleanupWorkflowWorker(params.sessionId, worker, active);
+        if (worker != null) cleanupWorkflowWorker(params.sessionId, worker, active);
         throw error;
       } finally {
         busy.delete(params.sessionId);
@@ -386,6 +397,7 @@ async function servePublicConnection(
       ));
       githubNotify ??= upstream.notify.bind(upstream);
       const sessionId = randomUUID();
+      await sessionJournal.create(sessionId, project);
       sessions.set(sessionId, {
         request: {
           cwd: params.cwd,
@@ -419,16 +431,22 @@ async function servePublicConnection(
       const accepted = new Promise<void>((resolve) => setTimeout(resolve, 0));
       const controlOperation = coreProjectOperation(params.prompt);
       const turn = accepted
-        .then(() => controlOperation == null
-          ? runV2PublicTurn(options, sessions, active, params, upstream)
-          : runV2ProjectControlTurn(
-            sessions,
-            params,
-            upstream,
-            controlOperation,
-            projectControls,
-            persistProjectControls,
-          ))
+        .then(async () => {
+          await sessionJournal.prompt(
+            params.sessionId,
+            params.prompt as unknown as PromptRequest["prompt"],
+          );
+          return controlOperation == null
+            ? runV2PublicTurn(options, sessionJournal, sessions, active, params, upstream)
+            : runV2ProjectControlTurn(
+              sessions,
+              params,
+              upstream,
+              controlOperation,
+              projectControls,
+              persistProjectControls,
+            );
+        })
         .catch(() => {})
         .finally(() => v2Turns.delete(params.sessionId));
       v2Turns.set(params.sessionId, turn);
@@ -467,6 +485,7 @@ async function servePublicConnection(
 
 async function runV2PublicTurn(
   options: StartRedskillsAcpControlPlaneOptions,
+  sessionJournal: AcpSessionJournal,
   sessions: Map<string, PublicSession>,
   active: Map<string, ActiveWorkflowWorker>,
   params: acpV2.PromptRequest,
@@ -482,30 +501,36 @@ async function runV2PublicTurn(
 
   let worker: ActiveWorkflowWorker | undefined;
   try {
-    worker = active.get(params.sessionId);
-    if (worker == null) {
-      worker = await admitNativeAcpWorker(options, session, params.sessionId, async (
-        _method: typeof methods.client.session.update,
-        notice: SessionNotification,
-      ) => {
-        const update = translateV1UpdateToV2(notice.update, messageId);
-        if (update == null) return;
-        await upstream.notify(acpV2.methods.client.session.update, {
-          sessionId: params.sessionId,
-          update,
-          _meta: notice._meta,
-        });
+    const forward = async (_method: typeof methods.client.session.update, notice: SessionNotification) => {
+      const update = translateV1SessionUpdateToV2(notice.update, messageId);
+      if (update == null) return;
+      await upstream.notify(acpV2.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update,
+        _meta: notice._meta,
       });
-      active.set(params.sessionId, worker);
-      await notifyWorkerLifecycle(worker, "admission");
-    }
-    if (worker.idleTimer != null) clearTimeout(worker.idleTimer);
-    const response = await worker.connection.agent.request(methods.agent.session.prompt, {
-      sessionId: worker.downstreamSessionId,
-      prompt: params.prompt as unknown as PromptRequest["prompt"],
-      ...(params._meta == null ? {} : { _meta: params._meta }),
-    });
+    };
+    const turn = await requestWorkflowTurn(
+      params.sessionId,
+      active,
+      {
+        sessionId: params.sessionId,
+        prompt: params.prompt as unknown as PromptRequest["prompt"],
+        ...(params._meta == null ? {} : { _meta: params._meta }),
+      },
+      (replacement) => admitNativeAcpWorker(
+        options,
+        sessionJournal,
+        session,
+        params.sessionId,
+        forward,
+        replacement,
+      ),
+    );
+    worker = turn.worker;
+    const response = turn.response;
     const outcome = workflowOutcome(response);
+    await sessionJournal.checkpoint(params.sessionId, response, outcome);
     if (outcome != null) {
       await notifyWorkerLifecycle(worker, "terminal-outcome", outcome);
       await reapWorkflowWorker(params.sessionId, worker, active, outcome);
@@ -532,31 +557,13 @@ async function runV2PublicTurn(
   }
 }
 
-function translateV1UpdateToV2(
-  update: SessionNotification["update"],
-  messageId: string,
-): acpV2.SessionUpdate | undefined {
-  if (update.sessionUpdate === "plan") {
-    return {
-      sessionUpdate: "plan_update",
-      plan: { type: "items", planId: "primary", entries: update.entries },
-    };
-  }
-  if (update.sessionUpdate === "agent_message_chunk") {
-    return {
-      sessionUpdate: "agent_message_chunk",
-      messageId,
-      content: update.content as acpV2.ContentBlock,
-    };
-  }
-  return undefined;
-}
-
 async function admitNativeAcpWorker(
   options: StartRedskillsAcpControlPlaneOptions,
+  sessionJournal: AcpSessionJournal,
   session: PublicSession,
   publicSessionId: string,
   forward: AgentConnection["client"]["notify"],
+  replacement: boolean,
 ): Promise<ActiveWorkflowWorker> {
   const endpointId = randomBytes(6).toString("hex");
   const endpoint = join(options.paths.runtimeDir, "acp-workers", `${endpointId}.sock`);
@@ -595,6 +602,7 @@ async function admitNativeAcpWorker(
           },
         },
       };
+      await sessionJournal.update(publicSessionId, params.update);
       await forward(methods.client.session.update, notice);
     });
   const connection = downstreamApp.connect(socketStream(workerSocket));
@@ -606,14 +614,17 @@ async function admitNativeAcpWorker(
       _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR } },
     });
     requireCompatibleWireMajor(initialized._meta, true);
+    const recovery = replacement ? sessionJournal.recovery(publicSessionId) : undefined;
     const downstreamSession = await connection.agent.request(methods.agent.session.new, {
       cwd: session.project.workspacePath,
       mcpServers: session.request.mcpServers as McpServer[],
       ...(session.request.additionalDirectories == null
         ? {}
         : { additionalDirectories: session.request.additionalDirectories }),
+      ...(recovery == null ? {} : { _meta: replacementRecoveryMeta(session.request._meta, recovery) }),
     });
     downstreamSessionId = downstreamSession.sessionId;
+    await sessionJournal.worker(publicSessionId, launched.worker.worker_id, downstreamSessionId, replacement);
   } catch (error) {
     connection.close();
     workerSocket.destroy();
@@ -677,6 +688,7 @@ export async function runRedskillsAcpAdapter(paths: RedskilledPaths): Promise<nu
 export async function runNativeAcpWorker(socketPath: string): Promise<number> {
   const controllers = new Map<string, AbortController>();
   const sessions = new Set<string>();
+  const recoveries = new Map<string, AcpSessionRecoveryCheckpoint>();
   const app = agent({ name: "RedSkills native Worker" })
     .onRequest(methods.agent.initialize, ({ params }) => {
       requireCompatibleWireMajor(params._meta, true);
@@ -687,9 +699,11 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
         _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR, worker: true } },
       };
     })
-    .onRequest(methods.agent.session.new, () => {
+    .onRequest(methods.agent.session.new, ({ params }) => {
       const sessionId = randomUUID();
       sessions.add(sessionId);
+      const recovery = sessionRecoveryFromMeta(params._meta);
+      if (recovery != null) recoveries.set(sessionId, recovery);
       return { sessionId };
     })
     .onRequest(methods.agent.session.prompt, async ({ params, client: parent }) => {
@@ -697,6 +711,11 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
       const controller = new AbortController();
       controllers.set(params.sessionId, controller);
       try {
+        const recovery = recoveries.get(params.sessionId);
+        if (recovery != null) {
+          recoveries.delete(params.sessionId);
+          await notifySessionRecovery(parent, params.sessionId, recovery);
+        }
         await parent.notify(methods.client.session.update, {
           sessionId: params.sessionId,
           update: {

--- a/apps/redskilled/src/acp-session-journal.ts
+++ b/apps/redskilled/src/acp-session-journal.ts
@@ -1,0 +1,233 @@
+/**
+ * Durable public ACP session evidence owned by redskilled.
+ *
+ * This is deliberately not a provider transcript. It retains only inputs and
+ * updates visible at the public ACP boundary plus daemon-owned Worker pointers
+ * and completed-turn checkpoints. In particular, `agent_thought_chunk` is
+ * never admitted to the journal or to a replacement checkpoint.
+ */
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  methods,
+  type AgentConnection,
+  type NewSessionRequest,
+  type PromptRequest,
+  type PromptResponse,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import type { AcpProjectWorkspace } from "./project-workspace.js";
+
+export type AcpSessionJournalEntry =
+  | { readonly sequence: number; readonly kind: "prompt"; readonly prompt: PromptRequest["prompt"] }
+  | { readonly sequence: number; readonly kind: "plan"; readonly update: SessionNotification["update"] }
+  | {
+    readonly sequence: number;
+    readonly kind: "workflow-pointer";
+    readonly worker_id: string;
+    readonly worker_session_id: string;
+    readonly replacement: boolean;
+  }
+  | {
+    readonly sequence: number;
+    readonly kind: "checkpoint";
+    readonly stop_reason: PromptResponse["stopReason"];
+    readonly workflow_outcome?: string;
+  };
+
+type WithoutSequence<T> = T extends unknown ? Omit<T, "sequence"> : never;
+type AcpSessionJournalEntryInput = WithoutSequence<AcpSessionJournalEntry>;
+
+export interface AcpSessionJournalRecord {
+  readonly public_session_id: string;
+  readonly project_id: string;
+  readonly project_label: string;
+  readonly workspace_path: string;
+  readonly entries: readonly AcpSessionJournalEntry[];
+}
+
+interface AcpSessionJournalSnapshot {
+  readonly version: 1;
+  readonly sessions: readonly AcpSessionJournalRecord[];
+}
+
+export interface AcpSessionRecoveryCheckpoint {
+  readonly version: 1;
+  readonly source: "redskilled-public-journal";
+  readonly public_session_id: string;
+  readonly completed_turns: number;
+  readonly entries: readonly AcpSessionJournalEntry[];
+}
+
+export interface AcpSessionJournal {
+  create(publicSessionId: string, project: AcpProjectWorkspace): Promise<void>;
+  prompt(publicSessionId: string, prompt: PromptRequest["prompt"]): Promise<void>;
+  update(publicSessionId: string, update: SessionNotification["update"]): Promise<void>;
+  worker(
+    publicSessionId: string,
+    workerId: string,
+    workerSessionId: string,
+    replacement: boolean,
+  ): Promise<void>;
+  checkpoint(publicSessionId: string, response: PromptResponse, workflowOutcome?: string): Promise<void>;
+  recovery(publicSessionId: string): AcpSessionRecoveryCheckpoint;
+}
+
+export function acpSessionJournalPath(registrationIntentPath: string): string {
+  return join(dirname(registrationIntentPath), "redskilled.acp-sessions.toon");
+}
+
+export async function createAcpSessionJournal(path: string): Promise<AcpSessionJournal> {
+  const sessions = await readSnapshot(path);
+  let tail: Promise<void> = Promise.resolve();
+
+  const persist = (): Promise<void> => {
+    const snapshot: AcpSessionJournalSnapshot = { version: 1, sessions: [...sessions.values()] };
+    tail = tail.then(() => writeSnapshot(path, snapshot));
+    return tail;
+  };
+
+  const append = (publicSessionId: string, entry: AcpSessionJournalEntryInput): Promise<void> => {
+    const held = sessions.get(publicSessionId);
+    if (held == null) throw new Error("unknown durable RedSkills ACP session");
+    sessions.set(publicSessionId, {
+      ...held,
+      entries: [...held.entries, { ...entry, sequence: held.entries.length + 1 } as AcpSessionJournalEntry],
+    });
+    return persist();
+  };
+
+  return {
+    create(publicSessionId, project) {
+      sessions.set(publicSessionId, {
+        public_session_id: publicSessionId,
+        project_id: project.projectId,
+        project_label: project.projectLabel,
+        workspace_path: project.workspacePath,
+        entries: [],
+      });
+      return persist();
+    },
+    prompt(publicSessionId, prompt) {
+      return append(publicSessionId, { kind: "prompt", prompt });
+    },
+    update(publicSessionId, update) {
+      // Plans are public recovery authority. Message chunks remain public on the
+      // live wire but are not needed to reconstruct work, and thought chunks are
+      // intentionally never persisted.
+      if (update.sessionUpdate !== "plan") return Promise.resolve();
+      return append(publicSessionId, { kind: "plan", update });
+    },
+    worker(publicSessionId, workerId, workerSessionId, replacement) {
+      return append(publicSessionId, {
+        kind: "workflow-pointer",
+        worker_id: workerId,
+        worker_session_id: workerSessionId,
+        replacement,
+      });
+    },
+    checkpoint(publicSessionId, response, workflowOutcome) {
+      return append(publicSessionId, {
+        kind: "checkpoint",
+        stop_reason: response.stopReason,
+        ...(workflowOutcome == null ? {} : { workflow_outcome: workflowOutcome }),
+      });
+    },
+    recovery(publicSessionId) {
+      const held = sessions.get(publicSessionId);
+      if (held == null) throw new Error("unknown durable RedSkills ACP session");
+      return {
+        version: 1,
+        source: "redskilled-public-journal",
+        public_session_id: publicSessionId,
+        completed_turns: held.entries.filter((entry) => entry.kind === "checkpoint").length,
+        entries: [...held.entries],
+      };
+    },
+  };
+}
+
+export function replacementRecoveryMeta(
+  meta: NewSessionRequest["_meta"],
+  recovery: AcpSessionRecoveryCheckpoint,
+): NonNullable<NewSessionRequest["_meta"]> {
+  const redskills = (meta as { redskills?: object } | undefined)?.redskills ?? {};
+  return {
+    ...(meta ?? {}),
+    redskills: { ...redskills, recovery },
+  };
+}
+
+export function sessionRecoveryFromMeta(meta: NewSessionRequest["_meta"]): AcpSessionRecoveryCheckpoint | undefined {
+  const recovery = (meta as { redskills?: { recovery?: AcpSessionRecoveryCheckpoint } } | undefined)
+    ?.redskills?.recovery;
+  return recovery?.source === "redskilled-public-journal" ? recovery : undefined;
+}
+
+export async function notifySessionRecovery(
+  parent: AgentConnection["client"],
+  downstreamSessionId: string,
+  recovery: AcpSessionRecoveryCheckpoint,
+): Promise<void> {
+  const turns = recovery.completed_turns;
+  await parent.notify(methods.client.session.update, {
+    sessionId: downstreamSessionId,
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: `native Worker resumed ${turns} completed turn${turns === 1 ? "" : "s"} from the public journal\n`,
+      },
+    },
+    _meta: { redskills: { lifecycle: { event: "checkpoint-resume" } } },
+  });
+}
+
+async function readSnapshot(path: string): Promise<Map<string, AcpSessionJournalRecord>> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return new Map();
+    throw error;
+  }
+  const parsed = parseSnapshot(raw);
+  if (!isSnapshot(parsed)) return new Map();
+  return new Map(parsed.sessions.map((session) => [session.public_session_id, session]));
+}
+
+async function writeSnapshot(path: string, snapshot: AcpSessionJournalSnapshot): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(temporary, `${encode(snapshot as unknown as JsonValue)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await rename(temporary, path);
+}
+
+function parseSnapshot(raw: string): unknown {
+  const body = raw.trim();
+  if (!body) return null;
+  try {
+    return decode(body);
+  } catch {
+    return null;
+  }
+}
+
+function isSnapshot(value: unknown): value is AcpSessionJournalSnapshot {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const snapshot = value as Record<string, unknown>;
+  return snapshot.version === 1 && Array.isArray(snapshot.sessions) && snapshot.sessions.every((candidate) => {
+    if (candidate == null || typeof candidate !== "object" || Array.isArray(candidate)) return false;
+    const session = candidate as Record<string, unknown>;
+    return typeof session.public_session_id === "string" &&
+      typeof session.project_id === "string" &&
+      typeof session.project_label === "string" &&
+      typeof session.workspace_path === "string" &&
+      Array.isArray(session.entries);
+  });
+}

--- a/apps/redskilled/src/acp-worker-lifecycle.ts
+++ b/apps/redskilled/src/acp-worker-lifecycle.ts
@@ -4,6 +4,7 @@ import {
   methods,
   type AgentConnection,
   type ClientConnection,
+  type PromptRequest,
   type PromptResponse,
 } from "@agentclientprotocol/sdk";
 
@@ -71,4 +72,48 @@ export function cleanupWorkflowWorker(
   worker.connection.close();
   worker.socket.destroy();
   void rm(worker.endpoint, { force: true });
+}
+
+/** Run one public turn, replacing an unhealthy Worker at most once. */
+export async function requestWorkflowTurn(
+  publicSessionId: string,
+  active: Map<string, ActiveWorkflowWorker>,
+  params: PromptRequest,
+  admit: (replacement: boolean) => Promise<ActiveWorkflowWorker>,
+): Promise<{ readonly worker: ActiveWorkflowWorker; readonly response: PromptResponse }> {
+  let worker = active.get(publicSessionId);
+  if (worker == null) {
+    worker = await admit(false);
+    active.set(publicSessionId, worker);
+    await notifyWorkerLifecycle(worker, "admission");
+  }
+  if (worker.idleTimer != null) clearTimeout(worker.idleTimer);
+
+  const request = async (held: ActiveWorkflowWorker) => {
+    if (held.cancelled) {
+      await held.connection.agent.notify(methods.agent.session.cancel, {
+        sessionId: held.downstreamSessionId,
+      });
+    }
+    return held.connection.agent.request(methods.agent.session.prompt, {
+      sessionId: held.downstreamSessionId,
+      prompt: params.prompt,
+      ...(params._meta == null ? {} : { _meta: params._meta }),
+    });
+  };
+  try {
+    return { worker, response: await request(worker) };
+  } catch {
+    cleanupWorkflowWorker(publicSessionId, worker, active);
+  }
+
+  const replacement = await admit(true);
+  active.set(publicSessionId, replacement);
+  await notifyWorkerLifecycle(replacement, "replacement");
+  try {
+    return { worker: replacement, response: await request(replacement) };
+  } catch (error) {
+    cleanupWorkflowWorker(publicSessionId, replacement, active);
+    throw error;
+  }
 }

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -4,7 +4,7 @@ import { createServer, type Server } from "node:http";
 import { createRequire } from "node:module";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { Readable, Writable } from "node:stream";
 import {
   client,
@@ -13,6 +13,7 @@ import {
   type SessionNotification,
   type Stream,
 } from "@agentclientprotocol/sdk";
+import { decode } from "@reddb-io/toon";
 import { afterEach, describe, expect, it } from "vitest";
 import { socketAnswers } from "../src/daemon.js";
 import { readRedskilledEvents } from "../src/event-lane.js";
@@ -34,6 +35,96 @@ afterEach(async () => {
 });
 
 describe("the public RedSkills ACP v1 control plane", () => {
+  it("replaces a dead Worker and resumes the same public session from its observable journal", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-acp-replacement-"));
+    roots.push(root);
+    const env = {
+      ...process.env,
+      HOME: root,
+      XDG_RUNTIME_DIR: root,
+      REDSKILLED_MACHINE_DIR: root,
+      REDSKILLED_PLACEMENT: "off",
+      REDSKILLED_SESSION: `test:${root}`,
+    };
+    const paths = resolveRedskilledPaths({ env, homeDir: root });
+    const daemon = launchCli([
+      "serve",
+      "--socket", paths.socketPath,
+      "--lease", paths.leasePath,
+      "--events", paths.eventLanePath,
+      "--machine-claim", paths.machineClaimPath,
+      "--idle-ms", "60000",
+    ], env, ["ignore", "ignore", "pipe"]);
+    await waitFor(() => socketAnswers(paths.socketPath, 1_000), "redskilled daemon socket");
+
+    const adapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
+    const updates: SessionNotification[] = [];
+    const acpClient = client({ name: "redskilled-acp-replacement-test" })
+      .onNotification(methods.client.session.update, ({ params }) => {
+        updates.push(params);
+      });
+    const connection = acpClient.connect(childStream(adapter));
+    await connection.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "redskilled-replacement-client", version: "1" },
+    });
+    const session = await connection.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
+    const first = await connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "begin durable workflow" }],
+    });
+    const firstBirth = await waitForEvent(paths.eventLanePath, "worker-birth", workerId(first._meta));
+
+    process.kill(firstBirth.pid, "SIGKILL");
+    await waitForEvent(paths.eventLanePath, "worker-death", firstBirth.worker_id);
+    updates.length = 0;
+
+    const continued = await connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "continue durable workflow" }],
+    });
+    expect(continued.stopReason).toBe("end_turn");
+    expect(workerId(continued._meta)).not.toBe(firstBirth.worker_id);
+    expect(updates.map(lifecycleEvent).filter(Boolean)).toEqual([
+      "replacement",
+      "checkpoint-resume",
+      "tool-activity",
+    ]);
+    expect(new Set(updates.map((update) => update.sessionId))).toEqual(new Set([session.sessionId]));
+    expect(updates.filter(agentText).map(agentText).join("\n")).toContain("resumed 1 completed turn");
+
+    const journalPath = join(dirname(paths.registrationIntentPath), "redskilled.acp-sessions.toon");
+    const journal = decode(await readFile(journalPath, "utf8")) as unknown as {
+      version: number;
+      sessions: Array<{
+        public_session_id: string;
+        entries: Array<{ kind: string }>;
+        provider_transcript?: unknown;
+      }>;
+    };
+    const durable = journal.sessions.find((entry) => entry.public_session_id === session.sessionId);
+    expect(journal.version).toBe(1);
+    expect(durable?.entries.map((entry) => entry.kind)).toEqual([
+      "prompt",
+      "workflow-pointer",
+      "plan",
+      "plan",
+      "checkpoint",
+      "prompt",
+      "workflow-pointer",
+      "plan",
+      "plan",
+      "checkpoint",
+    ]);
+    expect(durable).not.toHaveProperty("provider_transcript");
+    expect(JSON.stringify(durable)).not.toMatch(/chain[-_ ]of[-_ ]thought|agent_thought/i);
+
+    connection.close();
+    adapter.stdin?.end();
+    daemon.kill("SIGTERM");
+  }, 30_000);
+
   it("reuses one bounded Workflow Worker across related turns and reaps every terminal outcome", async () => {
     const root = await mkdtemp(join(tmpdir(), "redskilled-acp-control-plane-"));
     roots.push(root);
@@ -444,6 +535,11 @@ function workerId(meta: unknown): string {
 function lifecycleEvent(update: SessionNotification): string | undefined {
   return (update._meta as { redskills?: { lifecycle?: { event?: string } } } | undefined)
     ?.redskills?.lifecycle?.event;
+}
+
+function agentText(update: SessionNotification): string {
+  if (update.update.sessionUpdate !== "agent_message_chunk" || update.update.content.type !== "text") return "";
+  return update.update.content.text;
 }
 
 function git(cwd: string, ...args: string[]): void {


### PR DESCRIPTION
Automated AFK landing for #3889. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3889

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789426607&installation_model_id=20659&pr_number=3923&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3923&signature=8e9f00a3c25e2d1780744160b5f48fd543dc18ddae6c0046e6000d28115bc7ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->