### PR TITLE
fix: #3893 Windows Named Pipes preserve the local ACP authority model

### DIFF
--- a/.changeset/redskilled-windows-named-pipes.md
+++ b/.changeset/redskilled-windows-named-pipes.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": minor
+---
+
+Carry the public RedSkills and daemon-assigned Worker ACP contracts over Windows Named Pipes while retaining Unix sockets on Linux and stdio only at launch edges.

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -361,6 +361,46 @@ jobs:
         if: env.RUN_ANY != 'true'
         run: echo "No non-dev package is in the affected cone (scope ${{ needs.scope.outputs.mode }}) — no suite to run."
 
+  # The local ACP authority contract is deliberately focused enough to run on
+  # both native endpoint families. Linux proves the known daemon Unix socket and
+  # daemon-assigned Worker sockets; Windows proves the same public and Worker ACP
+  # exchanges over Named Pipes. Stdio appears only in the launch-edge adapter.
+  acp-local-transport:
+    runs-on: ${{ matrix.os }}
+    needs: scope
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    env:
+      RUN_ACP: ${{ contains(fromJSON(needs.scope.outputs.test_packages), 'apps/redskilled') }}
+    steps:
+      - name: Checkout
+        if: env.RUN_ACP == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - if: env.RUN_ACP == 'true'
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+
+      - if: env.RUN_ACP == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+
+      - name: Install workspace dependencies
+        if: env.RUN_ACP == 'true'
+        env:
+          REDDB_SKIP_POSTINSTALL: "1"
+        run: pnpm install --frozen-lockfile
+
+      - name: Test host-native ACP authority transport
+        if: env.RUN_ACP == 'true'
+        run: pnpm -C apps/redskilled test:acp-local-transport
+
+      - name: Report narrowed scope
+        if: env.RUN_ACP != 'true'
+        run: echo "apps/redskilled is not in the affected cone — no local ACP transport check to run."
+
   # Branch protection requires a check named `test`, so the name survives the
   # fan-out as an aggregate: the work moved, the contract did not.
   test:
@@ -371,7 +411,7 @@ jobs:
     # and shrink their own steps, so a docs-only PR reaches this job green.
     if: always()
     runs-on: ubuntu-latest
-    needs: [scope, test-shard, test-packages]
+    needs: [scope, test-shard, test-packages, acp-local-transport]
     steps:
       - name: Fail when a test dependency failed or was cancelled
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -379,6 +419,7 @@ jobs:
           echo "scope=${{ needs.scope.result }}"
           echo "test-shard=${{ needs['test-shard'].result }}"
           echo "test-packages=${{ needs['test-packages'].result }}"
+          echo "acp-local-transport=${{ needs['acp-local-transport'].result }}"
           exit 1
 
       - name: Report aggregate result

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -43,6 +43,7 @@
     "test:acp-agent-catalog": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-agent-catalog.test.ts",
     "test:acp-conformance": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-conformance.test.ts",
     "test:acp-control-plane": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-control-plane.test.ts",
