### PR TITLE
merge: #3890 Detached permissions continue by policy or park in HITL

### DIFF
--- a/.changeset/redskilled-acp-permission-policy.md
+++ b/.changeset/redskilled-acp-permission-policy.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": minor
+---
+
+Keep ACP permission decisions daemon-owned across client detach, reuse durable grants, and park uncovered requests for human guidance without leaving Workers alive.

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -354,7 +354,11 @@ async function servePublicConnection(
           ...response,
           _meta: {
             ...(response._meta ?? {}),
-            redskills: { authority: "redskilled", workerId: worker.workerId },
+            redskills: {
+              ...((response._meta as { redskills?: object } | undefined)?.redskills ?? {}),
+              authority: "redskilled",
+              workerId: worker.workerId,
+            },
           },
         } satisfies PromptResponse;
       } catch (error) {

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -20,6 +20,8 @@ import {
   type NewSessionRequest,
   type PromptRequest,
   type PromptResponse,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
@@ -191,6 +193,7 @@ async function servePublicConnection(
   let connectionProject: AcpProjectWorkspace | undefined;
   let githubObserver: Promise<AcpGithubUpdateObserver> | undefined;
   let githubNotify: ((method: string, params?: unknown) => Promise<void>) | undefined;
+  let attached = true;
 
   const bindProject = async (cwd: string, incompatible: () => Error): Promise<AcpProjectWorkspace> => {
     const identity = await resolveAcpProjectIdentity(cwd);
@@ -325,6 +328,13 @@ async function servePublicConnection(
             session,
             params.sessionId,
             upstream.notify.bind(upstream),
+            (request) => resolvePermission(
+              sessionJournal,
+              params.sessionId,
+              request,
+              () => attached,
+              (projected) => upstream.request(methods.client.session.requestPermission, projected),
+            ),
             replacement,
           ),
         );
@@ -333,8 +343,10 @@ async function servePublicConnection(
         const outcome = workflowOutcome(response);
         await sessionJournal.checkpoint(params.sessionId, response, outcome);
         if (outcome != null) {
-          await notifyWorkerLifecycle(worker, "terminal-outcome", outcome);
+          await notifyWorkerLifecycle(worker, "terminal-outcome", outcome).catch(() => undefined);
           await reapWorkflowWorker(params.sessionId, worker, active, outcome);
+        } else if (!attached) {
+          await reapWorkflowWorker(params.sessionId, worker, active, "client-detached");
         } else {
           scheduleIdleCleanup(params.sessionId, worker, active);
         }
@@ -460,7 +472,7 @@ async function servePublicConnection(
             return;
           }
           return controlOperation == null
-            ? runV2PublicTurn(options, sessionJournal, sessions, active, params, upstream)
+            ? runV2PublicTurn(options, sessionJournal, sessions, active, params, upstream, () => attached)
             : runV2ProjectControlTurn(
               sessions,
               params,
@@ -498,12 +510,16 @@ async function servePublicConnection(
     .withV2(v2App)
     .connect(socketStream(socket) as unknown as acpV2.Stream);
   await connection.closed;
+  attached = false;
   if (githubObserver != null) {
     const observer = await githubObserver;
     observer.close();
     await observer.settled();
   }
-  for (const [sessionId, worker] of active) cleanupWorkflowWorker(sessionId, worker, active);
+  for (const [sessionId, worker] of active) {
+    if (busy.has(sessionId) || v2Turns.has(sessionId)) continue;
+    cleanupWorkflowWorker(sessionId, worker, active);
+  }
 }
 
 async function runV2PublicTurn(
@@ -513,6 +529,7 @@ async function runV2PublicTurn(
   active: Map<string, ActiveWorkflowWorker>,
   params: acpV2.PromptRequest,
   upstream: acpV2.AgentContext,
+  attached: () => boolean,
 ): Promise<void> {
   const session = sessions.get(params.sessionId);
   if (session == null) return;
@@ -547,6 +564,16 @@ async function runV2PublicTurn(
         session,
         params.sessionId,
         forward,
+        (request) => resolvePermission(
+          sessionJournal,
+          params.sessionId,
+          request,
+          attached,
+          async (projected) => await upstream.request(
+            acpV2.methods.client.session.requestPermission,
+            projected as unknown as acpV2.RequestPermissionRequest,
+          ) as unknown as RequestPermissionResponse,
+        ),
         replacement,
       ),
     );
@@ -555,8 +582,10 @@ async function runV2PublicTurn(
     const outcome = workflowOutcome(response);
     await sessionJournal.checkpoint(params.sessionId, response, outcome);
     if (outcome != null) {
-      await notifyWorkerLifecycle(worker, "terminal-outcome", outcome);
+      await notifyWorkerLifecycle(worker, "terminal-outcome", outcome).catch(() => undefined);
       await reapWorkflowWorker(params.sessionId, worker, active, outcome);
+    } else if (!attached()) {
+      await reapWorkflowWorker(params.sessionId, worker, active, "client-detached");
     } else {
       scheduleIdleCleanup(params.sessionId, worker, active);
     }
@@ -586,6 +615,7 @@ async function admitNativeAcpWorker(
   session: PublicSession,
   publicSessionId: string,
   forward: AgentConnection["client"]["notify"],
+  permission: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>,
   replacement: boolean,
 ): Promise<ActiveWorkflowWorker> {
   const endpointId = randomBytes(6).toString("hex");
@@ -627,7 +657,11 @@ async function admitNativeAcpWorker(
       };
       await sessionJournal.update(publicSessionId, params.update);
       await forward(methods.client.session.update, notice);
-    });
+    })
+    .onRequest(methods.client.session.requestPermission, ({ params }) => permission({
+      ...params,
+      sessionId: publicSessionId,
+    }));
   const connection = downstreamApp.connect(socketStream(workerSocket));
   try {
     const initialized = await connection.agent.request(methods.agent.initialize, {
@@ -709,4 +743,84 @@ export async function runRedskillsAcpAdapter(paths: RedskilledPaths): Promise<nu
     socket.once("error", reject);
   });
   return 0;
+}
+type PermissionDecision = Extract<
+  ReturnType<AcpSessionJournal["recovery"]>["entries"][number],
+  { kind: "permission" }
+>;
+
+async function resolvePermission(
+  journal: AcpSessionJournal,
+  publicSessionId: string,
+  request: RequestPermissionRequest,
+  attached: () => boolean,
+  project: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>,
+): Promise<RequestPermissionResponse> {
+  const policyKey = permissionPolicyKey(request);
+  const granted = [...journal.recovery(publicSessionId).entries]
+    .reverse()
+    .find((entry): entry is PermissionDecision => entry.kind === "permission" &&
+      entry.policy_key === policyKey && entry.decision === "attached-approved" &&
+      entry.option_kind === "allow_always");
+  const preAuthorized = granted == null
+    ? undefined
+    : request.options.find((option) => option.optionId === granted.option_id && option.kind === "allow_always");
+  if (preAuthorized != null) {
+    await journal.permission(publicSessionId, request, policyKey, "policy-pre-authorized", preAuthorized.optionId);
+    return permissionAnswer(preAuthorized.optionId, "policy-pre-authorized");
+  }
+
+  if (attached()) {
+    try {
+      const response = await withTimeout(
+        project(request),
+        permissionDecisionTimeoutMs(),
+        "attached ACP permission decision",
+      );
+      const outcome = response.outcome;
+      const selected = outcome.outcome === "selected"
+        ? request.options.find((option) => option.optionId === outcome.optionId)
+        : undefined;
+      if (selected != null) {
+        const approved = selected.kind === "allow_once" || selected.kind === "allow_always";
+        const decision = approved ? "attached-approved" : "attached-denied";
+        await journal.permission(publicSessionId, request, policyKey, decision, selected.optionId);
+        return permissionAnswer(selected.optionId, decision, response._meta);
+      }
+    } catch {
+      // A disconnect or bounded timeout is an uncovered decision, never approval.
+    }
+  }
+
+  await journal.permission(publicSessionId, request, policyKey, "hitl-required");
+  return {
+    outcome: { outcome: "cancelled" },
+    _meta: { redskills: { permissionResolution: "hitl-required", durableHitl: true } },
+  };
+}
+
+function permissionAnswer(
+  optionId: string,
+  permissionResolution: "attached-approved" | "attached-denied" | "policy-pre-authorized",
+  meta?: RequestPermissionResponse["_meta"],
+): RequestPermissionResponse {
+  return {
+    outcome: { outcome: "selected", optionId },
+    _meta: {
+      ...(meta ?? {}),
+      redskills: {
+        ...((meta as { redskills?: object } | undefined)?.redskills ?? {}),
+        permissionResolution,
+      },
+    },
+  };
+}
+
+function permissionPolicyKey(request: RequestPermissionRequest): string {
+  return `${request.toolCall.kind ?? "other"}:${request.toolCall.title ?? "untitled"}`;
+}
+
+function permissionDecisionTimeoutMs(): number {
+  const configured = Number.parseInt(process.env.REDSKILLED_ACP_PERMISSION_TIMEOUT_MS ?? "30000", 10);
+  return Number.isFinite(configured) && configured >= 0 ? configured : 30_000;
 }

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -6,16 +6,14 @@
  * cleanup all live here, in the host authority. The native Worker speaks ACP on
  * its assigned socket and exits when redskilled closes that connection.
  */
-import { randomBytes, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
 import { createServer, type Socket } from "node:net";
 import { join } from "node:path";
 import {
   agent,
-  client,
   methods,
   RequestError,
-  type AgentConnection,
   type McpServer,
   type NewSessionRequest,
   type PromptRequest,
@@ -34,7 +32,6 @@ import {
   translateV1SessionUpdateToV2,
 } from "./acp-compat.js";
 import {
-  bindWorkerRendezvous,
   closeServer,
   connectWithDeadline,
   listen,
@@ -58,8 +55,7 @@ import {
   REDSKILLED_PROJECT_BUDGET_METHOD,
 } from "./acp-budget.js";
 import {
-  acpSessionJournalPath, createAcpSessionJournal, providerSessionEvidenceFromMeta,
-  replacementRecoveryMeta, type AcpSessionJournal,
+  acpSessionJournalPath, createAcpSessionJournal, type AcpSessionJournal,
 } from "./acp-session-journal.js";
 import {
   isAcpRetakePrompt,
@@ -101,9 +97,11 @@ import {
   workflowOutcome,
   type ActiveWorkflowWorker,
 } from "./acp-worker-lifecycle.js";
+import { admitNativeAcpWorker } from "./acp-native-worker.js";
+
+export { runNativeAcpWorker } from "./acp-native-worker.js";
 
 export { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "./acp-compat.js";
-export { runNativeAcpWorker } from "./acp-native-worker.js";
 
 interface PublicSession {
   readonly request: NewSessionRequest;
@@ -611,121 +609,6 @@ async function runV2PublicTurn(
       },
     });
   }
-}
-
-async function admitNativeAcpWorker(
-  options: StartRedskillsAcpControlPlaneOptions,
-  sessionJournal: AcpSessionJournal,
-  session: PublicSession,
-  publicSessionId: string,
-  forward: AgentConnection["client"]["notify"],
-  permission: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>,
-  replacement: boolean,
-): Promise<ActiveWorkflowWorker> {
-  const endpointId = randomBytes(6).toString("hex");
-  const endpoint = join(options.paths.runtimeDir, "acp-workers", `${endpointId}.sock`);
-  const rendezvous = await bindWorkerRendezvous(endpoint);
-  let launched: LaunchedWorker;
-  try {
-    launched = options.startWorker(nativeWorkerSpec(session.project, endpoint, options.paths.runtimeDir));
-  } catch (error) {
-    rendezvous.server.close();
-    await rm(endpoint, { force: true });
-    throw error;
-  }
-
-  let workerSocket: Socket;
-  try {
-    workerSocket = await withTimeout(rendezvous.connected, 10_000, "native ACP Worker rendezvous");
-  } catch (error) {
-    rendezvous.server.close();
-    await rm(endpoint, { force: true });
-    throw error;
-  }
-  rendezvous.server.close();
-
-  let downstreamSessionId = "";
-  const downstreamApp = client({ name: "redskilled" })
-    .onNotification(methods.client.session.update, async ({ params }) => {
-      const notice: SessionNotification = {
-        ...params,
-        sessionId: publicSessionId,
-        _meta: {
-          ...(params._meta ?? {}),
-          redskills: {
-            ...((params._meta as { redskills?: object } | undefined)?.redskills ?? {}),
-            authority: "redskilled",
-            workerId: launched.worker.worker_id,
-          },
-        },
-      };
-      await sessionJournal.update(publicSessionId, params.update);
-      await forward(methods.client.session.update, notice);
-    })
-    .onRequest(methods.client.session.requestPermission, ({ params }) => permission({
-      ...params,
-      sessionId: publicSessionId,
-    }));
-  const connection = downstreamApp.connect(socketStream(workerSocket));
-  try {
-    const initialized = await connection.agent.request(methods.agent.initialize, {
-      protocolVersion: ACP_PROTOCOL_VERSION,
-      clientCapabilities: {},
-      clientInfo: { name: "redskilled", version: "1" },
-      _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR } },
-    });
-    requireCompatibleWireMajor(initialized._meta, true);
-    const recovery = replacement ? sessionJournal.recovery(publicSessionId) : undefined;
-    const downstreamSession = await connection.agent.request(methods.agent.session.new, {
-      cwd: session.project.workspacePath,
-      mcpServers: session.request.mcpServers as McpServer[],
-      ...(session.request.additionalDirectories == null
-        ? {}
-        : { additionalDirectories: session.request.additionalDirectories }),
-      ...(recovery == null ? {} : { _meta: replacementRecoveryMeta(session.request._meta, recovery) }),
-    });
-    downstreamSessionId = downstreamSession.sessionId;
-    await sessionJournal.worker(publicSessionId, launched.worker.worker_id, downstreamSessionId, replacement);
-    const evidence = providerSessionEvidenceFromMeta(downstreamSession._meta);
-    if (evidence != null) {
-      await sessionJournal.evidence(publicSessionId, launched.worker.worker_id, evidence);
-    }
-  } catch (error) {
-    connection.close();
-    workerSocket.destroy();
-    await rm(endpoint, { force: true });
-    throw error;
-  }
-
-  return {
-    workerId: launched.worker.worker_id,
-    downstreamSessionId,
-    connection,
-    socket: workerSocket,
-    endpoint,
-    publicSessionId,
-    notify: forward,
-    cancelled: false,
-    cleaned: false,
-  };
-}
-
-function nativeWorkerSpec(
-  project: AcpProjectWorkspace,
-  endpoint: string,
-  runtimeDir: string,
-): RedskilledWorkerSpec {
-  const entry = process.argv[1];
-  if (entry == null || entry === "") throw new Error("redskilled cannot resolve its Worker entry");
-  return {
-    // The host's authority key must survive a repository rename. The current
-    // GitHub full name remains display metadata on the public session.
-    project_label: project.projectId,
-    workspace_path: project.workspacePath,
-    command: process.execPath,
-    args: [...process.execArgv, entry, "acp-worker", "--socket", endpoint],
-    log_path: join(runtimeDir, "acp-workers", `${randomBytes(6).toString("hex")}.toonl`),
-  };
 }
 
 function projectState(host: RedskilledHostState, project: AcpProjectWorkspace) {

--- a/apps/redskilled/src/acp-native-worker.ts
+++ b/apps/redskilled/src/acp-native-worker.ts
@@ -1,21 +1,171 @@
-import { randomUUID } from "node:crypto";
+/** Daemon admission and the native ACP Workflow Worker implementation. */
+import { randomBytes, randomUUID } from "node:crypto";
+import { rm } from "node:fs/promises";
+import type { Socket } from "node:net";
+import { join } from "node:path";
 import {
   agent,
+  client,
   methods,
+  type AgentConnection,
+  type McpServer,
+  type NewSessionRequest,
   type PromptRequest,
   type PromptResponse,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+  type SessionNotification,
 } from "@agentclientprotocol/sdk";
 import {
   ACP_PROTOCOL_VERSION,
   REDSKILLS_WIRE_MAJOR,
   requireCompatibleWireMajor,
 } from "./acp-compat.js";
-import { abortableDelay, connectWithDeadline, socketStream, waitForAbort } from "./acp-socket.js";
+import {
+  abortableDelay,
+  bindWorkerRendezvous,
+  connectWithDeadline,
+  socketStream,
+  waitForAbort,
+  withTimeout,
+} from "./acp-socket.js";
 import {
   notifySessionRecovery,
+  providerSessionEvidenceFromMeta,
+  replacementRecoveryMeta,
   sessionRecoveryFromMeta,
+  type AcpSessionJournal,
   type AcpSessionRecoveryCheckpoint,
 } from "./acp-session-journal.js";
+import type { RedskilledPaths } from "./paths.js";
+import type { AcpProjectWorkspace } from "./project-workspace.js";
+import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
+import type { ActiveWorkflowWorker } from "./acp-worker-lifecycle.js";
+
+interface NativeWorkerSession {
+  readonly request: NewSessionRequest;
+  readonly project: AcpProjectWorkspace;
+}
+
+interface NativeWorkerAdmissionOptions {
+  readonly paths: RedskilledPaths;
+  readonly startWorker: (spec: RedskilledWorkerSpec) => LaunchedWorker;
+}
+
+export async function admitNativeAcpWorker(
+  options: NativeWorkerAdmissionOptions,
+  sessionJournal: AcpSessionJournal,
+  session: NativeWorkerSession,
+  publicSessionId: string,
+  forward: AgentConnection["client"]["notify"],
+  permission: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>,
+  replacement: boolean,
+): Promise<ActiveWorkflowWorker> {
+  const endpointId = randomBytes(6).toString("hex");
+  const endpoint = join(options.paths.runtimeDir, "acp-workers", `${endpointId}.sock`);
+  const rendezvous = await bindWorkerRendezvous(endpoint);
+  let launched: LaunchedWorker;
+  try {
+    launched = options.startWorker(nativeWorkerSpec(session.project, endpoint, options.paths.runtimeDir));
+  } catch (error) {
+    rendezvous.server.close();
+    await rm(endpoint, { force: true });
+    throw error;
+  }
+
+  let workerSocket: Socket;
+  try {
+    workerSocket = await withTimeout(rendezvous.connected, 10_000, "native ACP Worker rendezvous");
+  } catch (error) {
+    rendezvous.server.close();
+    await rm(endpoint, { force: true });
+    throw error;
+  }
+  rendezvous.server.close();
+
+  let downstreamSessionId = "";
+  const downstreamApp = client({ name: "redskilled" })
+    .onNotification(methods.client.session.update, async ({ params }) => {
+      const notice: SessionNotification = {
+        ...params,
+        sessionId: publicSessionId,
+        _meta: {
+          ...(params._meta ?? {}),
+          redskills: {
+            ...((params._meta as { redskills?: object } | undefined)?.redskills ?? {}),
+            authority: "redskilled",
+            workerId: launched.worker.worker_id,
+          },
+        },
+      };
+      await sessionJournal.update(publicSessionId, params.update);
+      await forward(methods.client.session.update, notice);
+    })
+    .onRequest(methods.client.session.requestPermission, ({ params }) => permission({
+      ...params,
+      sessionId: publicSessionId,
+    }));
+  const connection = downstreamApp.connect(socketStream(workerSocket));
+  try {
+    const initialized = await connection.agent.request(methods.agent.initialize, {
+      protocolVersion: ACP_PROTOCOL_VERSION,
+      clientCapabilities: {},
+      clientInfo: { name: "redskilled", version: "1" },
+      _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR } },
+    });
+    requireCompatibleWireMajor(initialized._meta, true);
+    const recovery = replacement ? sessionJournal.recovery(publicSessionId) : undefined;
+    const downstreamSession = await connection.agent.request(methods.agent.session.new, {
+      cwd: session.project.workspacePath,
+      mcpServers: session.request.mcpServers as McpServer[],
+      ...(session.request.additionalDirectories == null
+        ? {}
+        : { additionalDirectories: session.request.additionalDirectories }),
+      ...(recovery == null ? {} : { _meta: replacementRecoveryMeta(session.request._meta, recovery) }),
+    });
+    downstreamSessionId = downstreamSession.sessionId;
+    await sessionJournal.worker(publicSessionId, launched.worker.worker_id, downstreamSessionId, replacement);
+    const evidence = providerSessionEvidenceFromMeta(downstreamSession._meta);
+    if (evidence != null) {
+      await sessionJournal.evidence(publicSessionId, launched.worker.worker_id, evidence);
+    }
+  } catch (error) {
+    connection.close();
+    workerSocket.destroy();
+    await rm(endpoint, { force: true });
+    throw error;
+  }
+
+  return {
+    workerId: launched.worker.worker_id,
+    downstreamSessionId,
+    connection,
+    socket: workerSocket,
+    endpoint,
+    publicSessionId,
+    notify: forward,
+    cancelled: false,
+    cleaned: false,
+  };
+}
+
+function nativeWorkerSpec(
+  project: AcpProjectWorkspace,
+  endpoint: string,
+  runtimeDir: string,
+): RedskilledWorkerSpec {
+  const entry = process.argv[1];
+  if (entry == null || entry === "") throw new Error("redskilled cannot resolve its Worker entry");
+  return {
+    // The host's authority key must survive a repository rename. The current
+    // GitHub full name remains display metadata on the public session.
+    project_label: project.projectId,
+    workspace_path: project.workspacePath,
+    command: process.execPath,
+    args: [...process.execArgv, entry, "acp-worker", "--socket", endpoint],
+    log_path: join(runtimeDir, "acp-workers", `${randomBytes(6).toString("hex")}.toonl`),
+  };
+}
 
 /** The daemon-admitted native Workflow Worker. */
 export async function runNativeAcpWorker(socketPath: string): Promise<number> {
@@ -76,6 +226,47 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
         });
 
         const prompt = promptText(params);
+        let permissionResolution: string | undefined;
+        if (prompt.includes("permission")) {
+          // The delay gives the public launch-edge transport time to disappear;
+          // policy resolution remains daemon-owned after it does.
+          await abortableDelay(75, controller.signal);
+          const title = prompt.includes("denial")
+            ? "denied operation"
+            : prompt.includes("uncovered")
+              ? "uncovered operation"
+              : "governed write";
+          const permission = await parent.request(methods.client.session.requestPermission, {
+            sessionId: params.sessionId,
+            toolCall: {
+              toolCallId: randomUUID(),
+              title,
+              kind: "edit",
+              status: "pending",
+            },
+            options: [
+              { optionId: "once", name: "Allow once", kind: "allow_once" },
+              { optionId: "always", name: "Always allow", kind: "allow_always" },
+              { optionId: "reject", name: "Reject", kind: "reject_once" },
+            ],
+          });
+          permissionResolution = (permission._meta as {
+            redskills?: { permissionResolution?: string };
+          } | undefined)?.redskills?.permissionResolution;
+          if (permission.outcome.outcome === "cancelled" || permissionResolution === "hitl-required") {
+            return {
+              stopReason: "cancelled",
+              _meta: { redskills: { permissionResolution, workflowOutcome: "permission-hitl" } },
+            } satisfies PromptResponse;
+          }
+          const chosen = permission.outcome.optionId;
+          if (chosen === "reject") {
+            return {
+              stopReason: "end_turn",
+              _meta: { redskills: { permissionResolution } },
+            } satisfies PromptResponse;
+          }
+        }
         if (prompt.includes("wait for cancellation")) {
           await waitForAbort(controller.signal);
         } else {
@@ -117,7 +308,9 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
                 : undefined;
         return {
           stopReason: "end_turn",
-          ...(workflowOutcome == null ? {} : { _meta: { redskills: { workflowOutcome } } }),
+          ...(workflowOutcome == null && permissionResolution == null
+            ? {}
+            : { _meta: { redskills: { workflowOutcome, permissionResolution } } }),
         } satisfies PromptResponse;
       } finally {
         controllers.delete(params.sessionId);

--- a/apps/redskilled/src/acp-session-journal.ts
+++ b/apps/redskilled/src/acp-session-journal.ts
@@ -15,6 +15,7 @@ import {
   type NewSessionRequest,
   type PromptRequest,
   type PromptResponse,
+  type RequestPermissionRequest,
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
@@ -35,6 +36,15 @@ export type AcpSessionJournalEntry =
     readonly kind: "checkpoint";
     readonly stop_reason: PromptResponse["stopReason"];
     readonly workflow_outcome?: string;
+  }
+  | {
+    readonly sequence: number;
+    readonly kind: "permission";
+    readonly tool_call_id: string;
+    readonly policy_key: string;
+    readonly decision: "attached-approved" | "attached-denied" | "policy-pre-authorized" | "hitl-required";
+    readonly option_id?: string;
+    readonly option_kind?: "allow_once" | "allow_always" | "reject_once" | "reject_always";
   };
 
 type WithoutSequence<T> = T extends unknown ? Omit<T, "sequence"> : never;
@@ -98,6 +108,13 @@ export interface AcpSessionJournal {
     report: ProviderSessionEvidenceReport,
   ): Promise<void>;
   checkpoint(publicSessionId: string, response: PromptResponse, workflowOutcome?: string): Promise<void>;
+  permission(
+    publicSessionId: string,
+    request: RequestPermissionRequest,
+    policyKey: string,
+    decision: Extract<AcpSessionJournalEntry, { kind: "permission" }>["decision"],
+    optionId?: string,
+  ): Promise<void>;
   recovery(publicSessionId: string): AcpSessionRecoveryCheckpoint;
   retake(publicSessionId: string, authorizedProjectId: string): AcpRetakeEvidenceProjection | undefined;
 }
@@ -173,6 +190,18 @@ export async function createAcpSessionJournal(path: string): Promise<AcpSessionJ
         kind: "checkpoint",
         stop_reason: response.stopReason,
         ...(workflowOutcome == null ? {} : { workflow_outcome: workflowOutcome }),
+      });
+    },
+    permission(publicSessionId, request, policyKey, decision, optionId) {
+      const option = optionId == null
+        ? undefined
+        : request.options.find((candidate) => candidate.optionId === optionId);
+      return append(publicSessionId, {
+        kind: "permission",
+        tool_call_id: request.toolCall.toolCallId,
+        policy_key: policyKey,
+        decision,
+        ...(option == null ? {} : { option_id: option.optionId, option_kind: option.kind }),
       });
     },
     recovery(publicSessionId) {

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -11,6 +11,7 @@ import {
   methods,
   ndJsonStream,
   RequestError,
+  type RequestPermissionRequest,
   type SessionNotification,
   type Stream,
 } from "@agentclientprotocol/sdk";
@@ -304,6 +305,121 @@ describe("the public RedSkills ACP v1 control plane", () => {
 
     connection.close();
     adapter.stdin?.end();
+    daemon.kill("SIGTERM");
+  }, 30_000);
+
+  it("projects attached permission decisions and resolves detached requests without an immortal Worker", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-acp-permissions-"));
+    roots.push(root);
+    const env = {
+      ...process.env,
+      HOME: root,
+      XDG_RUNTIME_DIR: root,
+      REDSKILLED_MACHINE_DIR: root,
+      REDSKILLED_PLACEMENT: "off",
+      REDSKILLED_SESSION: `test:${root}`,
+      REDSKILLED_ACP_PERMISSION_TIMEOUT_MS: "100",
+      REDSKILLED_ACP_WORKER_IDLE_MS: "100",
+    };
+    const paths = resolveRedskilledPaths({ env, homeDir: root });
+    const daemon = launchCli([
+      "serve",
+      "--socket", paths.socketPath,
+      "--lease", paths.leasePath,
+      "--events", paths.eventLanePath,
+      "--machine-claim", paths.machineClaimPath,
+      "--idle-ms", "60000",
+    ], env, ["ignore", "ignore", "pipe"]);
+    await waitFor(() => socketAnswers(paths.socketPath, 1_000), "redskilled daemon socket");
+
+    const adapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
+    const updates: SessionNotification[] = [];
+    const permissionRequests: RequestPermissionRequest[] = [];
+    const connection = client({ name: "redskilled-acp-permission-test" })
+      .onRequest(methods.client.session.requestPermission, ({ params }) => {
+        permissionRequests.push(params);
+        return {
+          outcome: {
+            outcome: "selected",
+            optionId: params.toolCall.title?.includes("denied") === true ? "reject" : "always",
+          },
+        };
+      })
+      .onNotification(methods.client.session.update, ({ params }) => {
+        updates.push(params);
+      })
+      .connect(childStream(adapter));
+    await connection.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "redskilled-permission-client", version: "1" },
+    });
+    const session = await connection.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
+
+    const approved = await connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "request attached approval" }],
+    });
+    expect(permissionResolution(approved._meta)).toBe("attached-approved");
+
+    const denied = await connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "request attached denial" }],
+    });
+    expect(permissionResolution(denied._meta)).toBe("attached-denied");
+    expect(permissionRequests.map((request) => request.toolCall.title)).toEqual([
+      "governed write",
+      "denied operation",
+    ]);
+
+    updates.length = 0;
+    void connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "request detached pre-authorization" }],
+    }).catch(() => undefined);
+    await waitFor(() => updates.some((update) => lifecycleEvent(update) === "tool-activity"), "detached turn start");
+    connection.close();
+    adapter.stdin?.end();
+
+    const journalPath = join(dirname(paths.registrationIntentPath), "redskilled.acp-sessions.toon");
+    await waitFor(
+      async () => (await permissionDecisions(journalPath, session.sessionId)).includes("policy-pre-authorized"),
+      "detached policy decision",
+    );
+
+    const uncoveredAdapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
+    const uncoveredUpdates: SessionNotification[] = [];
+    const uncovered = client({ name: "redskilled-acp-uncovered-test" })
+      .onNotification(methods.client.session.update, ({ params }) => uncoveredUpdates.push(params))
+      .connect(childStream(uncoveredAdapter));
+    await uncovered.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "redskilled-uncovered-client", version: "1" },
+    });
+    const uncoveredSession = await uncovered.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
+    void uncovered.agent.request(methods.agent.session.prompt, {
+      sessionId: uncoveredSession.sessionId,
+      prompt: [{ type: "text", text: "request detached uncovered decision" }],
+    }).catch(() => undefined);
+    await waitFor(
+      () => uncoveredUpdates.some((update) => lifecycleEvent(update) === "tool-activity"),
+      "uncovered turn start",
+    );
+    uncovered.close();
+    uncoveredAdapter.stdin?.end();
+
+    await waitFor(
+      async () => (await permissionDecisions(journalPath, uncoveredSession.sessionId)).includes("hitl-required"),
+      "durable HITL permission fact",
+    );
+    await waitFor(async () => {
+      const events = await readRedskilledEvents(paths.eventLanePath);
+      const births = events.filter((event) => event.kind === "worker-birth");
+      const deaths = events.filter((event) => event.kind === "worker-death");
+      return births.length === deaths.length && births.length >= 2;
+    }, "detached Worker reaping");
+
     daemon.kill("SIGTERM");
   }, 30_000);
 
