### PR TITLE
fix: #3955 Launcher resolves the installed tree before npm, on an exact version match

### DIFF
--- a/packages/shared/bundle-fetch.test.ts
+++ b/packages/shared/bundle-fetch.test.ts
@@ -290,6 +290,32 @@ describe("ensureBundle (npm transport)", () => {
     expect(writes).toEqual([]);
   });
 
+  it("keeps canary on npm even when the stable installed version exists", async () => {
+    const installed = `${INSTALL_ROOT}/versions/v${VERSION}/dist/${PLUGIN}.bundle.min.mjs`;
+    const spec = npmPackageSpec(VERSION, "canary");
+    const published = "1.141.0";
+    const bytes = bundleBytesFor(published);
+    const { io, files, materializes } = makeIO({
+      files: { [installed]: bundleBytesFor(VERSION) },
+      distTags: { canary: published },
+      packageBundles: {
+        [npmPackageSpec(published)]: { [PLUGIN]: bytes, ...packagedCompanions("-canary") },
+      },
+    });
+
+    const path = await ensureBundle(io, {
+      plugin: PLUGIN,
+      version: VERSION,
+      cacheDir: CACHE,
+      installRoot: INSTALL_ROOT,
+      channel: "canary",
+    });
+
+    expect(path).toBe(`${CACHE}/${PLUGIN}-canary.bundle.min.mjs`);
+    expect(materializes).toEqual([spec]);
+    expect(files[path]).toEqual(bytes);
+  });
+
   it("ignores a skewed installed-tree version and falls back to npm", async () => {
     const skewed = `${INSTALL_ROOT}/versions/v1.139.9/dist/${PLUGIN}.bundle.min.mjs`;
     const spec = npmPackageSpec(VERSION);

--- a/packages/shared/bundle-fetch.test.ts
+++ b/packages/shared/bundle-fetch.test.ts
@@ -27,6 +27,7 @@ import {
 
 const PLUGIN = "dev";
 const CACHE = "/cache/bundles";
+const INSTALL_ROOT = "/installed/red-skills";
 const VERSION = "1.140.0";
 
 const enc = (s: string) => new TextEncoder().encode(s);
@@ -269,6 +270,68 @@ describe("ensureBundle never writes an unversioned cache entry (#3153)", () => {
 });
 
 describe("ensureBundle (npm transport)", () => {
+  it("resolves an exact-version bundle from the installed tree without materialising npm", async () => {
+    const installed = `${INSTALL_ROOT}/versions/v${VERSION}/dist/${PLUGIN}.bundle.min.mjs`;
+    const spec = npmPackageSpec(VERSION);
+    const { io, materializes, writes } = makeIO({
+      files: { [installed]: bundleBytesFor(VERSION) },
+      offlineSpecs: [spec],
+    });
+
+    await expect(
+      ensureBundle(io, {
+        plugin: PLUGIN,
+        version: VERSION,
+        cacheDir: CACHE,
+        installRoot: INSTALL_ROOT,
+      }),
+    ).resolves.toBe(installed);
+    expect(materializes).toEqual([]);
+    expect(writes).toEqual([]);
+  });
+
+  it("ignores a skewed installed-tree version and falls back to npm", async () => {
+    const skewed = `${INSTALL_ROOT}/versions/v1.139.9/dist/${PLUGIN}.bundle.min.mjs`;
+    const spec = npmPackageSpec(VERSION);
+    const bytes = bundleBytesFor(VERSION);
+    const { io, files, materializes } = makeIO({
+      files: { [skewed]: bundleBytesFor("1.139.9") },
+      packageBundles: { [spec]: { [PLUGIN]: bytes, ...packagedCompanions() } },
+    });
+
+    const path = await ensureBundle(io, {
+      plugin: PLUGIN,
+      version: VERSION,
+      cacheDir: CACHE,
+      installRoot: INSTALL_ROOT,
+    });
+
+    const cached = resolveBundle({ plugin: PLUGIN, version: VERSION, cacheDir: CACHE });
+    expect(path).toBe(cached);
+    expect(materializes).toEqual([spec]);
+    expect(files[cached]).toEqual(bytes);
+  });
+
+  it("preserves npm resolution when the installed version is absent", async () => {
+    const spec = npmPackageSpec(VERSION);
+    const bytes = bundleBytesFor(VERSION);
+    const { io, files, materializes } = makeIO({
+      packageBundles: { [spec]: { [PLUGIN]: bytes, ...packagedCompanions() } },
+    });
+
+    const path = await ensureBundle(io, {
+      plugin: PLUGIN,
+      version: VERSION,
+      cacheDir: CACHE,
+      installRoot: INSTALL_ROOT,
+    });
+
+    const cached = resolveBundle({ plugin: PLUGIN, version: VERSION, cacheDir: CACHE });
+    expect(path).toBe(cached);
+    expect(materializes).toEqual([spec]);
+    expect(files[cached]).toEqual(bytes);
+  });
+
   it("is cache-first: a present cached bundle never invokes npm", async () => {
     const dest = resolveBundle({ plugin: PLUGIN, version: VERSION, cacheDir: CACHE });
     const { io, materializes } = makeIO({

--- a/packages/shared/bundle-fetch.ts
+++ b/packages/shared/bundle-fetch.ts
@@ -1,6 +1,7 @@
 /**
- * bundle-fetch.ts — pure-with-injected-IO resolver for per-plugin built bundles,
- * distributed over **npm** (ADR 0091, v2 transport cutover).
+ * bundle-fetch.ts — pure-with-injected-IO resolver for per-plugin built bundles.
+ * The installer's exact-version runtime tree answers first; misses fall through
+ * to **npm** (ADR 0091, v2 transport cutover; ADR 0146).
  *
  * ADR 0034 originally shipped every plugin bundle as a GitHub Release asset,
  * fetched into a version-keyed cache and verified with a hand-rolled Sigstore
@@ -244,8 +245,9 @@ export function registryPackageUrl(pkg: string = NPM_PACKAGE): string {
 }
 
 /**
- * Ensure the bundle for `plugin@version` exists in `cacheDir`; return its local
- * path. Cache-first: a cache hit returns immediately with no npm invocation.
+ * Ensure the bundle for `plugin@version` is locally available; return its path.
+ * An exact-version hit in the installer's stable runtime tree returns directly,
+ * followed by the version-keyed bundle cache. Neither path invokes npm.
  *
  * Cache miss: materialise `@reddb-io/red-skills@<pin>` via npm (npm verifies the
  * tarball shasum itself), copy the packaged `dist/<plugin>.bundle.min.mjs` into

--- a/packages/shared/bundle-fetch.ts
+++ b/packages/shared/bundle-fetch.ts
@@ -47,6 +47,8 @@ export interface EnsureBundleInput {
   /** `owner/name` GitHub repo — retained for call-site compatibility; unused. */
   repo?: string;
   cacheDir: string;
+  /** Root populated by the installer (`<root>/versions/v<version>/dist/`). */
+  installRoot?: string;
   /** Release channel; absent = `stable` (version-pinned). */
   channel?: ReleaseChannel;
 }
@@ -206,6 +208,22 @@ export function packagedBundleRelPath(plugin: string): string {
   return joinPath("dist", packagedBundleName(plugin));
 }
 
+/** Exact-version bundle path in the installer's versioned runtime tree. */
+function installedBundlePath(
+  plugin: string,
+  version: string,
+  installRoot: string,
+): string {
+  if (!isCacheableVersion(version)) {
+    throw new BundleFetchError(
+      "invalid-version",
+      `refusing to resolve the installed ${plugin} bundle for ${JSON.stringify(version ?? "")}`,
+    );
+  }
+  const versionDir = joinPath(joinPath(installRoot, "versions"), `v${version.trim()}`);
+  return joinPath(versionDir, packagedBundleRelPath(plugin));
+}
+
 /**
  * The npm package spec the client resolves for a channel + version. `stable`
  * pins the exact version (`@reddb-io/red-skills@2.0.0`); `canary` follows the
@@ -249,12 +267,22 @@ export async function ensureBundle(
   io: BundleIO,
   input: EnsureBundleInput,
 ): Promise<string> {
-  const { plugin, version, cacheDir, channel = "stable" } = input;
+  const { plugin, version, cacheDir, installRoot, channel = "stable" } = input;
   const dest = resolveBundle({ plugin, version, cacheDir, channel });
   const companionPlugins = companionBundlePlugins(plugin);
   const companionDests = companionPlugins.map((companion) =>
     resolveBundle({ plugin: companion, version, cacheDir, channel }),
   );
+
+  // The standalone installer already materialises every stable release under a
+  // versioned tree. Use only the exact manifest version: accepting another
+  // directory here would run one release's hook under another release's
+  // manifest. Canary remains an npm dist-tag and deliberately bypasses this
+  // stable-only tree.
+  if (channel !== "canary" && installRoot) {
+    const installed = installedBundlePath(plugin, version, installRoot);
+    if (await io.exists(installed)) return installed;
+  }
 
   // Stable is cache-first; canary is a floating npm dist-tag and must refresh.
   if (

--- a/packages/shared/entrypoint-cli.ts
+++ b/packages/shared/entrypoint-cli.ts
@@ -71,6 +71,11 @@ function cacheRoot(override?: string): string {
   return join(homedir(), ".cache", "red-skills", "bundles");
 }
 
+/** Versioned runtime tree populated by the standalone installer. */
+function installRoot(): string {
+  return process.env.RED_SKILLS_INSTALL_ROOT || join(homedir(), ".red-skills");
+}
+
 const realIO: BundleIO = {
   async materialize(spec, stagingDir) {
     await mkdir(stagingDir, { recursive: true });
@@ -341,7 +346,14 @@ async function runMode(plan: RunPlan): Promise<never> {
   let bundle = cachedBundlePath(plugin, version, cacheDir, channel) ?? distBundlePath(plugin);
   if (!bundle && (version || channel === "canary")) {
     try {
-      bundle = await ensureBundle(realIO, { plugin, version, repo: plan.repo, cacheDir, channel });
+      bundle = await ensureBundle(realIO, {
+        plugin,
+        version,
+        repo: plan.repo,
+        cacheDir,
+        installRoot: installRoot(),
+        channel,
+      });
     } catch (err) {
       const kind = err instanceof BundleFetchError ? err.kind : "unknown";
       const msg = err instanceof Error ? err.message : String(err);
@@ -418,7 +430,14 @@ async function fetchMode(plan: FetchPlan): Promise<never> {
       ? resolveBundle({ plugin, version, cacheDir, channel })
       : `${cacheDir}/${plugin}-<version>.bundle.min.mjs`;
   try {
-    const path = await ensureBundle(realIO, { plugin, version, repo: plan.repo, cacheDir, channel });
+    const path = await ensureBundle(realIO, {
+      plugin,
+      version,
+      repo: plan.repo,
+      cacheDir,
+      installRoot: installRoot(),
+      channel,
+    });
     process.stdout.write(`entrypoint: bundle ready at ${path} (${channel})\n`);
   } catch (err) {
     const kind = err instanceof BundleFetchError ? err.kind : "unknown";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -46,5 +46,8 @@
   "dependencies": {
     "@reddb-io/toon": "catalog:",
     "cli-args-parser": "^1.0.6"
+  },
+  "devDependencies": {
+    "vitest": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -651,6 +651,10 @@ importers:
       cli-args-parser:
         specifier: ^1.0.6
         version: 1.0.6
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@25.9.5)
 
 packages:
 


### PR DESCRIPTION
Automated AFK landing for #3955. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3955

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789513718&installation_model_id=20659&pr_number=3959&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3959&signature=2e2e7c62a23bdc4ccf76f9dc2b366033e8052a8fedad403429ac47298590b66c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->