+    "test:acp-local-transport": "vitest run tests/acp-local-transport.test.ts",
     "test:placement-contract": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/placement-contract.test.ts",
     "test:github-gateway": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/github-gateway.test.ts",
     "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/redskilled.bundle.min.mjs --asset redskilled.bundle.min.mjs --minify",

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -7,7 +7,7 @@
  * its assigned socket and exits when redskilled closes that connection.
  */
 import { randomUUID } from "node:crypto";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { createServer, type Socket } from "node:net";
 import { join } from "node:path";
 import {
@@ -35,6 +35,7 @@ import {
   closeServer,
   connectWithDeadline,
   listen,
+  removeAcpEndpoint,
   socketStream,
   withTimeout,
 } from "./acp-socket.js";
@@ -162,7 +163,7 @@ export async function startRedskillsAcpControlPlane(
     return pending;
   };
   await mkdir(join(paths.runtimeDir, "acp-workers"), { recursive: true, mode: 0o700 });
-  await rm(paths.acpSocketPath, { force: true });
+  await removeAcpEndpoint(paths.acpSocketPath);
 
   const server = createServer((socket) => {
     sockets.add(socket);
@@ -186,7 +187,7 @@ export async function startRedskillsAcpControlPlane(
       closed = true;
       for (const socket of sockets) socket.destroy();
       await closeServer(server);
-      await rm(paths.acpSocketPath, { force: true });
+      await removeAcpEndpoint(paths.acpSocketPath);
     },
   };
 }

--- a/apps/redskilled/src/acp-native-worker.ts
+++ b/apps/redskilled/src/acp-native-worker.ts
@@ -1,7 +1,6 @@
 /** Daemon admission and the native ACP Workflow Worker implementation. */
 import { randomBytes, randomUUID } from "node:crypto";
 import { constants, accessSync } from "node:fs";
-import { rm } from "node:fs/promises";
 import type { Socket } from "node:net";
 import { delimiter, isAbsolute, join } from "node:path";
 import {
@@ -28,6 +27,7 @@ import {
   abortableDelay,
   bindWorkerRendezvous,
   connectWithDeadline,
+  removeAcpEndpoint,
   socketStream,
   waitForAbort,
   withTimeout,
@@ -41,7 +41,7 @@ import {
   type AcpSessionRecoveryCheckpoint,
 } from "./acp-session-journal.js";
 import type { AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
-import type { RedskilledPaths } from "./paths.js";
+import { resolveAcpWorkerEndpoint, type RedskilledPaths } from "./paths.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
 import type { ActiveWorkflowWorker } from "./acp-worker-lifecycle.js";
@@ -67,14 +67,14 @@ export async function admitNativeAcpWorker(
   dispatch?: AcpTargetedDispatchIntent,
 ): Promise<ActiveWorkflowWorker> {
   const endpointId = randomBytes(6).toString("hex");
-  const endpoint = join(options.paths.runtimeDir, "acp-workers", `${endpointId}.sock`);
+  const endpoint = resolveAcpWorkerEndpoint(options.paths, endpointId);
   const rendezvous = await bindWorkerRendezvous(endpoint);
   let launched: LaunchedWorker;
   try {
     launched = options.startWorker(nativeWorkerSpec(session.project, endpoint, options.paths.runtimeDir));
   } catch (error) {
     rendezvous.server.close();
-    await rm(endpoint, { force: true });
+    await removeAcpEndpoint(endpoint);
     throw error;
   }
 
@@ -83,7 +83,7 @@ export async function admitNativeAcpWorker(
     workerSocket = await withTimeout(rendezvous.connected, 10_000, "native ACP Worker rendezvous");
   } catch (error) {
     rendezvous.server.close();
-    await rm(endpoint, { force: true });
+    await removeAcpEndpoint(endpoint);
     throw error;
   }
   rendezvous.server.close();
@@ -160,7 +160,7 @@ export async function admitNativeAcpWorker(
   } catch (error) {
     connection.close();
     workerSocket.destroy();
-    await rm(endpoint, { force: true });
+    await removeAcpEndpoint(endpoint);
     throw error;
   }
 

--- a/apps/redskilled/src/acp-socket.ts
+++ b/apps/redskilled/src/acp-socket.ts
@@ -14,12 +14,18 @@ export async function bindWorkerRendezvous(socketPath: string): Promise<{
   server: Server;
   connected: Promise<Socket>;
 }> {
-  await rm(socketPath, { force: true });
+  await removeAcpEndpoint(socketPath);
   let accept!: (socket: Socket) => void;
   const connected = new Promise<Socket>((resolve) => { accept = resolve; });
   const server = createServer((socket) => accept(socket));
   await listen(server, socketPath);
   return { server, connected };
+}
+
+/** Unix sockets leave filesystem nodes; Windows Named Pipes die with the server handle. */
+export async function removeAcpEndpoint(endpoint: string): Promise<void> {
+  if (endpoint.startsWith("\\\\.\\pipe\\")) return;
+  await rm(endpoint, { force: true });
 }
 
 export async function listen(server: Server, socketPath: string): Promise<void> {

--- a/apps/redskilled/src/acp-worker-lifecycle.ts
+++ b/apps/redskilled/src/acp-worker-lifecycle.ts
@@ -1,4 +1,3 @@
-import { rm } from "node:fs/promises";
 import type { Socket } from "node:net";
 import {
   methods,
@@ -8,6 +7,7 @@ import {
   type PromptResponse,
 } from "@agentclientprotocol/sdk";
 import type { AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
+import { removeAcpEndpoint } from "./acp-socket.js";
 
 export interface ActiveWorkflowWorker {
   readonly workerId: string;
@@ -91,7 +91,7 @@ export function cleanupWorkflowWorker(
   if (active.get(sessionId) === worker) active.delete(sessionId);
   worker.connection.close();
   worker.socket.destroy();
-  void rm(worker.endpoint, { force: true });
+  void removeAcpEndpoint(worker.endpoint);
 }
 
 export function workerTransportIsClosed(worker: ActiveWorkflowWorker): boolean {

--- a/apps/redskilled/src/paths.ts
+++ b/apps/redskilled/src/paths.ts
@@ -45,6 +45,8 @@ export function redskilledResourceIncidentRoot(homeDir: string): string {
 }
 
 export interface RedskilledPaths {
+  /** Host ABI selecting Unix sockets or Windows Named Pipes for ACP authorities. */
+  readonly platform: NodeJS.Platform;
   /** The raw session scope this daemon serves — never published. */
   readonly sessionKey: string;
   /** 12-hex digest of {@link sessionKey}: the publishable session identity. */
@@ -121,6 +123,7 @@ export function resolveMachineIdHash(options: ResolveRedskilledPathsOptions = {}
 
 /** Where the daemon lives, and the machine-wide claim it must hold to live there. PURE. */
 export function resolveRedskilledPaths(options: ResolveRedskilledPathsOptions = {}): RedskilledPaths {
+  const platform = options.platform ?? process.platform;
   const sessionKey = resolveSessionKey(options);
   const runtimeDir = options.runtimeDir ?? runtimeSocketDir({
     key: `redskilled:${sessionKey}`,
@@ -129,6 +132,7 @@ export function resolveRedskilledPaths(options: ResolveRedskilledPathsOptions = 
     uid: options.uid,
   });
   const machineIdHash = resolveMachineIdHash(options);
+  const sessionKeyHash = shortDigest(sessionKey);
   const machineClaimPathOfThisHost = resolveMachineClaimPath({
     env: options.env,
     machineIdHash,
@@ -139,12 +143,15 @@ export function resolveRedskilledPaths(options: ResolveRedskilledPathsOptions = 
     ?? (options.runtimeDir == null ? process.env.HOME : options.runtimeDir)
     ?? runtimeDir;
   return {
+    platform,
     sessionKey,
-    sessionKeyHash: shortDigest(sessionKey),
+    sessionKeyHash,
     machineIdHash,
     runtimeDir,
     socketPath: join(runtimeDir, REDSKILLED_SOCKET_FILE),
-    acpSocketPath: join(runtimeDir, REDSKILLED_ACP_SOCKET_FILE),
+    acpSocketPath: platform === "win32"
+      ? windowsNamedPipe(`redskilled-${sessionKeyHash}-acp`)
+      : join(runtimeDir, REDSKILLED_ACP_SOCKET_FILE),
     lockPath: join(runtimeDir, "redskilled.spawn.lock"),
     leasePath: join(runtimeDir, "redskilled.lease.toon"),
     eventLanePath: join(redskilledHomeDir(homeDir), REDSKILLED_EVENT_LANE_FILE),
@@ -157,6 +164,18 @@ export function resolveRedskilledPaths(options: ResolveRedskilledPathsOptions = 
     machineClaimPathOfThisHost,
     machineClaimPath: options.machineClaimPath ?? machineClaimPathOfThisHost,
   };
+}
+
+/** Daemon-assigned reconnectable endpoint for one disposable ACP Worker. */
+export function resolveAcpWorkerEndpoint(paths: RedskilledPaths, endpointId: string): string {
+  if (!/^[a-z0-9-]+$/i.test(endpointId)) throw new Error("ACP Worker endpoint id must be alphanumeric or kebab-case");
+  return paths.platform === "win32"
+    ? windowsNamedPipe(`redskilled-${paths.sessionKeyHash}-worker-${endpointId}`)
+    : join(paths.runtimeDir, "acp-workers", `${endpointId}.sock`);
+}
+
+function windowsNamedPipe(name: string): string {
+  return `\\\\.\\pipe\\${name}`;
 }
 
 function shortDigest(value: string): string {

--- a/apps/redskilled/tests/acp-local-transport.test.ts
+++ b/apps/redskilled/tests/acp-local-transport.test.ts
@@ -1,0 +1,218 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, extname, join, resolve } from "node:path";
+import { Readable, Writable } from "node:stream";
+import { pathToFileURL } from "node:url";
+import {
+  client,
+  methods,
+  ndJsonStream,
+  type Stream,
+} from "@agentclientprotocol/sdk";
+import { decode } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+import { acpSessionJournalPath } from "../src/acp-session-journal.js";
+import { startRedskillsAcpControlPlane } from "../src/acp-control-plane.js";
+import {
+  resolveAcpWorkerEndpoint,
+  resolveRedskilledPaths,
+} from "../src/paths.js";
+import type { LaunchedWorker, RedskilledWorkerSpec } from "../src/worker-launch.js";
+
+const require_ = createRequire(import.meta.url);
+const tsxLoader = require_.resolve("tsx");
+const childAgentFixture = resolve(__dirname, "fixtures", "bin", "redcode");
+const stdioAdapterProgram = `
+  import { runRedskillsAcpAdapter } from ${JSON.stringify(pathToFileURL(resolve(__dirname, "..", "src", "acp-control-plane.ts")).href)};
+  import { resolveRedskilledPaths } from ${JSON.stringify(pathToFileURL(resolve(__dirname, "..", "src", "paths.ts")).href)};
+  process.exitCode = await runRedskillsAcpAdapter(resolveRedskilledPaths());
+`;
+const workerProgram = `
+  import { runNativeAcpWorker } from ${JSON.stringify(pathToFileURL(resolve(__dirname, "..", "src", "acp-native-worker.ts")).href)};
+  const endpoint = process.env.REDSKILLED_TEST_WORKER_ENDPOINT;
+  if (endpoint == null || endpoint === "") throw new Error("missing test Worker endpoint");
+  process.exitCode = await runNativeAcpWorker(endpoint, {
+    agent: "redcode",
+    transport: "stdio",
+    command: process.execPath,
+    args: [${JSON.stringify(childAgentFixture)}, "acp"],
+  });
+`;
+const children: ChildProcess[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const child of children.splice(0)) {
+    if (child.exitCode == null && child.signalCode == null) child.kill("SIGKILL");
+  }
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("the host-native local ACP authority transport", () => {
+  it("reconnects stdio projections to one public endpoint and distinct daemon-assigned Worker endpoints", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-acp-local-transport-"));
+    roots.push(root);
+    const env = {
+      ...process.env,
+      HOME: root,
+      XDG_RUNTIME_DIR: root,
+      REDSKILLED_MACHINE_DIR: root,
+      REDSKILLED_SESSION: `test:${root}`,
+      REDSKILLED_ACP_WORKER_IDLE_MS: "100",
+    };
+    const paths = resolveRedskilledPaths({ env, homeDir: root });
+    const assignedWorkerEndpoints: string[] = [];
+    let workerSequence = 0;
+    const controlPlane = await startRedskillsAcpControlPlane({
+      paths,
+      hostState: () => ({ workers: [] }) as never,
+      startWorker: (spec) => launchTestWorker(spec, env, assignedWorkerEndpoints, ++workerSequence),
+    });
+
+    try {
+      expect(controlPlane.socketPath).toBe(paths.acpSocketPath);
+      expectLocalEndpoint(paths.acpSocketPath, join(paths.runtimeDir, "redskilled-acp.sock"));
+      expectLocalEndpoint(
+        resolveAcpWorkerEndpoint(paths, "fixture"),
+        join(paths.runtimeDir, "acp-workers", "fixture.sock"),
+      );
+
+      const first = await openStdioProjection(env, "first");
+      await exerciseWorkflow(first.connection, root, "first turn");
+      await closeStdioProjection(first);
+
+      const journalPath = acpSessionJournalPath(paths.registrationIntentPath);
+      const afterFirstDisconnect = decode(await readFile(journalPath, "utf8")) as unknown as {
+        sessions: readonly unknown[];
+      };
+      expect(afterFirstDisconnect.sessions).toHaveLength(1);
+
+      const second = await openStdioProjection(env, "second");
+      await exerciseWorkflow(second.connection, root, "second turn");
+      await closeStdioProjection(second);
+
+      expect(assignedWorkerEndpoints).toHaveLength(2);
+      expect(new Set(assignedWorkerEndpoints).size).toBe(2);
+      for (const endpoint of assignedWorkerEndpoints) {
+        if (process.platform === "win32") {
+          expectLocalEndpoint(endpoint, "unused-on-Windows");
+        } else {
+          expect(dirname(endpoint)).toBe(join(paths.runtimeDir, "acp-workers"));
+          expect(extname(endpoint)).toBe(".sock");
+        }
+        expect(endpoint).not.toBe(paths.acpSocketPath);
+      }
+
+      const afterSecondDisconnect = decode(await readFile(journalPath, "utf8")) as unknown as {
+        sessions: readonly unknown[];
+      };
+      expect(afterSecondDisconnect.sessions).toHaveLength(2);
+    } finally {
+      await controlPlane.close();
+    }
+  }, 30_000);
+});
+
+function launchTestWorker(
+  spec: RedskilledWorkerSpec,
+  env: NodeJS.ProcessEnv,
+  assignedEndpoints: string[],
+  sequence: number,
+): LaunchedWorker {
+  const endpoint = flagValue(spec.args ?? [], "--socket");
+  assignedEndpoints.push(endpoint);
+  const child = spawn(process.execPath, [
+    "--import", tsxLoader,
+    "--input-type=module",
+    "--eval", workerProgram,
+  ], {
+    cwd: spec.workspace_path,
+    env: { ...env, REDSKILLED_TEST_WORKER_ENDPOINT: endpoint },
+    stdio: "ignore",
+  });
+  children.push(child);
+  if (child.pid == null) throw new Error("test Worker did not start");
+  return {
+    worker: {
+      worker_id: `transport-worker-${sequence}`,
+      project_label: spec.project_label,
+      pid: child.pid,
+      started_at: new Date().toISOString(),
+      workspace_path: spec.workspace_path,
+      isolated: false,
+      warnings: [],
+    },
+    child,
+  } as unknown as LaunchedWorker;
+}
+
+async function openStdioProjection(env: NodeJS.ProcessEnv, label: string): Promise<{
+  child: ChildProcess;
+  connection: ReturnType<ReturnType<typeof client>["connect"]>;
+}> {
+  const child = spawn(process.execPath, [
+    "--import", tsxLoader,
+    "--input-type=module",
+    "--eval", stdioAdapterProgram,
+  ], {
+    env,
+    stdio: ["pipe", "pipe", "ignore"],
+  });
+  children.push(child);
+  const connection = client({ name: `${label}-stdio-projection` }).connect(childStream(child));
+  await connection.agent.request(methods.agent.initialize, {
+    protocolVersion: 1,
+    clientCapabilities: {},
+    clientInfo: { name: `${label}-transport-client`, version: "1" },
+  });
+  return { child, connection };
+}
+
+async function exerciseWorkflow(
+  connection: ReturnType<ReturnType<typeof client>["connect"]>,
+  cwd: string,
+  text: string,
+): Promise<void> {
+  const session = await connection.agent.request(methods.agent.session.new, { cwd, mcpServers: [] });
+  await expect(connection.agent.request(methods.agent.session.prompt, {
+    sessionId: session.sessionId,
+    prompt: [{ type: "text", text }],
+  })).resolves.toMatchObject({ stopReason: "end_turn" });
+}
+
+async function closeStdioProjection(projection: {
+  child: ChildProcess;
+  connection: ReturnType<ReturnType<typeof client>["connect"]>;
+}): Promise<void> {
+  projection.connection.close();
+  projection.child.stdin?.end();
+  if (projection.child.exitCode == null && projection.child.signalCode == null) {
+    await once(projection.child, "exit");
+  }
+}
+
+function childStream(child: ChildProcess): Stream {
+  if (child.stdin == null || child.stdout == null) throw new Error("ACP adapter did not expose stdio");
+  return ndJsonStream(
+    Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+    Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+  );
+}
+
+function flagValue(args: readonly string[], flag: string): string {
+  const index = args.indexOf(flag);
+  const value = args[index + 1];
+  if (index < 0 || value == null || value === "") throw new Error(`missing ${flag} in Worker argv`);
+  return value;
+}
+
+function expectLocalEndpoint(endpoint: string, posixEndpoint: string): void {
+  if (process.platform === "win32") {
+    expect(endpoint).toMatch(/^\\\\\.\\pipe\\redskilled-[a-f0-9]{12}-(?:acp|worker-[a-z0-9-]+)$/);
+    return;
+  }
+  expect(endpoint).toBe(posixEndpoint);
+}


### PR DESCRIPTION
Automated AFK landing for #3893. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3893

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789434030&installation_model_id=20659&pr_number=3933&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3933&signature=df92b1e8010b66da6d01726ed4eb9a8eded7c68304351702ff90b9969163dbc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->