### PR TITLE
fix: #3924 ACP Worker replacement retries only objectively dead transports

### DIFF
--- a/apps/redskilled/src/acp-worker-lifecycle.ts
+++ b/apps/redskilled/src/acp-worker-lifecycle.ts
@@ -74,6 +74,11 @@ export function cleanupWorkflowWorker(
   void rm(worker.endpoint, { force: true });
 }
 
+function workerTransportIsClosed(worker: ActiveWorkflowWorker): boolean {
+  return worker.socket.destroyed || worker.socket.readableEnded || worker.socket.writableEnded ||
+    !worker.socket.readable || !worker.socket.writable;
+}
+
 /** Run one public turn, replacing an unhealthy Worker at most once. */
 export async function requestWorkflowTurn(
   publicSessionId: string,
@@ -103,7 +108,11 @@ export async function requestWorkflowTurn(
   };
   try {
     return { worker, response: await request(worker) };
-  } catch {
+  } catch (error) {
+    if (!workerTransportIsClosed(worker)) {
+      scheduleIdleCleanup(publicSessionId, worker, active);
+      throw error;
+    }
     cleanupWorkflowWorker(publicSessionId, worker, active);
   }
 

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -2,7 +2,7 @@ import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import { createRequire } from "node:module";
-import type { AddressInfo } from "node:net";
+import { Socket, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { Readable, Writable } from "node:stream";
@@ -10,6 +10,7 @@ import {
   client,
   methods,
   ndJsonStream,
+  RequestError,
   type SessionNotification,
   type Stream,
 } from "@agentclientprotocol/sdk";
@@ -18,6 +19,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { socketAnswers } from "../src/daemon.js";
 import { readRedskilledEvents } from "../src/event-lane.js";
 import { resolveRedskilledPaths } from "../src/paths.js";
+import { requestWorkflowTurn, type ActiveWorkflowWorker } from "../src/acp-worker-lifecycle.js";
 
 const require_ = createRequire(import.meta.url);
 const tsxLoader = require_.resolve("tsx");
@@ -32,6 +34,50 @@ afterEach(async () => {
   }
   for (const server of servers.splice(0)) await new Promise<void>((resolve) => server.close(() => resolve()));
   for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("ACP Workflow Worker replacement authority", () => {
+  it("does not replace or replay when a live Worker returns a semantic ACP error", async () => {
+    const publicSessionId = "public-session";
+    const semanticError = RequestError.invalidRequest("the live Worker refused this prompt");
+    let promptRequests = 0;
+    let replacementAdmissions = 0;
+    const worker = {
+      workerId: "worker-one",
+      downstreamSessionId: "downstream-session",
+      connection: {
+        agent: {
+          request: async () => {
+            promptRequests += 1;
+            throw semanticError;
+          },
+        },
+        close: () => undefined,
+      },
+      socket: new Socket(),
+      endpoint: "unused-test-endpoint",
+      publicSessionId,
+      notify: async () => undefined,
+      cancelled: false,
+      cleaned: false,
+    } as unknown as ActiveWorkflowWorker;
+    const active = new Map([[publicSessionId, worker]]);
+
+    await expect(requestWorkflowTurn(
+      publicSessionId,
+      active,
+      { sessionId: publicSessionId, prompt: [{ type: "text", text: "perform one semantic request" }] },
+      async () => {
+        replacementAdmissions += 1;
+        throw new Error("a healthy Worker must not be replaced");
+      },
+    )).rejects.toBe(semanticError);
+
+    expect(promptRequests).toBe(1);
+    expect(replacementAdmissions).toBe(0);
+    expect(active.get(publicSessionId)).toBe(worker);
+    expect(worker.cleaned).toBe(false);
+  });
 });
 
 describe("the public RedSkills ACP v1 control plane", () => {


### PR DESCRIPTION
Automated AFK landing for #3924. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3924

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789428055&installation_model_id=20659&pr_number=3928&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3928&signature=39a2bc48bc7f979942cd83c9794c0b79ce18e16c7462c4c3baa35229236670c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->