### PR TITLE
fix(dev): restore two guards today's merges dropped

### DIFF
--- a/.changeset/main-is-green-again.md
+++ b/.changeset/main-is-green-again.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Restore two guards today's merges dropped: dependency promotion in the close cascade, and the publish-time presence check for every bundle the core package stages.

--- a/apps/dev/src/core/boot-sweep.ts
+++ b/apps/dev/src/core/boot-sweep.ts
@@ -199,6 +199,10 @@ export function decideDependencyPromotion(
   dependent: DependentIssue,
   hitlTypes: readonly string[] = [],
 ): DependencyPromotionDecision {
+  // The dependency ROLE is required of both callers, and that is the point: a
+  // promotion removes the park role and adds ready/human, so a Ticket that does
+  // not carry the role has nothing to be promoted FROM. A stale `req:*` left on
+  // an already-queued Ticket is exactly what this refuses.
   if (!(dependent.labels ?? []).includes(LABEL_DEPENDENCY)) {
     return { outcome: "held", reason: "missing-dependency-role", pending: [] };
   }
@@ -346,6 +350,19 @@ export async function planUnblockSweep(
     // blockers closing frees a HUMAN-ONLY Ticket for its human, never for an agent.
     const carried = hostHitlTypesIn(labels, hitlTypes);
     const lane: PromotionLane = carried.length > 0 ? "human" : "agent";
+
+    // A Ticket already parked for a human is not the sweep's to promote, and
+    // the refusal comes BEFORE the blocker lookups: asking the tracker about
+    // blockers whose answer cannot change the outcome spends a request out of
+    // the same budget every other read shares (#3940 regression).
+    if (labels.includes(LABEL_HUMAN)) {
+      held.push({
+        issue: candidate.number,
+        outcome: "held",
+        reason: `already parked ${LABEL_HUMAN}; a human owns this park, not the sweep`,
+      });
+      continue;
+    }
 
     // Prefer the structured req:* dependency labels when present.
     if (reqIds.length > 0) {

--- a/apps/dev/tests/boot-sweep.test.ts
+++ b/apps/dev/tests/boot-sweep.test.ts
@@ -115,11 +115,22 @@ describe("cascadeAuditComment", () => {
 describe("planCloseCascade", () => {
   it("promotes a dependent whose every req is closed", () => {
     const deps: DependentIssue[] = [
-      { number: 20, reqs: [{ n: 9, closed: true }] },
+      { number: 20, labels: ["blocked:dependency"], reqs: [{ n: 9, closed: true }] },
     ];
     expect(planCloseCascade(9, deps)).toEqual([
       { number: 20, refs: ["#9"], reqLabels: ["req:9"], comment: "🤖 /afk unblocked: all dependencies closed (#9).", lane: "agent", hitlTypes: [] },
     ]);
+  });
+
+  it("does not promote a dependent that carries no dependency role", () => {
+    // The role is what a promotion removes, so a Ticket without it has nothing
+    // to be promoted FROM — a stale `req:*` on an already-queued Ticket is
+    // exactly this case. Shared with the Unblock Sweep so the two cannot drift
+    // (#3940); before that they disagreed and the sweep silently promoted none.
+    const deps: DependentIssue[] = [
+      { number: 23, labels: ["req:9"], reqs: [{ n: 9, closed: true }] },
+    ];
+    expect(planCloseCascade(9, deps)).toEqual([]);
   });
 
   it("does not promote when one req is still open", () => {
@@ -136,7 +147,7 @@ describe("planCloseCascade", () => {
 
   it("names every satisfied dep in ascending order on a multi-req promote", () => {
     const deps: DependentIssue[] = [
-      { number: 30, reqs: [{ n: 9, closed: true }, { n: 8, closed: true }] },
+      { number: 30, labels: ["blocked:dependency"], reqs: [{ n: 9, closed: true }, { n: 8, closed: true }] },
     ];
     expect(planCloseCascade(9, deps)).toEqual([
       { number: 30, refs: ["#8", "#9"], reqLabels: ["req:8", "req:9"], comment: "🤖 /afk unblocked: all dependencies closed (#8, #9).", lane: "agent", hitlTypes: [] },
@@ -145,7 +156,7 @@ describe("planCloseCascade", () => {
 
   it("plans only the satisfied dependents across a mixed batch", () => {
     const deps: DependentIssue[] = [
-      { number: 20, reqs: [{ n: 9, closed: true }] }, // promote
+      { number: 20, labels: ["blocked:dependency"], reqs: [{ n: 9, closed: true }] }, // promote
       { number: 21, reqs: [{ n: 9, closed: true }, { n: 8, closed: false }] }, // skip
       { number: 22, reqs: [] }, // skip
     ];

--- a/apps/dev/tests/castle-resident-packaging.test.ts
+++ b/apps/dev/tests/castle-resident-packaging.test.ts
@@ -21,8 +21,14 @@ describe("MCP-to-ACP adapter packaging", () => {
 
   it("checks it in the npm tarball and the release backup", async () => {
     const workflow = await read(".github/workflows/red-publish.yml");
-    expect(workflow).toContain(`package/dist/${ARTIFACT}`);
-    expect(workflow).toContain(`dist/${ARTIFACT}`);
+    // The publish-time presence guard moved out of the workflow YAML into the
+    // boundary script (#3957), so assert it WHERE IT LIVES. The script derives
+    // the list from `prepare.mjs`, which is why staging the artifact is enough
+    // to be guarded — and why a hand-edited list cannot silently drop it again.
+    const boundaries = await read("scripts/check-npm-tarball-boundaries.mjs");
+    expect(boundaries).toContain("stagedCoreBundles");
+    expect(boundaries).toContain("package/dist/");
+    expect(workflow).toContain("check-npm-tarball-boundaries.mjs");
     expect(workflow, "the retired sibling is still checked").not.toContain("castle-resident.bundle.min.mjs");
   });
 

--- a/scripts/check-npm-tarball-boundaries.mjs
+++ b/scripts/check-npm-tarball-boundaries.mjs
@@ -85,6 +85,11 @@ function checkCore(root, tarball) {
     }
   }
 
+  const unexpectedTokenizer = `package/dist/${MEMORY_TOKENIZER_ASSET}`;
+  if (listing.includes(unexpectedTokenizer)) {
+    throw new Error(`core npm tarball unexpectedly contains ${unexpectedTokenizer}`);
+  }
+
   const forbidden = listing.find(
     (entry) => entry.startsWith("package/apps/") || entry.startsWith("package/packages/"),
   );

--- a/scripts/check-npm-tarball-boundaries.mjs
+++ b/scripts/check-npm-tarball-boundaries.mjs
@@ -45,6 +45,24 @@ function requireEntry(listing, expected, label) {
   }
 }
 
+/**
+ * Every bundle `prepare.mjs` stages into the core package, read from that file
+ * so the two cannot drift. Hand-listing them is what let six of them — the
+ * `redskilled-mcp` server every agent launches among them — lose their
+ * publish-time presence guard when the per-plugin bundles were contracted out
+ * (#3957): the absence check for plugins landed, and the presence check for
+ * what the core still carries did not come with it. A bin shim passing is not
+ * the same fact: the shim forwards to a bundle that has to be in the tarball.
+ */
+function stagedCoreBundles(root) {
+  const prepare = readFileSync(join(root, "packaging/npm/scripts/prepare.mjs"), "utf8");
+  const names = [...prepare.matchAll(/dest:\s*"([^"]+\.bundle\.min\.mjs)"/g)].map((m) => m[1]);
+  if (names.length === 0) {
+    throw new Error("check-npm-tarball-boundaries: prepare.mjs staged no bundles — the parse is stale");
+  }
+  return names;
+}
+
 function checkCore(root, tarball) {
   const listing = materializeListing(tarball);
   const packageJson = readJson(join(root, "packaging/npm/package.json"));
@@ -56,7 +74,7 @@ function checkCore(root, tarball) {
     "package/scripts/generate-codex-manifests.mjs",
     "package/scripts/generate-gemini-manifests.mjs",
     "package/scripts/generate-pi-manifests.mjs",
-    "package/dist/opencode-host.bundle.min.mjs",
+    ...stagedCoreBundles(root).map((name) => `package/dist/${name}`),
   ];
   for (const expected of required) requireEntry(listing, expected, "core npm");
 

--- a/scripts/test-bundle-app-contract.sh
+++ b/scripts/test-bundle-app-contract.sh
@@ -115,6 +115,22 @@ MEMORY_BUNDLE="dist/memory.bundle.min.mjs"
 MEMORY_TOKENIZER="dist/memory-tokenizer.asset.cjs"
 MEMORY_BUNDLE_BEFORE=10698895
 RANK_TABLE_PREFIX='bpe_ranks:"! 0 IQ== Ig== Iw=='
+memory_asset_backup="$(mktemp -d)"
+for asset in "$MEMORY_BUNDLE" "$MEMORY_TOKENIZER"; do
+  if [[ -f "$asset" ]]; then
+    cp "$asset" "$memory_asset_backup/$(basename "$asset")"
+  fi
+done
+cleanup_memory_assets() {
+  for asset in "$MEMORY_BUNDLE" "$MEMORY_TOKENIZER"; do
+    rm -f -- "$asset"
+    if [[ -f "$memory_asset_backup/$(basename "$asset")" ]]; then
+      cp "$memory_asset_backup/$(basename "$asset")" "$asset"
+    fi
+  done
+  rm -rf -- "$memory_asset_backup"
+}
+trap cleanup_memory_assets EXIT
 
 if grep -qF -- '--lazy-asset-entry src/tokenizer-asset.ts' "$MEMORY_PACKAGE" \
   && grep -qF -- '--lazy-asset memory-tokenizer.asset.cjs' "$MEMORY_PACKAGE"; then

--- a/scripts/test-bundle-app-contract.sh
+++ b/scripts/test-bundle-app-contract.sh
@@ -161,13 +161,17 @@ else
 fi
 rm -r -- "$lazy_probe"
 
-for package_writer in packaging/npm/scripts/prepare.mjs scripts/build-pi-packages.mjs; do
-  if grep -qF 'memory-tokenizer.asset.cjs' "$package_writer"; then
-    pass "$package_writer stages the memory tokenizer asset"
-  else
-    fail "$package_writer must stage the memory tokenizer asset"
-  fi
-done
+if grep -qF 'memory-tokenizer.asset.cjs' scripts/build-pi-packages.mjs; then
+  pass "scripts/build-pi-packages.mjs stages the memory tokenizer asset"
+else
+  fail "scripts/build-pi-packages.mjs must stage the memory tokenizer asset"
+fi
+
+if grep -qF 'memory-tokenizer.asset.cjs' packaging/npm/scripts/prepare.mjs; then
+  fail "packaging/npm/scripts/prepare.mjs must not stage the plugin-owned memory tokenizer asset"
+else
+  pass "packaging/npm/scripts/prepare.mjs leaves the memory tokenizer asset in the memory plugin package"
+fi
 
 if (( failures > 0 )); then
   printf '\n%d failure(s)\n' "$failures" >&2

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -154,11 +154,14 @@ for expected in \
   .gemini-plugin/marketplace.json \
   scripts/generate-codex-manifests.mjs \
   scripts/generate-gemini-manifests.mjs \
-  scripts/generate-pi-manifests.mjs \
-  dist/opencode-host.bundle.min.mjs; do
+  scripts/generate-pi-manifests.mjs; do
   mkdir -p "$core_tree/$(dirname "$expected")"
   : > "$core_tree/$expected"
 done
+while IFS= read -r bundle; do
+  mkdir -p "$core_tree/dist"
+  : > "$core_tree/dist/$bundle"
+done < <(node -e 'const fs=require("fs");const source=fs.readFileSync("packaging/npm/scripts/prepare.mjs","utf8");for(const match of source.matchAll(/dest:\s*"([^"]+\.bundle\.min\.mjs)"/g))console.log(match[1])')
 cp packaging/npm/package.json "$core_tree/package.json"
 tar -czf "$contract_fixture/core.tgz" -C "$contract_fixture/core-tree" package
 
@@ -232,6 +235,18 @@ if node scripts/check-npm-tarball-boundaries.mjs \
   fail "core tarball carrying a per-plugin runtime bundle must fail the publish contract"
 else
   pass "core tarball carrying a per-plugin runtime bundle fails the publish contract"
+fi
+
+rm -f "$bad_core_tree/dist/$first_plugin.bundle.min.mjs"
+: > "$bad_core_tree/dist/memory-tokenizer.asset.cjs"
+tar -czf "$contract_fixture/bad-core-tokenizer.tgz" -C "$contract_fixture/bad-core" package
+if node scripts/check-npm-tarball-boundaries.mjs \
+  --root "$ROOT" \
+  --core "$contract_fixture/bad-core-tokenizer.tgz" \
+  --plugins "$plugin_tarballs" >/dev/null 2>&1; then
+  fail "core tarball carrying the memory tokenizer asset must fail the publish contract"
+else
+  pass "core tarball carrying the memory tokenizer asset fails the publish contract"
 fi
 rm -rf "$contract_fixture"
 


### PR DESCRIPTION
`main` is red in two places tonight, and in both cases the PR that caused it never ran the file that caught it.

## 1 — Dependency promotion (from #3940)

Bisected: `798a81a43` → **74/74**; `2b3d1e419` (the #3940 merge) → **4 failed**.

Unifying the two predicates behind `decideDependencyPromotion` was the right call — the sweep and `cascade_status` genuinely disagreed, which is the bug #3940 was for. Two things came with it:

- the Unblock Sweep now spends a **blocker lookup on a candidate already parked `ready-for-human`** before refusing it. The test demanded zero calls; a request whose answer cannot change the outcome still spends the same budget every other read shares. It now refuses before asking, and says why.
- `boot-sweep.test.ts` — which that PR never ran — had three cascade fixtures **omitting the dependency role**.

On the fixtures I first fixed this the other way, giving the cascade an option to waive the role. That was wrong, and what settled it was the production caller: `runCloseCascade` back-fills the real labels from `listByLabel` before planning, so a genuinely parked dependent **does** carry the role. And promotion *removes* the park role — a Ticket without it has nothing to be promoted from; a stale `req:*` on an already-queued Ticket is exactly what the gate should refuse. So the gate stays shared, the fixtures gain the label production always supplies, and a **new case pins the gate in the file that used to assert the opposite**, so the contradiction cannot return quietly.

## 2 — Publish presence (from #3957)

Contracting the per-plugin bundles out of the core package landed the *absence* check and left the *presence* check behind. The relocated list named the bins, the three marketplaces, the generators and **one** bundle — so six more the core still stages lost their publish-time guard, including `redskilled-mcp`, the server every agent launches. A passing bin shim is not the same fact: the shim forwards to a bundle that has to be in the tarball.

The list is now **derived from `prepare.mjs`**, so staging a bundle is what makes it guarded and a hand-edit cannot drop one again. **1 bundle required before, 7 now.** The packaging test moves with the guard — asserting it where it lives instead of grepping workflow YAML for a line that moved.

## Verification

- `pnpm -C apps/dev test` — 6702 tests, green (the one failure on this branch before the packaging fix was #3957's, reproduced on pristine `main` first).
- `pnpm typecheck` — 16 packages; `pnpm -C apps/dev test:invariants` — 207/207.
- The promotion family re-run together: boot-sweep, resident-unblock, sweep-reads-see-the-tracker, unblock-sweep-says-why, boot-cleanup, deadend-audit — 157 passing.

**Worth noting separately:** both regressions passed CI on their own PRs. Whatever scopes the test run by affected cone did not include the file that pins the contract each change broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJDnFnkFDW8WkR3Fk1ysGw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789520143&installation_model_id=20659&pr_number=3964&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3964&signature=d652ce35a3409ce4bc7157d910e7be9eb50fa5e08469770598a3a5fe511c26b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->