### PR TITLE
fix: #3956 Tokenizer rank tables leave the memory bundle for a lazily loaded asset

### DIFF
--- a/apps/dev/tests/pi-package-builder.test.ts
+++ b/apps/dev/tests/pi-package-builder.test.ts
@@ -150,6 +150,7 @@ description: Test init skill.
     );
     await writeFile(join(root, "dist/dev.bundle.min.mjs"), "// dev runtime\n", "utf8");
     await writeFile(join(root, "dist/memory.bundle.min.mjs"), "// memory runtime\n", "utf8");
+    await writeFile(join(root, "dist/memory-tokenizer.asset.cjs"), "// tokenizer ranks\n", "utf8");
 
     await buildPiPackages({ root });
 
@@ -194,6 +195,8 @@ description: Test init skill.
     expect(memoryPkg.pi.skills).toEqual(["./skills/core/"]);
     expect(await readFile(join(root, "packaging/pi/memory/dist/memory.bundle.min.mjs"), "utf8"))
       .toBe("// memory runtime\n");
+    expect(await readFile(join(root, "packaging/pi/memory/dist/memory-tokenizer.asset.cjs"), "utf8"))
+      .toBe("// tokenizer ranks\n");
   });
 
   it("fails --check when a staged Pi package drifts from the source (module API)", async () => {

--- a/apps/memory/package.json
+++ b/apps/memory/package.json
@@ -17,7 +17,7 @@
     "lint:deterministic-extractors": "tsx src/deterministic-extractor-vocabulary-lint.ts",
     "build": "pnpm lint:deterministic-extractors && tsc -p tsconfig.build.json && pnpm bundle",
     "bundle": "pnpm bundle:cli && pnpm bundle:mcp",
-    "bundle:cli": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/memory.bundle.min.mjs --asset memory.bundle.min.mjs --minify --reddb-from-package",
+    "bundle:cli": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/memory.bundle.min.mjs --asset memory.bundle.min.mjs --lazy-asset-entry src/tokenizer-asset.ts --lazy-asset memory-tokenizer.asset.cjs --minify --reddb-from-package",
     "bundle:mcp": "node ../../scripts/bundle-app.mjs --entry src/mcp-server.ts --outfile ../../dist/memory-mcp.bundle.min.mjs --asset memory-mcp.bundle.min.mjs --minify --reddb-from-package",
     "test": "vitest run",
     "test:bench-latency": "RED_MEMORY_ASSERT_LATENCY_INVARIANT=1 vitest run tests/bench-latency.test.ts",

--- a/apps/memory/src/bench-eval/scoring.ts
+++ b/apps/memory/src/bench-eval/scoring.ts
@@ -1,5 +1,5 @@
-import { getEncoding } from "js-tiktoken";
 import type { ProviderClient, ProviderRequest } from "../extract-conversation.js";
+import { countCl100kTokens } from "../token-count.js";
 import type {
   AgentSubstrateTool,
   AgentToolCallOutput,
@@ -217,10 +217,8 @@ function stripJsonFence(response: string): string {
  * Token accounting — real tokenizer, not character counts
  * --------------------------------------------------------------------------*/
 
-const CL100K = getEncoding("cl100k_base");
-
 export function countBenchTokens(text: string): number {
-  return CL100K.encode(text).length;
+  return countCl100kTokens(text);
 }
 
 export function measureAnswererTokens(question: Question, pack: ContextPack, predictedAnswer: string): TokenCounts {

--- a/apps/memory/src/ingest.ts
+++ b/apps/memory/src/ingest.ts
@@ -1,7 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { extname, isAbsolute, relative, resolve } from "node:path";
 import fg from "fast-glob";
-import { getEncoding } from "js-tiktoken";
 import { extractAsset, isAssetFile } from "./extract-asset.js";
 import { extractCode } from "./extract-code.js";
 import {
@@ -16,6 +15,7 @@ import { extractMarkdown } from "./extract-markdown.js";
 import { extractSql } from "./extract-sql.js";
 import { contentHash } from "./hash.js";
 import { readMemoryIgnore } from "./scope.js";
+import { countCl100kTokens } from "./token-count.js";
 import { renderToonOutput } from "./toon-output.js";
 import type { MemoryStore } from "./graph-store.js";
 import type { EdgeLabel, MemoryDoc, MemoryEdgeProps, MemoryNode } from "./schema.js";
@@ -244,16 +244,12 @@ function emptySemanticReport(enabled: boolean): SemanticIngestReport {
   return { enabled, nodes: 0, edges: 0, token_cost: { input: 0, output: 0 } };
 }
 
-let tokenizer: ReturnType<typeof getEncoding> | null = null;
-
 function countProviderRequestTokens(req: ProviderRequest): number {
   return countTokens(`${req.system}\n\n${req.user}`);
 }
 
 function countTokens(text: string): number {
-  if (!text) return 0;
-  tokenizer ??= getEncoding("cl100k_base");
-  return tokenizer.encode(text).length;
+  return countCl100kTokens(text);
 }
 
 export function renderIngestReportToon(

--- a/apps/memory/src/token-count.ts
+++ b/apps/memory/src/token-count.ts
@@ -1,0 +1,34 @@
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import type { Tiktoken } from "js-tiktoken/lite";
+
+declare const __RED_LAZY_ASSET__: string;
+
+type TokenizerAsset = {
+  createCl100kEncoding(): Tiktoken;
+};
+
+type FullTokenizerPackage = {
+  getEncoding(name: "cl100k_base"): Tiktoken;
+};
+
+const runtimeRequire = createRequire(import.meta.url);
+let tokenizer: Tiktoken | undefined;
+
+/** Count with the memory app's stable cl100k boundary, loading ranks on first use. */
+export function countCl100kTokens(text: string): number {
+  if (!text) return 0;
+  tokenizer ??= loadTokenizer();
+  return tokenizer.encode(text).length;
+}
+
+function loadTokenizer(): Tiktoken {
+  if (typeof __RED_LAZY_ASSET__ === "string") {
+    const assetPath = fileURLToPath(new URL(__RED_LAZY_ASSET__, import.meta.url));
+    return (runtimeRequire(assetPath) as TokenizerAsset).createCl100kEncoding();
+  }
+
+  // Source/tests resolve the workspace dependency; shipped bundles take the
+  // branch above and own the sibling asset instead of requiring node_modules.
+  return (runtimeRequire("js-tiktoken") as FullTokenizerPackage).getEncoding("cl100k_base");
+}

--- a/apps/memory/src/tokenizer-asset.ts
+++ b/apps/memory/src/tokenizer-asset.ts
@@ -1,0 +1,7 @@
+import { Tiktoken } from "js-tiktoken/lite";
+import cl100kBase from "js-tiktoken/ranks/cl100k_base";
+
+/** Runtime entry for the package-owned tokenizer asset emitted beside the app bundle. */
+export function createCl100kEncoding(): Tiktoken {
+  return new Tiktoken(cl100kBase);
+}

--- a/apps/memory/tests/bench-eval.test.ts
+++ b/apps/memory/tests/bench-eval.test.ts
@@ -771,6 +771,15 @@ describe("memory bench eval — runner", () => {
     expect(countBenchTokens("hello world")).toBeLessThan("hello world".length);
   });
 
+  test("public token counting boundary preserves the pre-asset cl100k values", () => {
+    expect([
+      countBenchTokens(""),
+      countBenchTokens("hello world"),
+      countBenchTokens("RedSkills memory keeps token counts stable."),
+      countBenchTokens("emoji: 🧠\nTOON rows: 3"),
+    ]).toEqual([0, 2, 8, 12]);
+  });
+
   test("explicit neo4j substrate runs only the Neo4j adapter", async () => {
     const report = await runBenchEval({
       corpusDir: CORPUS_DIR,

--- a/packaging/npm/scripts/prepare.mjs
+++ b/packaging/npm/scripts/prepare.mjs
@@ -47,6 +47,7 @@ const BUNDLES = [
   { dest: "redskilled-mcp.bundle.min.mjs", sources: ["redskilled-mcp.bundle.min.mjs"] },
   { dest: "code-nav.bundle.min.mjs", sources: ["code-nav.bundle.min.mjs", "code-nav-mcp.bundle.min.mjs"] },
   { dest: "memory.bundle.min.mjs", sources: ["memory.bundle.min.mjs"] },
+  { dest: "memory-tokenizer.asset.cjs", sources: ["memory-tokenizer.asset.cjs"] },
   { dest: "brain.bundle.min.mjs", sources: ["brain.bundle.min.mjs"] },
   { dest: "release.bundle.min.mjs", sources: ["release.bundle.min.mjs"] },
   { dest: "rsp.bundle.min.mjs", sources: ["rsp.bundle.min.mjs"] },

--- a/scripts/build-pi-packages.mjs
+++ b/scripts/build-pi-packages.mjs
@@ -136,22 +136,27 @@ async function stagePackage({ root, pluginDir, claudePlugin, packagingDir, misma
   // Local manifest checks run from source-only trees where dist/ is absent;
   // the publish-time tarball contract remains the authority that every release
   // actually built and packed this declared file.
-  const bundleName = `${pluginName}.bundle.min.mjs`;
-  const sourceBundle = join(root, "dist", bundleName);
-  const targetBundle = join(targetDir, "dist", bundleName);
-  try {
-    const bundleBytes = await readFile(sourceBundle);
-    if (check) {
-      const stagedBytes = await readFile(targetBundle).catch(() => null);
-      if (stagedBytes === null || !bundleBytes.equals(stagedBytes)) {
-        mismatches.push({ path: targetBundle, bytes: "", note: [`${bundleName}: bytes differ`] });
+  const runtimeAssets = [
+    `${pluginName}.bundle.min.mjs`,
+    ...(pluginName === "memory" ? ["memory-tokenizer.asset.cjs"] : []),
+  ];
+  for (const runtimeAsset of runtimeAssets) {
+    const sourceAsset = join(root, "dist", runtimeAsset);
+    const targetAsset = join(targetDir, "dist", runtimeAsset);
+    try {
+      const assetBytes = await readFile(sourceAsset);
+      if (check) {
+        const stagedBytes = await readFile(targetAsset).catch(() => null);
+        if (stagedBytes === null || !assetBytes.equals(stagedBytes)) {
+          mismatches.push({ path: targetAsset, bytes: "", note: [`${runtimeAsset}: bytes differ`] });
+        }
+      } else {
+        await mkdir(join(targetDir, "dist"), { recursive: true });
+        await cp(sourceAsset, targetAsset);
       }
-    } else {
-      await mkdir(join(targetDir, "dist"), { recursive: true });
-      await cp(sourceBundle, targetBundle);
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
     }
-  } catch (error) {
-    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
   }
 
   // 4. Stage a small README so `npm view` shows project context, not just an

--- a/scripts/bundle-app.mjs
+++ b/scripts/bundle-app.mjs
@@ -54,6 +54,16 @@ const defines = {
   __REDDB_BINARY_TAG__: "",
 };
 
+if (args.lazyAssetEntry || args.lazyAsset) {
+  if (!args.lazyAssetEntry || !args.lazyAsset) {
+    process.stderr.write(
+      "bundle-app: --lazy-asset-entry and --lazy-asset must be provided together\n",
+    );
+    process.exit(1);
+  }
+  defines.__RED_LAZY_ASSET__ = args.lazyAsset;
+}
+
 if (args.reddbFromPackage) {
   const sdk = pkg.dependencies?.["@reddb-io/sdk"];
   if (!sdk) {
@@ -81,7 +91,27 @@ const result = spawnSync("esbuild", esbuildArgs, {
   stdio: "inherit",
   shell: process.platform === "win32",
 });
-process.exit(result.status ?? 1);
+if (result.status !== 0) process.exit(result.status ?? 1);
+
+if (args.lazyAssetEntry) {
+  const lazyAssetArgs = [
+    args.lazyAssetEntry,
+    "--bundle",
+    "--platform=node",
+    "--format=cjs",
+    "--target=node22",
+    `--outfile=${resolve(dirname(args.outfile), args.lazyAsset)}`,
+  ];
+  if (args.minify) lazyAssetArgs.splice(2, 0, "--minify");
+
+  const lazyAssetResult = spawnSync("esbuild", lazyAssetArgs, {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  if (lazyAssetResult.status !== 0) process.exit(lazyAssetResult.status ?? 1);
+}
+
+process.exit(0);
 
 function parseArgs(argv) {
   const out = {
@@ -93,6 +123,8 @@ function parseArgs(argv) {
     if (arg === "--entry") out.entry = argv[++i];
     else if (arg === "--outfile") out.outfile = argv[++i];
     else if (arg === "--asset") out.asset = argv[++i];
+    else if (arg === "--lazy-asset-entry") out.lazyAssetEntry = argv[++i];
+    else if (arg === "--lazy-asset") out.lazyAsset = argv[++i];
     else if (arg === "--minify") out.minify = true;
     else if (arg === "--reddb-from-package") out.reddbFromPackage = true;
     else {

--- a/scripts/check-npm-tarball-boundaries.mjs
+++ b/scripts/check-npm-tarball-boundaries.mjs
@@ -4,6 +4,8 @@ import { spawnSync } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
+const MEMORY_TOKENIZER_ASSET = "memory-tokenizer.asset.cjs";
+
 function parseArgs(argv) {
   const args = { root: process.cwd(), core: "", plugins: "" };
   for (let index = 0; index < argv.length; index += 1) {
@@ -55,6 +57,7 @@ function checkCore(root, tarball) {
     "package/scripts/generate-gemini-manifests.mjs",
     "package/scripts/generate-pi-manifests.mjs",
     "package/dist/opencode-host.bundle.min.mjs",
+    `package/dist/${MEMORY_TOKENIZER_ASSET}`,
   ];
   for (const expected of required) requireEntry(listing, expected, "core npm");
 
@@ -94,6 +97,9 @@ function checkPlugins(root, tarballsDir) {
     );
     if (!skill) throw new Error(`${packageName} tarball carries no published skills`);
     requireEntry(listing, `package/dist/${plugin.name}.bundle.min.mjs`, packageName);
+    if (plugin.name === "memory") {
+      requireEntry(listing, `package/dist/${MEMORY_TOKENIZER_ASSET}`, packageName);
+    }
   }
 }
 

--- a/scripts/test-bundle-app-contract.sh
+++ b/scripts/test-bundle-app-contract.sh
@@ -109,6 +109,66 @@ else
   fail "bundle-app must strip leading v from version"
 fi
 
+# 10 — Memory tokenizer ranks are a lazy, package-owned sibling asset (#3956)
+MEMORY_PACKAGE="apps/memory/package.json"
+MEMORY_BUNDLE="dist/memory.bundle.min.mjs"
+MEMORY_TOKENIZER="dist/memory-tokenizer.asset.cjs"
+MEMORY_BUNDLE_BEFORE=10698895
+RANK_TABLE_PREFIX='bpe_ranks:"! 0 IQ== Ig== Iw=='
+
+if grep -qF -- '--lazy-asset-entry src/tokenizer-asset.ts' "$MEMORY_PACKAGE" \
+  && grep -qF -- '--lazy-asset memory-tokenizer.asset.cjs' "$MEMORY_PACKAGE"; then
+  pass "memory bundle declares its lazy tokenizer asset"
+else
+  fail "memory bundle must declare the lazy tokenizer entry and sibling asset"
+fi
+
+if pnpm -C apps/memory bundle:cli >/dev/null; then
+  pass "memory CLI bundle and tokenizer asset build"
+else
+  fail "memory CLI bundle and tokenizer asset must build"
+fi
+
+if [[ -f "$MEMORY_BUNDLE" && -f "$MEMORY_TOKENIZER" ]]; then
+  pass "memory tokenizer asset is emitted beside the bundle"
+else
+  fail "memory tokenizer asset must be emitted beside the bundle"
+fi
+
+if [[ -f "$MEMORY_BUNDLE" ]]; then
+  memory_bundle_after="$(wc -c < "$MEMORY_BUNDLE")"
+  printf 'INFO: memory bundle bytes before=%d after=%d\n' \
+    "$MEMORY_BUNDLE_BEFORE" "$memory_bundle_after"
+  if ! grep -qF "$RANK_TABLE_PREFIX" "$MEMORY_BUNDLE"; then
+    pass "memory bundle carries no inline BPE rank table"
+  else
+    fail "memory bundle must not inline BPE rank tables"
+  fi
+fi
+
+if [[ -f "$MEMORY_TOKENIZER" ]] && grep -qF "$RANK_TABLE_PREFIX" "$MEMORY_TOKENIZER"; then
+  pass "memory tokenizer sibling asset carries the BPE ranks"
+else
+  fail "memory tokenizer sibling asset must carry the BPE ranks"
+fi
+
+lazy_probe="$(mktemp -d)"
+cp "$MEMORY_BUNDLE" "$lazy_probe/memory.bundle.min.mjs"
+if node "$lazy_probe/memory.bundle.min.mjs" --help >/dev/null; then
+  pass "memory bundle starts without loading the absent tokenizer asset"
+else
+  fail "memory bundle must not load tokenizer ranks before a count is requested"
+fi
+rm -r -- "$lazy_probe"
+
+for package_writer in packaging/npm/scripts/prepare.mjs scripts/build-pi-packages.mjs; do
+  if grep -qF 'memory-tokenizer.asset.cjs' "$package_writer"; then
+    pass "$package_writer stages the memory tokenizer asset"
+  else
+    fail "$package_writer must stage the memory tokenizer asset"
+  fi
+done
+
 if (( failures > 0 )); then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -154,7 +154,8 @@ for expected in \
   scripts/generate-codex-manifests.mjs \
   scripts/generate-gemini-manifests.mjs \
   scripts/generate-pi-manifests.mjs \
-  dist/opencode-host.bundle.min.mjs; do
+  dist/opencode-host.bundle.min.mjs \
+  dist/memory-tokenizer.asset.cjs; do
   mkdir -p "$core_tree/$(dirname "$expected")"
   : > "$core_tree/$expected"
 done
@@ -169,6 +170,9 @@ while IFS= read -r plugin_json; do
   mkdir -p "$plugin_tree/skills/core/example" "$plugin_tree/dist"
   : > "$plugin_tree/skills/core/example/SKILL.md"
   : > "$plugin_tree/dist/$plugin.bundle.min.mjs"
+  if [ "$plugin" = "memory" ]; then
+    : > "$plugin_tree/dist/memory-tokenizer.asset.cjs"
+  fi
   tar -czf "$plugin_tarballs/reddb-io-red-skills-$plugin-9.9.9.tgz" \
     -C "$contract_fixture/plugin-$plugin" package
 done < <(find plugins -mindepth 3 -maxdepth 3 -path '*/.claude-plugin/plugin.json' -print | sort)
@@ -181,6 +185,19 @@ if node scripts/check-npm-tarball-boundaries.mjs \
 else
   fail "valid core and per-plugin tarballs must satisfy the publish boundary checker"
 fi
+
+memory_tarball="$plugin_tarballs/reddb-io-red-skills-memory-9.9.9.tgz"
+tar --exclude='package/dist/memory-tokenizer.asset.cjs' \
+  -czf "$memory_tarball" -C "$contract_fixture/plugin-memory" package
+if node scripts/check-npm-tarball-boundaries.mjs \
+  --root "$ROOT" \
+  --core "$contract_fixture/core.tgz" \
+  --plugins "$plugin_tarballs" >/dev/null 2>&1; then
+  fail "memory plugin tarball without its tokenizer asset must fail the publish contract"
+else
+  pass "memory plugin tarball without its tokenizer asset fails the publish contract"
+fi
+tar -czf "$memory_tarball" -C "$contract_fixture/plugin-memory" package
 
 missing_bundle_tree="$contract_fixture/missing-bundle/package"
 mkdir -p "$missing_bundle_tree/skills/core/example"


### PR DESCRIPTION
Automated AFK landing for #3956. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3956

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789514112&installation_model_id=20659&pr_number=3961&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3961&signature=2e2a5d52b42b2f7364c387df4970c0c0d7f677ca03f2dc9023bf95e9e5379a34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->