### PR TITLE
fix(dev): a closed activation gate says so instead of "undeclared"

### DIFF
--- a/.changeset/gate-closed-says-so.md
+++ b/.changeset/gate-closed-says-so.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Narrate a closed activation gate as such instead of reporting every Validation moment as undeclared.

--- a/apps/dev/src/commands/run/command.ts
+++ b/apps/dev/src/commands/run/command.ts
@@ -37,8 +37,8 @@ import * as fsx from "../../runtime/fs.js";
 import { migrateLegacyDevPaths } from "../../runtime/red-path-migration.js";
 import type { GhContext } from "../../runtime/gh.js";
 import {
+  auditConfigLoad,
   getConfig,
-  loadConfig,
   readSetupCommands,
   readValidationMoments,
   readValidationResourceBudget,
@@ -323,9 +323,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
     return 1;
   }
 
-  // Load the declaration schedule before constructing the feedback worktree
-  // that will materialise the Worker's fixed branch tip.
-  const config = loadConfig(paths.configPath, { warn: () => undefined });
+  // Load the declaration schedule before the feedback worktree that materialises
+  // the Worker's branch tip. Audited so an empty schedule can name the gate (#3939).
+  const configAudit = auditConfigLoad(paths.configPath, { warn: () => undefined });
 
   // Per-issue mutable attempt context the process deps' envelope/iter-log close
   // over; buildProcessInput resets it before each processIssue call. Built
@@ -342,7 +342,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     attemptDir: () => current.attemptDir,
     supervisorLane: process.env[SUPERVISOR_LANE_ENV] || undefined,
     ...(publishHostLogLine == null ? {} : { publishHostLogLine }),
-  }, readValidationMoments(config));
+  }, readValidationMoments(configAudit.values), configAudit);
   let gateWaitPublication: Promise<void> = Promise.resolve();
 
   // Feedback worktree manager — checks out the worker branch at its own tip.
