### PR TITLE
fix: #3892 Native Docker and Podman share one Worker placement contract

### DIFF
--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -43,6 +43,7 @@
     "test:acp-agent-catalog": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-agent-catalog.test.ts",
     "test:acp-conformance": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-conformance.test.ts",
     "test:acp-control-plane": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-control-plane.test.ts",
+    "test:placement-contract": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/placement-contract.test.ts",
     "test:github-gateway": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/github-gateway.test.ts",
     "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/redskilled.bundle.min.mjs --asset redskilled.bundle.min.mjs --minify",
     "build": "pnpm run typecheck && pnpm run bundle",

--- a/apps/redskilled/src/daemon/budget-grace.ts
+++ b/apps/redskilled/src/daemon/budget-grace.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import type { RedskilledWorkerView } from "../host-state.js";
+import { parseContainerPlacementHandle } from "../reattach.js";
 
 export const DEFAULT_REDSKILLED_BUDGET_GRACE_MS = 30_000;
 export const REDSKILLED_BUDGET_GRACE_SIGNAL: NodeJS.Signals = "SIGUSR2";
@@ -67,6 +68,15 @@ export function createBudgetGraceRuntime(options: BudgetGraceRuntimeOptions): Re
 
 /** Signal the unit when there is one; otherwise signal the detached Worker tree. */
 export function signalWorkerForBudgetGrace(worker: RedskilledWorkerView): boolean {
+  const container = parseContainerPlacementHandle(worker.unit);
+  if (container != null) {
+    const sent = spawnSync(
+      container.engine,
+      ["kill", `--signal=${REDSKILLED_BUDGET_GRACE_SIGNAL}`, container.name],
+      { stdio: "ignore" },
+    );
+    return sent.error == null && sent.status === 0;
+  }
   if (worker.unit != null && worker.unit !== "") {
     const sent = spawnSync(
       "systemctl",

--- a/apps/redskilled/src/daemon/unit-death.ts
+++ b/apps/redskilled/src/daemon/unit-death.ts
@@ -4,6 +4,7 @@ import type {
   RedskilledUnitExitFacts,
   RedskilledUnitExitFactsProbe,
 } from "../reattach.js";
+import { parseContainerPlacementHandle } from "../reattach.js";
 
 type UnitDeathFacts = Pick<
   RecordWorkerEventInput,
@@ -26,7 +27,7 @@ export async function resolveUnitDeath(
   probe: RedskilledUnitExitFactsProbe,
   fallback: ResolvedUnitDeath,
 ): Promise<ResolvedUnitDeath> {
-  if (worker.unit == null || worker.unit === "") return fallback;
+  if (worker.unit == null || worker.unit === "" || parseContainerPlacementHandle(worker.unit) != null) return fallback;
   const receipt = await Promise.resolve(probe(worker.unit)).catch(() => null);
   if (receipt == null) return fallback;
   return {

--- a/apps/redskilled/src/reattach.ts
+++ b/apps/redskilled/src/reattach.ts
@@ -34,6 +34,17 @@ import { isPidAlive } from "@reddb-io/shared/resident-core.js";
 import type { RedskilledWorkerView } from "./host-state.js";
 import { DEFAULT_WORKER_UNIT_PREFIX } from "./worker-placement.js";
 
+export interface RedskilledContainerPlacementHandle {
+  readonly engine: "docker" | "podman";
+  readonly name: string;
+}
+
+/** Decode the durable lifecycle handle shared by Docker and Podman. */
+export function parseContainerPlacementHandle(value: string | null | undefined): RedskilledContainerPlacementHandle | null {
+  const match = value?.match(/^(docker|podman):\/\/([a-z0-9][a-z0-9_.-]*)$/);
+  return match == null ? null : { engine: match[1] as "docker" | "podman", name: match[2]! };
+}
+
 /** Answers "is this Worker still running?" for one Worker. */
 export type RedskilledLivenessProbe = (worker: RedskilledWorkerView) => boolean | Promise<boolean>;
 
@@ -137,8 +148,16 @@ export const REDSKILLED_LIVENESS_GRACE_MS = 30_000;
 
 /** The default probe: the unit when there is one, the pid when there is not. */
 export function detectWorkerLiveness(worker: RedskilledWorkerView): boolean {
+  const container = parseContainerPlacementHandle(worker.unit);
+  if (container != null) return isContainerActive(container);
   if (worker.unit != null && worker.unit !== "") return isUnitActive(worker.unit);
   return isPidAlive(worker.pid);
+}
+
+/** Ask the selected engine whether the named container is still running. */
+export function isContainerActive(handle: RedskilledContainerPlacementHandle): boolean {
+  const probe = spawnSync(handle.engine, ["inspect", "--format={{.State.Running}}", handle.name], { encoding: "utf8" });
+  return probe.error == null && probe.status === 0 && (probe.stdout ?? "").trim() === "true";
 }
 
 /** True when systemd reports `unit` in a running state for this user session. */
@@ -272,6 +291,15 @@ export const REDSKILLED_UNOWNED_PROJECT_LABEL = "(unowned)";
  * whose memory the host promises to watch and never measures.
  */
 export function detectUnitMainPid(unit: string): number | null {
+  const container = parseContainerPlacementHandle(unit);
+  if (container != null) {
+    const probe = spawnSync(container.engine, ["inspect", "--format={{.State.Pid}}", container.name], {
+      encoding: "utf8",
+    });
+    if (probe.error != null || probe.status !== 0) return null;
+    const pid = Number.parseInt((probe.stdout ?? "").trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  }
   const probe = spawnSync("systemctl", ["--user", "show", "--property=MainPID", "--value", unit], {
     encoding: "utf8",
   });
@@ -429,6 +457,16 @@ export async function stopWorker(
   worker: RedskilledWorkerView,
   io: RedskilledStopWorkerIO = DEFAULT_STOP_WORKER_IO,
 ): Promise<boolean> {
+  const container = parseContainerPlacementHandle(worker.unit);
+  if (container != null) {
+    try {
+      await stopContainer(container);
+    } catch {
+      // The process-group fallback below remains the last line of authority.
+    }
+    if (!isContainerActive(container)) return true;
+    return await io.killTree(worker.pgid ?? worker.pid);
+  }
   if (worker.unit != null && worker.unit !== "") {
     try {
       await io.stopUnit(worker.unit);
@@ -438,6 +476,15 @@ export async function stopWorker(
     if (!io.unitActive(worker.unit) && !io.leaderAlive(worker.pid)) return true;
   }
   return await io.killTree(worker.pgid ?? worker.pid);
+}
+
+/** Place one bounded engine stop request without transferring lifecycle ownership. */
+export async function stopContainer(handle: RedskilledContainerPlacementHandle): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const request = spawn(handle.engine, ["stop", "--time=10", handle.name], { stdio: "ignore" });
+    request.once("error", () => resolve());
+    request.once("close", () => resolve());
+  });
 }
 
 /**

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -33,8 +33,10 @@ import {
   detectWorkerPlacementProbes,
   placementEnabled,
   planWorkerPlacement,
+  workerPlacementDriverPolicy,
   type RedskilledPlacementTarget,
   type RedskilledWorkerBudget,
+  type WorkerPlacementDriverPolicy,
   type WorkerPlacementPlan,
   type WorkerPlacementProbes,
 } from "./worker-placement.js";
@@ -124,6 +126,8 @@ export interface LaunchWorkerOptions {
   readonly admission: RedskilledAdmissionVerdict;
   readonly forkSha?: string;
   readonly probes?: WorkerPlacementProbes;
+  /** Host-owned placement limits resolved by redskilled, never by the Project. */
+  readonly driverPolicy?: WorkerPlacementDriverPolicy;
   /**
    * The ceiling the host derived for this Worker (`deriveWorkerScopeCeiling`).
    *
@@ -329,6 +333,7 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
     env: workerEnv,
     enabled: options.enabled ?? placementEnabled(env),
     probes,
+    driverPolicy: options.driverPolicy ?? workerPlacementDriverPolicy(env),
     pipeOutput: logReady || spec.input != null,
   });
 

--- a/apps/redskilled/src/worker-placement.ts
+++ b/apps/redskilled/src/worker-placement.ts
@@ -40,6 +40,12 @@ import {
 /** Env kill-switch: `REDSKILLED_PLACEMENT=off` launches unisolated — loudly. */
 export const REDSKILLED_PLACEMENT_ENV = "REDSKILLED_PLACEMENT";
 
+/** Comma-separated host allow-list for Worker placement drivers. */
+export const REDSKILLED_PLACEMENT_DRIVERS_ENV = "REDSKILLED_PLACEMENT_DRIVERS";
+
+/** Host default image used when a Project permits container placement. */
+export const REDSKILLED_CONTAINER_IMAGE_ENV = "REDSKILLED_CONTAINER_IMAGE";
+
 /** The unit-name prefix when a client states none. */
 export const DEFAULT_WORKER_UNIT_PREFIX = "red-worker";
 
@@ -77,6 +83,8 @@ export interface WorkerPlacementProbes {
    * with a sentence rather than a flag.
    */
   readonly posix: RedskilledPosixReach;
+  /** Container CLIs reachable to the daemon, or null when absent. */
+  readonly containerEngines?: Readonly<Record<"docker" | "podman", string | null>>;
 }
 
 /** The POSIX shell a launch wraps itself in when the host actually has it. */
@@ -99,6 +107,31 @@ export interface RedskilledPlacementTarget {
    */
   readonly isolation: "transient-unit" | "job-object" | "posix-limits" | "inherit";
   readonly unit_prefix?: string;
+  /** Hard Project compatibility constraint. The host still makes the choice. */
+  readonly allowed_drivers?: readonly WorkerPlacementDriver[];
+  /** Project ordering inside the compatible set; it grants no host capability. */
+  readonly preferred_drivers?: readonly WorkerPlacementDriver[];
+  /** Immutable image reference or host-approved tag used by Docker/Podman. */
+  readonly container_image?: string;
+}
+
+export type WorkerPlacementDriver = "native" | "docker" | "podman";
+
+export interface WorkerPlacementDriverPolicy {
+  /** Hard host allow-list. An empty intersection refuses admission. */
+  readonly allowed_drivers: readonly WorkerPlacementDriver[];
+  /** Host ordering after Project preference. */
+  readonly preferred_drivers?: readonly WorkerPlacementDriver[];
+  /** Host default used only when the Project did not state an image. */
+  readonly container_image?: string;
+}
+
+/** A placement refusal is an admission refusal: no process has been born. */
+export class WorkerPlacementAdmissionRefusal extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkerPlacementAdmissionRefusal";
+  }
 }
 
 /** The resource budget for one Worker. Every field is optional and opaque. */
@@ -122,7 +155,7 @@ export interface RedskilledWorkerBudget {
  * `none` is a first-class answer, not an absent one: an unisolated launch is a
  * decision the host made, and it is read alongside its warning.
  */
-export type WorkerPlacementBackend = "transient-unit" | "job-object" | "posix-limits" | "none";
+export type WorkerPlacementBackend = "transient-unit" | "job-object" | "posix-limits" | "docker" | "podman" | "none";
 
 /** The Job Object a Windows plan asks for. The handle itself is minted at launch. */
 export interface WorkerJobObjectPlan {
@@ -131,6 +164,8 @@ export interface WorkerJobObjectPlan {
 }
 
 export interface WorkerPlacementPlan {
+  /** Placement changes mechanism only; every value materializes the same Worker. */
+  readonly driver: WorkerPlacementDriver;
   /**
    * True when the Worker runs inside a resource group of its own.
    *
@@ -203,6 +238,10 @@ export function detectWorkerPlacementProbes(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
 ): WorkerPlacementProbes {
+  const containerEngines = {
+    docker: which("docker", env),
+    podman: which("podman", env),
+  } as const;
   const noPosix = posixLimitsUnavailable(`POSIX shell placement is unavailable on platform=${platform}`);
   if (platform === "win32") {
     return {
@@ -211,16 +250,17 @@ export function detectWorkerPlacementProbes(
       userSession: false,
       jobObjects: loadJobObjectBinding({ platform }),
       posix: noPosix,
+      containerEngines,
     };
   }
   const noJobObjects = jobObjectsUnavailable(
     `Job Object placement is the Windows backend (platform=${platform}), so there is no native reach to load here`,
   );
   if (platform === "darwin") {
-    return { platform, systemdRun: null, userSession: false, jobObjects: noJobObjects, posix: detectPosixReach(env) };
+    return { platform, systemdRun: null, userSession: false, jobObjects: noJobObjects, posix: detectPosixReach(env), containerEngines };
   }
   if (platform !== "linux") {
-    return { platform, systemdRun: null, userSession: false, jobObjects: noJobObjects, posix: noPosix };
+    return { platform, systemdRun: null, userSession: false, jobObjects: noJobObjects, posix: noPosix, containerEngines };
   }
   const runtimeDir = (env.XDG_RUNTIME_DIR ?? "").trim();
   const userSession = runtimeDir !== "" && existsSync(join(runtimeDir, "systemd", "private"));
@@ -230,6 +270,7 @@ export function detectWorkerPlacementProbes(
     userSession,
     jobObjects: noJobObjects,
     posix: detectPosixReach(env),
+    containerEngines,
   };
 }
 
@@ -306,6 +347,8 @@ export interface PlanWorkerPlacementOptions {
   readonly memoryCeiling?: { readonly memory_max: string | null; readonly reason: string };
   readonly target?: RedskilledPlacementTarget;
   readonly probes: WorkerPlacementProbes;
+  /** Host-owned hard policy. Defaults to the daemon environment. */
+  readonly driverPolicy?: WorkerPlacementDriverPolicy;
   /** False when the env kill-switch declined isolation host-wide. */
   readonly enabled?: boolean;
   /** Extra `KEY=VALUE` environment for the Worker. */
@@ -350,6 +393,16 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
   const declaredBudget = budget.memory_high != null || budget.memory_max != null || budget.cpu_weight != null;
   const target = opts.target ?? { isolation: "transient-unit" as const };
 
+  const driverPolicy = opts.driverPolicy ?? workerPlacementDriverPolicy(process.env);
+  const driver = selectWorkerPlacementDriver({
+    policy: opts.enabled === false ? { ...driverPolicy, allowed_drivers: ["native"] } : driverPolicy,
+    target,
+    probes: opts.probes,
+  });
+  if (driver !== "native") {
+    return planContainerPlacement(opts, args, budget, ceilingValue, driver, driverPolicy);
+  }
+
   const unisolated = (isolationWarning: string): WorkerPlacementPlan => {
     const reach = opts.probes.posix;
     const coreLimited = opts.probes.platform === "linux" && reach.available;
@@ -357,6 +410,7 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
       ? `${isolationWarning}; core dumps are not capped because ${reach.reason}`
       : isolationWarning;
     return {
+      driver: "native",
       isolated: false,
       backend: "none",
       command: coreLimited ? reach.shell : opts.command,
@@ -445,6 +499,7 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
     opts.budget == null ? undefined : { ...opts.budget, max_processes: undefined },
   );
   return {
+    driver: "native",
     isolated: true,
     backend: "transient-unit",
     unit,
@@ -457,6 +512,116 @@ export function planWorkerPlacement(opts: PlanWorkerPlacementOptions): WorkerPla
     environment,
     ...(unenforced != null ? { budgetWarning: unenforced } : {}),
   };
+}
+
+/** Resolve host policy without consulting any Project checkout. */
+export function workerPlacementDriverPolicy(
+  env: NodeJS.ProcessEnv = process.env,
+): WorkerPlacementDriverPolicy {
+  const declared = (env[REDSKILLED_PLACEMENT_DRIVERS_ENV] ?? "").trim();
+  const allowed = declared === ""
+    ? (["native", "docker", "podman"] as const)
+    : declared.split(",").map((value) => value.trim()).filter(isWorkerPlacementDriver);
+  return {
+    allowed_drivers: unique(allowed),
+    preferred_drivers: ["native", "docker", "podman"],
+    ...((env[REDSKILLED_CONTAINER_IMAGE_ENV] ?? "").trim() === ""
+      ? {}
+      : { container_image: env[REDSKILLED_CONTAINER_IMAGE_ENV]!.trim() }),
+  };
+}
+
+/** Choose one compatible available mechanism. PURE over injected probes. */
+export function selectWorkerPlacementDriver(input: {
+  readonly policy: WorkerPlacementDriverPolicy;
+  readonly target: RedskilledPlacementTarget;
+  readonly probes: WorkerPlacementProbes;
+}): WorkerPlacementDriver {
+  const projectAllowed = input.target.allowed_drivers ?? (["native", "docker", "podman"] as const);
+  const allowed = new Set(input.policy.allowed_drivers.filter((driver) => projectAllowed.includes(driver)));
+  // `inherit` is explicitly a native-process request; putting it in a container
+  // would contradict the Project instead of merely changing isolation.
+  if (input.target.isolation === "inherit") {
+    allowed.delete("docker");
+    allowed.delete("podman");
+  }
+  const image = input.target.container_image?.trim() || input.policy.container_image?.trim();
+  const available = (driver: WorkerPlacementDriver): boolean => driver === "native" ||
+    (image != null && image !== "" && input.probes.containerEngines?.[driver] != null);
+  const order = unique<WorkerPlacementDriver>([
+    ...(input.target.preferred_drivers ?? []),
+    ...(input.policy.preferred_drivers ?? []),
+    "native",
+    "docker",
+    "podman",
+  ]);
+  const selected = order.find((driver) => allowed.has(driver) && available(driver));
+  if (selected != null) return selected;
+  const host = input.policy.allowed_drivers.join(", ") || "none";
+  const project = projectAllowed.join(", ") || "none";
+  throw new WorkerPlacementAdmissionRefusal(
+    `redskilled refused this Worker before birth: no compatible placement driver is available ` +
+      `(host allows: ${host}; Project allows: ${project}; Docker=${input.probes.containerEngines?.docker ?? "unavailable"}; ` +
+      `Podman=${input.probes.containerEngines?.podman ?? "unavailable"}; container image=${image ?? "unstated"})`,
+  );
+}
+
+function planContainerPlacement(
+  opts: PlanWorkerPlacementOptions,
+  args: readonly string[],
+  budget: RedskilledWorkerBudget,
+  ceilingValue: string | null,
+  driver: "docker" | "podman",
+  policy: WorkerPlacementDriverPolicy,
+): WorkerPlacementPlan {
+  const engine = opts.probes.containerEngines?.[driver];
+  const image = opts.target?.container_image?.trim() || policy.container_image?.trim();
+  if (engine == null || image == null || image === "") {
+    throw new WorkerPlacementAdmissionRefusal(`redskilled refused this Worker before birth: ${driver} lost compatibility during placement planning`);
+  }
+  const handle = `${driver}://${workerJobObjectName(opts.projectLabel, opts.workerId, opts.target?.unit_prefix)}`;
+  const containerName = handle.slice(handle.indexOf("://") + 3);
+  const containerArgs = [
+    "run", "--rm", `--name=${containerName}`,
+    `--label=io.reddb.redskilled.worker=${opts.workerId}`,
+    `--volume=${opts.workspacePath}:${opts.workspacePath}`,
+    `--workdir=${opts.workspacePath}`,
+  ];
+  if (budget.memory_high != null) containerArgs.push(`--memory-reservation=${budget.memory_high}`);
+  if (budget.memory_max != null) containerArgs.push(`--memory=${budget.memory_max}`);
+  if (budget.cpu_weight != null) containerArgs.push(`--cpu-shares=${budget.cpu_weight}`);
+  if (budget.max_processes != null) containerArgs.push(`--pids-limit=${budget.max_processes}`);
+  const environment = workerPlacementEnvironment(opts, {
+    scope: handle,
+    memory_ceiling: ceilingValue,
+    scope_degradation: null,
+  });
+  for (const [key, value] of Object.entries({ ...(opts.env ?? {}), ...environment })) {
+    containerArgs.push(`--env=${key}=${value}`);
+  }
+  containerArgs.push(image, opts.command, ...args);
+  return {
+    driver,
+    isolated: true,
+    backend: driver,
+    command: engine,
+    args: containerArgs,
+    unit: handle,
+    budget,
+    environment,
+    ...(ceilingValue == null ? {} : { memoryCeiling: ceilingValue }),
+    ...(budget.cpu_seconds == null
+      ? {}
+      : { budgetWarning: `${driver} placement cannot enforce cpu_seconds; redskilled's sampling floor remains authoritative` }),
+  };
+}
+
+function isWorkerPlacementDriver(value: string): value is WorkerPlacementDriver {
+  return value === "native" || value === "docker" || value === "podman";
+}
+
+function unique<T>(values: readonly T[]): T[] {
+  return [...new Set(values)];
 }
 
 /**
@@ -490,6 +655,7 @@ function planPosixLimitsPlacement(
   const declaredMemory = effectiveBudget.memory_high != null || effectiveBudget.memory_max != null;
   const warning = describePosixPlacement(limits);
   return {
+    driver: "native",
     isolated: false,
     backend: "posix-limits",
     command: reach.shell,
@@ -550,6 +716,7 @@ function planJobObjectPlacement(
   const limits = planJobLimits(effectiveBudget);
   const name = workerJobObjectName(opts.projectLabel, opts.workerId, opts.target?.unit_prefix);
   return {
+    driver: "native",
     isolated: true,
     backend: "job-object",
     command: opts.command,

--- a/apps/redskilled/tests/daemon-reattach-survivor.test.ts
+++ b/apps/redskilled/tests/daemon-reattach-survivor.test.ts
@@ -123,6 +123,7 @@ function unitBackedLaunch(state: TestUnitLauncher) {
       admission: options.admission,
       warnings: [],
       plan: {
+        driver: "native",
         isolated: true,
         backend: "transient-unit",
         command: "systemd-run",

--- a/apps/redskilled/tests/early-worker-death.test.ts
+++ b/apps/redskilled/tests/early-worker-death.test.ts
@@ -54,6 +54,7 @@ function earlyExitLaunch(state: { exit?: (code: number) => void }) {
       admission: options.admission,
       warnings: [],
       plan: {
+        driver: "native",
         isolated: false,
         backend: "none",
         command: options.spec.command,

--- a/apps/redskilled/tests/placement-contract.test.ts
+++ b/apps/redskilled/tests/placement-contract.test.ts
@@ -1,0 +1,146 @@
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import { commandRedskilledWorker } from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
+import { launchWorker, type RedskilledWorkerSpec } from "../src/worker-launch.js";
+import {
+  planWorkerPlacement,
+  WorkerPlacementAdmissionRefusal,
+  type WorkerPlacementDriver,
+  type WorkerPlacementProbes,
+} from "../src/worker-placement.js";
+
+const roots: string[] = [];
+const daemons: RedskilledDaemon[] = [];
+const DRIVERS = ["native", "docker", "podman"] as const satisfies readonly WorkerPlacementDriver[];
+
+const PROBES: WorkerPlacementProbes = {
+  platform: "linux",
+  systemdRun: "/usr/bin/systemd-run",
+  userSession: true,
+  jobObjects: { available: false, reason: "not Windows" },
+  posix: { available: true, shell: "/bin/sh", nice: null },
+  containerEngines: { docker: "/usr/bin/docker", podman: "/usr/bin/podman" },
+};
+
+afterEach(async () => {
+  for (const daemon of daemons.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function paths(): Promise<RedskilledPaths> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-placement-contract-"));
+  roots.push(root);
+  return resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `placement:${root}`, REDSKILLED_MACHINE_DIR: root },
+    runtimeDir: root,
+  });
+}
+
+function spec(driver: WorkerPlacementDriver, workerId: string): RedskilledWorkerSpec {
+  return {
+    worker_id: workerId,
+    project_label: "acme/widgets",
+    workspace_path: "/workspace",
+    command: "/usr/bin/node",
+    args: ["worker.js"],
+    placement: {
+      isolation: "transient-unit",
+      allowed_drivers: [driver],
+      container_image: "example.test/red-worker:fixture",
+    },
+  };
+}
+
+function fakeChild(pid: number): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  Object.assign(child, { pid, stdin: null, stdout: null, stderr: null, unref() {} });
+  return child;
+}
+
+describe("Worker placement admission", () => {
+  it("refuses deterministically when host policy and Project requirements share no available driver", () => {
+    expect(() => planWorkerPlacement({
+      workerId: "w-refused",
+      projectLabel: "acme/widgets",
+      workspacePath: "/workspace",
+      command: "/usr/bin/node",
+      probes: { ...PROBES, containerEngines: { docker: null, podman: null } },
+      driverPolicy: { allowed_drivers: ["docker", "podman"] },
+      target: {
+        isolation: "transient-unit",
+        allowed_drivers: ["docker"],
+        container_image: "example.test/red-worker:fixture",
+      },
+    })).toThrowError(WorkerPlacementAdmissionRefusal);
+  });
+});
+
+describe.each(DRIVERS)("%s placement shared lifecycle", (driver) => {
+  it("lets redskilled alone create, observe, cancel, replace, and reap the Worker", async () => {
+    const daemonPaths = await paths();
+    const alive = new Set<string>();
+    let births = 0;
+    let stops = 0;
+    const daemon = await startRedskilledDaemon({
+      paths: daemonPaths,
+      idleMs: 60_000,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      livenessGraceMs: 0,
+      liveness: (worker) => alive.has(worker.worker_id),
+      stopWorker: (worker) => {
+        stops += 1;
+        alive.delete(worker.worker_id);
+        return true;
+      },
+      launch: (options) => {
+        births += 1;
+        const launched = launchWorker({
+          ...options,
+          probes: PROBES,
+          openLog: false,
+          spawnFn: (_command: string, _args: readonly string[], _spawn: SpawnOptions) => fakeChild(40_000 + births),
+        });
+        alive.add(launched.worker.worker_id);
+        return launched;
+      },
+    });
+    daemons.push(daemon);
+
+    const first = daemon.startWorker(spec(driver, `w-${driver}-1`));
+    expect(first.plan.driver).toBe(driver);
+    if (driver === "native") {
+      expect(first.plan.backend).toBe("transient-unit");
+      expect(first.worker.unit).toMatch(/\.service$/);
+    } else {
+      expect(first.plan.backend).toBe(driver);
+      expect(first.plan.command).toBe(`/usr/bin/${driver}`);
+      expect(first.plan.args).toContain("example.test/red-worker:fixture");
+      expect(first.plan.args).toContain("--volume=/workspace:/workspace");
+      expect(first.worker.unit).toMatch(new RegExp(`^${driver}://`));
+    }
+    expect(daemon.hostState().workers.map((worker) => worker.worker_id)).toEqual([`w-${driver}-1`]);
+
+    await commandRedskilledWorker(daemonPaths, {
+      command: "stop",
+      worker_id: `w-${driver}-1`,
+      session_project: "acme/widgets",
+    });
+    expect(stops).toBe(1);
+    expect(daemon.hostState().workers).toEqual([]);
+
+    const replacement = daemon.startWorker(spec(driver, `w-${driver}-2`));
+    expect(replacement.plan.driver).toBe(driver);
+    expect(births).toBe(2);
+
+    alive.delete(`w-${driver}-2`);
+    await daemon.sweepWorkerLiveness();
+    expect(daemon.hostState().workers).toEqual([]);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #3892. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3892

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789432520&installation_model_id=20659&pr_number=3931&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3931&signature=4ec549f857719e35a6e0379071cf2914d8d232333a4f16002469dc97b5cac9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->