### PR TITLE
fix: #3957 Core npm package drops the per-plugin bundles and the publish contract asserts their absence

### DIFF
--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -694,20 +694,14 @@ jobs:
           # as missing. Matching each expected entry against the captured listing with
           # a here-string (no pipe) lets tar always read to completion.
           listing="$(tar -tzf "$tarball")"
-          for expected in \
-            package/dist/dev.bundle.min.mjs \
-            package/dist/redskilled-mcp.bundle.min.mjs \
-            package/dist/code-nav.bundle.min.mjs \
-            package/dist/memory.bundle.min.mjs \
-            package/dist/brain.bundle.min.mjs \
-            package/dist/rsp.bundle.min.mjs \
-            package/dist/rsp-core.bundle.min.mjs \
-            package/dist/redskilled.bundle.min.mjs; do
-            if ! grep -qxF "$expected" <<<"$listing"; then
-              echo "::error::npm tarball missing $expected"
+          while IFS= read -r plugin_json; do
+            plugin="$(node -p "require('../../${plugin_json}').name")"
+            unexpected="package/dist/$plugin.bundle.min.mjs"
+            if grep -qxF "$unexpected" <<<"$listing"; then
+              echo "::error::npm tarball unexpectedly contains $unexpected"
               exit 1
             fi
-          done
+          done < <(find ../../plugins -mindepth 3 -maxdepth 3 -path '*/.claude-plugin/plugin.json' -print | sort | sed 's#^../../##')
           core_tarball="$PWD/$tarball"
           cd ../..
           node scripts/check-npm-tarball-boundaries.mjs \
@@ -721,7 +715,6 @@ jobs:
           smoke="$(mktemp -d)"
           npm install "./$tarball" --prefix "$smoke" --no-audit --no-fund --ignore-scripts --loglevel=error
           pkg="$smoke/node_modules/@reddb-io/red-skills"
-          node "$pkg/bin/red-skills-dev.mjs" --version
           node "$pkg/bin/red-skills-redskilled-mcp.mjs" --help
           # code-nav launches via an npm-shim bin (#1396) that resolves the packaged
           # code-nav bundle; smoke both the shim and the bundle it resolves.
@@ -842,16 +835,10 @@ jobs:
           # (v2.0.1 took >2min to become resolvable, exhausting the previous
           # ~105s budget). 10 attempts at attempt*15s ≈ 11min total budget.
           for attempt in 1 2 3 4 5 6 7 8 9 10; do
-            if output="$(npx -y -p "@reddb-io/red-skills@${version}" red-skills-dev --version 2>&1)"; then
-              printf '%s\n' "$output"
-              if grep -qF "dev ${version} " <<<"$output"; then
-                echo "registry smoke returned @reddb-io/red-skills@${version}"
-                exit 0
-              fi
-              echo "::error::registry smoke returned unexpected version output for @reddb-io/red-skills@${version}"
-              exit 1
+            if resolved="$(npm view "@reddb-io/red-skills@${version}" version 2>/dev/null)" && [ "$resolved" = "${version}" ]; then
+              echo "registry smoke returned @reddb-io/red-skills@${version}"
+              exit 0
             fi
-            printf '%s\n' "$output" >&2
             if [ "$attempt" -eq 10 ]; then
               echo "::error::registry did not serve @reddb-io/red-skills@${version} after publish"
               exit 1

