### PR TITLE
fix: #3895 Major handover drains Workers and preserves one endpoint owner

### DIFF
--- a/.changeset/redskilled-major-handover.md
+++ b/.changeset/redskilled-major-handover.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": minor
+---
+
+Add a durable quiescent cross-major handover boundary that drains or terminally accounts for Workers, flushes pending GitHub writes, releases the old authority, and resumes interrupted state migration before activating the new major.

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -17,6 +17,7 @@
     "./github-gateway": "./src/github-gateway.ts",
     "./launch-template": "./src/launch-template.ts",
     "./live-metrics": "./src/live-metrics.ts",
+    "./major-handover": "./src/major-handover.ts",
     "./orphan-reaper": "./src/orphan-reaper.ts",
     "./paths": "./src/paths.ts",
     "./project-breaker": "./src/project-breaker.ts",

--- a/apps/redskilled/src/major-handover.ts
+++ b/apps/redskilled/src/major-handover.ts
@@ -1,0 +1,283 @@
+/** Durable, resumable cross-major authority handover for redskilled. */
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+
+export type RedskilledMajorHandoverPhase = "quiesced" | "released" | "migrated" | "active";
+
+export interface RedskilledMajorHandoverWorker {
+  readonly worker_id: string;
+  readonly outcome: "drained" | "terminally-accounted";
+}
+
+/**
+ * Migration metadata only. Project workflow state remains in its durable stores
+ * and is never copied through a cross-major process or checkpoint payload.
+ */
+export interface RedskilledMajorHandoverCheckpoint {
+  readonly version: 1;
+  readonly handover_id: string;
+  readonly from_major: number;
+  readonly to_major: number;
+  readonly phase: RedskilledMajorHandoverPhase;
+  readonly workers: readonly RedskilledMajorHandoverWorker[];
+  readonly checkpointed_at: string;
+  readonly released_at?: string;
+  readonly migrated_at?: string;
+  readonly activated_at?: string;
+}
+
+export interface QuiesceRedskilledMajorInput {
+  readonly fromMajor: number;
+  readonly toMajor: number;
+  /** Close every route that could admit new work before observing Workers. */
+  stopAdmission(): Promise<void>;
+  /** Finish live Workers or durably record one terminal outcome for each. */
+  drainWorkers(): Promise<readonly RedskilledMajorHandoverWorker[]>;
+  /** Settle the old major's serialized GitHub outbox before budget release. */
+  flushGithubWrites(): Promise<void>;
+  /** Release Projects, the GitHub budget, and the one public endpoint together. */
+  releaseAuthority(): Promise<void>;
+}
+
+export interface ActivateRedskilledMajorInput {
+  readonly toMajor: number;
+  /** Idempotently migrate durable stores while neither major is authoritative. */
+  migrate(checkpoint: RedskilledMajorHandoverCheckpoint): Promise<void>;
+  /** Bind the endpoint and begin admission only after migration completes. */
+  assumeAuthority(): Promise<void>;
+}
+
+export interface RedskilledMajorHandover {
+  read(): Promise<RedskilledMajorHandoverCheckpoint | null>;
+  quiesce(input: QuiesceRedskilledMajorInput): Promise<RedskilledMajorHandoverCheckpoint>;
+  activate(input: ActivateRedskilledMajorInput): Promise<RedskilledMajorHandoverCheckpoint>;
+}
+
+export interface CreateRedskilledMajorHandoverOptions {
+  readonly clock?: () => string;
+  readonly id?: () => string;
+}
+
+/**
+ * Create the one checkpoint lane shared by the outgoing and incoming majors.
+ *
+ * The old major checkpoints only after admission, Workers, and pending writes
+ * are quiescent. It retains all authority until that checkpoint is durable. The
+ * new major may migrate only from `released`, and may assume authority only from
+ * `migrated`. Re-entering either method resumes at the last durable phase.
+ */
+export function createRedskilledMajorHandover(
+  path: string,
+  options: CreateRedskilledMajorHandoverOptions = {},
+): RedskilledMajorHandover {
+  const clock = options.clock ?? (() => new Date().toISOString());
+  const id = options.id ?? randomUUID;
+  let tail: Promise<unknown> = Promise.resolve();
+
+  const serialized = <T>(operation: () => Promise<T>): Promise<T> => {
+    const next = tail.then(operation, operation);
+    tail = next.then(() => undefined, () => undefined);
+    return next;
+  };
+
+  const read = async (): Promise<RedskilledMajorHandoverCheckpoint | null> => {
+    try {
+      return parseCheckpoint(decode((await readFile(path, "utf8")).trim()));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
+  };
+
+  const persist = async (
+    checkpoint: RedskilledMajorHandoverCheckpoint,
+  ): Promise<RedskilledMajorHandoverCheckpoint> => {
+    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+    const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+    await writeFile(temporary, `${encode(checkpoint as unknown as JsonValue)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(temporary, path);
+    return checkpoint;
+  };
+
+  return {
+    read,
+    quiesce(input) {
+      return serialized(async () => {
+        requireMajorPair(input.fromMajor, input.toMajor);
+        let checkpoint = await read();
+        if (checkpoint?.phase === "active" && checkpoint.to_major === input.fromMajor) checkpoint = null;
+        if (checkpoint != null) requireSameHandover(checkpoint, input.fromMajor, input.toMajor);
+        if (checkpoint?.phase === "released" || checkpoint?.phase === "migrated" || checkpoint?.phase === "active") {
+          return checkpoint;
+        }
+
+        await input.stopAdmission();
+        if (checkpoint == null) {
+          const workers = validateWorkers(await input.drainWorkers());
+          await input.flushGithubWrites();
+          checkpoint = await persist({
+            version: 1,
+            handover_id: nonEmpty(id(), "a major handover needs an id"),
+            from_major: input.fromMajor,
+            to_major: input.toMajor,
+            phase: "quiesced",
+            workers,
+            checkpointed_at: timestamp(clock()),
+          });
+        }
+
+        await input.releaseAuthority();
+        return await persist({
+          ...checkpoint,
+          phase: "released",
+          released_at: timestamp(clock()),
+        });
+      });
+    },
+    activate(input) {
+      return serialized(async () => {
+        requireMajor(input.toMajor, "target");
+        let checkpoint = await read();
+        if (checkpoint == null) throw new Error("redskilled major handover has no durable checkpoint");
+        if (checkpoint.to_major !== input.toMajor) {
+          throw new Error(
+            `redskilled major handover targets wire major ${checkpoint.to_major}, not ${input.toMajor}`,
+          );
+        }
+        if (checkpoint.phase === "quiesced") {
+          throw new Error("redskilled major handover cannot migrate before the old major releases authority");
+        }
+        if (checkpoint.phase === "active") return checkpoint;
+
+        if (checkpoint.phase === "released") {
+          await input.migrate(checkpoint);
+          checkpoint = await persist({
+            ...checkpoint,
+            phase: "migrated",
+            migrated_at: timestamp(clock()),
+          });
+        }
+
+        await input.assumeAuthority();
+        return await persist({
+          ...checkpoint,
+          phase: "active",
+          activated_at: timestamp(clock()),
+        });
+      });
+    },
+  };
+}
+
+function requireMajorPair(fromMajor: number, toMajor: number): void {
+  requireMajor(fromMajor, "source");
+  requireMajor(toMajor, "target");
+  if (fromMajor === toMajor) throw new Error("a major handover must cross RedSkills wire majors");
+}
+
+function requireMajor(major: number, label: string): void {
+  if (!Number.isSafeInteger(major) || major <= 0) {
+    throw new Error(`a major handover needs one positive ${label} wire major`);
+  }
+}
+
+function requireSameHandover(
+  checkpoint: RedskilledMajorHandoverCheckpoint,
+  fromMajor: number,
+  toMajor: number,
+): void {
+  if (checkpoint.from_major !== fromMajor || checkpoint.to_major !== toMajor) {
+    throw new Error(
+      `unfinished redskilled major handover ${checkpoint.from_major}->${checkpoint.to_major} ` +
+        `cannot be replaced by ${fromMajor}->${toMajor}`,
+    );
+  }
+}
+
+function validateWorkers(
+  workers: readonly RedskilledMajorHandoverWorker[],
+): readonly RedskilledMajorHandoverWorker[] {
+  const seen = new Set<string>();
+  return workers.map((worker) => {
+    const workerId = nonEmpty(worker.worker_id, "a major handover Worker needs an id");
+    if (seen.has(workerId)) throw new Error(`major handover accounts for Worker ${JSON.stringify(workerId)} twice`);
+    seen.add(workerId);
+    if (worker.outcome !== "drained" && worker.outcome !== "terminally-accounted") {
+      throw new Error(`major handover Worker ${JSON.stringify(workerId)} has no terminal outcome`);
+    }
+    return { worker_id: workerId, outcome: worker.outcome };
+  });
+}
+
+function parseCheckpoint(value: unknown): RedskilledMajorHandoverCheckpoint {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("redskilled major handover checkpoint is not a snapshot");
+  }
+  const record = value as Record<string, unknown>;
+  const allowed = new Set([
+    "version",
+    "handover_id",
+    "from_major",
+    "to_major",
+    "phase",
+    "workers",
+    "checkpointed_at",
+    "released_at",
+    "migrated_at",
+    "activated_at",
+  ]);
+  if (Object.keys(record).some((key) => !allowed.has(key))) {
+    throw new Error("redskilled major handover checkpoint contains workflow state or an unknown field");
+  }
+  if (record.version !== 1) throw new Error("redskilled major handover checkpoint has an unsupported version");
+  requireMajorPair(record.from_major as number, record.to_major as number);
+  if (!isPhase(record.phase)) throw new Error("redskilled major handover checkpoint has an invalid phase");
+  if (!Array.isArray(record.workers)) throw new Error("redskilled major handover checkpoint has no Worker accounting");
+
+  const checkpoint: RedskilledMajorHandoverCheckpoint = {
+    version: 1,
+    handover_id: nonEmpty(record.handover_id, "redskilled major handover checkpoint has no id"),
+    from_major: record.from_major as number,
+    to_major: record.to_major as number,
+    phase: record.phase,
+    workers: validateWorkers(record.workers as RedskilledMajorHandoverWorker[]),
+    checkpointed_at: timestamp(record.checkpointed_at),
+    ...(record.released_at == null ? {} : { released_at: timestamp(record.released_at) }),
+    ...(record.migrated_at == null ? {} : { migrated_at: timestamp(record.migrated_at) }),
+    ...(record.activated_at == null ? {} : { activated_at: timestamp(record.activated_at) }),
+  };
+  requirePhaseTimestamps(checkpoint);
+  return checkpoint;
+}
+
+function isPhase(value: unknown): value is RedskilledMajorHandoverPhase {
+  return value === "quiesced" || value === "released" || value === "migrated" || value === "active";
+}
+
+function requirePhaseTimestamps(checkpoint: RedskilledMajorHandoverCheckpoint): void {
+  if (checkpoint.phase !== "quiesced" && checkpoint.released_at == null) {
+    throw new Error("released major handover checkpoint has no release timestamp");
+  }
+  if ((checkpoint.phase === "migrated" || checkpoint.phase === "active") && checkpoint.migrated_at == null) {
+    throw new Error("migrated major handover checkpoint has no migration timestamp");
+  }
+  if (checkpoint.phase === "active" && checkpoint.activated_at == null) {
+    throw new Error("active major handover checkpoint has no activation timestamp");
+  }
+}
+
+function nonEmpty(value: unknown, message: string): string {
+  if (typeof value !== "string" || value.trim() === "") throw new Error(message);
+  return value.trim();
+}
+
+function timestamp(value: unknown): string {
+  const timestamp = nonEmpty(value, "a major handover checkpoint needs a timestamp");
+  if (!Number.isFinite(Date.parse(timestamp))) throw new Error("a major handover checkpoint timestamp is invalid");
+  return timestamp;
+}

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -19,6 +19,7 @@ import { decode } from "@reddb-io/toon";
 import { afterEach, describe, expect, it } from "vitest";
 import { socketAnswers } from "../src/daemon.js";
 import { readRedskilledEvents } from "../src/event-lane.js";
+import { createRedskilledMajorHandover } from "../src/major-handover.js";
 import { resolveRedskilledPaths } from "../src/paths.js";
 import { requestWorkflowTurn, type ActiveWorkflowWorker } from "../src/acp-worker-lifecycle.js";
 
@@ -78,6 +79,104 @@ describe("ACP Workflow Worker replacement authority", () => {
     expect(replacementAdmissions).toBe(0);
     expect(active.get(publicSessionId)).toBe(worker);
     expect(worker.cleaned).toBe(false);
+  });
+});
+
+describe("quiescent RedSkills major handover", () => {
+  it("drains the old authority and resumes an interrupted migration before the new major accepts work", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-major-handover-"));
+    roots.push(root);
+    const checkpointPath = join(root, "major-handover.toon");
+    const order: string[] = [];
+    const observations: Array<{ old: string[]; next: string[] }> = [];
+    const old = new Set(["projects", "workers", "endpoint", "github-budget"]);
+    const next = new Set<string>();
+    let accepting = true;
+    let migrationAttempts = 0;
+    const observe = () => {
+      observations.push({ old: [...old].sort(), next: [...next].sort() });
+      expect([...old].filter((authority) => next.has(authority))).toEqual([]);
+    };
+    const handover = createRedskilledMajorHandover(checkpointPath, {
+      clock: () => `2026-08-16T01:0${order.length}:00.000Z`,
+    });
+
+    const checkpoint = await handover.quiesce({
+      fromMajor: 1,
+      toMajor: 2,
+      async stopAdmission() {
+        order.push("stop-admission");
+        accepting = false;
+        observe();
+      },
+      async drainWorkers() {
+        order.push("drain-workers");
+        expect(accepting).toBe(false);
+        old.delete("workers");
+        observe();
+        return [{ worker_id: "worker-one", outcome: "terminally-accounted" }];
+      },
+      async flushGithubWrites() {
+        order.push("flush-github-writes");
+        expect(old.has("workers")).toBe(false);
+        observe();
+      },
+      async releaseAuthority() {
+        order.push("release-old-authority");
+        expect((await handover.read())?.phase).toBe("quiesced");
+        old.clear();
+        observe();
+      },
+    });
+
+    expect(order).toEqual([
+      "stop-admission",
+      "drain-workers",
+      "flush-github-writes",
+      "release-old-authority",
+    ]);
+    expect(checkpoint).toMatchObject({
+      version: 1,
+      from_major: 1,
+      to_major: 2,
+      phase: "released",
+      workers: [{ worker_id: "worker-one", outcome: "terminally-accounted" }],
+    });
+    expect(checkpoint).not.toHaveProperty("workflow_state");
+
+    await expect(handover.activate({
+      toMajor: 2,
+      async migrate() {
+        migrationAttempts += 1;
+        order.push("migration-interrupted");
+        observe();
+        throw new Error("fixture interruption");
+      },
+      async assumeAuthority() {
+        throw new Error("an interrupted migration must not activate the new major");
+      },
+    })).rejects.toThrow("fixture interruption");
+    expect((await handover.read())?.phase).toBe("released");
+    expect(next.size).toBe(0);
+
+    const activated = await handover.activate({
+      toMajor: 2,
+      async migrate() {
+        migrationAttempts += 1;
+        order.push("migrate-state");
+        observe();
+      },
+      async assumeAuthority() {
+        order.push("assume-new-authority");
+        for (const authority of ["projects", "workers", "endpoint", "github-budget"]) next.add(authority);
+        observe();
+      },
+    });
+
+    expect(migrationAttempts).toBe(2);
+    expect(activated.phase).toBe("active");
+    expect(order.slice(-2)).toEqual(["migrate-state", "assume-new-authority"]);
+    expect(observations.every(({ old, next }) => old.every((authority) => !next.includes(authority)))).toBe(true);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #3895. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3895

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789434978&installation_model_id=20659&pr_number=3935&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3935&signature=04a00da31661675ded8433b7e5b96de02af75ba1657ed7013121d90806334c47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->