### PR TITLE
fix: #3945 install.sh installs the npm packages instead of the release source tarball, with node and npm as hard preconditions

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,14 +4,14 @@
 # Intended curl entrypoint:
 #   curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash
 #
-# The script resolves the latest GitHub Release by default, installs that source
-# tree under ~/.red-skills, detects supported local CLIs, then wires each host:
+# The script resolves the published npm packages by default, materialises their
+# runtime tree under ~/.red-skills, detects supported local CLIs, then wires each host:
 #   - Claude Code: marketplace + plugins
 #   - Codex CLI: marketplace + plugins
 #   - OpenCode/RedCode: generated plugin/skill/MCP/statusline surface
 #
 # The Claude and Codex marketplaces are registered from the GitHub source
-# (reddb-io/red-skills), not from the downloaded snapshot: `plugin marketplace
+# (reddb-io/red-skills), not from the materialised tree: `plugin marketplace
 # update` re-reads whatever source was registered, so a directory registration
 # freezes the machine at its install-day version. `--local-marketplace` opts
 # into the directory form for offline and dev installs; re-running the installer
@@ -59,21 +59,21 @@ Installs RedSkills into every detected supported CLI:
 
 Options:
   --version <tag>       Install a specific release tag (default: latest release).
-                        Pins the downloaded source cache, not the marketplace;
+                        Pins the materialised npm packages, not the marketplace;
                         combine with --local-marketplace to pin Claude/Codex too.
-  --install-root <dir>  Install source cache here (default: ~/.red-skills)
+  --install-root <dir>  Install versioned runtime trees here (default: ~/.red-skills)
   --only <list>         Comma list: claude,codex,opencode,redcode,pi (default: auto-detect)
   --claude-scope <s>    Claude install scope: user, project, or local (default: user)
   --pi-scope <s>        Pi install scope: user or project (default: user)
-  --source-dir <dir>    Use an existing red-skills checkout instead of downloading
+  --source-dir <dir>    Use an existing red-skills checkout instead of npm packages
   --local-marketplace   Register the Claude/Codex marketplace from the local
                         source directory instead of the GitHub source. Offline
                         and dev installs only: a directory-sourced marketplace
                         can never see a release published after install day.
   --uninstall           Remove RedSkills from detected/specified CLIs
   --force               Reinstall plugins where the host supports removal
-  --purge               With --uninstall, also remove the RedSkills source cache
-  --refresh             Re-download the selected release source
+  --purge               With --uninstall, also remove the RedSkills install tree
+  --refresh             Re-materialise the selected npm packages
   --opencode-copy       Copy OpenCode-compatible SKILL.md files instead of symlinking
   --dry-run             Print actions without writing
   -h, --help            Show this help
@@ -83,7 +83,7 @@ Environment:
   RED_SKILLS_CLAUDE_SCOPE, RED_SKILLS_PI_SCOPE, RED_SKILLS_SOURCE_DIR,
   RED_SKILLS_ACTION, RED_SKILLS_FORCE, RED_SKILLS_PURGE, RED_SKILLS_REFRESH,
   RED_SKILLS_OPENCODE_COPY, RED_SKILLS_MARKETPLACE_SOURCE (github|local),
-  RED_SKILLS_REPO, GITHUB_TOKEN.
+  RED_SKILLS_REPO.
 EOF
 }
 
@@ -159,93 +159,12 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "$1 is required"
 }
 
-curl_json() {
-  local url="$1"
-  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-    curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" "$url"
-  else
-    curl -fsSL "$url"
-  fi
-}
-
-curl_file() {
-  local url="$1"
-  local out="$2"
-  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-    curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" "$url" -o "$out"
-  else
-    curl -fsSL "$url" -o "$out"
-  fi
-}
-
-latest_release_tag() {
-  local api="https://api.github.com/repos/$REPO/releases/latest"
-  local tag
-  tag="$(curl_json "$api" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
-  [[ -n "$tag" ]] || die "could not resolve latest release from $api"
-  printf '%s\n' "$tag"
-}
-
 safe_release_tag() {
   local tag="$1"
   case "$tag" in
     v[0-9]*.[0-9]*.[0-9]* | [0-9]*.[0-9]*.[0-9]*) printf '%s\n' "$tag" ;;
     *) die "release tag must look like vX.Y.Z, got '$tag'" ;;
   esac
