### PR TITLE
fix: #3944 Release publishes the per-plugin packages and the publish contract asserts both package boundaries

### DIFF
--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -663,9 +663,19 @@ jobs:
         if: steps.target.outputs.publish == 'true'
         env:
           NEXT: ${{ steps.target.outputs.tag }}
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
         run: |
           set -euo pipefail
           version="${NEXT#v}"
+          # Materialise every generated plugin package before the first npm
+          # mutation. The plugin tree is the package set; adding a plugin must
+          # make this contract fan out without editing the workflow.
+          pnpm pi:packages:build
+          plugin_pack_dir="$(mktemp -d)"
+          while IFS= read -r plugin_json; do
+            plugin="$(node -p "require('./${plugin_json}').name")"
+            pnpm --dir "packaging/pi/$plugin" pack --pack-destination "$plugin_pack_dir"
+          done < <(find plugins -mindepth 3 -maxdepth 3 -path '*/.claude-plugin/plugin.json' -print | sort)
           # Pin the package version to the tag being published. packaging/npm is
           # outside the pnpm workspace, so changesets never versions it; the tag
           # is its only source of truth and `Verify the tag matches the tree`
@@ -698,6 +708,13 @@ jobs:
               exit 1
             fi
           done
+          core_tarball="$PWD/$tarball"
+          cd ../..
+          node scripts/check-npm-tarball-boundaries.mjs \
+            --root "$PWD" \
+            --core "$core_tarball" \
+            --plugins "$plugin_pack_dir"
+          cd packaging/npm
           # Contract check: install the packed tarball into a throwaway prefix and
           # run the REAL packaged clients (the bins the launcher execs) — proves the
           # tarball resolves and runs before we publish it.
@@ -762,8 +779,12 @@ jobs:
             echo "::error::NPM_TOKEN secret absent — cannot publish @reddb-io/red-skills@${version}"
             exit 1
           fi
-          cd packaging/npm
           npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
+          # Publish the derived plugin set first. Until core@version is visible,
+          # no consumer can select the new release; once core is visible, every
+          # matching plugin package already resolves.
+          pnpm pi:packages:publish
+          cd packaging/npm
           # Publish must be idempotent so a re-run after a transient
           # post-publish failure (for example registry-propagation lag in the
           # smoke step) can resume the publish tail instead of dying on a
@@ -778,28 +799,6 @@ jobs:
           # which points npm dist-tag `canary` at an already-published version.
           pnpm publish --access public --no-git-checks
 
-      - name: Build + publish Pi packages to npm
-        if: steps.target.outputs.publish == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NEXT: ${{ steps.target.outputs.tag }}
-          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
-        run: |
-          set -euo pipefail
-          version="${NEXT#v}"
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "::error::NPM_TOKEN secret absent — cannot publish @reddb-io/red-skills-<plugin>@${version}"
-            exit 1
-          fi
-          # Stage the npm-ready Pi packages from plugins/<name>/skills/<bucket>/
-          # into packaging/pi/<name>/. The build runs before publish so the
-          # tarball carries the current source, not a stale staging.
-          pnpm pi:packages:build
-          # Idempotent on already-published (same shape as @reddb-io/red-skills):
-          # a re-run after transient post-publish failure resumes the publish
-          # tail instead of dying on publish-over-published conflict.
-          pnpm pi:packages:publish
-
       - name: Smoke published Pi packages from registry
         if: steps.target.outputs.publish == 'true'
         env:
@@ -809,7 +808,8 @@ jobs:
           version="${NEXT#v}"
           # Registry read replicas can lag the publish by several minutes
           # (same budget as the @reddb-io/red-skills smoke above).
-          for plugin in dev memory brain; do
+          while IFS= read -r plugin_json; do
+            plugin="$(node -p "require('./${plugin_json}').name")"
             for attempt in 1 2 3 4 5 6 7 8 9 10; do
               # `npm view <pkg>@<version> version` prints just the resolved
               # version string (e.g. `2.76.0`); compare it exactly. The prior
@@ -825,7 +825,7 @@ jobs:
             done
             echo "::error::registry smoke failed for @reddb-io/red-skills-${plugin}@${version} after 10 attempts"
             exit 1