--- a/packages/shared/bundle-fetch.test.ts
+++ b/packages/shared/bundle-fetch.test.ts
@@ -14,6 +14,7 @@ import {
   isCacheableVersion,
   newestPublished,
   newestSameMajor,
+  npmBundlePackageSpec,
   npmPackageSpec,
   packagedBundleName,
   packagedBundleRelPath,
@@ -64,12 +65,18 @@ function makeIO(opts: {
   const io: BundleIO = {
     async materialize(spec, stagingDir) {
       materializes.push(spec);
-      if ((opts.offlineSpecs ?? []).includes(spec)) {
+      const coreSpec = coreEquivalentSpec(spec);
+      if ((opts.offlineSpecs ?? []).includes(spec) || (opts.offlineSpecs ?? []).includes(coreSpec)) {
         throw new Error("getaddrinfo ENOTFOUND registry.npmjs.org");
       }
-      const bundles = packages[spec] ?? packages[resolveDistTagSpec(spec, opts.distTags ?? {})];
+      const resolved = resolveDistTagSpec(spec, opts.distTags ?? {});
+      const bundles = packages[spec] ?? packages[resolved] ?? packages[coreEquivalentSpec(resolved)];
       if (!bundles) throw new Error(`npm ERR! 404 '${spec}' is not in this registry`);
-      const root = `${stagingDir}/node_modules/${NPM_PACKAGE}`;
+      const packageName = spec.slice(0, spec.lastIndexOf("@"));
+      const root = `${stagingDir}/node_modules/${packageName}`;
+      files[`${root}/package.json`] = enc(JSON.stringify({
+        version: resolved.slice(resolved.lastIndexOf("@") + 1),
+      }));
       for (const [plugin, bytes] of Object.entries(bundles)) {
         files[`${root}/${packagedBundleRelPath(plugin)}`] = bytes;
       }
@@ -123,11 +130,15 @@ function cachedCompanions(version = VERSION): Record<string, Uint8Array> {
 }
 
 function resolveDistTagSpec(spec: string, tags: Record<string, string>): string {
-  const prefix = `${NPM_PACKAGE}@`;
-  if (!spec.startsWith(prefix)) return spec;
-  const ref = spec.slice(prefix.length);
+  const separator = spec.lastIndexOf("@");
+  const packageName = spec.slice(0, separator);
+  const ref = spec.slice(separator + 1);
   const version = tags[ref];
-  return version ? `${NPM_PACKAGE}@${version}` : spec;
+  return version ? `${packageName}@${version}` : spec;
+}
+
+function coreEquivalentSpec(spec: string): string {
+  return `${NPM_PACKAGE}@${spec.slice(spec.lastIndexOf("@") + 1)}`;
 }
 
 describe("npm spec + registry URL builders", () => {
@@ -135,6 +146,8 @@ describe("npm spec + registry URL builders", () => {
     expect(npmPackageSpec(VERSION, "stable")).toBe(`${NPM_PACKAGE}@1.140.0`);
     expect(npmPackageSpec(VERSION)).toBe(`${NPM_PACKAGE}@1.140.0`);
     expect(npmPackageSpec(VERSION, "canary")).toBe(`${NPM_PACKAGE}@${CANARY_DIST_TAG}`);
+    expect(npmBundlePackageSpec("dev", VERSION)).toBe("@reddb-io/red-skills-dev@1.140.0");
+    expect(npmBundlePackageSpec("code-nav", VERSION)).toBe(`${NPM_PACKAGE}@1.140.0`);
   });
 
   it("builds a %2F-escaped registry URL and no releases/download path", () => {
@@ -224,7 +237,7 @@ describe("ensureBundle never writes an unversioned cache entry (#3153)", () => {
 
     const path = await ensureBundle(io, { plugin: PLUGIN, version: VERSION, cacheDir: CACHE });
 
-    expect(materializes).toEqual([spec]);
+    expect(materializes).toEqual([npmBundlePackageSpec(PLUGIN, VERSION), spec]);
     expect(path).toBe(resolveBundle({ plugin: PLUGIN, version: VERSION, cacheDir: CACHE }));
     // Moved aside, not inherited: a host already in this state must recover on
     // its next boot without hand-editing the cache.
@@ -312,7 +325,10 @@ describe("ensureBundle (npm transport)", () => {
     });
 
     expect(path).toBe(`${CACHE}/${PLUGIN}-canary.bundle.min.mjs`);
-    expect(materializes).toEqual([spec]);
+    expect(materializes).toEqual([
+      spec,
+      npmBundlePackageSpec(PLUGIN, published),
+    ]);
     expect(files[path]).toEqual(bytes);
   });
 
@@ -334,15 +350,18 @@ describe("ensureBundle (npm transport)", () => {
 
     const cached = resolveBundle({ plugin: PLUGIN, version: VERSION, cacheDir: CACHE });
     expect(path).toBe(cached);
-    expect(materializes).toEqual([spec]);
+    expect(materializes).toEqual([npmBundlePackageSpec(PLUGIN, VERSION), spec]);
     expect(files[cached]).toEqual(bytes);
   });
 
   it("preserves npm resolution when the installed version is absent", async () => {
-    const spec = npmPackageSpec(VERSION);
+    const spec = npmBundlePackageSpec(PLUGIN, VERSION);
     const bytes = bundleBytesFor(VERSION);
     const { io, files, materializes } = makeIO({
-      packageBundles: { [spec]: { [PLUGIN]: bytes, ...packagedCompanions() } },
+      packageBundles: {
+        [spec]: { [PLUGIN]: bytes },
+        [npmPackageSpec(VERSION)]: packagedCompanions(),
+      },
     });
 
     const path = await ensureBundle(io, {
@@ -354,7 +373,7 @@ describe("ensureBundle (npm transport)", () => {
 
     const cached = resolveBundle({ plugin: PLUGIN, version: VERSION, cacheDir: CACHE });
     expect(path).toBe(cached);
-    expect(materializes).toEqual([spec]);
+    expect(materializes).toEqual([spec, npmPackageSpec(VERSION)]);
     expect(files[cached]).toEqual(bytes);
   });
 
@@ -377,7 +396,7 @@ describe("ensureBundle (npm transport)", () => {
     const dest = resolveBundle({ plugin: PLUGIN, version: VERSION, cacheDir: CACHE });
     const path = await ensureBundle(io, { plugin: PLUGIN, version: VERSION, cacheDir: CACHE });
     expect(path).toBe(dest);
-    expect(materializes).toEqual([spec]);
+    expect(materializes).toEqual([npmBundlePackageSpec(PLUGIN, VERSION), spec]);
     expect(files[dest]).toEqual(bytes);
     for (const companion of companionBundlePlugins(PLUGIN)) {
       const companionDest = resolveBundle({ plugin: companion, version: VERSION, cacheDir: CACHE });
@@ -395,7 +414,7 @@ describe("ensureBundle (npm transport)", () => {
     });
     const path = await ensureBundle(io, { plugin: PLUGIN, version: VERSION, cacheDir: CACHE });
     expect(path).toBe(dest);
-    expect(materializes).toEqual([spec]);
+    expect(materializes).toEqual([npmBundlePackageSpec(PLUGIN, VERSION), spec]);
     expect(files[dest]).toEqual(devBytes);
     for (const companion of companionBundlePlugins(PLUGIN)) {
       const companionDest = resolveBundle({ plugin: companion, version: VERSION, cacheDir: CACHE });
@@ -434,7 +453,10 @@ describe("ensureBundle (npm transport)", () => {
       channel: "canary",
     });
     expect(path).toBe(`${CACHE}/dev-canary.bundle.min.mjs`);
-    expect(materializes).toEqual([spec]);
+    expect(materializes).toEqual([
+      spec,
+      npmBundlePackageSpec(PLUGIN, published),
+    ]);
     expect(files[dest]).toEqual(bytes);
     for (const companion of companionBundlePlugins(PLUGIN)) {
       expect(files[`${CACHE}/${companion}-canary.bundle.min.mjs`], companion).toEqual(
@@ -461,7 +483,10 @@ describe("ensureBundle (npm transport)", () => {
       channel: "canary",
     });
     expect(path).toBe(dest);
-    expect(materializes).toEqual([spec]);
+    expect(materializes).toEqual([
+      spec,
+      npmBundlePackageSpec(PLUGIN, published),
+    ]);
     expect(files[dest]).toEqual(bytes);
     for (const companion of companionBundlePlugins(PLUGIN)) {
       expect(files[`${CACHE}/${companion}-canary.bundle.min.mjs`], companion).toEqual(

--- a/packages/shared/bundle-fetch.ts
+++ b/packages/shared/bundle-fetch.ts
@@ -10,9 +10,10 @@
  * longer accepts ("invalid bundle"), and the self-update lane polled a
  * `releases/download/v1/` release that never existed (eternal 404). There was no
  * working installed base to preserve, so ADR 0091 **deletes** that channel: the
- * bundles now ship inside a single npm package `@reddb-io/red-skills`, resolved
- * at the exact pinned version via npm's own cache and shasum/provenance
- * integrity. No GitHub-release download, no client-side signature verification.
+ * bundles now ship inside `@reddb-io/red-skills-<plugin>`, resolved at the exact
+ * pinned version via npm's own cache and shasum/provenance integrity. Core keeps
+ * the non-plugin companions. No GitHub-release download, no client-side
+ * signature verification.
  *
  * This module holds ZERO real IO: every side effect (npm materialisation, file
  * read/write, existence check, registry query) is injected via {@link BundleIO}.
@@ -23,7 +24,7 @@
 
 import { type ReleaseChannel } from "./channel.js";
 
-/** The single npm package that carries every plugin's built bundle. */
+/** The core npm package that carries host tooling and non-plugin bundles. */
 export const NPM_PACKAGE = "@reddb-io/red-skills";
 
 /** Public npm registry base (self-update version discovery reads from here). */
@@ -62,8 +63,8 @@ export interface EnsureBundleInput {
  */
 export interface BundleIO {
   /**
-   * Materialise the npm package `spec` (`@reddb-io/red-skills@<pin>`) into
-   * `stagingDir` using npm's own cache, and return the installed package root
+   * Materialise the npm package `spec` into `stagingDir` using npm's own cache,
+   * and return the installed package root
    * directory (the folder that contains `dist/<plugin>.bundle.min.mjs`). Honours
    * npm's local cache-first behaviour, so a warm cache does no network IO.
    */
@@ -239,6 +240,24 @@ export function npmPackageSpec(
   return `${NPM_PACKAGE}@${ref}`;
 }
 
+/** Non-plugin runtimes that remain in the core package after ADR 0146. */
+const CORE_PACKAGE_BUNDLES = new Set(["code-nav", ...companionBundlePlugins("dev")]);
+
+/** The package that owns one bundle after the per-plugin package split. */
+export function npmBundlePackage(plugin: string): string {
+  return CORE_PACKAGE_BUNDLES.has(plugin) ? NPM_PACKAGE : `${NPM_PACKAGE}-${plugin}`;
+}
+
+/** Exact package spec used to materialise one bundle from npm. */
+export function npmBundlePackageSpec(
+  plugin: string,
+  version: string,
+  channel: ReleaseChannel = "stable",
+): string {
+  const ref = channel === "canary" ? CANARY_DIST_TAG : version;
+  return `${npmBundlePackage(plugin)}@${ref}`;
+}
+
 /** Registry metadata URL for the package (scoped name is `%2F`-escaped). */
 export function registryPackageUrl(pkg: string = NPM_PACKAGE): string {
   return `${NPM_REGISTRY_BASE}/${pkg.replace("/", "%2F")}`;
@@ -249,12 +268,12 @@ export function registryPackageUrl(pkg: string = NPM_PACKAGE): string {
  * An exact-version hit in the installer's stable runtime tree returns directly,
  * followed by the version-keyed bundle cache. Neither path invokes npm.
  *
- * Cache miss: materialise `@reddb-io/red-skills@<pin>` via npm (npm verifies the
- * tarball shasum itself), copy the packaged `dist/<plugin>.bundle.min.mjs` into
- * the cache, return it. The canary channel deliberately skips the cache hit and
- * refreshes from `@reddb-io/red-skills@canary` every time because its npm
- * dist-tag is the moving pointer. Integrity comes from npm; there is no
- * client-side signature step.
+ * Cache miss: materialise `@reddb-io/red-skills-<plugin>@<pin>` via npm (npm
+ * verifies the tarball shasum itself), copy its bundle into the cache, and
+ * return it. Non-plugin companions still materialise from core. The canary
+ * channel deliberately skips the cache hit, resolves core's moving dist-tag,
+ * and materialises the plugin at that exact version every time. Integrity comes
+ * from npm; there is no client-side signature step.
  *
  * Failure modes raise a typed {@link BundleFetchError} and never write a partial
  * bundle to the cache:
@@ -295,11 +314,36 @@ export async function ensureBundle(
     return dest;
   }
 
-  const spec = npmPackageSpec(version, channel);
+  const packageName = npmBundlePackage(plugin);
+  let spec = npmBundlePackageSpec(plugin, version, channel);
   const stagingDir = joinPath(
     cacheDir,
     `.staging-${plugin}-${channel === "canary" ? "canary" : version}`,
   );
+
+  let companionRoot: string | undefined;
+  let companionSpec: string | undefined;
+
+  // Only core owns the moving `canary` tag. Resolve that tag's immutable
+  // version from core, then ask the plugin package for the exact same version.
+  // This preserves the one channel pointer without requiring N coordinated npm
+  // dist-tag writes for every promotion.
+  if (channel === "canary" && packageName !== NPM_PACKAGE) {
+    companionSpec = npmPackageSpec(version, channel);
+    try {
+      companionRoot = await io.materialize(companionSpec, `${stagingDir}-core`);
+      const manifest = JSON.parse(
+        new TextDecoder().decode(await io.readFile(joinPath(companionRoot, "package.json"))),
+      ) as { version?: unknown };
+      if (typeof manifest.version !== "string" || !isCacheableVersion(manifest.version)) {
+        throw new Error("package.json has no cacheable version");
+      }
+      spec = npmBundlePackageSpec(plugin, manifest.version);
+    } catch (err) {
+      if (err instanceof BundleFetchError) throw err;
+      throw classifyMaterializeError(err, companionSpec);
+    }
+  }
 
   let pkgRoot: string;
   try {
@@ -308,11 +352,29 @@ export async function ensureBundle(
     throw classifyMaterializeError(err, spec);
   }
 
+  const bundleRoots = new Map<string, { root: string; spec: string }>([
+    [plugin, { root: pkgRoot, spec }],
+  ]);
+  if (companionPlugins.length > 0 && packageName !== NPM_PACKAGE && !companionRoot) {
+    companionSpec = npmPackageSpec(version, channel);
+    try {
+      companionRoot = await io.materialize(companionSpec, `${stagingDir}-core`);
+    } catch (err) {
+      throw classifyMaterializeError(err, companionSpec);
+    }
+  }
+  if (companionRoot && companionSpec) {
+    for (const companion of companionPlugins) {
+      bundleRoots.set(companion, { root: companionRoot, spec: companionSpec });
+    }
+  }
+
   for (const bundlePlugin of [plugin, ...companionPlugins]) {
+    const owner = bundleRoots.get(bundlePlugin) ?? { root: pkgRoot, spec };
     const srcRel = packagedBundleRelPath(bundlePlugin);
-    const src = joinPath(pkgRoot, srcRel);
+    const src = joinPath(owner.root, srcRel);
     if (!(await io.exists(src))) {
-      throw new BundleFetchError("bundle-missing", `npm package ${spec} has no ${srcRel}`);
+      throw new BundleFetchError("bundle-missing", `npm package ${owner.spec} has no ${srcRel}`);
     }
     const bundleDest =
       bundlePlugin === plugin

--- a/packages/shared/entrypoint-cli.ts
+++ b/packages/shared/entrypoint-cli.ts
@@ -40,6 +40,7 @@ import {
   bundleFileName,
   ensureBundle,
   isCacheableVersion,
+  npmBundlePackage,
   resolveBundle,
 } from "./bundle-fetch.js";
 import { type ReleaseChannel, channelReleaseRef, resolveChannel } from "./channel.js";
@@ -80,9 +81,9 @@ const realIO: BundleIO = {
   async materialize(spec, stagingDir) {
     await mkdir(stagingDir, { recursive: true });
     // `npm install <spec> --prefix <staging>` resolves the pinned package via
-    // npm's own cache (cache-first, shasum-verified) and lands it at
-    // <staging>/node_modules/@reddb-io/red-skills. --no-save keeps the staging
-    // dir free of a package.json; --ignore-scripts because our package has no
+    // npm's own cache (cache-first, shasum-verified) and lands it under
+    // <staging>/node_modules/. --no-save keeps the staging dir free of a root
+    // package.json; --ignore-scripts because our packages have no
     // postinstall (ADR 0091) and we never want to run arbitrary lifecycle code.
     const res = spawnSync(
       "npm",
@@ -103,7 +104,9 @@ const realIO: BundleIO = {
     if (res.status !== 0) {
       throw new Error(`npm install ${spec} -> ${res.status}: ${(res.stderr || "").trim()}`);
     }
-    return join(stagingDir, "node_modules", ...NPM_PACKAGE.split("/"));
+    const versionSeparator = spec.lastIndexOf("@");
+    const packageName = spec.slice(0, versionSeparator);
+    return join(stagingDir, "node_modules", ...packageName.split("/"));
   },
   async readFile(path) {
     return new Uint8Array(await readFile(path));
@@ -370,7 +373,7 @@ async function runMode(plan: RunPlan): Promise<never> {
     process.stderr.write(
       `entrypoint: could not resolve the ${plugin} runtime bundle (${want}).\n` +
         `  Looked in cache ${cacheDir} and repo-root dist/.\n` +
-        `  The bundle ships inside the ${NPM_PACKAGE} npm package (ADR 0091),\n` +
+        `  The bundle ships inside the ${npmBundlePackage(plugin)} npm package (ADR 0146),\n` +
         `  resolved via npm on first run; ensure network access, or build locally:\n` +
         `    pnpm -C apps/${plugin} run bundle\n`,
     );

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -65,6 +65,8 @@ export {
   fetchPublishedVersionHorizon,
   newestPublished,
   newestSameMajor,
+  npmBundlePackage,
+  npmBundlePackageSpec,
   npmPackageSpec,
   packagedBundleName,
   packagedBundleRelPath,

--- a/packages/shared/self-update.test.ts
+++ b/packages/shared/self-update.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   NPM_PACKAGE,
   companionBundlePlugins,
+  npmBundlePackageSpec,
   packagedBundleRelPath,
   registryPackageUrl,
   resolveBundle,
@@ -383,7 +384,7 @@ describe("backgroundSelfUpdate (registry discovery + npm materialize)", () => {
     expect(fetches).toEqual([registryPackageUrl()]);
     expect(fetches.every((u) => !u.includes("releases/download"))).toBe(true);
     // The pinned target package was materialised.
-    expect(materializes).toEqual([npmSpec(updated)]);
+    expect(materializes).toEqual([npmBundlePackageSpec(PLUGIN, updated), npmSpec(updated)]);
     // Bundle cached under the target version.
     const bundlePath = resolveBundle({ plugin: PLUGIN, version: updated, cacheDir: CACHE });
     expect(files[bundlePath]).toEqual(bundleBytesFor(updated));

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -1,34 +1,34 @@
 # @reddb-io/red-skills
 
-The RedSkills plugin runtime bundles (`dev`, `code-nav`, `memory`, `brain`), distributed over
-**npm** — the v2 client transport (ADR 0091), replacing the broken GitHub-release
-+ hand-rolled sigstore channel.
+The RedSkills core package distributed over **npm**. It carries compatibility
+bin shims, marketplace manifests, host generators, and the non-plugin runtimes
+those surfaces consume.
 
-The tarball carries the platform-independent JS bundles under `dist/` plus bin
-shims (`red-skills-dev`, `red-skills-code-nav`, `red-skills-memory`,
-`red-skills-brain`) that exec the corresponding packaged bundle. **No
-postinstall download** — the bundles ship in the tarball, so integrity is npm's
-own shasum/provenance and delivery is atomic.
+Each plugin runtime now ships beside its skills in
+`@reddb-io/red-skills-<plugin>` (ADR 0146), so the core tarball does not duplicate
+`dev`, `internal`, `memory`, or `brain`. The standalone installer materialises
+the core and exact-version plugin packages into one installed tree; the retained
+bin shims execute the bundles from that composed tree.
 
 ## Client resolution
 
-The RedSkills launchers resolve the exact pinned version via npm
-(`npm install @reddb-io/red-skills@<version>` / `npx -y @reddb-io/red-skills@<pin>`
-semantics), cache-first. See `packages/shared/bundle-fetch.ts`. The `canary`
-channel is the npm `canary` dist-tag.
+The RedSkills launchers first resolve an exact-version bundle from the installed
+tree. When that version is absent, they materialise its per-plugin package via
+npm. See `packages/shared/bundle-fetch.ts`. The `canary` channel remains the npm
+`canary` dist-tag and deliberately bypasses the stable installed tree.
 
 ## Divergence from reddb's postinstall-fetch pattern
 
 reddb's sibling package fetches per-platform **Rust** binaries in a postinstall
-step. RedSkills bundles are **platform-independent JS** (~2MB each) that fit
-inside the tarball, so we ship them directly — atomic delivery, registry
-shasum/provenance integrity, no postinstall network hop. (The Memory/Brain
+step. RedSkills bundles are **platform-independent JS**, so each plugin package
+ships its bundle directly — atomic delivery, registry shasum/provenance integrity,
+no postinstall network hop. (The Memory/Brain
 runtimes' native `red` engine binary is the one per-platform artifact that
 cannot live in the tarball; those plugins resolve it separately at runtime.)
 
 ## Publishing
 
 The Release standard owns the package's product version and `vX.Y.Z` tag (ADR
-0139). Built bundles are staged into `dist/` by `scripts/prepare.mjs` before a
-registry pack or publish operation; the removed legacy publish workflow is no
-longer a second release owner.
+0139). Non-plugin supporting bundles are staged into core `dist/` by
+`scripts/prepare.mjs`; plugin bundles are staged into their derived packages by
+`scripts/build-pi-packages.mjs` before the registry pack/publish operation.

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reddb-io/red-skills",
   "version": "0.0.0",
-  "description": "RedSkills plugin runtime bundles (dev, code-nav, memory, brain) distributed over npm \u2014 the v2 client transport (ADR 0091). Carries the platform-independent JS bundles inside the tarball plus thin bin shims; no postinstall download.",
+  "description": "RedSkills core npm package: compatibility bin shims, marketplace manifests, host generators, and non-plugin supporting runtimes. Plugin bundles ship in @reddb-io/red-skills-<plugin> packages (ADR 0146).",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packaging/npm/scripts/prepare.mjs
+++ b/packaging/npm/scripts/prepare.mjs
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 /**
- * prepare.mjs — stage the built plugin bundles into this npm package's `dist/`
- * before `pnpm pack` / publish (ADR 0091). Copies the platform-independent JS
- * bundles from the repo-root `dist/` (produced by `pnpm bundle`) into
- * `packaging/npm/dist/` so they ship inside the tarball.
+ * prepare.mjs — stage the built non-plugin bundles into this npm package's
+ * `dist/` before `pnpm pack` / publish (ADR 0146). Per-plugin runtime bundles
+ * ship from `@reddb-io/red-skills-<plugin>` instead; this core package keeps
+ * only the supporting runtimes its retained bin/host surfaces need.
  *
  * Missing bundles are reported and skipped rather than failing hard, so a
- * partial build (e.g. only the dev bundle) still packs — the pre-publish
- * contract check is the gate that a required bundle actually resolves.
+ * partial supporting-runtime build can still pack — the pre-publish contract
+ * check is the gate that every required core surface actually resolves.
  */
-import { chmodSync, copyFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,21 +34,14 @@ const HOST_WIRING_FILES = [
   "scripts/lib/manifest-core.mjs",
 ];
 
-// Each entry stages one bundle into this package's dist/. `dest` is the packaged
-// filename the bin shims / launchers resolve; the first existing `sources` entry
-// is copied to it. Most bundles are named identically by `pnpm bundle`, but
-// code-nav's turbo outfile is `code-nav-mcp.bundle.min.mjs` while the packaged /
-// release-asset name is `code-nav.bundle.min.mjs` — so it lists both: CI's
-// dedicated code-nav step pre-copies the asset name, and the plain `pnpm bundle`
-// path falls back to the turbo outfile. No bundle silently skips as "not built".
+// Each entry stages one non-plugin bundle into this package's dist/. `dest` is
+// the packaged filename a retained bin/host surface resolves; the first existing
+// `sources` entry is copied to it. The plugin tree is staged independently by
+// scripts/build-pi-packages.mjs and must never be duplicated here.
 const BUNDLES = [
   { dest: "opencode-host.bundle.min.mjs", sources: ["opencode-host.bundle.min.mjs"] },
-  { dest: "dev.bundle.min.mjs", sources: ["dev.bundle.min.mjs"] },
   { dest: "redskilled-mcp.bundle.min.mjs", sources: ["redskilled-mcp.bundle.min.mjs"] },
   { dest: "code-nav.bundle.min.mjs", sources: ["code-nav.bundle.min.mjs", "code-nav-mcp.bundle.min.mjs"] },
-  { dest: "memory.bundle.min.mjs", sources: ["memory.bundle.min.mjs"] },
-  { dest: "memory-tokenizer.asset.cjs", sources: ["memory-tokenizer.asset.cjs"] },
-  { dest: "brain.bundle.min.mjs", sources: ["brain.bundle.min.mjs"] },
   { dest: "release.bundle.min.mjs", sources: ["release.bundle.min.mjs"] },
   { dest: "rsp.bundle.min.mjs", sources: ["rsp.bundle.min.mjs"] },
   { dest: "rsp-core.bundle.min.mjs", sources: ["rsp-core.bundle.min.mjs"] },
@@ -64,6 +57,9 @@ for (const relativePath of HOST_WIRING_FILES) {
   process.stdout.write(`prepare: staged ${relativePath}\n`);
 }
 
+// `prepare` is a producer, not an overlay. A bundle staged by an older checkout
+// must not leak back into a later core tarball after the package boundary moves.
+rmSync(destDist, { recursive: true, force: true });
 mkdirSync(destDist, { recursive: true });
 let staged = 0;
 for (const { dest, sources } of BUNDLES) {

--- a/scripts/check-npm-tarball-boundaries.mjs
+++ b/scripts/check-npm-tarball-boundaries.mjs
@@ -57,9 +57,15 @@ function checkCore(root, tarball) {
     "package/scripts/generate-gemini-manifests.mjs",
     "package/scripts/generate-pi-manifests.mjs",
     "package/dist/opencode-host.bundle.min.mjs",
-    `package/dist/${MEMORY_TOKENIZER_ASSET}`,
   ];
   for (const expected of required) requireEntry(listing, expected, "core npm");
+
+  for (const plugin of pluginManifests(root)) {
+    const unexpected = `package/dist/${plugin.name}.bundle.min.mjs`;
+    if (listing.includes(unexpected)) {
+      throw new Error(`core npm tarball unexpectedly contains ${unexpected}`);
+    }
+  }
 
   const forbidden = listing.find(
     (entry) => entry.startsWith("package/apps/") || entry.startsWith("package/packages/"),

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -90,24 +90,25 @@ else
   pass "missing NPM_TOKEN does not skip publish"
 fi
 
-if grep -qF 'npx -y -p "@reddb-io/red-skills@${version}" red-skills-dev --version' "$WORKFLOW"; then
-  pass "registry smoke uses npx against the published package version"
+if grep -qF 'npm view "@reddb-io/red-skills@${version}" version' "$WORKFLOW" &&
+   grep -qF '[ "$resolved" = "${version}" ]' "$WORKFLOW"; then
+  pass "registry smoke resolves the exact published core package version"
 else
-  fail "registry smoke must run the real client via npx from the npm registry"
+  fail "registry smoke must resolve the exact core package version from npm"
 fi
 
-if grep -qF 'package/dist/code-nav.bundle.min.mjs' "$WORKFLOW" &&
-   grep -qF 'npm tarball missing $expected' "$WORKFLOW"; then
-  pass "pack contract checks the code-nav bundle is in the npm tarball"
+if grep -qF 'package/dist/$plugin.bundle.min.mjs' "$WORKFLOW" &&
+   grep -qF 'npm tarball unexpectedly contains $unexpected' "$WORKFLOW"; then
+  pass "pack contract rejects every derived plugin bundle in the core tarball"
 else
-  fail "pack contract must fail when code-nav is missing from the npm tarball"
+  fail "pack contract must reject core plugin bundles derived from the plugin tree"
 fi
 
 if grep -qF 'test -x "$smoke/node_modules/.bin/red-skills-code-nav"' "$WORKFLOW" &&
    grep -qF 'test -f "$smoke/node_modules/@reddb-io/red-skills/dist/code-nav.bundle.min.mjs"' "$WORKFLOW"; then
-  pass "pack contract checks the code-nav npm bin and packaged bundle"
+  pass "pack contract checks the retained code-nav npm bin and supporting bundle"
 else
-  fail "pack contract must verify the code-nav npm bin and packaged bundle"
+  fail "pack contract must verify the retained code-nav npm bin and supporting bundle"
 fi
 
 if grep -qF 'node scripts/check-npm-tarball-boundaries.mjs' "$WORKFLOW" &&
@@ -154,8 +155,7 @@ for expected in \
   scripts/generate-codex-manifests.mjs \
   scripts/generate-gemini-manifests.mjs \
   scripts/generate-pi-manifests.mjs \
-  dist/opencode-host.bundle.min.mjs \
-  dist/memory-tokenizer.asset.cjs; do
+  dist/opencode-host.bundle.min.mjs; do
   mkdir -p "$core_tree/$(dirname "$expected")"
   : > "$core_tree/$expected"
 done
@@ -213,24 +213,30 @@ else
   pass "per-plugin tarball without its runtime bundle fails the publish contract"
 fi
 
+# Restore the valid per-plugin tarball so this mutation can fail only because
+# the core crossed the package boundary, never because of the prior mutation.
+plugin_tree="$contract_fixture/plugin-$first_plugin/package"
+tar -czf "$plugin_tarballs/reddb-io-red-skills-$first_plugin-9.9.9.tgz" \
+  -C "$contract_fixture/plugin-$first_plugin" package
+
 bad_core_tree="$contract_fixture/bad-core/package"
 mkdir -p "$contract_fixture/bad-core"
 cp -R "$core_tree" "$bad_core_tree"
-mkdir -p "$bad_core_tree/apps/dev"
-: > "$bad_core_tree/apps/dev/runtime.ts"
+mkdir -p "$bad_core_tree/dist"
+: > "$bad_core_tree/dist/$first_plugin.bundle.min.mjs"
 tar -czf "$contract_fixture/bad-core.tgz" -C "$contract_fixture/bad-core" package
 if node scripts/check-npm-tarball-boundaries.mjs \
   --root "$ROOT" \
   --core "$contract_fixture/bad-core.tgz" \
   --plugins "$plugin_tarballs" >/dev/null 2>&1; then
-  fail "core tarball carrying the runtime app tree must fail the publish contract"
+  fail "core tarball carrying a per-plugin runtime bundle must fail the publish contract"
 else
-  pass "core tarball carrying the runtime app tree fails the publish contract"
+  pass "core tarball carrying a per-plugin runtime bundle fails the publish contract"
 fi
 rm -rf "$contract_fixture"
 
 if grep -qF 'registry smoke returned' "$WORKFLOW" &&
-   grep -qF 'dev ${version} ' "$WORKFLOW"; then
+   grep -qF '[ "$resolved" = "${version}" ]' "$WORKFLOW"; then
   pass "registry smoke verifies the reported release version"
 else
   fail "registry smoke must fail when --version does not report the release version"


### PR DESCRIPTION
Automated AFK landing for #3957. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3957

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789515310&installation_model_id=20659&pr_number=3962&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3962&signature=ae15af0d5b6f7292bf43d4794e1992159e78ce2dcbae1474ac9bd3ee432edd6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->