### PR TITLE
fix: #3938 A git failure kills the host daemon, taking every project's registration and every live Worker with it

### DIFF
--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -1006,18 +1006,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
             const admission = admit(spec);
             if (!admission.admitted) throw new RedskilledAdmissionError(admission.reason, admission);
             const key = redskilledTrunkRefreshKey(trunk);
-            launched = await startAfterProjectHooks(() => {
-              // Birth serialization may be held by a synchronous project hook.
-              // Do not start a fallible git promise until this turn can attach
-              // its await; otherwise a routine fetch/rev-parse failure rejects
-              // unhandled while the earlier hook still owns the lane.
-              let fork = burstForks.get(key);
-              if (fork == null) {
-                fork = refreshFork(trunk);
-                burstForks.set(key, fork);
-              }
-              return admitAndStartWorker(spec, trunk, fork, admission);
-            });
+            let fork = burstForks.get(key);
+            if (fork == null) { fork = refreshFork(trunk); burstForks.set(key, fork); }
+            // The serialized birth lane may not await this until a synchronous hook settles.
+            void fork.catch(() => undefined);
+            launched = await startAfterProjectHooks(() => admitAndStartWorker(spec, trunk, fork, admission));
           }
         } catch (err) {
           refusal = err instanceof Error ? err.message : String(err);

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -1006,12 +1006,18 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
             const admission = admit(spec);
             if (!admission.admitted) throw new RedskilledAdmissionError(admission.reason, admission);
             const key = redskilledTrunkRefreshKey(trunk);
-            let fork = burstForks.get(key);
-            if (fork == null) {
-              fork = refreshFork(trunk);
-              burstForks.set(key, fork);
-            }
-            launched = await startAfterProjectHooks(() => admitAndStartWorker(spec, trunk, fork, admission));
+            launched = await startAfterProjectHooks(() => {
+              // Birth serialization may be held by a synchronous project hook.
+              // Do not start a fallible git promise until this turn can attach
+              // its await; otherwise a routine fetch/rev-parse failure rejects
+              // unhandled while the earlier hook still owns the lane.
+              let fork = burstForks.get(key);
+              if (fork == null) {
+                fork = refreshFork(trunk);
+                burstForks.set(key, fork);
+              }
+              return admitAndStartWorker(spec, trunk, fork, admission);
+            });
           }
         } catch (err) {
           refusal = err instanceof Error ? err.message : String(err);

--- a/apps/redskilled/tests/demand-loop.test.ts
+++ b/apps/redskilled/tests/demand-loop.test.ts
@@ -361,7 +361,7 @@ describe("the daemon drives the demand loop itself", () => {
     const refused = await daemon.driveDemand();
 
     expect(refused.refusal).toMatch(/refused-unreachable-trunk-remote/);
-    expect(daemon.hostState().registrations.map((entry) => entry.project_label)).toEqual(["acme/widgets"]);
+    expect(daemon.hostState().registrations?.map((entry) => entry.project_label)).toEqual(["acme/widgets"]);
   });
 
   it("births Workers up to a registered project's target, with no process of the project's own", async () => {

--- a/apps/redskilled/tests/demand-loop.test.ts
+++ b/apps/redskilled/tests/demand-loop.test.ts
@@ -326,6 +326,44 @@ describe("the daemon drives the demand loop itself", () => {
     expect(fetches).toBe(3);
   });
 
+  it("keeps a failing trunk refresh handled while an earlier synchronous hook holds the birth lane", async () => {
+    const launched: LaunchWorkerOptions[] = [];
+    const workspace = await scratch("redskilled-workspace-");
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      demandMs: 0,
+      launch: recordingLaunch(launched),
+      refreshTrunk: async () => {
+        await new Promise((resolve) => setImmediate(resolve));
+        throw new Error("fatal: Needed a single revision");
+      },
+      queueDiscovery: { intervalMs: 0, transport: async () => answer([1]) },
+    });
+    running.push(daemon);
+
+    daemon.registerProject({
+      ...registration("acme/widgets", 3, workspace),
+      trunk: { remote: "origin", branch: "main" },
+      hooks: {
+        "worker-birth": { argv: ["notify"], mode: "sync", deadline_ms: 30 },
+      },
+    });
+    daemon.startWorker({
+      worker_id: "source",
+      project_label: "acme/widgets",
+      workspace_path: workspace,
+      command: "work",
+    });
+    await daemon.pollQueueDiscovery();
+
+    const refused = await daemon.driveDemand();
+
+    expect(refused.refusal).toMatch(/refused-unreachable-trunk-remote/);
+    expect(daemon.hostState().registrations.map((entry) => entry.project_label)).toEqual(["acme/widgets"]);
+  });
+
   it("births Workers up to a registered project's target, with no process of the project's own", async () => {
     const launched: LaunchWorkerOptions[] = [];
     const workspace = await scratch("redskilled-workspace-");


### PR DESCRIPTION
Automated AFK landing for #3938. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3938

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789483735&installation_model_id=20659&pr_number=3951&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3951&signature=db164be0338911142e223f3b074012d6b6d633ad010f18a1047ecbddc8482bfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->