-}
-
-download_release_asset_if_available() {
-  local tag="$1"
-  local source="$2"
-  local asset="opencode-host.bundle.min.mjs"
-  local out="$source/dist/$asset"
-  local url="https://github.com/$REPO/releases/download/$tag/$asset"
-
-  if [[ "$DRY_RUN" == "true" ]]; then
-    log "would download optional release asset $url"
-    return 0
-  fi
-
-  mkdir -p "$source/dist"
-  if [[ "$REFRESH" == "true" || ! -f "$out" ]]; then
-    if curl_file "$url" "$out.tmp"; then
-      mv "$out.tmp" "$out"
-      log "downloaded optional release asset $asset"
-    else
-      rm -f "$out.tmp"
-      warn "optional release asset $asset is unavailable for $tag; OpenCode install may build from source"
-    fi
-  fi
-
-  local generated_asset="opencode-host.generated.tgz"
-  local generated_out="$source/dist/$generated_asset"
-  local generated_url="https://github.com/$REPO/releases/download/$tag/$generated_asset"
-  if [[ "$REFRESH" == "true" || ! -f "$source/dist/opencode/.release-generated" ]]; then
-    if curl_file "$generated_url" "$generated_out.tmp"; then
-      mv "$generated_out.tmp" "$generated_out"
-      tar -xzf "$generated_out" -C "$source"
-      log "downloaded optional release asset $generated_asset"
-    else
-      rm -f "$generated_out.tmp"
-      warn "optional release asset $generated_asset is unavailable for $tag; OpenCode install may generate from source"
-    fi
-  fi
-
-  local rsp_asset rsp_out rsp_url
-  mkdir -p "$source/packaging/npm/dist"
-  for rsp_asset in rsp.bundle.min.mjs rsp-core.bundle.min.mjs; do
-    rsp_out="$source/packaging/npm/dist/$rsp_asset"
-    rsp_url="https://github.com/$REPO/releases/download/$tag/$rsp_asset"
-    if [[ "$REFRESH" == "true" || ! -f "$rsp_out" ]]; then
-      if curl_file "$rsp_url" "$rsp_out.tmp"; then
-        mv "$rsp_out.tmp" "$rsp_out"
-        log "downloaded optional release asset $rsp_asset"
-      else
-        rm -f "$rsp_out.tmp"
-        warn "optional release asset $rsp_asset is unavailable for $tag; RSP may build from source"
-      fi
-    fi
-  done
 }
 
 prepare_source() {
@@ -258,65 +177,84 @@ prepare_source() {
     return 0
   fi
 
-  require_cmd curl
-  require_cmd tar
   require_cmd mktemp
 
   local tag="$VERSION"
-  if [[ "$tag" == "latest" ]]; then
-    tag="$(latest_release_tag)"
-  fi
-  tag="$(safe_release_tag "$tag")"
-  VERSION="$tag"
-
   local versions_dir="$INSTALL_ROOT/versions"
-  local cache_dir="$INSTALL_ROOT/cache"
-  local dest="$versions_dir/$tag"
   local current="$INSTALL_ROOT/current"
-  local archive="$cache_dir/$tag.tar.gz"
+  local npm_version="$tag"
+  if [[ "$tag" != "latest" ]]; then
+    tag="$(safe_release_tag "$tag")"
+    npm_version="${tag#v}"
+  fi
 
   if [[ "$DRY_RUN" == "true" ]]; then
-    log "would install $REPO@$tag under $dest"
+    log "would materialise @reddb-io/red-skills@$npm_version and plugin packages under $versions_dir/$tag"
     SOURCE_DIR="$current"
     return 0
   fi
 
-  mkdir -p "$versions_dir" "$cache_dir"
+  mkdir -p "$versions_dir"
+
+  local tmp core package_dir package_version plugin bundle resolved_version dest
+  local -a plugins=(dev memory brain internal)
+  local -a specs=("@reddb-io/red-skills@$npm_version")
+  for plugin in "${plugins[@]}"; do
+    specs+=("@reddb-io/red-skills-$plugin@$npm_version")
+  done
+
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+  log "materialising ${specs[*]}"
+  npm install "${specs[@]}" --prefix "$tmp" \
+    --no-save --no-audit --no-fund --ignore-scripts --loglevel=error
+
+  core="$tmp/node_modules/@reddb-io/red-skills"
+  [[ -f "$core/package.json" ]] || die "npm did not materialise @reddb-io/red-skills"
+  resolved_version="$(node -e 'process.stdout.write(require(process.argv[1]).version || "")' "$core/package.json")"
+  [[ -n "$resolved_version" ]] || die "@reddb-io/red-skills package has no version"
+  if [[ "$VERSION" == "latest" ]]; then
+    tag="v$resolved_version"
+  elif [[ "$resolved_version" != "$npm_version" ]]; then
+    die "npm resolved @reddb-io/red-skills@$resolved_version, expected $npm_version"
+  fi
+  VERSION="$tag"
+  dest="$versions_dir/$tag"
+
+  for plugin in "${plugins[@]}"; do
+    package_dir="$tmp/node_modules/@reddb-io/red-skills-$plugin"
+    bundle="$package_dir/dist/$plugin.bundle.min.mjs"
+    [[ -f "$package_dir/package.json" ]] || die "npm did not materialise @reddb-io/red-skills-$plugin"
+    [[ -f "$bundle" ]] || die "@reddb-io/red-skills-$plugin package is missing dist/$plugin.bundle.min.mjs"
+    package_version="$(node -e 'process.stdout.write(require(process.argv[1]).version || "")' "$package_dir/package.json")"
+    [[ "$package_version" == "$resolved_version" ]] \
+      || die "npm resolved @reddb-io/red-skills-$plugin@$package_version, expected $resolved_version"
+  done
+
   if [[ "$REFRESH" == "true" ]]; then
-    rm -rf "$dest" "$archive"
+    rm -rf "$dest"
   fi
-
   if [[ ! -d "$dest" ]]; then
-    local url="https://github.com/$REPO/archive/refs/tags/$tag.tar.gz"
-    local tmp extracted
-    tmp="$(mktemp -d)"
-    trap 'rm -rf "$tmp"' RETURN
-    log "downloading $url"
-    curl -fsSL "$url" -o "$archive"
-    # Extracted twice on purpose, and only the second failure counts.
-    # The archive carries an AGENTS.md -> CLAUDE.md symlink, and Git
-    # Bash's tar emulates symlink() as a copy of the target — which
-    # fails on the first pass when the link precedes its target in
-    # archive order, and succeeds on the second because by then the
-    # target exists on disk. Unix extracts clean on the first pass and
-    # never reaches the retry.
-    tar -xzf "$archive" -C "$tmp" 2>/dev/null || tar -xzf "$archive" -C "$tmp"
-    extracted="$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
-    [[ -n "$extracted" ]] || die "archive did not contain a source directory"
     rm -rf "$dest.tmp"
-    mv "$extracted" "$dest.tmp"
+    mkdir -p "$dest.tmp/plugins" "$dest.tmp/dist"
+    cp -R "$core/." "$dest.tmp/"
+    for plugin in "${plugins[@]}"; do
+      package_dir="$tmp/node_modules/@reddb-io/red-skills-$plugin"
+      bundle="$package_dir/dist/$plugin.bundle.min.mjs"
+      cp -R "$package_dir" "$dest.tmp/plugins/$plugin"
+      cp "$bundle" "$dest.tmp/dist/$plugin.bundle.min.mjs"
+    done
     mv "$dest.tmp" "$dest"
-    rm -rf "$tmp"
-    trap - RETURN
   else
-    log "using cached source $dest"
+    log "using cached npm materialisation $dest"
   fi
 
-  download_release_asset_if_available "$tag" "$dest"
+  rm -rf "$tmp"
+  trap - RETURN
   rm -f "$current"
   ln -s "$dest" "$current"
   SOURCE_DIR="$current"
-  log "current source -> $dest"
+  log "current install -> $dest"
 }
 
 # The reference a host CLI registers the marketplace from. The GitHub source is
@@ -494,11 +432,9 @@ install_pi() {
   fi
 
   local args=("$SOURCE_DIR/scripts/install-pi.sh")
-  # The universal installer always installs from the local release checkout
-  # (SOURCE_DIR is the cached tarball under ~/.red-skills/versions/<tag>),
-  # which keeps paths stable across re-runs of the same release. End users
-  # who want the npm surface run `pi install npm:@reddb-io/red-skills-<plugin>`
-  # directly; this script gives them the version-pinned cache instead.
+  # The universal installer points Pi at the composed, versioned runtime tree
+  # so all hosts share one stable materialisation across re-runs. Direct Pi
+  # installs may still use `npm:@reddb-io/red-skills-<plugin>`.
   args+=("--source-dir" "$SOURCE_DIR")
   if [[ "$PI_SCOPE" == "project" ]]; then
     args+=("--project" "${PI_PROJECT_DIR:-$PWD}")
@@ -871,6 +807,8 @@ if [[ "$ACTION" == "uninstall" ]]; then
   exit 0
 fi
 
+require_cmd node
+require_cmd npm
 prepare_source
 
 installed_any="false"

--- a/scripts/test-install-release-assets.sh
+++ b/scripts/test-install-release-assets.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
-# Regression test for release assets in the installed `current` tree on Git Bash.
-#
-# Git Bash emulates `ln -s <directory>` by copying the directory.  Therefore all
-# release-only assets must be downloaded before `current` is created.  The RSP
-# launcher also needs its separately published bundle beside the source archive.
+# Regression test for npm materialisation in the installed `current` tree.
 
 set -euo pipefail
 
@@ -13,53 +9,73 @@ cd "$ROOT"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-fixture="$tmp/red-skills-v9.9.9"
+packages="$tmp/packages"
+core="$packages/red-skills"
 mkdir -p \
-  "$fixture/.claude-plugin" \
-  "$fixture/.agents/plugins" \
-  "$fixture/scripts" \
-  "$fixture/packaging/npm/bin"
-printf '{}\n' >"$fixture/.claude-plugin/marketplace.json"
-printf '{}\n' >"$fixture/.agents/plugins/marketplace.json"
+  "$core/.claude-plugin" \
+  "$core/.agents/plugins" \
+  "$core/scripts" \
+  "$core/dist"
+printf '{"name":"@reddb-io/red-skills","version":"9.9.9"}\n' >"$core/package.json"
+printf '{}\n' >"$core/.claude-plugin/marketplace.json"
+printf '{}\n' >"$core/.agents/plugins/marketplace.json"
+printf 'opencode bundle\n' >"$core/dist/opencode-host.bundle.min.mjs"
 
-cat >"$fixture/scripts/install-opencode.sh" <<'INSTALL_OPENCODE'
+cat >"$core/scripts/install-opencode.sh" <<'INSTALL_OPENCODE'
 #!/usr/bin/env bash
 set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 test -f "$root/dist/opencode-host.bundle.min.mjs"
-test -f "$root/packaging/npm/dist/rsp.bundle.min.mjs"
-test -f "$root/packaging/npm/dist/rsp-core.bundle.min.mjs"
+for plugin in dev memory brain internal; do
+  test -f "$root/plugins/$plugin/package.json"
+  test -f "$root/plugins/$plugin/skills/example/SKILL.md"
+  test -f "$root/dist/$plugin.bundle.min.mjs"
+done
+test ! -e "$root/apps"
+test ! -e "$root/packages"
 INSTALL_OPENCODE
-chmod +x "$fixture/scripts/install-opencode.sh"
-printf '%s\n' '#!/usr/bin/env node' >"$fixture/packaging/npm/bin/rsp.mjs"
+chmod +x "$core/scripts/install-opencode.sh"
 
-fixture_archive="$tmp/v9.9.9.tar.gz"
-tar -czf "$fixture_archive" -C "$tmp" "$(basename "$fixture")"
+for plugin in dev memory brain internal; do
+  package="$packages/red-skills-$plugin"
+  mkdir -p "$package/skills/example" "$package/dist"
+  printf '{"name":"@reddb-io/red-skills-%s","version":"9.9.9"}\n' "$plugin" >"$package/package.json"
+  printf '# Example\n' >"$package/skills/example/SKILL.md"
+  printf '%s bundle\n' "$plugin" >"$package/dist/$plugin.bundle.min.mjs"
+done
 
-# curl serves the source archive and the two independently published bundles.
-# The generated OpenCode archive is optional and intentionally unavailable.
-cat >"$tmp/curl" <<'FAKE_CURL'
+# npm installs the local fixture packages into the same node_modules shape as
+# registry packages. No network-capable command is available to the installer.
+cat >"$tmp/npm" <<'FAKE_NPM'
 #!/usr/bin/env bash
 set -euo pipefail
-url=""
-out=""
+test "$1" = "install"
+shift
+prefix=""
+specs=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    -o) out="$2"; shift 2 ;;
-    http*) url="$1"; shift ;;
-    *) shift ;;
+    --prefix) prefix="$2"; shift 2 ;;
+    --*) shift ;;
+    *) specs+=("$1"); shift ;;
   esac
 done
