### PR TITLE
fix: #3659 Project control surfaces report observed facts, never requested intent

### DIFF
--- a/apps/dev/src/commands/stop.ts
+++ b/apps/dev/src/commands/stop.ts
@@ -8,6 +8,7 @@ import * as ghx from "../runtime/gh.js";
 import { createRedskilledBirthPort } from "../runtime/redskilled-birth.js";
 import { LABEL_HUMAN, LABEL_READY, LABEL_RUNNING } from "../core/triage-labels.js";
 import { blockedLabelsIn } from "../core/state-transition.js";
+import { projectStopStatus } from "../core/project-stop.js";
 
 async function readWorkerPid(pidFile: string): Promise<number | null> {
   try {
@@ -177,6 +178,10 @@ async function stopProjectWithReconcile(
   stdout.write(
     encodeToon({
       op: "stop",
+      status: projectStopStatus({
+        deregistered: released.deregistered,
+        unreachable: released.refusal !== undefined,
+      }),
       deregistered: released.deregistered,
       workers_stopped: released.workersStopped.length,
       claims_released: claimsReleased,

--- a/apps/dev/src/core/project-stop.ts
+++ b/apps/dev/src/core/project-stop.ts
@@ -1,0 +1,10 @@
+export type ProjectStopStatus = "unreachable" | "already-stopped" | "stopped";
+
+/** Classify only what the Project authority observed, never the requested intent. */
+export function projectStopStatus(input: {
+  readonly deregistered: boolean;
+  readonly unreachable: boolean;
+}): ProjectStopStatus {
+  if (input.unreachable) return "unreachable";
+  return input.deregistered ? "stopped" : "already-stopped";
+}

--- a/apps/dev/src/mcp/dependencies.ts
+++ b/apps/dev/src/mcp/dependencies.ts
@@ -58,6 +58,7 @@ import {
   releaseProjectRegistration,
   waitStatusImpl,
 } from "./project.js";
+import { projectStopStatus } from "../core/project-stop.js";
 import { laneLogs, projectFields, workerVitals } from "./vitals.js";
 import {
   buildQueueStatus,
@@ -162,7 +163,16 @@ export function createCastleMcpDependencies(
     // project's Workers. There is no process of the project's own left to kill
     // (ADR 0130 Amendment 4), so `force` no longer selects a harder teardown —
     // the kill is the daemon's either way.
-    projectStop: async () => ({ status: "stopped", ...(await releaseProjectRegistration(root)) }),
+    projectStop: async () => {
+      const observed = await releaseProjectRegistration(root);
+      return {
+        status: projectStopStatus({
+          deregistered: observed.deregistered,
+          unreachable: observed.warnings != null,
+        }),
+        ...observed,
+      };
+    },
     hostState: () => createRedskilledBirthPort({ root }).hostState(),
     hostDashboard: () => createRedskilledBirthPort({ root }).hostDashboard(),
     hostProvisionCheck: () => createRedskilledBirthPort({ root }).provisionCheck(),

--- a/apps/dev/tests/mcp-project-registration.test.ts
+++ b/apps/dev/tests/mcp-project-registration.test.ts
@@ -482,6 +482,7 @@ describe("stopping work deregisters the project", () => {
     expect(daemon.registrations()).toHaveLength(1);
 
     const stopped = await deps.projectStop({}) as Record<string, unknown>;
+    expect(stopped.status).toBe("stopped");
     expect(stopped.deregistered).toBe(true);
     expect(daemon.registrations()).toEqual([]);
 
@@ -491,5 +492,20 @@ describe("stopping work deregisters the project", () => {
       status: "registered",
       target: 2,
     });
+  });
+
+  it("distinguishes an already-stopped Project from a completed stop", async () => {
+    await liveHost();
+    const root = await project();
+    const stopped = await createCastleMcpDependencies(root).projectStop({}) as Record<string, unknown>;
+
+    expect(stopped).toMatchObject({ status: "already-stopped", deregistered: false });
+  });
+
+  it("reports an unreachable authority without rewriting the request as stopped", async () => {
+    const root = await project();
+    const stopped = await createCastleMcpDependencies(root).projectStop({}) as Record<string, unknown>;
+
+    expect(stopped).toMatchObject({ status: "unreachable", deregistered: false });
   });
 });

--- a/apps/dev/tests/stop-command.test.ts
+++ b/apps/dev/tests/stop-command.test.ts
@@ -168,6 +168,7 @@ describe("stopCommand — project stop", () => {
     expect(code).toBe(0);
     const out = text();
     expect(out).toContain("op: stop");
+    expect(out).toContain("status: already-stopped");
     expect(out).toContain("deregistered: false");
     expect(out).toContain("claims_released: 0");
   });
@@ -180,6 +181,7 @@ describe("stopCommand — project stop", () => {
     expect(code).toBe(0);
     const out = text();
     expect(out).toContain("deregistered: true");
+    expect(out).toContain("status: stopped");
     expect(out).toContain("workers_stopped: 2");
   });
 
@@ -215,6 +217,7 @@ describe("stopCommand — project stop", () => {
     const code = await stopCommand([], "/repo", stream, io);
 
     expect(code).toBe(1);
+    expect(text()).toContain("status: unreachable");
     expect(text()).toContain("redskilled daemon unreachable");
   });
 

--- a/apps/redskilled/src/acp-github.ts
+++ b/apps/redskilled/src/acp-github.ts
@@ -187,11 +187,20 @@ export function bindAcpProjectGithubCustodyStatus(
   return async (): Promise<RedskilledGithubCustodyStatus | undefined> => {
     if (gateway == null) return undefined;
     const project = projectForConnection();
-    const selection = await gateway.credentialForProject({
-      projectId: project.projectId,
-      projectLabel: project.projectLabel,
-      workspacePath: project.workspacePath,
-    });
+    let selection;
+    try {
+      selection = await gateway.credentialForProject({
+        projectId: project.projectId,
+        projectLabel: project.projectLabel,
+        workspacePath: project.workspacePath,
+      });
+    } catch (error) {
+      // Project control remains observable when optional GitHub custody has no
+      // usable credential profile. Credential-bound custody mutations still
+      // return their typed authorization refusal through their own methods.
+      if (error instanceof RedskilledGithubCredentialProfileError) return undefined;
+      throw error;
+    }
     if (selection == null) return undefined;
     const reader = gateway.gateway.forProject({
       projectId: project.projectId,

--- a/apps/redskilled/src/github-custody.ts
+++ b/apps/redskilled/src/github-custody.ts
@@ -43,6 +43,10 @@ export interface RedskilledGithubCustodyFault {
   readonly kind: "inert-custodian";
   readonly threshold_ms: number;
   readonly age_ms: number;
+  readonly repair: {
+    readonly method: "_redskills/github_custody_handoff";
+    readonly params: RedskilledGithubCustodyHandoff;
+  };
 }
 
 export interface RedskilledGithubCustodyRecord extends RedskilledGithubCustodyHandoff {
@@ -261,7 +265,7 @@ export function createGithubCustodian(options: CreateGithubCustodianOptions): Gi
       const key = custodyKey(project.projectId, valid.pull_request);
       executions.set(key, { project, credential });
       if (record.state !== "terminal") schedule(key, 0);
-      return publicRecord(record, options.clock(), options.inertMs);
+      return publicRecord(record, options.clock(), options.tickMs, options.inertMs);
     },
     async status(project, credential) {
       await register(project, credential);
@@ -274,7 +278,7 @@ export function createGithubCustodian(options: CreateGithubCustodianOptions): Gi
         records: current.records
           .filter((record) => record.project_id === project.projectId)
           .sort((left, right) => left.pull_request - right.pull_request)
-          .map((record) => publicRecord(record, now, options.inertMs)),
+          .map((record) => publicRecord(record, now, options.tickMs, options.inertMs)),
       };
     },
     close() {
@@ -289,16 +293,31 @@ export function createGithubCustodian(options: CreateGithubCustodianOptions): Gi
 function publicRecord(
   record: RedskilledGithubCustodyRecord,
   now: string,
+  tickMs: number,
   inertMs: number,
 ): RedskilledGithubCustodyRecord {
   if (record.state === "terminal") return withoutFault(record);
   const lastActivity = record.last_tick_at ?? record.handed_off_at;
   const age = Date.parse(now) - Date.parse(lastActivity);
-  if (!Number.isFinite(age) || age <= inertMs) return withoutFault(record);
+  const threshold = record.last_tick_at == null ? Math.min(tickMs, inertMs) : inertMs;
+  if (!Number.isFinite(age) || age < threshold) return withoutFault(record);
   return {
     ...record,
     next_action: "repair-custodian",
-    fault: { kind: "inert-custodian", threshold_ms: inertMs, age_ms: Math.max(0, age) },
+    fault: {
+      kind: "inert-custodian",
+      threshold_ms: threshold,
+      age_ms: Math.max(0, age),
+      repair: {
+        method: "_redskills/github_custody_handoff",
+        params: {
+          pull_request: record.pull_request,
+          owner_ticket: record.owner_ticket,
+          branch: record.branch,
+          base: record.base,
+        },
+      },
+    },
   };
 }
 

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -17,6 +17,7 @@ export const PROJECT_CONTROL_METHODS = [
 
 export type ProjectControlOperation = "drain" | "stop";
 type ProjectDrainIntent = "inactive" | "draining" | "stopped";
+export type ProjectControlOperationStatus = "draining" | "already-draining" | "stopped" | "already-stopped";
 
 interface ProjectControlUpdate {
   readonly sequence: number;
@@ -73,23 +74,30 @@ export async function applyProjectControl(
   projectControls: Map<string, ProjectControlState>,
   persist: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>,
 ) {
-  const held = projectControls.get(project.projectId) ?? {
+  const held = projectControls.get(project.projectId);
+  if (held == null && operation === "stop") {
+    return { ...projectControlSnapshot(project, projectControls), status: "already-stopped" as const };
+  }
+  const observed = held ?? {
     drainIntent: "inactive" as const,
     revision: 0,
     updates: [],
   };
   const requestedIntent = operation === "drain" ? "draining" as const : "stopped" as const;
-  if (held.drainIntent === requestedIntent) return projectControlSnapshot(project, projectControls);
-  const revision = held.revision + 1;
+  if (observed.drainIntent === requestedIntent) {
+    const status = operation === "drain" ? "already-draining" as const : "already-stopped" as const;
+    return { ...projectControlSnapshot(project, projectControls), status };
+  }
+  const revision = observed.revision + 1;
   const next = new Map(projectControls);
   next.set(project.projectId, {
     drainIntent: requestedIntent,
     revision,
-    updates: [...held.updates, { sequence: revision, operation, drain_intent: requestedIntent }],
+    updates: [...observed.updates, { sequence: revision, operation, drain_intent: requestedIntent }],
   });
   await persist(next);
   projectControls.set(project.projectId, next.get(project.projectId)!);
-  return projectControlSnapshot(project, projectControls);
+  return { ...projectControlSnapshot(project, projectControls), status: requestedIntent };
 }
 
 export function projectControlStorePath(registrationIntentPath: string): string {
@@ -152,7 +160,7 @@ export async function notifyV1ProjectControl(
   upstream: AgentConnection["client"],
   sessionId: string,
   operation: ProjectControlOperation,
-  control: ReturnType<typeof projectControlSnapshot>,
+  control: Awaited<ReturnType<typeof applyProjectControl>>,
 ): Promise<void> {
   await upstream.notify(methods.client.session.update, {
     sessionId,

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -820,6 +820,16 @@ describe("the public RedSkills ACP v1 control plane", () => {
       },
     });
     const firstSession = await first.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
+    const unregisteredStop = await first.agent.request<ProjectControlOperationResult>(
+      "_redskills/project_stop",
+      {},
+    );
+    expect(unregisteredStop).toMatchObject({
+      status: "already-stopped",
+      drain_intent: "inactive",
+      revision: 0,
+      updates: [],
+    });
     const coreDrain = await first.agent.request(methods.agent.session.prompt, {
       sessionId: firstSession.sessionId,
       prompt: [{ type: "text", text: "/drain" }],
@@ -858,8 +868,9 @@ describe("the public RedSkills ACP v1 control plane", () => {
     const observed = await second.agent.request<ProjectControlSnapshot>("_redskills/project_status", {});
     expect(observed).toEqual(projectControlMeta(coreDrain._meta));
 
-    const stopped = await second.agent.request<ProjectControlSnapshot>("_redskills/project_stop", {});
+    const stopped = await second.agent.request<ProjectControlOperationResult>("_redskills/project_stop", {});
     expect(stopped).toMatchObject({
+      status: "stopped",
       drain_intent: "stopped",
       revision: 2,
       updates: [
@@ -867,6 +878,12 @@ describe("the public RedSkills ACP v1 control plane", () => {
         { sequence: 2, operation: "stop", drain_intent: "stopped" },
       ],
     });
+    await expect(second.agent.request<ProjectControlOperationResult>("_redskills/project_stop", {}))
+      .resolves.toMatchObject({
+        status: "already-stopped",
+        drain_intent: "stopped",
+        revision: 2,
+      });
     second.close();
     secondAdapter.stdin?.end();
 
@@ -914,11 +931,16 @@ interface ProjectControlSnapshot {
   }>;
 }
 
+interface ProjectControlOperationResult extends ProjectControlSnapshot {
+  readonly status: "draining" | "already-draining" | "stopped" | "already-stopped";
+}
+
 function projectControlMeta(meta: unknown): ProjectControlSnapshot {
   const control = (meta as { redskills?: { projectControl?: unknown } } | undefined)
     ?.redskills?.projectControl;
   expect(control).toMatchObject({ version: 1, project_id: expect.any(String) });
-  return control as ProjectControlSnapshot;
+  const { status: _status, ...snapshot } = control as ProjectControlOperationResult;
+  return snapshot;
 }
 
 function projectMeta(meta: unknown): { projectId: string; projectLabel: string; workspacePath: string } {

--- a/apps/redskilled/tests/github-custody.test.ts
+++ b/apps/redskilled/tests/github-custody.test.ts
@@ -174,6 +174,58 @@ describe("redskilled GitHub merge custody", () => {
     expect(releases).toBeLessThanOrEqual(1);
     gateway.close();
   });
+
+  it("finds a never-ticked obligation within one declared tick and gives ACP a repair call", async () => {
+    const root = await fixtureRoot("redskilled-github-custody-never-ticked-");
+    let now = "2026-08-15T20:00:00.000Z";
+    const gateway = createRedskilledGithubGateway({
+      upstream: async () => ({ value: {}, budget: null }),
+      outboxPath: join(root, "github-outbox.toon"),
+      custodyPath: join(root, "github-custody.toon"),
+      custodyTickMs: 1_000,
+      custodyInertMs: 60_000,
+      clock: () => now,
+      writeUpstream: async () => ({ number: 73 }),
+      custodyUpstream: {
+        async observe() {
+          throw new Error("the closed fixture must never tick");
+        },
+        async arm() {
+          throw new Error("the closed fixture must never tick");
+        },
+      },
+    });
+    const project = gateway.forProject({
+      projectId: "github:101",
+      projectLabel: "acme/widgets",
+      workspacePath: join(root, "workspace"),
+      credentialProfile: "engineering",
+    }, { secret: "fixture" });
+    const handoff = {
+      pull_request: 73,
+      owner_ticket: 3659,
+      branch: "worker/3659",
+      base: "main",
+    } as const;
+
+    await project.handoffMergeCustody(handoff);
+    gateway.close();
+    now = "2026-08-15T20:00:01.001Z";
+
+    expect((await project.mergeCustodyStatus()).records[0]).toMatchObject({
+      pull_request: 73,
+      last_tick_at: null,
+      next_action: "repair-custodian",
+      fault: {
+        kind: "inert-custodian",
+        threshold_ms: 1_000,
+        repair: {
+          method: "_redskills/github_custody_handoff",
+          params: handoff,
+        },
+      },
+    });
+  });
 });
 
 async function fixtureRoot(prefix: string): Promise<string> {


### PR DESCRIPTION
Automated AFK landing for #3659. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3659

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789434259&installation_model_id=20659&pr_number=3934&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3934&signature=eab857807c6040bcfca7bc03293f1676c4328a9806fd24b1c467a0eccb861719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->