### PR TITLE
merge: #3843 Re-seed measurement: rounds per landed Ticket in the Envelope

### DIFF
--- a/.changeset/reseed-measurement.md
+++ b/.changeset/reseed-measurement.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Record Re-seed rounds as a durable measurement in Worker state and terminal Envelopes.

--- a/apps/dev/src/core/envelope-emit.ts
+++ b/apps/dev/src/core/envelope-emit.ts
@@ -108,6 +108,8 @@ export interface SectionBodies {
   appraisal?: string;
   /** Resolved worker base ref/sha evidence (issue #1380). */
   base?: string;
+  /** Aggregatable Re-seed rounds/cause fact for a landed Worker (#3843). */
+  reseed?: string;
   /** One `<lifecycle> <command> exit=<rc>` line per user-declared hook that ran
    * (issue #215). Empty/undefined skips the section. Excluded on `discarded`. */
   hooks?: string;
@@ -146,6 +148,7 @@ export function buildSections(
   if (status === "done") {
     if (sections.appraisal !== undefined) out.push({ name: "appraisal", body: sections.appraisal });
     if (sections.validation !== undefined) out.push({ name: "validation", body: sections.validation });
+    if (sections.reseed !== undefined) out.push({ name: "reseed", body: sections.reseed, fenced: true, fenceLang: "toon" });
     if (sections.base !== undefined) out.push({ name: "base", body: sections.base });
   } else if (status === "blocked") {
     out.push({ name: "notes", body: sections.notes ?? "" });

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -772,10 +772,8 @@ export async function processIssue(
     deps.lookups.worktreeDiff !== undefined &&
     // /go direct-PR skips review; /go no-mistakes and /afk run it.
     (!isGoLane || isPrePrPipelineActive(input.runMode, input.laneLabel));
-  // ONE budget for every Re-seed this Worker may spend (ADR 0129): the lane
-  // supplies the ceiling and the review's reservation, the operator's configured
-  // counter supplies only the gate's share. A tier escalation therefore draws
-  // its own round instead of muting gate correction outright.
+  // ONE budget covers every Re-seed this Worker may spend (ADR 0129), including
+  // independent tier-escalation draws and the gate/review shares.
   const reseedBudget = withGateSubCap(
     resolveReseedBudget({
       laneLabel: input.laneLabel,
@@ -792,9 +790,7 @@ export async function processIssue(
   // the composition itself always starts from the ORIGINAL handoff, which is
   // what keeps the prompt flat while the state inside it accumulates.
   let reseedOutstanding: ReseedOutstanding = EMPTY_RESEED_OUTSTANDING;
-  /** Rounds re-seeded so far. Distinct from `roundOrdinal`, which also counts
-   * the recovery re-runs a crashed agent buys — those are not Re-seed rounds and
-   * must not read as budget spent. */
+  /** Re-seed rounds, excluding recovery re-runs counted by `roundOrdinal`. */
   let reseedRound = 0;
   /** Compose the re-seeded prompt from the original handoff plus the current
    * outstanding state, and report the round in one history line. */

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -170,6 +170,7 @@ import {
   withoutReviewOutstanding,
 } from "./reseed-handoff.js";
 import { decideTierEscalation } from "./tier-escalation.js";
+import { reseedMeasurementFact } from "./reseed-measurement.js";
 import { failureSignature, parseValidationFailureSignature } from "../failure-signature.js";
 import type { BaseMovement } from "../stale-base-drift.js";
 import {
@@ -784,6 +785,7 @@ export async function processIssue(
     isGoLane ? goVerifyRetryCap : afkGateCap,
   );
   let reseedSpend: ReseedSpend = {};
+  deps.markState?.({ "current.reseed": reseedMeasurementFact(reseedSpend) });
   const gateSubCap = reseedBudget.subCaps.gate;
   // What is outstanding RIGHT NOW (ADR 0129 decision 7, #2728). It survives
   // across rounds so a gate round that follows a blocking review carries BOTH;
@@ -897,6 +899,7 @@ export async function processIssue(
     const draw = reseedDraw(reseedBudget, cause, reseedSpend);
     if (!draw.allowed) return "refused";
     reseedSpend = recordReseedDraw(reseedSpend, cause);
+    deps.markState?.({ "current.reseed": reseedMeasurementFact(reseedSpend) });
     roundOrdinal += 1;
     reseedRound += 1;
     const gate = req.gate ?? "feedback";
@@ -2009,6 +2012,7 @@ export async function processIssue(
       lastValidationScope,
       noSourceDiffWarning,
       appraisalScore,
+      reseedMeasurementFact(reseedSpend),
     );
     await recordOutcomeBestEffort(common, "done", { durationS });
     markLandingPhase("close", { step: "close-issue", status: "start" });

--- a/apps/dev/src/core/process-issue/reseed-measurement.ts
+++ b/apps/dev/src/core/process-issue/reseed-measurement.ts
@@ -1,0 +1,50 @@
+import { encode, type JsonValue } from "@reddb-io/toon";
+import { RESEED_CAUSES, type ReseedCause, type ReseedSpend } from "./reseed-budget.js";
+
+export interface ReseedMeasurementFact {
+  readonly version: 1;
+  readonly rounds: number;
+  readonly by_cause: Readonly<Record<ReseedCause, number>>;
+}
+
+export interface ReseedMeasurementAggregate {
+  readonly workers: number;
+  readonly rounds: number;
+  readonly by_cause: Readonly<Record<ReseedCause, number>>;
+}
+
+function measuredRounds(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : 0;
+}
+
+/** Freeze the Worker's in-memory budget spend into a stable Envelope/state fact. */
+export function reseedMeasurementFact(spend: ReseedSpend): ReseedMeasurementFact {
+  const byCause = Object.fromEntries(
+    RESEED_CAUSES.map((cause) => [cause, measuredRounds(spend[cause])]),
+  ) as Record<ReseedCause, number>;
+  return {
+    version: 1,
+    rounds: RESEED_CAUSES.reduce((sum, cause) => sum + byCause[cause], 0),
+    by_cause: byCause,
+  };
+}
+
+/** Aggregate already-recorded Worker facts without reconstructing lifecycle events. */
+export function aggregateReseedMeasurements(
+  facts: readonly ReseedMeasurementFact[],
+): ReseedMeasurementAggregate {
+  const byCause: Record<ReseedCause, number> = { gate: 0, tier: 0, review: 0 };
+  for (const fact of facts) {
+    for (const cause of RESEED_CAUSES) byCause[cause] += measuredRounds(fact.by_cause[cause]);
+  }
+  return {
+    workers: facts.length,
+    rounds: RESEED_CAUSES.reduce((sum, cause) => sum + byCause[cause], 0),
+    by_cause: byCause,
+  };
+}
+
+/** TOON is the repository's structured Envelope wire format. */
+export function renderReseedMeasurement(fact: ReseedMeasurementFact): string {
+  return encode(fact as unknown as JsonValue);
+}

--- a/apps/dev/src/core/process-issue/terminal-envelope.ts
+++ b/apps/dev/src/core/process-issue/terminal-envelope.ts
@@ -3,6 +3,7 @@ import type { AttemptStatus } from "../envelope.js";
 import { formatValidationScope, type ValidationScope } from "../validation-scope.js";
 import type { ProcessIssueDeps, ProcessIssueInput, WorkerBaseResolution } from "./types.js";
 import { formatBaseResolution } from "./types.js";
+import { renderReseedMeasurement, type ReseedMeasurementFact } from "./reseed-measurement.js";
 
 /** The terminal-stage state needed to assemble an Envelope. */
 export interface EnvelopeStage {
@@ -50,6 +51,7 @@ export async function emitDone(
   validationScope?: ValidationScope,
   validationNotice?: string,
   appraisalScore?: number,
+  reseed?: ReseedMeasurementFact,
 ): Promise<boolean> {
   const { deps, input } = c;
   const scopeHeader = validationScope ? `${formatValidationScope(validationScope)}\n` : "";
@@ -68,6 +70,7 @@ export async function emitDone(
     sections: {
       ...(appraisalScore === undefined ? {} : { appraisal: `Score: ${appraisalScore}` }),
       validation: validationBody,
+      ...(reseed === undefined ? {} : { reseed: renderReseedMeasurement(reseed) }),
       ...(c.resolvedBase ? { base: formatBaseResolution(c.resolvedBase) } : {}),
     },
     historyPath: deps.historyPath,

--- a/apps/dev/src/types/state.ts
+++ b/apps/dev/src/types/state.ts
@@ -120,6 +120,17 @@ export const AfkCurrentSchema = z.object({
    * the existing `output_tokens` heartbeat counter for the report surface. */
   output_shaping_variant: z.string().default(""),
   output_shaping_enabled: z.boolean().default(false),
+  /** Re-seed rounds spent by this Worker, retained as an aggregatable fact for
+   * landed-Ticket experiments. Zero is an observed result, never absence. */
+  reseed: z.object({
+    version: z.literal(1).default(1),
+    rounds: z.number().int().nonnegative().default(0),
+    by_cause: z.object({
+      gate: z.number().int().nonnegative().default(0),
+      tier: z.number().int().nonnegative().default(0),
+      review: z.number().int().nonnegative().default(0),
+    }).default({ gate: 0, tier: 0, review: 0 }),
+  }).default({ version: 1, rounds: 0, by_cause: { gate: 0, tier: 0, review: 0 } }),
   /** What the ORCHESTRATOR is blocked on, when it is blocked on something that
    * spawns no child and writes nothing — today the two host-wide gate locks
    * (#2985). Empty means "not blocked". Without it a worker waiting up to an

--- a/apps/dev/tests/reseed-measurement.test.ts
+++ b/apps/dev/tests/reseed-measurement.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { aggregateReseedMeasurements, reseedMeasurementFact } from "../src/core/process-issue/reseed-measurement.js";
+import { harness, processIssue } from "./process-issue.test-helpers.js";
+
+describe("Re-seed measurement fact (#3843)", () => {
+  it("records two rounds in the landed Worker's state and Envelope", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackResults: [false, false, true],
+      reseedGateBudget: 3,
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.statePatches).toContainEqual({
+      "current.reseed": {
+        version: 1,
+        rounds: 2,
+        by_cause: { gate: 2, tier: 0, review: 0 },
+      },
+    });
+    const envelope = trace.envelopeBodies.at(-1) ?? "";
+    expect(envelope).toContain('<details data-section="reseed">');
+    expect(envelope).toContain("rounds: 2");
+    expect(envelope).toContain("gate: 2");
+  });
+
+  it("aggregates Worker fixtures by cause", () => {
+    const aggregate = aggregateReseedMeasurements([
+      reseedMeasurementFact({ gate: 2 }),
+      reseedMeasurementFact({ tier: 1, review: 1 }),
+      reseedMeasurementFact({ gate: 1, review: 1 }),
+    ]);
+
+    expect(aggregate).toEqual({
+      workers: 3,
+      rounds: 6,
+      by_cause: { gate: 3, tier: 1, review: 2 },
+    });
+  });
+});


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3843 -->
🤖 **Re-seed trail** — #3843 on `afk/3843-re-seed-measurement-rounds-per-landed-ti`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3843; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3843 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/dev`]
{"schema":"red.afk.validation.v1","name":"feedback:pnpm -C apps/dev test:invariants","status":"failed","command":"pnpm -C apps/dev test:invariants","exitCode":1,"durationMs":51,"summary":"failing: FAIL tests/file-size-guard.test.ts > file-size ratchet — a split nothing enforces is a split that comes back > holds the live tree to the threshold and the shrink-only baseline —  - Array [] + Array [ +   Object { +     \"kind\": \"over-baseline\", +     \"lines\": 2244, +     \"path\": \"apps/dev/src/core/process-issue/lifecycle.ts\", +     \"reason\": \"apps/dev/src/core/process-issue/lifecycle.ts grew from 2240 to 2244 lines. The baseline is shrink-only: lower the number as the file is decomposed, never raise it.\", +   }, + ]   ❯ tests/file-size-guard.test.ts:46:7      44|         : `file-size ratchet: ${findings.length} finding(s).\\n${render…      45|           `Baseline: apps/dev/src/core/file-size-guard.ts (FILE_SIZE_B…      46|     ).toEqual([]);        |       ^      47|   });      48|   ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯","resources":{"source":"cgroup-v2","sampled_before":"2026-08-15T23:09:14.793Z","sampled_after":"2026-08-15T23:10:05.848Z","memory_current_before_bytes":254926848,"memory_current_after_bytes":258277376,"memory_peak_bytes":2480549888,"memory_max_bytes":2736193536,"cpu_usage_delta_usec":56901185,"cpu_throttled_delta_usec":0,"pids_peak":214,"memory_events_delta":{},"pids_events_delta":{}}}
Verdict: mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted.
```

Closes #3843