-case "$url" in
-  */archive/refs/tags/v9.9.9.tar.gz) cp "$FIXTURE_ARCHIVE" "$out" ;;
-  */opencode-host.bundle.min.mjs) printf 'opencode bundle\n' >"$out" ;;
-  */rsp.bundle.min.mjs) printf 'rsp bundle\n' >"$out" ;;
-  */rsp-core.bundle.min.mjs) printf 'rsp core bundle\n' >"$out" ;;
-  */opencode-host.generated.tgz) exit 22 ;;
-  *) printf 'unexpected URL: %s\n' "$url" >&2; exit 64 ;;
-esac
-FAKE_CURL
-chmod +x "$tmp/curl"
+test -n "$prefix"
+expected=(
+  "@reddb-io/red-skills@9.9.9"
+  "@reddb-io/red-skills-dev@9.9.9"
+  "@reddb-io/red-skills-memory@9.9.9"
+  "@reddb-io/red-skills-brain@9.9.9"
+  "@reddb-io/red-skills-internal@9.9.9"
+)
+test "${specs[*]}" = "${expected[*]}"
+mkdir -p "$prefix/node_modules/@reddb-io"
+for source in "$FIXTURE_PACKAGES"/*; do
+  cp -R "$source" "$prefix/node_modules/@reddb-io/$(basename "$source")"
+done
+printf '%s\n' "${specs[*]}" >>"$NPM_STUB_LOG"
+FAKE_NPM
+chmod +x "$tmp/npm"
 
 # Reproduce Git Bash rather than Unix symlinks: `ln -s dir current` copies dir.
 cat >"$tmp/ln" <<'FAKE_LN'
@@ -77,17 +93,48 @@ FAKE_OPENCODE
 chmod +x "$tmp/opencode"
 
 stdout="$tmp/stdout"
-if ! FIXTURE_ARCHIVE="$fixture_archive" PATH="$tmp:$PATH" \
+if ! FIXTURE_PACKAGES="$packages" NPM_STUB_LOG="$tmp/npm.log" PATH="$tmp:$PATH" \
   scripts/install.sh \
     --version v9.9.9 \
     --install-root "$tmp/install" \
     --only opencode >"$stdout" 2>&1; then
-  printf 'FAIL: installer did not leave a complete current tree under Git Bash semantics\n' >&2
+  printf 'FAIL: installer did not materialise the npm packages into current\n' >&2
   sed 's/^/    /' "$stdout" >&2
   exit 1
 fi
 
-test -f "$tmp/install/current/dist/opencode-host.bundle.min.mjs"
-test -f "$tmp/install/current/packaging/npm/dist/rsp.bundle.min.mjs"
-test -f "$tmp/install/current/packaging/npm/dist/rsp-core.bundle.min.mjs"
-printf 'ok: release assets are present before Git Bash creates current\n'
+version="$tmp/install/versions/v9.9.9"
+test -f "$version/.claude-plugin/marketplace.json"
+test -f "$version/.agents/plugins/marketplace.json"
+test -f "$version/dist/opencode-host.bundle.min.mjs"
+for plugin in dev memory brain internal; do
+  test -f "$version/plugins/$plugin/skills/example/SKILL.md"
+  test -f "$version/dist/$plugin.bundle.min.mjs"
+done
+test ! -e "$version/apps"
+test ! -e "$version/packages"
+test -f "$tmp/install/current/plugins/dev/skills/example/SKILL.md"
+test "$(wc -l <"$tmp/npm.log")" -eq 1
+
+# node and npm are install-wide preconditions: npm absence refuses before a
+# detected host can be wired.
+no_npm="$tmp/no-npm"
+mkdir -p "$no_npm"
+ln -s "$(command -v bash)" "$no_npm/bash"
+ln -s "$(command -v node)" "$no_npm/node"
+cat >"$no_npm/opencode" <<'FAKE_OPENCODE_MISSING_NPM'
+#!/usr/bin/env bash
+printf 'wired\n' >>"$HOST_STUB_LOG"
+FAKE_OPENCODE_MISSING_NPM
+chmod +x "$no_npm/opencode"
+: >"$tmp/host.log"
+if HOST_STUB_LOG="$tmp/host.log" PATH="$no_npm" \
+  scripts/install.sh --version v9.9.9 --install-root "$tmp/missing-npm" --only opencode \
+  >"$tmp/missing-npm.out" 2>&1; then
+  printf 'FAIL: installer accepted a host without npm\n' >&2
+  exit 1
+fi
+grep -qF 'npm is required' "$tmp/missing-npm.out"
+test ! -s "$tmp/host.log"
+
+printf 'ok: installer materialises release npm packages before wiring hosts\n'


### PR DESCRIPTION
Automated AFK landing for #3945. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3945

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789476556&installation_model_id=20659&pr_number=3948&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3948&signature=26d75828c9f86391b0952bcdb6fb431565520958f1e1a206938bf69c05195a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->