### PR TITLE
chore: #3943 Core npm package carries the marketplace manifests and host generators, and no monorepo source

### DIFF
--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -23,8 +23,17 @@
     "rsp": "bin/rsp.mjs"
   },
   "files": [
+    ".agents/plugins/marketplace.json",
+    ".claude-plugin/marketplace.json",
+    ".gemini-plugin/marketplace.json",
     "bin/",
     "dist/",
-    "README.md"
+    "README.md",
+    "scripts/generate-codex-manifests.mjs",
+    "scripts/generate-gemini-manifests.mjs",
+    "scripts/generate-pi-manifests.mjs",
+    "scripts/install-opencode.sh",
+    "scripts/install-pi.sh",
+    "scripts/lib/manifest-core.mjs"
   ]
 }

--- a/packaging/npm/scripts/prepare.mjs
+++ b/packaging/npm/scripts/prepare.mjs
@@ -9,7 +9,7 @@
  * partial build (e.g. only the dev bundle) still packs — the pre-publish
  * contract check is the gate that a required bundle actually resolves.
  */
-import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -19,6 +19,21 @@ const repoRoot = join(pkgRoot, "..", "..");
 const srcDist = join(repoRoot, "dist");
 const destDist = join(pkgRoot, "dist");
 
+// Host wiring runs from the installed package tree, not from monorepo source.
+// Stage only the public manifests and the generators the installer invokes;
+// package.json's explicit files allowlist is the final tarball boundary.
+const HOST_WIRING_FILES = [
+  ".agents/plugins/marketplace.json",
+  ".claude-plugin/marketplace.json",
+  ".gemini-plugin/marketplace.json",
+  "scripts/generate-codex-manifests.mjs",
+  "scripts/generate-gemini-manifests.mjs",
+  "scripts/generate-pi-manifests.mjs",
+  "scripts/install-opencode.sh",
+  "scripts/install-pi.sh",
+  "scripts/lib/manifest-core.mjs",
+];
+
 // Each entry stages one bundle into this package's dist/. `dest` is the packaged
 // filename the bin shims / launchers resolve; the first existing `sources` entry
 // is copied to it. Most bundles are named identically by `pnpm bundle`, but
@@ -27,6 +42,7 @@ const destDist = join(pkgRoot, "dist");
 // dedicated code-nav step pre-copies the asset name, and the plain `pnpm bundle`
 // path falls back to the turbo outfile. No bundle silently skips as "not built".
 const BUNDLES = [
+  { dest: "opencode-host.bundle.min.mjs", sources: ["opencode-host.bundle.min.mjs"] },
   { dest: "dev.bundle.min.mjs", sources: ["dev.bundle.min.mjs"] },
   { dest: "redskilled-mcp.bundle.min.mjs", sources: ["redskilled-mcp.bundle.min.mjs"] },
   { dest: "code-nav.bundle.min.mjs", sources: ["code-nav.bundle.min.mjs", "code-nav-mcp.bundle.min.mjs"] },
@@ -37,6 +53,15 @@ const BUNDLES = [
   { dest: "rsp-core.bundle.min.mjs", sources: ["rsp-core.bundle.min.mjs"] },
   { dest: "redskilled.bundle.min.mjs", sources: ["redskilled.bundle.min.mjs"] },
 ];
+
+for (const relativePath of HOST_WIRING_FILES) {
+  const source = join(repoRoot, relativePath);
+  const destination = join(pkgRoot, relativePath);
+  mkdirSync(dirname(destination), { recursive: true });
+  copyFileSync(source, destination);
+  chmodSync(destination, statSync(source).mode);
+  process.stdout.write(`prepare: staged ${relativePath}\n`);
+}
 
 mkdirSync(destDist, { recursive: true });
 let staged = 0;


### PR DESCRIPTION
Automated AFK landing for #3943. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3943

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789475898&installation_model_id=20659&pr_number=3947&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3947&signature=c14cda1f6e6560850c5463cd31eaa21b344af17f1483874b4d61891632d3be7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->