### PR TITLE
fix: #3844 Preflight flag: feedback commands surfaced pre-DONE

### DIFF
--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -1136,21 +1136,20 @@ export function defaultTier(runner: string, taskClass: AfkModelTier = "think"): 
 export const VALIDATION_MOMENTS = ["iteration", "post_done", "landing"] as const;
 export type ValidationMoment = (typeof VALIDATION_MOMENTS)[number];
 export const SUBSECOND_BRANCH_FAULT_KEY = "subsecond_failures_are_branch_fault" as const;
-
+export const PREFLIGHT_KEY = "preflight" as const;
 export interface GeneratedSurfaceDeclaration {
   readonly paths: readonly string[];
   readonly command: string;
 }
-
 export const GeneratedSurfaceDeclarationSchema = z.object({
   paths: z.array(z.string().min(1)).min(1),
   command: z.string().min(1),
 });
-
 export const ValidationMomentsSchema = z.object({
   iteration: z.array(z.string()).optional(),
   post_done: z.array(z.string()).optional(),
   landing: z.array(z.string()).optional(),
+  preflight: z.boolean().optional(),
   subsecondFailuresAreBranchFault: z.boolean().optional(),
   generated: GeneratedSurfaceDeclarationSchema.optional(),
 });
@@ -1158,10 +1157,10 @@ export interface ValidationMoments {
   iteration?: string[];
   post_done?: string[];
   landing?: string[];
+  preflight?: boolean;
   subsecondFailuresAreBranchFault?: boolean;
   generated?: GeneratedSurfaceDeclaration;
 }
