### PR TITLE
fix: #3891 Worker delegates to a child ACP Agent within its budget

### DIFF
--- a/apps/redskilled/src/acp-child-agent.ts
+++ b/apps/redskilled/src/acp-child-agent.ts
@@ -1,0 +1,199 @@
+/** Worker-owned ACP Client for one governed child coding Agent. */
+import { spawn, type ChildProcess } from "node:child_process";
+import { Readable, Writable } from "node:stream";
+import {
+  client,
+  methods,
+  ndJsonStream,
+  type AgentConnection,
+  type ClientConnection,
+  type McpServer,
+  type PromptRequest,
+  type PromptResponse,
+  type RequestPermissionResponse,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk";
+import type { AcpEndpoint } from "./acp-agent-catalog.js";
+import { ACP_PROTOCOL_VERSION, REDSKILLS_WIRE_MAJOR } from "./acp-compat.js";
+
+export interface ChildAgentSessionOptions {
+  readonly endpoint: AcpEndpoint;
+  readonly cwd: string;
+  readonly mcpServers: readonly McpServer[];
+  readonly additionalDirectories?: readonly string[];
+  readonly publicSessionId: string;
+  readonly parent: AgentConnection["client"];
+}
+
+interface ActiveChildAgent {
+  readonly child: ChildProcess;
+  readonly connection: ClientConnection;
+  readonly sessionId: string;
+  cleaned: boolean;
+}
+
+const DELEGATION_SCOPE = {
+  authority: "parent-worker",
+  budget: "parent-remaining",
+  cancellation: "parent-mediated",
+  permissions: "parent-mediated",
+} as const;
+
+/** One Workflow Worker may retain one child Agent, but never replace it more than once per turn. */
+export class WorkflowChildAgent {
+  readonly #options: ChildAgentSessionOptions;
+  #active: ActiveChildAgent | undefined;
+
+  constructor(options: ChildAgentSessionOptions) {
+    this.#options = options;
+  }
+
+  async prompt(params: PromptRequest): Promise<PromptResponse> {
+    let attempts = 1;
+    let active = this.#active ?? await this.#admit("child-admission");
+    try {
+      const response = await this.#request(active, params);
+      if (response.stopReason === "cancelled") this.#cleanup(active);
+      return childResponse(response, this.#options.endpoint.agent, attempts);
+    } catch (error) {
+      if (!childTransportIsClosed(active)) throw error;
+      this.#cleanup(active);
+    }
+
+    attempts += 1;
+    active = await this.#admit("child-replacement");
+    try {
+      const response = await this.#request(active, params);
+      if (response.stopReason === "cancelled") this.#cleanup(active);
+      return childResponse(response, this.#options.endpoint.agent, attempts);
+    } catch (error) {
+      this.#cleanup(active);
+      await this.#lifecycle("child-failure");
+      throw error;
+    }
+  }
+
+  async cancel(meta?: PromptRequest["_meta"]): Promise<void> {
+    const active = this.#active;
+    if (active == null) return;
+    await active.connection.agent.notify(methods.agent.session.cancel, {
+      sessionId: active.sessionId,
+      ...(meta == null ? {} : { _meta: meta }),
+    });
+  }
+
+  close(): void {
+    if (this.#active != null) this.#cleanup(this.#active);
+  }
+
+  async #admit(event: "child-admission" | "child-replacement"): Promise<ActiveChildAgent> {
+    const endpoint = this.#options.endpoint;
+    const child = spawn(endpoint.command, endpoint.args, {
+      cwd: this.#options.cwd,
+      env: process.env,
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    if (child.stdin == null || child.stdout == null) throw new Error("child ACP Agent did not expose stdio");
+
+    const app = client({ name: "RedSkills Workflow Worker" })
+      .onNotification(methods.client.session.update, ({ params }) => this.#options.parent.notify(
+        methods.client.session.update,
+        publicNotice(params, this.#options.publicSessionId, endpoint.agent),
+      ))
+      .onRequest(methods.client.session.requestPermission, ({ params }) => this.#options.parent.request(
+        methods.client.session.requestPermission,
+        { ...params, sessionId: this.#options.publicSessionId },
+      ) as Promise<RequestPermissionResponse>);
+    const connection = app.connect(ndJsonStream(
+      Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+      Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+    ));
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: ACP_PROTOCOL_VERSION,
+        clientCapabilities: {},
+        clientInfo: { name: "RedSkills Workflow Worker", version: "1" },
+        _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR } },
+      });
+      const session = await connection.agent.request(methods.agent.session.new, {
+        cwd: this.#options.cwd,
+        mcpServers: [...this.#options.mcpServers],
+        ...(this.#options.additionalDirectories == null
+          ? {}
+          : { additionalDirectories: [...this.#options.additionalDirectories] }),
+        _meta: { redskills: { delegation: DELEGATION_SCOPE } },
+      });
+      const active = { child, connection, sessionId: session.sessionId, cleaned: false };
+      this.#active = active;
+      await this.#lifecycle(event);
+      return active;
+    } catch (error) {
+      connection.close();
+      child.kill();
+      throw error;
+    }
+  }
+
+  #request(active: ActiveChildAgent, params: PromptRequest): Promise<PromptResponse> {
+    return active.connection.agent.request(methods.agent.session.prompt, {
+      sessionId: active.sessionId,
+      prompt: params.prompt,
+      _meta: {
+        ...(params._meta ?? {}),
+        redskills: {
+          ...((params._meta as { redskills?: object } | undefined)?.redskills ?? {}),
+          delegation: DELEGATION_SCOPE,
+        },
+      },
+    });
+  }
+
+  #cleanup(active: ActiveChildAgent): void {
+    if (active.cleaned) return;
+    active.cleaned = true;
+    if (this.#active === active) this.#active = undefined;
+    active.connection.close();
+    if (active.child.exitCode == null && active.child.signalCode == null) active.child.kill();
+  }
+
+  #lifecycle(event: string): Promise<void> {
+    return this.#options.parent.notify(methods.client.session.update, {
+      sessionId: this.#options.publicSessionId,
+      update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "" } },
+      _meta: { redskills: { lifecycle: { event, agent: this.#options.endpoint.agent } } },
+    });
+  }
+}
+
+function publicNotice(params: SessionNotification, sessionId: string, agent: string): SessionNotification {
+  return {
+    ...params,
+    sessionId,
+    _meta: {
+      ...(params._meta ?? {}),
+      redskills: {
+        ...((params._meta as { redskills?: object } | undefined)?.redskills ?? {}),
+        childAgent: agent,
+      },
+    },
+  };
+}
+
+function childResponse(response: PromptResponse, agent: string, attempts: number): PromptResponse {
+  return {
+    ...response,
+    _meta: {
+      ...(response._meta ?? {}),
+      redskills: {
+        ...((response._meta as { redskills?: object } | undefined)?.redskills ?? {}),
+        childAgent: agent,
+        childAttempts: attempts,
+      },
+    },
+  };
+}
+
+function childTransportIsClosed(active: ActiveChildAgent): boolean {
+  return active.child.exitCode != null || active.child.signalCode != null ||
+    active.child.stdin?.destroyed === true || active.child.stdout?.destroyed === true;
+}

--- a/apps/redskilled/src/acp-native-worker.ts
+++ b/apps/redskilled/src/acp-native-worker.ts
@@ -1,8 +1,9 @@
 /** Daemon admission and the native ACP Workflow Worker implementation. */
 import { randomBytes, randomUUID } from "node:crypto";
+import { constants, accessSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import type { Socket } from "node:net";
-import { join } from "node:path";
+import { delimiter, isAbsolute, join } from "node:path";
 import {
   agent,
   client,
@@ -16,6 +17,8 @@ import {
   type RequestPermissionResponse,
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
+import { ACP_AGENT_CATALOG, type AcpEndpoint } from "./acp-agent-catalog.js";
+import { WorkflowChildAgent } from "./acp-child-agent.js";
 import {
   ACP_PROTOCOL_VERSION,
   REDSKILLS_WIRE_MAJOR,
@@ -182,21 +185,68 @@ function nativeWorkerSpec(
 ): RedskilledWorkerSpec {
   const entry = process.argv[1];
   if (entry == null || entry === "") throw new Error("redskilled cannot resolve its Worker entry");
+  const childAgent = pinChildAgentExecutable(defaultChildAgentEndpoint());
   return {
     // The host's authority key must survive a repository rename. The current
     // GitHub full name remains display metadata on the public session.
     project_label: project.projectId,
     workspace_path: project.workspacePath,
     command: process.execPath,
-    args: [...process.execArgv, entry, "acp-worker", "--socket", endpoint],
+    args: [
+      ...process.execArgv,
+      entry,
+      "acp-worker",
+      "--socket", endpoint,
+      "--child-agent", childAgent.agent,
+      "--child-command", childAgent.command,
+      ...childAgent.args.flatMap((arg) => ["--child-arg", arg]),
+    ],
     log_path: join(runtimeDir, "acp-workers", `${randomBytes(6).toString("hex")}.toonl`),
   };
 }
 
+function pinChildAgentExecutable(endpoint: AcpEndpoint): AcpEndpoint {
+  if (isAbsolute(endpoint.command) || endpoint.command.includes("/") || endpoint.command.includes("\\")) {
+    return endpoint;
+  }
+  const extensions = process.platform === "win32"
+    ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";")
+    : [""];
+  for (const directory of (process.env.PATH ?? "").split(delimiter)) {
+    if (directory === "") continue;
+    for (const extension of extensions) {
+      const candidate = join(directory, `${endpoint.command}${extension}`);
+      try {
+        accessSync(candidate, constants.X_OK);
+        return { ...endpoint, command: candidate };
+      } catch {
+        // Try the next host PATH entry; child launch still accounts for total absence.
+      }
+    }
+  }
+  return endpoint;
+}
+
+function defaultChildAgentEndpoint(): AcpEndpoint {
+  const descriptor = ACP_AGENT_CATALOG.find(({ id }) => id === "redcode");
+  if (descriptor == null || descriptor.kind !== "native") {
+    throw new Error("the governed Redcode child ACP endpoint is not configured");
+  }
+  return {
+    agent: descriptor.id,
+    transport: "stdio",
+    command: descriptor.command[0],
+    args: descriptor.command.slice(1),
+  };
+}
+
 /** The daemon-admitted native Workflow Worker. */
-export async function runNativeAcpWorker(socketPath: string): Promise<number> {
+export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpEndpoint): Promise<number> {
   const controllers = new Map<string, AbortController>();
-  const sessions = new Set<string>();
+  const sessions = new Map<string, {
+    readonly request: NewSessionRequest;
+    child?: WorkflowChildAgent;
+  }>();
   const recoveries = new Map<string, AcpSessionRecoveryCheckpoint>();
   const app = agent({ name: "RedSkills native Worker" })
     .onRequest(methods.agent.initialize, ({ params }) => {
@@ -210,7 +260,7 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
     })
     .onRequest(methods.agent.session.new, ({ params }) => {
       const sessionId = randomUUID();
-      sessions.add(sessionId);
+      sessions.set(sessionId, { request: params });
       const recovery = sessionRecoveryFromMeta(params._meta);
       if (recovery != null) recoveries.set(sessionId, recovery);
       return {
@@ -226,7 +276,8 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
       };
     })
     .onRequest(methods.agent.session.prompt, async ({ params, client: parent }) => {
-      if (!sessions.has(params.sessionId)) throw new Error("unknown native Worker ACP session");
+      const held = sessions.get(params.sessionId);
+      if (held == null) throw new Error("unknown native Worker ACP session");
       const controller = new AbortController();
       controllers.set(params.sessionId, controller);
       try {
@@ -234,6 +285,20 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
         if (recovery != null) {
           recoveries.delete(params.sessionId);
           await notifySessionRecovery(parent, params.sessionId, recovery);
+        }
+        const prompt = promptText(params);
+        if (prompt.includes("delegate child")) {
+          held.child ??= new WorkflowChildAgent({
+            endpoint: childEndpoint,
+            cwd: held.request.cwd,
+            mcpServers: held.request.mcpServers,
+            ...(held.request.additionalDirectories == null
+              ? {}
+              : { additionalDirectories: held.request.additionalDirectories }),
+            publicSessionId: params.sessionId,
+            parent,
+          });
+          return await held.child.prompt(params);
         }
         await parent.notify(methods.client.session.update, {
           sessionId: params.sessionId,
@@ -250,8 +315,6 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
           },
           _meta: { redskills: { lifecycle: { event: "tool-activity" } } },
         });
-
-        const prompt = promptText(params);
         let permissionResolution: string | undefined;
         if (prompt.includes("permission")) {
           // The delay gives the public launch-edge transport time to disappear;
@@ -342,13 +405,15 @@ export async function runNativeAcpWorker(socketPath: string): Promise<number> {
         controllers.delete(params.sessionId);
       }
     })
-    .onNotification(methods.agent.session.cancel, ({ params }) => {
+    .onNotification(methods.agent.session.cancel, async ({ params }) => {
       controllers.get(params.sessionId)?.abort();
+      await sessions.get(params.sessionId)?.child?.cancel(params._meta);
     });
 
   const socket = await connectWithDeadline(socketPath, 10_000);
   const connection = app.connect(socketStream(socket));
   await connection.closed;
+  for (const session of sessions.values()) session.child?.close();
   return 0;
 }
 

--- a/apps/redskilled/src/acp-worker-command.ts
+++ b/apps/redskilled/src/acp-worker-command.ts
@@ -1,0 +1,30 @@
+/** Internal CLI adapter for a daemon-selected Workflow Worker child endpoint. */
+import { parseFlags } from "@reddb-io/shared/args.js";
+import { ACP_AGENT_IDS, type AcpAgentId } from "./acp-agent-catalog.js";
+import { runNativeAcpWorker } from "./acp-native-worker.js";
+
+const ACP_WORKER_FLAGS = {
+  socket: { kind: "value", coerce: (raw: string) => raw },
+  "child-agent": { kind: "value", coerce: requireAcpAgentId },
+  "child-command": { kind: "value", coerce: (raw: string) => raw },
+  "child-arg": { kind: "value", type: "array", coerce: (raw: string) => raw },
+} as const;
+
+export async function runAcpWorkerCommand(args: readonly string[]): Promise<number> {
+  const { values } = parseFlags(args, ACP_WORKER_FLAGS);
+  if (values.socket == null || values.socket === "") throw new Error("acp-worker requires --socket");
+  if (values["child-agent"] == null || values["child-command"] == null) {
+    throw new Error("acp-worker requires a daemon-selected child ACP Agent endpoint");
+  }
+  return await runNativeAcpWorker(values.socket, {
+    agent: values["child-agent"],
+    transport: "stdio",
+    command: values["child-command"],
+    args: values["child-arg"] ?? [],
+  });
+}
+
+function requireAcpAgentId(raw: string): AcpAgentId {
+  if ((ACP_AGENT_IDS as readonly string[]).includes(raw)) return raw as AcpAgentId;
+  throw new Error(`unsupported child ACP Agent: ${raw}`);
+}

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -76,7 +76,8 @@ import {
 } from "./supervision.js";
 import { awaitRedskilledTakeoverCommit, isRedskilledSupervised } from "./self-replace.js";
 import { stabilizeRedskilledEntry } from "./stable-bundle.js";
-import { runNativeAcpWorker, runRedskillsAcpAdapter } from "./acp-control-plane.js";
+import { runRedskillsAcpAdapter } from "./acp-control-plane.js";
+import { runAcpWorkerCommand } from "./acp-worker-command.js";
 
 /**
  * Usage, as a CONSTANT — the answer owes nothing to the machine it is asked on.
@@ -245,8 +246,6 @@ const SERVE_FLAGS = {
   "queue-ms": { kind: "value", coerce: (raw: string) => Number(raw) },
   "demand-ms": { kind: "value", coerce: (raw: string) => Number(raw) },
 } as const;
-
-const ACP_WORKER_FLAGS = { socket: { kind: "value", coerce: (raw: string) => raw } } as const;
 
 /**
  * The env var naming the credential this host polls the tracker with.
@@ -604,9 +603,7 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
   }
 
   if (command === "acp-worker") {
-    const { values } = parseFlags(args, ACP_WORKER_FLAGS);
-    if (values.socket == null || values.socket === "") throw new Error("acp-worker requires --socket");
-    return await runNativeAcpWorker(values.socket);
+    return await runAcpWorkerCommand(args);
   }
 
   if (command === "stop") return await runStop(args);

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -82,6 +82,101 @@ describe("ACP Workflow Worker replacement authority", () => {
 });
 
 describe("the public RedSkills ACP v1 control plane", () => {
+  it("governs a nested child Agent through the public workflow session", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-acp-child-agent-"));
+    roots.push(root);
+    const env = {
+      ...process.env,
+      HOME: root,
+      XDG_RUNTIME_DIR: root,
+      REDSKILLED_MACHINE_DIR: root,
+      REDSKILLED_PLACEMENT: "off",
+      REDSKILLED_SESSION: `test:${root}`,
+      REDSKILLED_ACP_PERMISSION_TIMEOUT_MS: "500",
+      PATH: `${resolve(__dirname, "fixtures", "bin")}:${process.env.PATH ?? ""}`,
+    };
+    const paths = resolveRedskilledPaths({ env, homeDir: root });
+    const daemon = launchCli([
+      "serve",
+      "--socket", paths.socketPath,
+      "--lease", paths.leasePath,
+      "--events", paths.eventLanePath,
+      "--machine-claim", paths.machineClaimPath,
+      "--idle-ms", "60000",
+    ], env, ["ignore", "ignore", "pipe"]);
+    await waitFor(() => socketAnswers(paths.socketPath, 1_000), "redskilled daemon socket");
+
+    const adapter = launchCli(["acp"], env, ["pipe", "pipe", "pipe"]);
+    const updates: SessionNotification[] = [];
+    const permissionRequests: RequestPermissionRequest[] = [];
+    const connection = client({ name: "redskilled-nested-agent-test" })
+      .onNotification(methods.client.session.update, ({ params }) => {
+        updates.push(params);
+      })
+      .onRequest(methods.client.session.requestPermission, ({ params }) => {
+        permissionRequests.push(params);
+        return { outcome: { outcome: "selected", optionId: "once" } };
+      })
+      .connect(childStream(adapter));
+    await connection.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: "nested-agent-client", version: "1" },
+    });
+    const session = await connection.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
+
+    const delegated = await connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "delegate child permission workflow" }],
+    });
+    expect(delegated).toMatchObject({
+      stopReason: "end_turn",
+      _meta: {
+        redskills: {
+          childAgent: "redcode",
+          childAttempts: 1,
+          delegation: {
+            authority: "parent-worker",
+            budget: "parent-remaining",
+            cancellation: "parent-mediated",
+            permissions: "parent-mediated",
+          },
+        },
+      },
+    });
+    expect(permissionRequests).toHaveLength(1);
+    expect(permissionRequests[0]?.sessionId).toBe(session.sessionId);
+    expect(new Set(updates.map((update) => update.sessionId))).toEqual(new Set([session.sessionId]));
+    expect(updates.map(lifecycleEvent).filter(Boolean)).toContain("child-admission");
+
+    updates.length = 0;
+    const cancelled = connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "delegate child wait for cancellation" }],
+    });
+    await waitFor(() => updates.some((update) => lifecycleEvent(update) === "child-tool-activity"), "child activity");
+    await connection.agent.notify(methods.agent.session.cancel, { sessionId: session.sessionId });
+    await expect(cancelled).resolves.toMatchObject({ stopReason: "cancelled" });
+
+    updates.length = 0;
+    await expect(connection.agent.request(methods.agent.session.prompt, {
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "delegate child transport failure" }],
+    })).rejects.toThrow();
+    expect(updates.map(lifecycleEvent).filter(Boolean)).toEqual([
+      "admission",
+      "child-admission",
+      "child-tool-activity",
+      "child-replacement",
+      "child-tool-activity",
+      "child-failure",
+    ]);
+
+    connection.close();
+    adapter.stdin?.end();
+    daemon.kill("SIGTERM");
+  }, 30_000);
+
   it("replaces a dead Worker and resumes the same public session from its observable journal", async () => {
     const root = await mkdtemp(join(tmpdir(), "redskilled-acp-replacement-"));
     roots.push(root);

--- a/apps/redskilled/tests/fixtures/bin/redcode
+++ b/apps/redskilled/tests/fixtures/bin/redcode
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import { randomUUID } from "node:crypto";
+import { Readable, Writable } from "node:stream";
+import { agent, methods, ndJsonStream } from "@agentclientprotocol/sdk";
+
+if (process.argv[2] !== "acp") throw new Error("fixture redcode expects the acp subcommand");
+
+const sessions = new Map();
+const controllers = new Map();
+const app = agent({ name: "Redcode governed child fixture" })
+  .onRequest(methods.agent.initialize, () => ({
+    protocolVersion: 1,
+    agentCapabilities: { promptCapabilities: {} },
+    agentInfo: { name: "Redcode governed child fixture", version: "1" },
+  }))
+  .onRequest(methods.agent.session.new, ({ params }) => {
+    const sessionId = randomUUID();
+    sessions.set(sessionId, params._meta?.redskills?.delegation);
+    return { sessionId };
+  })
+  .onRequest(methods.agent.session.prompt, async ({ params, client: parent }) => {
+    if (!sessions.has(params.sessionId)) throw new Error("unknown child fixture session");
+    const controller = new AbortController();
+    controllers.set(params.sessionId, controller);
+    const text = params.prompt.filter((block) => block.type === "text").map((block) => block.text).join("\n");
+    const delegation = params._meta?.redskills?.delegation ?? sessions.get(params.sessionId);
+    try {
+      await parent.notify(methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "child Agent is executing the delegated prompt\n" },
+        },
+        _meta: { redskills: { lifecycle: { event: "child-tool-activity" } } },
+      });
+      if (text.includes("transport failure")) {
+        setTimeout(() => process.exit(86), 0);
+        await new Promise(() => {});
+      }
+
+      let permissionResolution;
+      if (text.includes("permission")) {
+        const permission = await parent.request(methods.client.session.requestPermission, {
+          sessionId: params.sessionId,
+          toolCall: { toolCallId: randomUUID(), title: "child governed write", kind: "edit", status: "pending" },
+          options: [
+            { optionId: "once", name: "Allow once", kind: "allow_once" },
+            { optionId: "reject", name: "Reject", kind: "reject_once" },
+          ],
+        });
+        permissionResolution = permission._meta?.redskills?.permissionResolution;
+      }
+
+      if (text.includes("wait for cancellation")) {
+        await new Promise((resolve) => controller.signal.addEventListener("abort", resolve, { once: true }));
+        return { stopReason: "cancelled" };
+      }
+      return {
+        stopReason: "end_turn",
+        _meta: {
+          redskills: {
+            childAgent: "redcode",
+            delegation,
+            ...(permissionResolution == null ? {} : { permissionResolution }),
+          },
+        },
+      };
+    } finally {
+      controllers.delete(params.sessionId);
+    }
+  })
+  .onNotification(methods.agent.session.cancel, ({ params }) => {
+    controllers.get(params.sessionId)?.abort();
+  });
+
+const stream = ndJsonStream(
+  Writable.toWeb(process.stdout),
+  Readable.toWeb(process.stdin),
+);
+const connection = app.connect(stream);
+await connection.closed;


### PR DESCRIPTION
Automated AFK landing for #3891. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3891

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789431421&installation_model_id=20659&pr_number=3929&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3929&signature=c4de053eb6320edd736f708394233ef2ef7d4558a2883fd7f485d74fbbdf93cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->