@@ -350,8 +350,8 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // post_done validates against the Worker's fork point, while freshness is
   // owned by the merge queue.
   const feedback = makeFeedbackWorktree(ctx.root, paths.feedbackWorktreesDir, undefined, {
-    resourceBudget: readValidationResourceBudget(config),
-    setupCommands: readSetupCommands(config),
+    resourceBudget: readValidationResourceBudget(configAudit.values),
+    setupCommands: readSetupCommands(configAudit.values),
     // A host-wide lock wait is the gate's only silent stall: no child, no
     // socket, no write, and `live=true` on every surface for as long as an hour
     // (#2985). Say it out loud on all three lanes the operator reads.
@@ -426,7 +426,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
 
   // --request/-r special block, threaded into the handoff the agent reads.
   const requestBlock = specialUserRequestBlock(flags.request);
-  const sessionHooksConfig = loadConfig(afkPaths(ctx.root).configPath);
+  const sessionHooksConfig = auditConfigLoad(afkPaths(ctx.root).configPath).values;
 
   // Validate hook names once before the session loop. An unknown hook name
   // (including a misspelled name where the user intended a list entry) must not
@@ -495,7 +495,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     gh: { listCandidates: () => ghx.resolveDispatchCandidates(ghCtx, flags.filter, consultedQueue) },
     classifyEligibility: async (candidate) => {
       queueTrustPolicy ??= parseTrustPolicy(
-        config,
+        configAudit.values,
         await processDeps.gh.repoVisibility?.(),
       );
       const canFailClosed =
@@ -745,7 +745,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // branch with no open pull request have no route to `main`, and a run that
   // exits 0 over them is recorded as successful — so nothing re-dispatches and
   // the branch sits on origin until a human reads `git branch -r` by hand.
-  const trunk = getConfig(config, "dev.trunk") || "main";
+  const trunk = getConfig(configAudit.values, "dev.trunk") || "main";
   const orphans = await censusOrphanedWork({
     lookups: processDeps.lookups,
     issues: summary.processed.map((p) => p.issue),

--- a/apps/dev/src/core/castle-worker-lane-bridge.ts
+++ b/apps/dev/src/core/castle-worker-lane-bridge.ts
@@ -17,7 +17,7 @@ import { createPhaseDurationTracker, phaseDurationsPath, type PhaseDurationTrack
 import { workerDisplayFromState } from "./worker-display-record.js";
 import type { AfkState } from "../types/state.js";
 import type { ValidationMoments } from "./config.js";
-import { validationMomentLogPayload } from "./validation-moments.js";
+import { type ValidationGateContext, validationMomentLogPayload } from "./validation-moments.js";
 
 export type WorkerLifecycleKind =
   | "worker.claimed"
@@ -269,8 +269,9 @@ export function createCastleWorkerLaneBridge(
 export async function createBootCastleWorkerLaneBridge(
   options: CastleWorkerLaneBridgeOptions,
   schedule: ValidationMoments,
+  gate: ValidationGateContext = {},
 ): Promise<CastleWorkerLaneBridge> {
   const bridge = createCastleWorkerLaneBridge(options);
-  await bridge.record("worker.validation_schedule", validationMomentLogPayload(schedule));
+  await bridge.record("worker.validation_schedule", validationMomentLogPayload(schedule, gate));
   return bridge;
 }

--- a/apps/dev/src/core/validation-moments.ts
+++ b/apps/dev/src/core/validation-moments.ts
@@ -47,9 +47,36 @@ export interface ValidationMomentDescription {
   readonly commands: string[];
 }
 
+/**
+ * Why the schedule is empty, when the reason is NOT the declaration (#3939).
+ *
+ * The activation gate discards the WHOLE `plugins.dev` block in a directory
+ * that never opted in (ADR 0067/0116, `auditConfigLoad`), so a repository that
+ * declared all three moments reads back as having declared none. The narration
+ * then reported the declaration's absence — the one thing the operator could
+ * see was false, because the block was sitting right there in the file they
+ * had just written.
+ *
+ * The two states take DIFFERENT repairs: an undeclared moment wants a block,
+ * an inert directory wants `plugins.dev.enabled: true`. Telling them apart is
+ * the whole job of this context.
+ *
+ * The field names are `ConfigLoadAudit`'s own, so an audit satisfies this
+ * structurally and a caller hands over the thing it already loaded rather than
+ * transcribing two fields out of it.
+ */
+export interface ValidationGateContext {
+  /** `ConfigLoadAudit.gateClosed` — the directory never opted into the plugin. */
+  readonly gateClosed?: boolean;
+  /** The config file the verdict came from, so the repair names a path. */
+  readonly path?: string;
+}
+
 export interface ValidationMomentSchedule {
   readonly narration: string;
   readonly moments: ValidationMomentDescription[];
+  /** True when every skip above is the gate's doing rather than the config's. */
+  readonly gateClosed: boolean;
 }
 
 /**
@@ -60,7 +87,11 @@ export interface ValidationMomentSchedule {
  * operator is deciding whether the engine ignored config or config said to do
  * nothing.
  */
-export function describeValidationMoments(schedule: ValidationMoments): ValidationMomentSchedule {
+export function describeValidationMoments(
+  schedule: ValidationMoments,
+  context: ValidationGateContext = {},
+): ValidationMomentSchedule {
+  const gateClosed = context.gateClosed === true;
   const moments = VALIDATION_MOMENTS.map((moment): ValidationMomentDescription => {
     const commands = schedule[moment];
     return {
@@ -70,21 +101,39 @@ export function describeValidationMoments(schedule: ValidationMoments): Validati
       commands: commands ?? [],
     };
   });
-  const narration = `Validation moments — ${moments.map((entry) => {
+  const reason = (entry: ValidationMomentDescription): string => {
+    // The gate wins the explanation: with the block discarded, `declared` is
+    // false for every moment regardless of what the file says, so reporting it
+    // would be reporting an artefact of the discard.
+    if (gateClosed) return "plugin inert here";
+    return entry.declared ? "empty declaration" : "undeclared";
+  };
+  const listing = moments.map((entry) => {
     if (entry.state === "declared") {
       return `${entry.moment}: declared [${entry.commands.join("; ")}]`;
     }
-    return `${entry.moment}: skip (${entry.declared ? "empty declaration" : "undeclared"})`;
-  }).join("; ")}`;
-  return { narration, moments };
+    return `${entry.moment}: skip (${reason(entry)})`;
+  }).join("; ");
+  // One repair sentence for the whole schedule rather than three copies: the
+  // moments are scanned, the repair is read once.
+  const repair = gateClosed
+    ? ` — \`plugins.dev.enabled\` is not \`true\`${
+      context.path === undefined ? "" : ` in ${context.path}`
+    }, so the entire \`plugins.dev\` block is discarded before any moment is read (ADR 0067)`
+    : "";
+  return { narration: `Validation moments — ${listing}${repair}`, moments, gateClosed };
 }
 
 export function validationMomentLogPayload(
   schedule: ValidationMoments,
+  context: ValidationGateContext = {},
 ): Record<string, unknown> {
-  const described = describeValidationMoments(schedule);
+  const described = describeValidationMoments(schedule, context);
   return {
     narration: described.narration,
     ...Object.fromEntries(described.moments.map(({ moment, state }) => [moment, state])),
+    // A structured reader must be able to tell the two silences apart without
+    // parsing prose.
+    gate: described.gateClosed ? "closed" : "open",
   };
 }

--- a/apps/dev/src/mcp/project.ts
+++ b/apps/dev/src/mcp/project.ts
@@ -42,7 +42,6 @@ import {
 import {
   auditConfigLoad,
   getConfig,
-  loadConfig,
   readStandingDrain,
   readValidationMoments,
   resolveTaskRoute,
@@ -158,8 +157,9 @@ export async function projectStatus(root: string): Promise<ProjectStatusOutput> 
     pluginCacheVersion: newestInstalledPluginVersion(),
   });
   const target = held?.target ?? 0;
-  const config = loadConfig(afkPaths(root).configPath, { warn: () => undefined });
-  const validationSchedule = describeValidationMoments(readValidationMoments(config));
+  const configAudit = auditConfigLoad(afkPaths(root).configPath, { warn: () => undefined });
+  const config = configAudit.values;
+  const validationSchedule = describeValidationMoments(readValidationMoments(config), configAudit);
   const standingStopped = held == null &&
       readStandingDrain(config) !== null &&
       lapse?.standing === true &&

--- a/apps/dev/tests/afk-castle-run-wiring.test.ts
+++ b/apps/dev/tests/afk-castle-run-wiring.test.ts
@@ -16,10 +16,15 @@ describe("afk run castle engine flip", () => {
     expect(source).not.toContain("summary = await runSession(deps, sessionCtx)");
   });
 
-  it("boots the Worker lane with the resolved Validation moment schedule", () => {
+  it("boots the Worker lane with the resolved Validation moment schedule and its gate verdict", () => {
     const source = readFileSync(runCommandTs, "utf8");
 
     expect(source).toContain("await createBootCastleWorkerLaneBridge({");
-    expect(source).toContain("}, readValidationMoments(config));");
+    // The audit rides along, not just the schedule: an empty schedule means
+    // one thing when the directory opted in and another when the gate
+    // discarded the whole block, and only the audit can tell them apart
+    // (#3939). Loading it plainly here would silently re-lose that.
+    expect(source).toContain("}, readValidationMoments(configAudit.values), configAudit);");
+    expect(source).toContain("auditConfigLoad(paths.configPath");
   });
 });

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -23,6 +23,10 @@ import {
   rootDevConfigCollisionsFromText,
   SANCTIONED_ROOT_CONFIG_KEYS,
 } from "../src/core/config.js";
+import {
+  describeValidationMoments,
+  validationMomentLogPayload,
+} from "../src/core/validation-moments.js";
 import { PROJECT_NAME_CONFIG_KEY } from "@reddb-io/shared/project-identity.js";
 import {
   DEFAULT_FLEET_WIDTH_CONFIG,
@@ -869,6 +873,56 @@ describe("config — block sequences (#430)", () => {
 });
 
 describe("config — validation moments (ADR 0135, #3284)", () => {
+  it("names the closed gate rather than calling a declared moment undeclared (#3939)", () => {
+    // The exact shape reported: every moment declared as the docs specify, and
+    // no `plugins.dev.enabled: true` anywhere. The gate discards the whole
+    // block, so the schedule is empty for a reason the file cannot show.
+    const text = [
+      "plugins:",
+      "  dev:",
+      "    afk:",
+      "      validation:",
+      "        iteration:",
+      "          - bun test",
+      "        post_done:",
+      "          - bun run typecheck",
+      "        landing:",
+      "          - bun run typecheck",
+      "",
+    ].join("\n");
+    const audit = auditConfigLoad("/x/.red/config.yaml", { read: () => text });
+
+    expect(audit.gateClosed).toBe(true);
+    expect(readValidationMoments(audit.values)).toEqual({});
+
+    const described = describeValidationMoments(readValidationMoments(audit.values), audit);
+
+    expect(described.gateClosed).toBe(true);
+    // The repair an operator needs is the flag, not a block they already wrote.
+    expect(described.narration).toContain("plugin inert here");
+    expect(described.narration).toContain("plugins.dev.enabled");
+    expect(described.narration).toContain("/x/.red/config.yaml");
+    expect(described.narration).not.toContain("undeclared");
+    expect(validationMomentLogPayload(readValidationMoments(audit.values), {
+      gateClosed: audit.gateClosed,
+    })).toMatchObject({ gate: "closed", iteration: "skip", post_done: "skip", landing: "skip" });
+  });
+
+  it("still says undeclared when the gate is open and the moment is absent (#3939)", () => {
+    // The other half of the distinction: an opted-in directory that declared
+    // nothing must keep reading as undeclared, or the fix would have traded
+    // one wrong answer for another.
+    const audit = auditConfigLoad("/x/.red/config.yaml", {
+      read: () => "plugins:\n  dev:\n    enabled: true\n",
+    });
+    const described = describeValidationMoments(readValidationMoments(audit.values), audit);
+
+    expect(audit.gateClosed).toBe(false);
+    expect(described.gateClosed).toBe(false);
+    expect(described.narration).toContain("iteration: skip (undeclared)");
+    expect(described.narration).not.toContain("plugin inert");
+  });
+
   it("accepts the experimental Preflight flag and defaults it off (#3844)", () => {
     const absent = loadConfig("/x/.red/config.yaml", {
       ignoreActivationGate: true,


### PR DESCRIPTION
Closes #3939.

## What was actually wrong

Not resolution — the **activation gate**. `red-dev/.red/config.yaml` declares all three Validation moments exactly as `docs/CONFIG.md` specifies and carries no `plugins.dev.enabled: true` anywhere. The gate (ADR 0067/0116) discards the **whole** `plugins.dev` block in a directory that never opted in, so `readValidationMoments` finds nothing and every moment narrates `skip (undeclared)`.

That is why every check in the report came back clean: YAML validity, key path, file tracked on `origin/main`, moment names present in the bundle — **none of them would surface a missing flag**. The one thing the operator could see was false, because the block was sitting right there in the file they had just written. red-dev landed 19 tickets ungated this way, and CI being green throughout was luck rather than design.

## What this changes

An undeclared moment wants a block; an inert directory wants the flag. Those are different repairs, so the narration now names which one it is:

```
BEFORE  Validation moments — iteration: skip (undeclared); post_done: skip (undeclared); landing: skip (undeclared)

AFTER   Validation moments — iteration: skip (plugin inert here); post_done: skip (plugin inert here); landing: skip (plugin inert here)
          — `plugins.dev.enabled` is not `true` in <path>, so the entire `plugins.dev` block is discarded before any moment is read (ADR 0067)
```

- the repair is stated **once** for the whole schedule, not three times: the moments are scanned, the repair is read;
- `validationMomentLogPayload` gains `gate: "closed" | "open"` so a structured reader never parses prose;
- `ConfigLoadAudit` satisfies the new context **structurally**, so a caller hands over what it already loaded instead of transcribing two fields out of it;
- `run/command.ts` and `status {scope: project}` audit rather than plainly load;
- an opted-in directory that declared nothing still reads `undeclared` — the second regression test exists so the fix cannot trade one wrong answer for another.

## Two notes on how it landed

**The file-size ratchet refused `command.ts` growing 819 → 825 and it was right.** Rather than raise a shrink-only baseline, the audit **replaces** `loadConfig` there instead of being added beside it; the file lands at **818**, under baseline, with no comment deleted to make room.

**The wiring test was pinning the wrong thing.** It asserted the literal `}, readValidationMoments(config));` — a source-text grep that would have passed while the gate verdict was silently dropped. It now pins the audit riding along.

## Verification

- `pnpm -C apps/dev test` — 6691 tests, all passing.
- `pnpm typecheck` — 16 packages.
- `pnpm -C apps/dev test:invariants` — 207/207.
- Against the real red-dev config, before and after its one-line repair: `gateClosed` true → false, moments resolving to their declared commands.

The repo-side half is reddb-io/red-dev#184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJDnFnkFDW8WkR3Fk1ysGw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789482781&installation_model_id=20659&pr_number=3950&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3950&signature=d086069037ba2f82732d9eb946699f19e7c6f404a1680fe7310daf5d56a5c0f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->