-          done
+          done < <(find plugins -mindepth 3 -maxdepth 3 -path '*/.claude-plugin/plugin.json' -print | sort)
 
       - name: Smoke published npm package from registry
         if: steps.target.outputs.publish == 'true'

--- a/apps/dev/tests/pi-package-publisher.test.ts
+++ b/apps/dev/tests/pi-package-publisher.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -10,6 +10,46 @@ const ROOT = join(import.meta.dirname, "..", "..", "..");
 const publisher = join(ROOT, "scripts/publish-pi-packages.mjs");
 
 describe("Pi package publisher (dry-run)", () => {
+  it("covers every package generated from the plugin tree", async () => {
+    const root = await mkdtemp(join(tmpdir(), "red-skills-pi-publish-generated-"));
+    const generated = (await readdir(join(ROOT, "packaging/pi"), { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+    const expected: string[] = [];
+
+    for (const plugin of generated) {
+      const source = JSON.parse(
+        await readFile(join(ROOT, "packaging/pi", plugin, "package.json"), "utf8"),
+      ) as { name: string };
+      const pkg = { name: source.name, version: "99.99.99-afk-contract" };
+      expected.push(`${pkg.name}@${pkg.version}`);
+      await mkdir(join(root, "packaging/pi", plugin), { recursive: true });
+      await writeFile(
+        join(root, "packaging/pi", plugin, "package.json"),
+        `${JSON.stringify(pkg, null, 2)}\n`,
+        "utf8",
+      );
+    }
+
+    // Keep the publisher's registry probe deterministic and offline.
+    const fakeBin = join(root, "bin");
+    await mkdir(fakeBin);
+    await writeFile(join(fakeBin, "npm"), "#!/usr/bin/env bash\nexit 1\n", "utf8");
+    await chmod(join(fakeBin, "npm"), 0o755);
+
+    const { stdout } = await execFileAsync(
+      "node",
+      [publisher, "--root", root, "--dry-run"],
+      { env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH ?? ""}` } },
+    );
+
+    for (const spec of expected) {
+      expect(stdout).toContain(`publish-pi: publishing ${spec}`);
+    }
+    expect(stdout.match(/publish-pi: publishing/g)?.length).toBe(expected.length);
+  });
+
   it("prints the would-be pnpm publish invocation per staged package and exits 0", async () => {
     const root = await mkdtemp(join(tmpdir(), "red-skills-pi-publish-"));
 

--- a/scripts/check-npm-tarball-boundaries.mjs
+++ b/scripts/check-npm-tarball-boundaries.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+function parseArgs(argv) {
+  const args = { root: process.cwd(), core: "", plugins: "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag !== "--root" && flag !== "--core" && flag !== "--plugins") {
+      throw new Error(`unknown argument: ${flag}`);
+    }
+    const value = argv[index + 1];
+    if (!value) throw new Error(`${flag} requires a value`);
+    args[flag.slice(2)] = value;
+    index += 1;
+  }
+  if (!args.core || !args.plugins) {
+    throw new Error("usage: check-npm-tarball-boundaries.mjs --core <tarball> --plugins <directory> [--root <repo>]");
+  }
+  return args;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function materializeListing(tarball) {
+  const result = spawnSync("tar", ["-tzf", tarball], {
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(`cannot list ${tarball}: ${result.stderr.trim() || `tar exited ${result.status}`}`);
+  }
+  return result.stdout.split("\n").filter(Boolean);
+}
+
+function requireEntry(listing, expected, label) {
+  if (!listing.includes(expected)) {
+    throw new Error(`${label} tarball missing ${expected}`);
+  }
+}
+
+function checkCore(root, tarball) {
+  const listing = materializeListing(tarball);
+  const packageJson = readJson(join(root, "packaging/npm/package.json"));
+  const required = [
+    ...Object.values(packageJson.bin).map((path) => `package/${path}`),
+    "package/.agents/plugins/marketplace.json",
+    "package/.claude-plugin/marketplace.json",
+    "package/.gemini-plugin/marketplace.json",
+    "package/scripts/generate-codex-manifests.mjs",
+    "package/scripts/generate-gemini-manifests.mjs",
+    "package/scripts/generate-pi-manifests.mjs",
+    "package/dist/opencode-host.bundle.min.mjs",
+  ];
+  for (const expected of required) requireEntry(listing, expected, "core npm");
+
+  const forbidden = listing.find(
+    (entry) => entry.startsWith("package/apps/") || entry.startsWith("package/packages/"),
+  );
+  if (forbidden) {
+    throw new Error(`core npm tarball crosses into the monorepo runtime/shared tree: ${forbidden}`);
+  }
+}
+
+function npmTarballPrefix(packageName) {
+  return `${packageName.replace(/^@/, "").replaceAll("/", "-")}-`;
+}
+
+function pluginManifests(root) {
+  const pluginsRoot = join(root, "plugins");
+  return readdirSync(pluginsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => readJson(join(pluginsRoot, entry.name, ".claude-plugin/plugin.json")))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function checkPlugins(root, tarballsDir) {
+  const tarballs = readdirSync(tarballsDir).filter((entry) => entry.endsWith(".tgz"));
+  for (const plugin of pluginManifests(root)) {
+    const packageName = `@reddb-io/red-skills-${plugin.name}`;
+    const prefix = npmTarballPrefix(packageName);
+    const matches = tarballs.filter((entry) => entry.startsWith(prefix));
+    if (matches.length !== 1) {
+      throw new Error(`${packageName}: expected one packed tarball, found ${matches.length}`);
+    }
+
+    const listing = materializeListing(join(tarballsDir, matches[0]));
+    const skill = listing.find(
+      (entry) => entry.startsWith("package/skills/") && entry.endsWith("/SKILL.md"),
+    );
+    if (!skill) throw new Error(`${packageName} tarball carries no published skills`);
+    requireEntry(listing, `package/dist/${plugin.name}.bundle.min.mjs`, packageName);
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  checkCore(args.root, args.core);
+  checkPlugins(args.root, args.plugins);
+  process.stdout.write("npm tarball boundaries ok\n");
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -110,6 +110,108 @@ else
   fail "pack contract must verify the code-nav npm bin and packaged bundle"
 fi
 
+if grep -qF 'node scripts/check-npm-tarball-boundaries.mjs' "$WORKFLOW" &&
+   grep -qF 'pnpm pi:packages:build' "$WORKFLOW"; then
+  pass "publish materialises and checks core plus derived per-plugin tarballs"
+else
+  fail "publish must check core and every derived per-plugin tarball before publishing"
+fi
+
+plugin_publish_line="$(grep -nF 'pnpm pi:packages:publish' "$WORKFLOW" | head -n1 | cut -d: -f1 || true)"
+core_publish_line="$(grep -nF 'pnpm publish --access public --no-git-checks' "$WORKFLOW" | head -n1 | cut -d: -f1 || true)"
+if [ -n "$plugin_publish_line" ] && [ -n "$core_publish_line" ] &&
+   [ "$plugin_publish_line" -lt "$core_publish_line" ]; then
+  pass "per-plugin versions publish before the matching core becomes resolvable"
+else
+  fail "per-plugin packages must publish before core to prevent a mixed release pair"
+fi
+
+if grep -qF "find plugins -mindepth 3 -maxdepth 3 -path '*/.claude-plugin/plugin.json'" "$WORKFLOW" &&
+   ! grep -qF 'for plugin in dev memory brain' "$WORKFLOW"; then
+  pass "per-plugin pack and smoke expectations derive from the plugin tree"
+else
+  fail "workflow must derive every per-plugin expectation from the plugin tree"
+fi
+
+# Exercise the archive boundary checker with real tarballs. The valid fixture
+# is assembled from the canonical core package manifest and plugin tree; the
+# two mutations specify the failures that must stop a release before npm sees
+# any package.
+contract_fixture="$(mktemp -d)"
+core_tree="$contract_fixture/core-tree/package"
+plugin_tarballs="$contract_fixture/plugin-tarballs"
+mkdir -p "$core_tree" "$plugin_tarballs"
+
+while IFS= read -r bin_path; do
+  mkdir -p "$core_tree/$(dirname "$bin_path")"
+  : > "$core_tree/$bin_path"
+done < <(node -e "const p=require('./packaging/npm/package.json'); console.log(Object.values(p.bin).join('\\n'))")
+
+for expected in \
+  .agents/plugins/marketplace.json \
+  .claude-plugin/marketplace.json \
+  .gemini-plugin/marketplace.json \
+  scripts/generate-codex-manifests.mjs \
+  scripts/generate-gemini-manifests.mjs \
+  scripts/generate-pi-manifests.mjs \
+  dist/opencode-host.bundle.min.mjs; do
+  mkdir -p "$core_tree/$(dirname "$expected")"
+  : > "$core_tree/$expected"
+done
+cp packaging/npm/package.json "$core_tree/package.json"
+tar -czf "$contract_fixture/core.tgz" -C "$contract_fixture/core-tree" package
+
+first_plugin=""
+while IFS= read -r plugin_json; do
+  plugin="$(node -p "require('./${plugin_json}').name")"
+  [ -n "$first_plugin" ] || first_plugin="$plugin"
+  plugin_tree="$contract_fixture/plugin-$plugin/package"
+  mkdir -p "$plugin_tree/skills/core/example" "$plugin_tree/dist"
+  : > "$plugin_tree/skills/core/example/SKILL.md"
+  : > "$plugin_tree/dist/$plugin.bundle.min.mjs"
+  tar -czf "$plugin_tarballs/reddb-io-red-skills-$plugin-9.9.9.tgz" \
+    -C "$contract_fixture/plugin-$plugin" package
+done < <(find plugins -mindepth 3 -maxdepth 3 -path '*/.claude-plugin/plugin.json' -print | sort)
+
+if node scripts/check-npm-tarball-boundaries.mjs \
+  --root "$ROOT" \
+  --core "$contract_fixture/core.tgz" \
+  --plugins "$plugin_tarballs" >/dev/null; then
+  pass "materialised tarball listings satisfy both package boundaries"
+else
+  fail "valid core and per-plugin tarballs must satisfy the publish boundary checker"
+fi
+
+missing_bundle_tree="$contract_fixture/missing-bundle/package"
+mkdir -p "$missing_bundle_tree/skills/core/example"
+: > "$missing_bundle_tree/skills/core/example/SKILL.md"
+tar -czf "$plugin_tarballs/reddb-io-red-skills-$first_plugin-9.9.9.tgz" \
+  -C "$contract_fixture/missing-bundle" package
+if node scripts/check-npm-tarball-boundaries.mjs \
+  --root "$ROOT" \
+  --core "$contract_fixture/core.tgz" \
+  --plugins "$plugin_tarballs" >/dev/null 2>&1; then
+  fail "per-plugin tarball without its runtime bundle must fail the publish contract"
+else
+  pass "per-plugin tarball without its runtime bundle fails the publish contract"
+fi
+
+bad_core_tree="$contract_fixture/bad-core/package"
+mkdir -p "$contract_fixture/bad-core"
+cp -R "$core_tree" "$bad_core_tree"
+mkdir -p "$bad_core_tree/apps/dev"
+: > "$bad_core_tree/apps/dev/runtime.ts"
+tar -czf "$contract_fixture/bad-core.tgz" -C "$contract_fixture/bad-core" package
+if node scripts/check-npm-tarball-boundaries.mjs \
+  --root "$ROOT" \
+  --core "$contract_fixture/bad-core.tgz" \
+  --plugins "$plugin_tarballs" >/dev/null 2>&1; then
+  fail "core tarball carrying the runtime app tree must fail the publish contract"
+else
+  pass "core tarball carrying the runtime app tree fails the publish contract"
+fi
+rm -rf "$contract_fixture"
+
 if grep -qF 'registry smoke returned' "$WORKFLOW" &&
    grep -qF 'dev ${version} ' "$WORKFLOW"; then
   pass "registry smoke verifies the reported release version"


### PR DESCRIPTION
Automated AFK landing for #3944. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3944

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789476827&installation_model_id=20659&pr_number=3949&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3949&signature=0e99a489907bbcec08957fab8a11af759d17b45b57b28de1625439280be1d989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->