### PR TITLE
fix: #3942 Per-plugin npm package carries its runtime bundle (expand)

### DIFF
--- a/apps/dev/tests/pi-package-builder.test.ts
+++ b/apps/dev/tests/pi-package-builder.test.ts
@@ -87,12 +87,12 @@ describe("Pi package builder", () => {
     await mkdir(join(root, "plugins/dev/skills/in-progress/scratch"), { recursive: true });
     await mkdir(join(root, "plugins/memory/.claude-plugin"), { recursive: true });
     await mkdir(join(root, "plugins/memory/skills/core/init"), { recursive: true });
+    await mkdir(join(root, "dist"), { recursive: true });
 
     await writeJson(join(root, ".claude-plugin/marketplace.json"), {
       name: "red-skills",
       plugins: [
         { name: "dev", source: "./plugins/dev", description: "Dev plugin." },
-        { name: "memory", source: "./plugins/memory", description: "Memory plugin." },
       ],
     });
 
@@ -148,6 +148,8 @@ description: Test init skill.
 `,
       "utf8",
     );
+    await writeFile(join(root, "dist/dev.bundle.min.mjs"), "// dev runtime\n", "utf8");
+    await writeFile(join(root, "dist/memory.bundle.min.mjs"), "// memory runtime\n", "utf8");
 
     await buildPiPackages({ root });
 
@@ -159,7 +161,7 @@ description: Test init skill.
       name: "@reddb-io/red-skills-dev",
       version: "9.9.9",
       publishConfig: { access: "public" },
-      files: expect.arrayContaining(["skills/**/*", "package.json", "README.md"]),
+      files: expect.arrayContaining(["skills/**/*", "dist/**/*", "package.json", "README.md"]),
     });
     // The build drops the local-only "private": true flag — the staged
     // package must be publishable. Verifying via negation: there is no
@@ -181,12 +183,17 @@ description: Test init skill.
       () => false,
     );
     expect(scratchExists).toBe(false);
+    expect(await readFile(join(root, "packaging/pi/dev/dist/dev.bundle.min.mjs"), "utf8"))
+      .toBe("// dev runtime\n");
 
-    // Memory mirrors the same shape with its core bucket
+    // Memory is discovered from plugins/* even though it is absent from the
+    // marketplace fixture, and mirrors the same shape with its own bundle.
     const memoryPkg = JSON.parse(
       await readFile(join(root, "packaging/pi/memory/package.json"), "utf8"),
     );
     expect(memoryPkg.pi.skills).toEqual(["./skills/core/"]);
+    expect(await readFile(join(root, "packaging/pi/memory/dist/memory.bundle.min.mjs"), "utf8"))
+      .toBe("// memory runtime\n");
   });
 
   it("fails --check when a staged Pi package drifts from the source (module API)", async () => {

--- a/packaging/pi/brain/package.json
+++ b/packaging/pi/brain/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "skills/**/*",
+    "dist/**/*",
     "package.json",
     "README.md"
   ]

--- a/packaging/pi/dev/package.json
+++ b/packaging/pi/dev/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "skills/**/*",
+    "dist/**/*",
     "package.json",
     "README.md"
   ]

--- a/packaging/pi/internal/package.json
+++ b/packaging/pi/internal/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "skills/**/*",
+    "dist/**/*",
     "package.json",
     "README.md"
   ]

--- a/packaging/pi/memory/package.json
+++ b/packaging/pi/memory/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "skills/**/*",
+    "dist/**/*",
     "package.json",
     "README.md"
   ]

--- a/scripts/build-pi-packages.mjs
+++ b/scripts/build-pi-packages.mjs
@@ -19,7 +19,7 @@
 //
 // Exit codes: 0 success; 1 drift detected; 2 usage error.
 
-import { cp, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -34,7 +34,6 @@ import {
 
 const PUBLISHED_BUCKETS = ["engineering", "knowledge", "productivity", "misc", "core", "maintainer"];
 const SKIP_BUCKETS = new Set(["in-progress", "deprecated"]);
-const NPM_SCOPE = "@reddb-io";
 const PACKAGING_ROOT = "packaging/pi";
 
 function isPublishedBucket(name) {
@@ -72,13 +71,13 @@ function buildNpmPackageJson(claudePlugin) {
     ...publishable,
     ...(releaseVersion ? { version: releaseVersion } : {}),
     publishConfig: { access: "public" },
-    files: ["skills/**/*", "package.json", "README.md"],
+    files: ["skills/**/*", "dist/**/*", "package.json", "README.md"],
   };
 }
 
-async function stagePackage({ root, plugin, claudePlugin, packagingDir, mismatches, check }) {
+async function stagePackage({ root, pluginDir, claudePlugin, packagingDir, mismatches, check }) {
   const pluginName = claudePlugin.name;
-  const pluginRoot = join(root, plugin.source);
+  const pluginRoot = join(root, "plugins", pluginDir);
   // packagingDir is already root-joined by buildPiPackages (e.g.
   // <root>/packaging/pi). Appending the plugin name here avoids the
   // double-join that would otherwise turn absolute paths into
@@ -133,7 +132,29 @@ async function stagePackage({ root, plugin, claudePlugin, packagingDir, mismatch
     }
   }
 
-  // 3. Stage a small README so `npm view` shows project context, not just an
+  // 3. Stage the plugin's built runtime when the release build has produced it.
+  // Local manifest checks run from source-only trees where dist/ is absent;
+  // the publish-time tarball contract remains the authority that every release
+  // actually built and packed this declared file.
+  const bundleName = `${pluginName}.bundle.min.mjs`;
+  const sourceBundle = join(root, "dist", bundleName);
+  const targetBundle = join(targetDir, "dist", bundleName);
+  try {
+    const bundleBytes = await readFile(sourceBundle);
+    if (check) {
+      const stagedBytes = await readFile(targetBundle).catch(() => null);
+      if (stagedBytes === null || !bundleBytes.equals(stagedBytes)) {
+        mismatches.push({ path: targetBundle, bytes: "", note: [`${bundleName}: bytes differ`] });
+      }
+    } else {
+      await mkdir(join(targetDir, "dist"), { recursive: true });
+      await cp(sourceBundle, targetBundle);
+    }
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+  }
+
+  // 4. Stage a small README so `npm view` shows project context, not just an
   // auto-generated "no description" stub.
   await writeGenerated(
     join(targetDir, "README.md"),
@@ -215,14 +236,16 @@ async function diffDirs(leftDir, rightDir) {
 
 export async function buildPiPackages({ root, check = false }) {
   const mismatches = [];
-  const claudeMarketplacePath = join(root, ".claude-plugin/marketplace.json");
-  const claudeMarketplace = await readJson(claudeMarketplacePath);
   const packagingDir = join(root, PACKAGING_ROOT);
+  const pluginDirs = (await readdir(join(root, "plugins"), { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
 
-  for (const plugin of claudeMarketplace.plugins) {
-    const pluginRoot = join(root, plugin.source);
+  for (const pluginDir of pluginDirs) {
+    const pluginRoot = join(root, "plugins", pluginDir);
     const claudePlugin = await readJson(join(pluginRoot, ".claude-plugin/plugin.json"));
-    await stagePackage({ root, plugin, claudePlugin, packagingDir, mismatches, check });
+    await stagePackage({ root, pluginDir, claudePlugin, packagingDir, mismatches, check });
   }
 
   if (check && mismatches.length > 0) {


### PR DESCRIPTION
Automated AFK landing for #3942. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3942

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789475407&installation_model_id=20659&pr_number=3946&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3946&signature=5fe9fe5200dc6620fa3b92c1db5929139f3543c77c511f6b9e2b377234f61c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->