-
 function validateValidationMomentShapes(values: ConfigValues, mappingContainers: ReadonlySet<string>): void {
   for (const root of ["afk.validation", "plugins.dev.afk.validation"]) {
     for (const moment of VALIDATION_MOMENTS) {
@@ -1174,17 +1173,18 @@ function validateValidationMomentShapes(values: ConfigValues, mappingContainers:
         throw new MalformedConfigError(`invalid config shape: \`${key}\` must be an ordered list of commands`);
       }
     }
-    const declarationKey = `${root}.${SUBSECOND_BRANCH_FAULT_KEY}`;
-    const declaration = values[declarationKey];
-    const descendants = Object.keys(values).filter((candidate) => candidate.startsWith(`${declarationKey}.`));
-    if (
-      descendants.length > 0 ||
-      (declaration !== undefined && declaration !== "true" && declaration !== "false") ||
-      (mappingContainers.has(declarationKey) && declaration === undefined)
-    ) {
-      throw new MalformedConfigError(`invalid config shape: \`${declarationKey}\` must be a boolean`);
+    for (const booleanKey of [PREFLIGHT_KEY, SUBSECOND_BRANCH_FAULT_KEY]) {
+      const declarationKey = `${root}.${booleanKey}`;
+      const declaration = values[declarationKey];
+      const descendants = Object.keys(values).filter((candidate) => candidate.startsWith(`${declarationKey}.`));
+      if (
+        descendants.length > 0 ||
+        (declaration !== undefined && declaration !== "true" && declaration !== "false") ||
+        (mappingContainers.has(declarationKey) && declaration === undefined)
+      ) {
+        throw new MalformedConfigError(`invalid config shape: \`${declarationKey}\` must be a boolean`);
+      }
     }
-
     const generatedRoot = `${root}.generated`;
     const generatedKeys = Object.keys(values).filter((candidate) => candidate.startsWith(`${generatedRoot}.`));
     const generatedDeclared = mappingContainers.has(generatedRoot) || generatedKeys.length > 0;
@@ -1256,6 +1256,8 @@ export function readValidationMoments(values: ConfigValues): ValidationMoments {
     }),
   ) as ValidationMoments;
 
+  const preflightDeclaration = values[`afk.validation.${PREFLIGHT_KEY}`];
+  if (preflightDeclaration !== undefined) schedule.preflight = preflightDeclaration === "true";
   const subsecondDeclaration = values[`afk.validation.${SUBSECOND_BRANCH_FAULT_KEY}`];
   if (subsecondDeclaration !== undefined) {
     schedule.subsecondFailuresAreBranchFault = subsecondDeclaration === "true";

--- a/apps/dev/src/core/handoff.ts
+++ b/apps/dev/src/core/handoff.ts
@@ -545,9 +545,35 @@ function withRspInstructions(protocol: string, runner: string | undefined): stri
   return `${protocol}\n\n${renderAmbientSkill(undefined, { runner: instructionRunner })}`;
 }
 
-export function exitProtocolFor(opts: { runMode?: string; structuredOutput?: boolean; runner?: string }): string {
+/** Render the experimental feedback-stage checklist without widening its command set. */
+export function buildPreflight(commands: readonly string[] | undefined): string {
+  const discovered = (commands ?? []).map((command) => command.trim()).filter(Boolean);
+  if (discovered.length === 0) return "";
+  return [
+    "<preflight>",
+    "Run this exact feedback-stage checklist before declaring DONE:",
+    ...discovered.map((command) => `- ${command}`),
+    "Do not add stricter commands; the post-DONE gate remains the enforcement point.",
+    "</preflight>",
+  ].join("\n");
+}
+
+function withPreflight(protocol: string, commands: readonly string[] | undefined): string {
+  const preflight = buildPreflight(commands);
+  if (preflight === "") return protocol;
+  return protocol.replace("</exit-protocol>", `${preflight}\n</exit-protocol>`);
+}
+
+export function exitProtocolFor(opts: {
+  runMode?: string;
+  structuredOutput?: boolean;
+  runner?: string;
+  preflightCommands?: readonly string[];
+}): string {
   if (opts.runMode === "scout") return SCOUT_EXIT_PROTOCOL;
-  if (!opts.structuredOutput) return withRspInstructions(EXIT_PROTOCOL, opts.runner);
   const closing = "</exit-protocol>";
-  return withRspInstructions(EXIT_PROTOCOL.replace(closing, `${AGENT_OUTPUT_INSTRUCTION}\n${closing}`), opts.runner);
+  const protocol = opts.structuredOutput
+    ? EXIT_PROTOCOL.replace(closing, `${AGENT_OUTPUT_INSTRUCTION}\n${closing}`)
+    : EXIT_PROTOCOL;
+  return withRspInstructions(withPreflight(protocol, opts.preflightCommands), opts.runner);
 }

--- a/apps/dev/src/core/process-issue/lifecycle.ts
+++ b/apps/dev/src/core/process-issue/lifecycle.ts
@@ -1144,6 +1144,12 @@ export async function processIssue(
     deps.appendIterLog(`🤖 ${reseedLane}: ${validation} Parked to ready-for-human.`);
     return { outcome: { stage: "review", ok: false }, next: "park", validation };
   };
+  const systemPromptFor = (runner: Runner): string => exitProtocolFor({
+    runMode: input.runMode,
+    structuredOutput: runnerSupportsStructuredOutput(toAgentRunner(runner)),
+    runner,
+    preflightCommands: deps.validationMoments?.preflight ? deps.validationMoments.post_done : undefined,
+  });
   // Gate-green fast path (issue #2397): when a prior branch already cleared the
   // feedback gate, skip the agent entirely on re-claim and re-validate directly.
   let gateGreenSkip = resumeIsGateGreen;
@@ -1189,11 +1195,7 @@ export async function processIssue(
         effort: initialTier.effort,
         handoffPath,
         handoffContent: currentHandoff,
-        systemPrompt: exitProtocolFor({
-          runMode: input.runMode,
-          structuredOutput: runnerSupportsStructuredOutput(toAgentRunner(activeRunner)),
-          runner: activeRunner,
-        }),
+        systemPrompt: systemPromptFor(activeRunner),
         branch,
         base: baseRef,
         cwd: input.attemptDir,
@@ -1283,11 +1285,7 @@ export async function processIssue(
           effort: fallbackTier.effort,
           handoffPath,
           handoffContent: currentHandoff,
-          systemPrompt: exitProtocolFor({
-            runMode: input.runMode,
-            structuredOutput: runnerSupportsStructuredOutput(toAgentRunner(other)),
-            runner: other,
-          }),
+          systemPrompt: systemPromptFor(other),
           branch,
           base,
           cwd: input.attemptDir,

--- a/apps/dev/src/core/validation-moments.ts
+++ b/apps/dev/src/core/validation-moments.ts
@@ -25,6 +25,7 @@ export const ENGINE_VALIDATION_MOMENTS = ["iteration", "post_done", "landing"] a
  * the reader exists, so an entry cannot outlive what it describes.
  */
 export const VALIDATION_SETTING_KEYS: Readonly<Record<string, string>> = {
+  preflight: "apps/dev/src/core/config.ts",
   generated: "apps/dev/src/core/generated-surfaces.ts",
   node_max_old_space_mb: "apps/dev/src/core/config.ts",
   heavy_available_memory_mb: "apps/dev/src/core/config.ts",

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -869,6 +869,22 @@ describe("config — block sequences (#430)", () => {
 });
 
 describe("config — validation moments (ADR 0135, #3284)", () => {
+  it("accepts the experimental Preflight flag and defaults it off (#3844)", () => {
+    const absent = loadConfig("/x/.red/config.yaml", {
+      ignoreActivationGate: true,
+      read: () => "afk:\n  validation:\n    post_done:\n      - pnpm test\n",
+    });
+    const enabled = loadConfig("/x/.red/config.yaml", {
+      ignoreActivationGate: true,
+      read: () => "afk:\n  validation:\n    preflight: true\n    post_done:\n      - pnpm test\n",
+    });
+
+    expect(readValidationMoments(absent).preflight ?? false).toBe(false);
+    expect(readValidationMoments(enabled).preflight).toBe(true);
+    expect(() => parseConfigYaml("afk:\n  validation:\n    preflight: sometimes\n"))
+      .toThrow(/afk\.validation\.preflight.*boolean/);
+  });
+
   it("reads the generated-surface cure beside the Validation moments", () => {
     const values = loadConfig("/x/.red/config.yaml", {
       read: () => [

--- a/apps/dev/tests/handoff.test.ts
+++ b/apps/dev/tests/handoff.test.ts
@@ -623,6 +623,27 @@ describe("buildMergeGate", () => {
   });
 });
 
+describe("exitProtocolFor Preflight (#3844)", () => {
+  it("is byte-identical to today's instruction when the flag is off", () => {
+    expect(exitProtocolFor({})).toBe(EXIT_PROTOCOL);
+    expect(exitProtocolFor({ preflightCommands: [] })).toBe(EXIT_PROTOCOL);
+  });
+
+  it("lists exactly the feedback commands once when the flag is on", () => {
+    const commands = ["pnpm typecheck", "pnpm -C apps/dev test:invariants"];
+    const out = exitProtocolFor({ preflightCommands: commands });
+    const lines = out.split("\n");
+
+    expect(out).toContain("<preflight>");
+    expect(out).toContain("before declaring DONE");
+    for (const command of commands) {
+      expect(lines.filter((line) => line === `- ${command}`)).toHaveLength(1);
+    }
+    expect(out).not.toContain("pnpm test:landing");
+    expect(out).not.toContain("adversarial review");
+  });
+});
+
 describe("buildIterationMoment", () => {
   it("lists each operator-declared iteration command in order", () => {
     const out = buildIterationMoment(["pnpm test", "pnpm typecheck"]);

--- a/apps/dev/tests/process-issue.lifecycle.test.ts
+++ b/apps/dev/tests/process-issue.lifecycle.test.ts
@@ -1153,6 +1153,28 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
     expect(handoff).toContain("- pnpm typecheck");
   });
 
+  it("surfaces only the feedback stage in the Worker instruction when Preflight is enabled (#3844)", async () => {
+    const commands = ["pnpm typecheck", "pnpm test:invariants"];
+    const { deps, input, trace } = harness({ outcome: "done", locked: false });
+    deps.validationMoments = {
+      preflight: true,
+      iteration: ["pnpm test:unit"],
+      post_done: commands,
+      landing: ["pnpm test:landing"],
+    };
+
+    await processIssue(deps, input);
+
+    const instruction = trace.runAgentCalls[0]?.systemPrompt ?? "";
+    const lines = instruction.split("\n");
+    expect(instruction).toContain("<preflight>");
+    for (const command of commands) {
+      expect(lines.filter((line) => line === `- ${command}`)).toHaveLength(1);
+    }
+    expect(instruction).not.toContain("pnpm test:unit");
+    expect(instruction).not.toContain("pnpm test:landing");
+  });
+
   it("runs declared post_done at the branch fork point even when the live base moves", async () => {
     const command = "pnpm test:fork-point";
     const { deps, input, trace } = harness({

--- a/apps/dev/tests/validation-setting-keys.test.ts
+++ b/apps/dev/tests/validation-setting-keys.test.ts
@@ -42,9 +42,9 @@ describe("validation setting keys (#3466)", () => {
   });
 
   it("classifies this repo's own declared keys the way the config means them", () => {
-    // A regeneration declaration and four resource
-    // knobs, none of which schedules anything.
-    for (const setting of ["generated", "node_max_old_space_mb", "heavy_available_memory_mb", "vitest_max_workers", "turbo_concurrency"]) {
+    // Preflight, a regeneration declaration, and four resource knobs; none of
+    // these schedules a Validation moment.
+    for (const setting of ["preflight", "generated", "node_max_old_space_mb", "heavy_available_memory_mb", "vitest_max_workers", "turbo_concurrency"]) {
       expect(isValidationSettingKey(setting), `${setting} is a setting, not a moment`).toBe(true);
     }
     expect(isValidationSettingKey("post_done")).toBe(false);

--- a/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/packaging/pi/dev/skills/engineering/afk/docs/CONFIG.md
@@ -132,6 +132,7 @@ plugins:
         skills: dev:tdd, dev:diagnose # optional exact worker allowlist; activation gates still apply
         runner_startup_baseline_ms: 840 # optional measured pre-projection historical baseline
       validation:
+        preflight: false
         subsecond_failures_are_branch_fault: false
         iteration:
           - pnpm --filter @reddb-io/dev exec vitest run tests/config.test.ts
@@ -187,6 +188,12 @@ list and also skips loudly.
 | `plugins.dev.afk.validation.post_done` | The engine runs these commands after DONE against the branch's fork point. The Worker's `<merge-gate>` repeats the exact list. | A correction re-runs only the failed subset, then folds back to the full declaration after that subset passes. |
 | `plugins.dev.afk.validation.landing` | The engine runs these commands immediately before push, PR creation, and queue entry. | Last local verdict; it does not try to predict a moving base. |
 | Merge queue | The repository's required CI checks run on the merge group. This is configured at the forge, not in RedSkills. | The merge queue is the CI-side final Validation moment and owns freshness against the merged result. |
+
+`plugins.dev.afk.validation.preflight` is an experimental boolean and defaults
+to `false`. When enabled, the Worker system instruction previews the exact
+`post_done` command list as a pre-DONE checklist. It never adds `iteration`,
+`landing`, review, or other commands, and the post-DONE gate still executes and
+enforces the declaration.
 
 `plugins.dev.afk.validation.subsecond_failures_are_branch_fault` is an optional
 boolean declaration beside that schedule. Verdict first trusts structured branch

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -181,7 +181,8 @@ host-authority boundary) ->
 MCP-session auto-registration and daemon recovery ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md` and
 `plugins/dev/skills/engineering/afk/MCP.md`;
-`/afk` local validation authority (`plugins.dev.afk.validation.{iteration,post_done,landing}`) ->
+`/afk` local validation authority (experimental `plugins.dev.afk.validation.preflight`
+plus the `iteration`, `post_done`, and `landing` moments) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` Appraisal promotion (`plugins.dev.review.appraisal_floor`, advisory `off`
 or a blocking 0–1 floor) ->

--- a/packaging/pi/dev/skills/engineering/red-setup/config-template.yaml
+++ b/packaging/pi/dev/skills/engineering/red-setup/config-template.yaml
@@ -47,6 +47,8 @@ plugins:
   #                               # AFK runs declared commands verbatim; the
   #                               # engine never substitutes a package manager.
   #     validation:               # operator-declared Validation moments (ADR 0135)
+  #       preflight: false        # experimental: preview exact post_done commands
+  #                               # before DONE; default off, gate still enforces
   #       subsecond_failures_are_branch_fault: false
   #                               # Set true only when the declared suite can
   #                               # legitimately fail in under one second.

--- a/plugins/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/plugins/dev/skills/engineering/afk/docs/CONFIG.md
@@ -132,6 +132,7 @@ plugins:
         skills: dev:tdd, dev:diagnose # optional exact worker allowlist; activation gates still apply
         runner_startup_baseline_ms: 840 # optional measured pre-projection historical baseline
       validation:
+        preflight: false
         subsecond_failures_are_branch_fault: false
         iteration:
           - pnpm --filter @reddb-io/dev exec vitest run tests/config.test.ts
@@ -187,6 +188,12 @@ list and also skips loudly.
 | `plugins.dev.afk.validation.post_done` | The engine runs these commands after DONE against the branch's fork point. The Worker's `<merge-gate>` repeats the exact list. | A correction re-runs only the failed subset, then folds back to the full declaration after that subset passes. |
 | `plugins.dev.afk.validation.landing` | The engine runs these commands immediately before push, PR creation, and queue entry. | Last local verdict; it does not try to predict a moving base. |
 | Merge queue | The repository's required CI checks run on the merge group. This is configured at the forge, not in RedSkills. | The merge queue is the CI-side final Validation moment and owns freshness against the merged result. |
+
+`plugins.dev.afk.validation.preflight` is an experimental boolean and defaults
+to `false`. When enabled, the Worker system instruction previews the exact
+`post_done` command list as a pre-DONE checklist. It never adds `iteration`,
+`landing`, review, or other commands, and the post-DONE gate still executes and
+enforces the declaration.
 
 `plugins.dev.afk.validation.subsecond_failures_are_branch_fault` is an optional
 boolean declaration beside that schedule. Verdict first trusts structured branch

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -181,7 +181,8 @@ host-authority boundary) ->
 MCP-session auto-registration and daemon recovery ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md` and
 `plugins/dev/skills/engineering/afk/MCP.md`;
-`/afk` local validation authority (`plugins.dev.afk.validation.{iteration,post_done,landing}`) ->
+`/afk` local validation authority (experimental `plugins.dev.afk.validation.preflight`
+plus the `iteration`, `post_done`, and `landing` moments) ->
 `plugins/dev/skills/engineering/afk/docs/CONFIG.md`;
 `/afk` Appraisal promotion (`plugins.dev.review.appraisal_floor`, advisory `off`
 or a blocking 0–1 floor) ->

--- a/plugins/dev/skills/engineering/red-setup/config-template.yaml
+++ b/plugins/dev/skills/engineering/red-setup/config-template.yaml
@@ -47,6 +47,8 @@ plugins:
   #                               # AFK runs declared commands verbatim; the
   #                               # engine never substitutes a package manager.
   #     validation:               # operator-declared Validation moments (ADR 0135)
+  #       preflight: false        # experimental: preview exact post_done commands
+  #                               # before DONE; default off, gate still enforces
   #       subsecond_failures_are_branch_fault: false
   #                               # Set true only when the declared suite can
   #                               # legitimately fail in under one second.


### PR DESCRIPTION
Automated AFK landing for #3844. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3844

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789432817&installation_model_id=20659&pr_number=3932&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3932&signature=065b2d4e632957c17bae4c24c79f7d6fc4b404279467e917f2b5e2f1164a8661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->