### PR TITLE
fix: #3940 unblock_sweep promotes nothing for an issue cascade_status reports as promotable

### DIFF
--- a/apps/dev/src/core/boot-sweep.ts
+++ b/apps/dev/src/core/boot-sweep.ts
@@ -158,6 +158,15 @@ export interface DependentIssue {
  * the `ready-for-human` park a HUMAN-ONLY type demands (#2966). */
 export type PromotionLane = "agent" | "human";
 
+/** One authority's answer to whether a structured dependency gate can open. */
+export type DependencyPromotionDecision =
+  | { readonly outcome: "promotable"; readonly plan: PromotionPlan }
+  | {
+      readonly outcome: "held";
+      readonly reason: "missing-dependency-role" | "no-dependencies" | "blockers-open";
+      readonly pending: readonly number[];
+    };
+
 /**
  * The lane sentence appended to a promotion's audit comment, so a human reading
  * the Ticket can tell a sweep promotion from a hand-set label AND see why it
@@ -182,6 +191,42 @@ export function promotionLaneNote(
 }
 
 /**
+ * Decide one structured `req:*` dependency promotion. Both the event-driven
+ * close cascade (and therefore `cascade_status`) and the Unblock Sweep call
+ * this function, so the dependency role and all-closed rule cannot drift.
+ */
+export function decideDependencyPromotion(
+  dependent: DependentIssue,
+  hitlTypes: readonly string[] = [],
+): DependencyPromotionDecision {
+  if (!(dependent.labels ?? []).includes(LABEL_DEPENDENCY)) {
+    return { outcome: "held", reason: "missing-dependency-role", pending: [] };
+  }
+  if (dependent.reqs.length === 0) {
+    return { outcome: "held", reason: "no-dependencies", pending: [] };
+  }
+  const pending = dependent.reqs.filter((req) => !req.closed).map((req) => req.n);
+  if (!shouldPromote(dependent.reqs.map((req) => (req.closed ? "CLOSED" : "open-or-unknown")))) {
+    return { outcome: "held", reason: "blockers-open", pending };
+  }
+
+  const reqs = dependent.reqs.map((req) => req.n).sort((a, b) => a - b);
+  const carried = hostHitlTypesIn(dependent.labels ?? [], hitlTypes);
+  const lane: PromotionLane = carried.length > 0 ? "human" : "agent";
+  return {
+    outcome: "promotable",
+    plan: {
+      number: dependent.number,
+      refs: reqs.map((n) => `#${n}`),
+      reqLabels: reqs.map((n) => `req:${n}`),
+      comment: cascadeAuditComment(reqs) + promotionLaneNote(lane, carried, hitlTypes),
+      lane,
+      hitlTypes: carried,
+    },
+  };
+}
+
+/**
  * Plan the event-driven close cascade triggered when `closedIssue` closes. For
  * each dependent issue carrying `req:closedIssue` (and possibly other `req:*`
  * deps), promote it IFF EVERY one of its `req:*` deps is now CLOSED (and it has
@@ -193,25 +238,14 @@ export function promotionLaneNote(
  * closed-states are resolved by the caller.
  */
 export function planCloseCascade(
-  closedIssue: number,
+  _closedIssue: number,
   dependents: readonly DependentIssue[],
   hitlTypes: readonly string[] = [],
 ): PromotionPlan[] {
   const plans: PromotionPlan[] = [];
   for (const dep of dependents) {
-    const states: DependencyClosureState[] = dep.reqs.map((r) => (r.closed ? "CLOSED" : "open-or-unknown"));
-    if (!shouldPromote(states)) continue;
-    const reqs = dep.reqs.map((r) => r.n).sort((a, b) => a - b);
-    const carried = hostHitlTypesIn(dep.labels ?? [], hitlTypes);
-    const lane: PromotionLane = carried.length > 0 ? "human" : "agent";
-    plans.push({
-      number: dep.number,
-      refs: reqs.map((n) => `#${n}`),
-      reqLabels: reqs.map((n) => `req:${n}`),
-      comment: cascadeAuditComment(reqs) + promotionLaneNote(lane, carried, hitlTypes),
-      lane,
-      hitlTypes: carried,
-    });
+    const decision = decideDependencyPromotion(dep, hitlTypes);
+    if (decision.outcome === "promotable") plans.push(decision.plan);
   }
   return plans;
 }
@@ -243,12 +277,21 @@ export type DependencyClosureLookup = (issue: number) => Promise<string | undefi
  * stuck dependency gate meant re-running the core by hand to find out which of
  * the three had happened (#3801). Every path that declines to promote now says
  * so here. */
-export interface UnblockOutcome {
+export interface UnblockCandidateOutcome {
   readonly issue: number;
   readonly outcome: "promoted" | "held" | "refused";
   /** Plain-words account an operator can act on, never an enum to look up. */
   readonly reason: string;
 }
+
+/** A sweep-wide read failure, distinct from a successful empty candidate set. */
+export interface UnblockReadFailureOutcome {
+  readonly outcome: "failed";
+  readonly surface: "candidate-list";
+  readonly reason: string;
+}
+
+export type UnblockOutcome = UnblockCandidateOutcome | UnblockReadFailureOutcome;
 
 /** Everything one sweep did: the promoted numbers callers already consumed, and
  * the per-candidate account that explains the ones missing from it. */
@@ -298,15 +341,6 @@ export async function planUnblockSweep(
   const plans: PromotionPlan[] = [];
   for (const candidate of candidates) {
     const labels = candidate.labels ?? [];
-    if (!labels.includes(LABEL_DEPENDENCY)) {
-      held.push({
-        issue: candidate.number,
-        outcome: "held",
-        reason: `listed as a candidate but carries no ${LABEL_DEPENDENCY} label`,
-      });
-      continue;
-    }
-
     const reqIds = parseReqLabels(labels);
     // The LANE is the candidate's own type, not the sweep's default (#2966):
     // blockers closing frees a HUMAN-ONLY Ticket for its human, never for an agent.
@@ -315,32 +349,43 @@ export async function planUnblockSweep(
 
     // Prefer the structured req:* dependency labels when present.
     if (reqIds.length > 0) {
-      const states: DependencyClosureState[] = [];
+      const reqs: DependentIssue["reqs"] = [];
       for (const id of reqIds) {
         const raw = await fetchBlockerState(id);
-        states.push(raw === "CLOSED" ? "CLOSED" : "open-or-unknown");
+        reqs.push({ n: id, closed: raw === "CLOSED" });
       }
-      if (shouldPromote(states)) {
-        plans.push({
-          number: candidate.number,
-          refs: reqIds.map((n) => `#${n}`),
-          reqLabels: reqIds.map((n) => `req:${n}`),
-          comment: cascadeAuditComment(reqIds) + promotionLaneNote(lane, carried, hitlTypes),
-          lane,
-          hitlTypes: carried,
+      const decision = decideDependencyPromotion(
+        { number: candidate.number, labels, reqs },
+        hitlTypes,
+      );
+      if (decision.outcome === "promotable") {
+        plans.push(decision.plan);
+      } else if (decision.reason === "missing-dependency-role") {
+        held.push({
+          issue: candidate.number,
+          outcome: "held",
+          reason: `listed as a candidate but carries no ${LABEL_DEPENDENCY} label`,
         });
       } else {
         // A blocker that did not answer is reported the same as one still open:
         // the lookup answers `open-or-unknown` for both, and the sweep holds in
         // either case. Naming the numbers is what turns "still blocked" into a
         // line an operator can check against the tracker.
-        const pending = reqIds.filter((_, index) => states[index] !== "CLOSED");
         held.push({
           issue: candidate.number,
           outcome: "held",
-          reason: `blocker(s) not confirmed closed: ${pending.map((n) => `#${n}`).join(", ")}`,
+          reason: `blocker(s) not confirmed closed: ${decision.pending.map((n) => `#${n}`).join(", ")}`,
         });
       }
+      continue;
+    }
+
+    if (!labels.includes(LABEL_DEPENDENCY)) {
+      held.push({
+        issue: candidate.number,
+        outcome: "held",
+        reason: `listed as a candidate but carries no ${LABEL_DEPENDENCY} label`,
+      });
       continue;
     }
 

--- a/apps/dev/src/runtime/gh/sweeps.ts
+++ b/apps/dev/src/runtime/gh/sweeps.ts
@@ -1,4 +1,7 @@
 import {
+  isGithubRateLimitError,
+} from "@reddb-io/github";
+import {
   LABEL_CRASHED,
   LABEL_DEPENDENCY,
   LABEL_HUMAN,
@@ -9,6 +12,7 @@ import {
 import type { IssueOpenState } from "../../core/reclaim.js";
 import type { ReconcileSweepCandidate, UnblockCandidate } from "../../core/boot-sweep.js";
 import { githubReadClient, githubRepo, type GhContext } from "./common.js";
+import type { GhReadFailure, GhReadResult } from "./read.js";
 import { readSingleObject } from "./single-object.js";
 
 /**
@@ -57,6 +61,20 @@ function labelNames(labels: GithubIssueListItem["labels"]): string[] {
 function reportSweepReadFailure(surface: string, error: unknown): void {
   const detail = error instanceof Error ? error.message : String(error);
   process.stderr.write(`🤖 /afk sweep read failed (${surface}); treating as empty: ${detail}\n`);
+}
+
+/** Preserve the shared typed read distinction at the paginated client seam. */
+function sweepReadFailure(error: unknown): GhReadFailure {
+  const quota = isGithubRateLimitError(error);
+  return {
+    surface: "rest",
+    classification: quota ? "quota" : "transport",
+    transient: quota,
+    code: -1,
+    stdout: "",
+    stderr: "",
+    message: error instanceof Error ? error.message : String(error),
+  };
 }
 
 async function listIssuesViaClient(
@@ -136,19 +154,24 @@ export async function blockerState(ctx: GhContext, issue: number): Promise<strin
   return String((read.row as { state?: string }).state ?? "") || undefined;
 }
 
-export async function listUnblockCandidates(ctx: GhContext): Promise<UnblockCandidate[]> {
+export async function listUnblockCandidates(
+  ctx: GhContext,
+): Promise<GhReadResult<UnblockCandidate>> {
   try {
     const rows = await listIssuesViaClient(ctx, `unblock:${LABEL_DEPENDENCY}`, {
       labels: LABEL_DEPENDENCY,
     });
-    return rows.map((row): UnblockCandidate => ({
-      number: Number(row.number ?? 0),
-      body: String(row.body ?? ""),
-      labels: labelNames(row.labels),
-    }));
+    return {
+      outcome: "rows",
+      rows: rows.map((row): UnblockCandidate => ({
+        number: Number(row.number ?? 0),
+        body: String(row.body ?? ""),
+        labels: labelNames(row.labels),
+      })),
+    };
   } catch (error) {
     reportSweepReadFailure("unblock candidates", error);
-    return [];
+    return { outcome: "failed", failure: sweepReadFailure(error) };
   }
 }
 

--- a/apps/dev/src/runtime/unblock-pass.ts
+++ b/apps/dev/src/runtime/unblock-pass.ts
@@ -34,6 +34,7 @@ import {
 } from "../core/boot-sweep.js";
 import { loadConfig, readHitlTypeLabels } from "../core/config.js";
 import * as ghx from "./gh.js";
+import type { GhReadResult } from "./gh/read.js";
 import { afkPaths, resolveRepoContext } from "./wire.js";
 
 /** The whole tracker surface one Unblock pass touches: read the blocked set,
@@ -42,7 +43,7 @@ import { afkPaths, resolveRepoContext } from "./wire.js";
  * glance that it needs no git, no worktree, and no boot probe. */
 export interface UnblockPassIo {
   /** Every open issue carrying `blocked:dependency`, with body and labels. */
-  listCandidates(): Promise<UnblockCandidate[]>;
+  listCandidates(): Promise<GhReadResult<UnblockCandidate>>;
   /** Whether blocker `issue` is CLOSED. A transient miss answers false, which
    * leaves the dependent blocked — the conservative direction. */
   issueClosed(issue: number): Promise<boolean>;
@@ -69,7 +70,20 @@ export interface UnblockPassIo {
  * promote identically.
  */
 export async function runUnblockPass(io: UnblockPassIo): Promise<UnblockSweepReport> {
-  const candidates = await io.listCandidates();
+  const read = await io.listCandidates();
+  if (read.outcome === "failed") {
+    return {
+      promoted: [],
+      outcomes: [
+        {
+          outcome: "failed",
+          surface: "candidate-list",
+          reason: read.failure.message,
+        },
+      ],
+    };
+  }
+  const candidates = read.rows;
   if (candidates.length === 0) return { promoted: [], outcomes: [] };
   return executeUnblockSweep(
     candidates,

--- a/apps/dev/src/runtime/wire/boot.ts
+++ b/apps/dev/src/runtime/wire/boot.ts
@@ -77,7 +77,7 @@ export async function collectBootOptions(
     localAll,
     checkedOut,
     landedLocalBranches,
-    unblockCandidates,
+    unblockCandidateRead,
     staleClaimDirs,
     legacyWorkDirs,
     reconcileSweepCandidates,
@@ -115,7 +115,8 @@ export async function collectBootOptions(
       landedLocalBranches,
       trunk: facts.configuredTrunk ?? DEFAULT_BRANCH,
     },
-    unblockCandidates,
+    unblockCandidates:
+      unblockCandidateRead.outcome === "rows" ? unblockCandidateRead.rows : [],
     staleClaimDirs,
     legacyWorkDirs,
     reconcileSweepCandidates,

--- a/apps/dev/tests/resident-unblock.test.ts
+++ b/apps/dev/tests/resident-unblock.test.ts
@@ -11,6 +11,8 @@ import {
   startResidentUnblockSweep,
   type ResidentUnblockTimers,
 } from "../src/resident-unblock.js";
+import { listUnblockCandidates } from "../src/runtime/gh/sweeps.js";
+import type { GhContext } from "../src/runtime/gh/common.js";
 import { runUnblockPass, type UnblockPassIo } from "../src/runtime/unblock-pass.js";
 
 const LEASE: SingletonLease = {
@@ -65,9 +67,12 @@ describe("Unblock pass (#3014)", () => {
     const edits: Array<{ issue: number; remove: string[]; add: string[] }> = [];
     const comments: Array<{ issue: number; body: string }> = [];
     const io: UnblockPassIo = {
-      listCandidates: async () => [
-        { number: 17, body: "", labels: ["blocked:dependency", "req:5", "type:ticket"] },
-      ],
+      listCandidates: async () => ({
+        outcome: "rows",
+        rows: [
+          { number: 17, body: "", labels: ["blocked:dependency", "req:5", "type:ticket"] },
+        ],
+      }),
       issueClosed: async (issue) => issue === 5,
       editLabels: async (issue, remove, add) => {
         edits.push({ issue, remove, add });
@@ -92,9 +97,12 @@ describe("Unblock pass (#3014)", () => {
   it("leaves a dependent blocked while any blocker is still open", async () => {
     const edits: number[] = [];
     const io: UnblockPassIo = {
-      listCandidates: async () => [
-        { number: 19, body: "", labels: ["blocked:dependency", "req:5", "req:6"] },
-      ],
+      listCandidates: async () => ({
+        outcome: "rows",
+        rows: [
+          { number: 19, body: "", labels: ["blocked:dependency", "req:5", "req:6"] },
+        ],
+      }),
       issueClosed: async (issue) => issue === 5,
       editLabels: async (issue) => {
         edits.push(issue);
@@ -112,7 +120,7 @@ describe("Unblock pass (#3014)", () => {
   it("costs one listing and no blocker lookup when nothing is blocked", async () => {
     const issueClosed = vi.fn(async () => true);
     const io: UnblockPassIo = {
-      listCandidates: async () => [],
+      listCandidates: async () => ({ outcome: "rows", rows: [] }),
       issueClosed,
       editLabels: async () => undefined,
       comment: async () => undefined,
@@ -120,6 +128,44 @@ describe("Unblock pass (#3014)", () => {
     };
 
     await expect(runUnblockPass(io)).resolves.toMatchObject({ promoted: [] });
+    expect(issueClosed).not.toHaveBeenCalled();
+  });
+
+  // A human-authority close has no Worker terminal event to drive the close
+  // cascade, so this pass is the safety net. If its live candidate listing
+  // fails, that must remain observably different from a successful empty read.
+  it("surfaces a failed live candidate listing instead of claiming nothing is blocked", async () => {
+    const issueClosed = vi.fn(async () => true);
+    const gh = {
+      repo: "reddb-io/red-skills",
+      cwd: "/nowhere",
+      github: {
+        conditionalPaginate: async () => {
+          throw new Error("HttpError: 503 Service Unavailable");
+        },
+        conditionalRest: async () => {
+          throw new Error("the candidate listing must paginate");
+        },
+      },
+    } as unknown as GhContext;
+    const io: UnblockPassIo = {
+      listCandidates: () => listUnblockCandidates(gh),
+      issueClosed,
+      editLabels: async () => undefined,
+      comment: async () => undefined,
+      hitlTypes: () => [],
+    };
+
+    await expect(runUnblockPass(io)).resolves.toEqual({
+      promoted: [],
+      outcomes: [
+        {
+          outcome: "failed",
+          surface: "candidate-list",
+          reason: "HttpError: 503 Service Unavailable",
+        },
+      ],
+    });
     expect(issueClosed).not.toHaveBeenCalled();
   });
 });

--- a/apps/dev/tests/sweep-reads-see-the-tracker.test.ts
+++ b/apps/dev/tests/sweep-reads-see-the-tracker.test.ts
@@ -58,7 +58,10 @@ describe("a sweep read reaches the tracker", () => {
       { number: 3795, body: "", labels: [], pull_request: { url: "…" } },
     ]);
 
-    const candidates = await listUnblockCandidates(ctx);
+    const read = await listUnblockCandidates(ctx);
+    expect(read.outcome).toBe("rows");
+    if (read.outcome !== "rows") throw new Error("candidate read unexpectedly failed");
+    const candidates = read.rows;
 
     expect(candidates.map((c) => c.number)).toEqual([3629, 3507]);
     expect(candidates[0]?.labels).toContain("req:3628");
@@ -115,12 +118,31 @@ describe("a sweep read reaches the tracker", () => {
 
 describe("a failed sweep read is named, never disguised as an empty tracker", () => {
   const cases: Array<[string, (ctx: GhContext) => Promise<unknown>]> = [
-    ["unblock candidates", (ctx) => listUnblockCandidates(ctx)],
     ["dependent lookup", (ctx) => listByLabel(ctx, "req:1")],
     ["parked candidates", (ctx) => listParkedMechanicalCandidates(ctx)],
     ["open pull requests", (ctx) => listOpenPullRequests(ctx)],
     ["issue comments", (ctx) => issueComments(ctx, 1)],
   ];
+
+  it("returns the typed failure behind the unblock candidate listing", async () => {
+    const written: string[] = [];
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      written.push(String(chunk));
+      return true;
+    });
+    const ctx = contextWith(() => new Error("HttpError: 503 Service Unavailable"));
+
+    try {
+      const read = await listUnblockCandidates(ctx);
+      expect(read).toMatchObject({
+        outcome: "failed",
+        failure: { surface: "rest", classification: "transport" },
+      });
+      expect(written.join("")).toContain("503 Service Unavailable");
+    } finally {
+      stderr.mockRestore();
+    }
+  });
 
   for (const [name, read] of cases) {
     it(`reports the failure behind ${name} while still answering conservatively`, async () => {

--- a/apps/dev/tests/unblock-sweep-says-why.test.ts
+++ b/apps/dev/tests/unblock-sweep-says-why.test.ts
@@ -5,7 +5,12 @@
 //
 // Each case below is one of those silences, now spoken.
 import { describe, expect, it } from "vitest";
-import { executeUnblockSweep, type UnblockSweepGh } from "../src/core/boot-sweep.js";
+import {
+  executeUnblockSweep,
+  planCloseCascade,
+  planUnblockSweep,
+  type UnblockSweepGh,
+} from "../src/core/boot-sweep.js";
 
 function recordingGh(): UnblockSweepGh & { edits: number[] } {
   const edits: number[] = [];
@@ -19,6 +24,20 @@ function recordingGh(): UnblockSweepGh & { edits: number[] } {
 }
 
 describe("the unblock sweep says why it did not promote", () => {
+  it("shares the dependency state-role gate with the close-cascade projection", async () => {
+    const labels = ["req:138"];
+    const cascade = planCloseCascade(138, [
+      { number: 140, labels, reqs: [{ n: 138, closed: true }] },
+    ]);
+    const sweep = await planUnblockSweep(
+      [{ number: 140, body: "", labels }],
+      async () => "CLOSED",
+    );
+
+    expect(cascade).toEqual([]);
+    expect(sweep).toEqual([]);
+  });
+
   it("names the blockers that are not confirmed closed", async () => {
     const report = await executeUnblockSweep(
       [{ number: 3801, body: "", labels: ["blocked:dependency", "req:3800", "req:3799"] }],


### PR DESCRIPTION
Automated AFK landing for #3940. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3940

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789483797&installation_model_id=20659&pr_number=3952&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3952&signature=77b901e0cf4b00c902397a90ac7db19126f5a2700c8ace49324603479a38e992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->