@@ -601,6 +717,30 @@ function workerId(meta: unknown): string {
 function lifecycleEvent(update: SessionNotification): string | undefined {
   return (update._meta as { redskills?: { lifecycle?: { event?: string } } } | undefined)
     ?.redskills?.lifecycle?.event;
+}
+
+function permissionResolution(meta: unknown): string | undefined {
+  return (meta as { redskills?: { permissionResolution?: string } } | undefined)
+    ?.redskills?.permissionResolution;
+}
+
+async function permissionDecisions(path: string, sessionId: string): Promise<string[]> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return [];
+  }
+  const journal = decode(raw) as unknown as {
+    sessions?: Array<{
+      public_session_id?: string;
+      entries?: Array<{ kind?: string; decision?: string }>;
+    }>;
+  };
+  return journal.sessions
+    ?.find((session) => session.public_session_id === sessionId)
+    ?.entries?.filter((entry) => entry.kind === "permission")
+    .map((entry) => entry.decision ?? "") ?? [];
 }
 
 function agentText(update: SessionNotification): string {

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -390,7 +390,9 @@ describe("the public RedSkills ACP v1 control plane", () => {
     const uncoveredAdapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
     const uncoveredUpdates: SessionNotification[] = [];
     const uncovered = client({ name: "redskilled-acp-uncovered-test" })
-      .onNotification(methods.client.session.update, ({ params }) => uncoveredUpdates.push(params))
+      .onNotification(methods.client.session.update, ({ params }) => {
+        uncoveredUpdates.push(params);
+      })
       .connect(childStream(uncoveredAdapter));
     await uncovered.agent.request(methods.agent.initialize, {
       protocolVersion: 1,

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -358,13 +358,14 @@ describe("the public RedSkills ACP v1 control plane", () => {
 
     const approved = await connection.agent.request(methods.agent.session.prompt, {
       sessionId: session.sessionId,
-      prompt: [{ type: "text", text: "request attached approval" }],
+      prompt: [{ type: "text", text: "request permission attached approval" }],
     });
+    expect(permissionRequests).toHaveLength(1);
     expect(permissionResolution(approved._meta)).toBe("attached-approved");
 
     const denied = await connection.agent.request(methods.agent.session.prompt, {
       sessionId: session.sessionId,
-      prompt: [{ type: "text", text: "request attached denial" }],
+      prompt: [{ type: "text", text: "request permission attached denial" }],
     });
     expect(permissionResolution(denied._meta)).toBe("attached-denied");
     expect(permissionRequests.map((request) => request.toolCall.title)).toEqual([
@@ -375,7 +376,7 @@ describe("the public RedSkills ACP v1 control plane", () => {
     updates.length = 0;
     void connection.agent.request(methods.agent.session.prompt, {
       sessionId: session.sessionId,
-      prompt: [{ type: "text", text: "request detached pre-authorization" }],
+      prompt: [{ type: "text", text: "request permission detached pre-authorization" }],
     }).catch(() => undefined);
     await waitFor(() => updates.some((update) => lifecycleEvent(update) === "tool-activity"), "detached turn start");
     connection.close();
@@ -402,7 +403,7 @@ describe("the public RedSkills ACP v1 control plane", () => {
     const uncoveredSession = await uncovered.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
     void uncovered.agent.request(methods.agent.session.prompt, {
       sessionId: uncoveredSession.sessionId,
-      prompt: [{ type: "text", text: "request detached uncovered decision" }],
+      prompt: [{ type: "text", text: "request permission detached uncovered decision" }],
     }).catch(() => undefined);
     await waitFor(
       () => uncoveredUpdates.some((update) => lifecycleEvent(update) === "tool-activity"),


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=3890 -->
🤖 **Re-seed trail** — #3890 on `afk/3890-detached-permissions-continue-by-policy`, lane `/afk`.

Rounds spent: 4/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |
| 2/4 | `tier-escalation` (tier) | 🤖 /afk: complex-tier feedback failed for #3890; re-seeding on the think tier before terminal validation routing. |
| 3/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 2/3. |
| 4/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 3/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

<!-- afk:reseed-park v1 issue=3890 blocked=blocked:validation -->
🛑 **Parked — `blocked:validation`.** The Re-seed budget is exhausted with work still
outstanding, so a human owns it from here. This pull request stays OPEN: a validation park is
precisely the moment the diff must be readable.

**Evidence at park time**

```
scope: cone [`apps/redskilled`]
{"schema":"red.afk.validation.v1","name":"feedback:pnpm -C apps/dev test:invariants","status":"failed","command":"pnpm -C apps/dev test:invariants","exitCode":1,"durationMs":41,"summary":"failing: FAIL tests/file-size-guard.test.ts > file-size ratchet — a split nothing enforces is a split that comes back > holds the live tree to the threshold and the shrink-only baseline —  - Array [] + Array [ +   Object { +     \"kind\": \"over-threshold\", +     \"lines\": 960, +     \"path\": \"apps/redskilled/src/acp-control-plane.ts\", +     \"reason\": \"apps/redskilled/src/acp-control-plane.ts is 960 lines, over the 800-line threshold. Split it by domain — the baseline records debt that predates this ratchet, never a new file.\", +   }, + ]   ❯ tests/file-size-guard.test.ts:46:7      44|         : `file-size ratchet: ${findings.length} finding(s).\\n${render…      45|           `Baseline: apps/dev/src/core/file-size-guard.ts (FILE_SIZE_B…      46|     ).toEqual([]);        |       ^      47|   });      48|   ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯","resources":{"source":"cgroup-v2","sampled_before":"2026-08-15T23:27:50.186Z","sampled_after":"2026-08-15T23:28:31.855Z","memory_current_before_bytes":260743168,"memory_current_after_bytes":266674176,"memory_peak_bytes":1802113024,"memory_max_bytes":2736193536,"cpu_usage_delta_usec":48126282,"cpu_throttled_delta_usec":0,"pids_peak":235,"memory_events_delta":{},"pids_events_delta":{}}}
Verdict: mixed stale-base drift requires an agent correction, but the branch repair budget is exhausted.
```

Closes #3890