### PR TITLE
fix(redskilled): route ACP through machine claim

### DIFF
--- a/.changeset/route-acp-rendezvous.md
+++ b/.changeset/route-acp-rendezvous.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Route public ACP clients through the live same-user machine claim when their runtime environment resolves a different local socket directory.

--- a/apps/redskilled/src/acp-client.ts
+++ b/apps/redskilled/src/acp-client.ts
@@ -15,6 +15,7 @@ import {
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
 import { ensureRedskilledDaemon } from "./client.js";
+import { resolveRedskilledClientEndpoint } from "./client-rendezvous.js";
 import { REDSKILLS_WIRE_MAJOR } from "./acp-compat.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "./paths.js";
 
@@ -72,7 +73,8 @@ export async function connectRedskillsProjectAcp(
   const version = options.version ?? "1";
   const paths = options.paths ?? resolveRedskilledPaths();
   await ensureRedskilledDaemon(paths);
-  const socket = await connectEndpoint(paths.acpSocketPath);
+  const endpoint = (await resolveRedskilledClientEndpoint(paths)).paths;
+  const socket = await connectEndpoint(endpoint.acpSocketPath);
   const pendingUpdates: SessionNotification["update"][] = [];
   let publicSessionId = "";
 

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -78,6 +78,7 @@ import { awaitRedskilledTakeoverCommit, isRedskilledSupervised } from "./self-re
 import { stabilizeRedskilledEntry } from "./stable-bundle.js";
 import { runRedskillsAcpAdapter } from "./acp-control-plane.js";
 import { runAcpWorkerCommand } from "./acp-worker-command.js";
+import { resolveRedskilledClientEndpoint } from "./client-rendezvous.js";
 
 /**
  * Usage, as a CONSTANT — the answer owes nothing to the machine it is asked on.
@@ -599,7 +600,7 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
   if (command === "acp") {
     const paths = resolveRedskilledPaths();
     await ensureRedskilledDaemon(paths);
-    return await runRedskillsAcpAdapter(paths);
+    return await runRedskillsAcpAdapter((await resolveRedskilledClientEndpoint(paths)).paths);
   }
 
   if (command === "acp-worker") {

--- a/apps/redskilled/src/client-rendezvous.ts
+++ b/apps/redskilled/src/client-rendezvous.ts
@@ -60,6 +60,9 @@ export async function resolveRedskilledClientEndpoint(
       ...paths,
       runtimeDir,
       socketPath: claim.socket_path,
+      acpSocketPath: paths.platform === "win32"
+        ? `\\\\.\\pipe\\redskilled-${claim.session_key_hash}-acp`
+        : join(runtimeDir, basename(paths.acpSocketPath)),
       lockPath: join(runtimeDir, basename(paths.lockPath)),
       leasePath: join(runtimeDir, basename(paths.leasePath)),
     },

--- a/apps/redskilled/tests/client-rendezvous-acp.test.ts
+++ b/apps/redskilled/tests/client-rendezvous-acp.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveRedskilledClientEndpoint } from "../src/client-rendezvous.js";
+import {
+  createRedskilledMachineClaimStore,
+  currentMachineOwner,
+} from "../src/machine-scope.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("ACP client rendezvous", () => {
+  it("routes both daemon endpoints through a same-user machine claim", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-acp-rendezvous-"));
+    roots.push(root);
+    const claimPath = join(root, "machine", "claim.toon");
+    const owner = resolveRedskilledPaths({
+      runtimeDir: join(root, "owner"),
+      machineClaimPath: claimPath,
+      homeDir: root,
+    });
+    const client = resolveRedskilledPaths({
+      runtimeDir: join(root, "client"),
+      machineClaimPath: claimPath,
+      homeDir: root,
+    });
+    const store = createRedskilledMachineClaimStore(claimPath, {
+      machineIdHash: owner.machineIdHash,
+      sessionKeyHash: owner.sessionKeyHash,
+      socketPath: owner.socketPath,
+    });
+    expect((await store.claim(currentMachineOwner())).claimed).toBe(true);
+
+    const endpoint = await resolveRedskilledClientEndpoint(client);
+
+    expect(endpoint.joined).toBe(true);
+    expect(endpoint.paths.socketPath).toBe(owner.socketPath);
+    expect(endpoint.paths.acpSocketPath).toBe(join(owner.runtimeDir, basename(client.acpSocketPath)));
+  });
+
+  it("derives the owning ACP named pipe from the claim's session hash", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-acp-rendezvous-win-"));
+    roots.push(root);
+    const claimPath = join(root, "machine", "claim.toon");
+    const owner = resolveRedskilledPaths({
+      platform: "win32",
+      runtimeDir: join(root, "owner"),
+      machineClaimPath: claimPath,
+      homeDir: root,
+      env: { REDSKILLED_SESSION: "owner" },
+    });
+    const client = resolveRedskilledPaths({
+      platform: "win32",
+      runtimeDir: join(root, "client"),
+      machineClaimPath: claimPath,
+      homeDir: root,
+      env: { REDSKILLED_SESSION: "client" },
+    });
+    const store = createRedskilledMachineClaimStore(claimPath, {
+      machineIdHash: owner.machineIdHash,
+      sessionKeyHash: owner.sessionKeyHash,
+      socketPath: owner.socketPath,
+    });
+    expect((await store.claim(currentMachineOwner())).claimed).toBe(true);
+
+    const endpoint = await resolveRedskilledClientEndpoint(client);
+
+    expect(endpoint.paths.acpSocketPath).toBe(`\\\\.\\pipe\\redskilled-${owner.sessionKeyHash}-acp`);
+  });
+});


### PR DESCRIPTION
## Summary
- route the public ACP endpoint alongside the daemon socket when same-user clients resolve a different runtime directory
- make both the typed ACP client and `redskilled acp` stdio adapter connect to the rendezvoused endpoint
- cover Unix sockets and Windows named pipes

This unblocks reddb-io/redcode#15 when Redcode runs with a different `XDG_RUNTIME_DIR` from the machine-scoped daemon owner.

## Validation
- `pnpm typecheck`
- `pnpm -C apps/redskilled exec vitest run tests/client-rendezvous-acp.test.ts tests/client-reconnect.test.ts tests/acp-control-plane.test.ts`
- `pnpm -C apps/dev test:invariants`

`acp-conformance.test.ts` currently times out waiting for `worker-death` in all four same-major cases on this branch and identically on the clean #3965 worktree; the focused rendezvous/control-plane tests are green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789554754&installation_model_id=20659&pr_number=3967&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3967&signature=f5b50aff0d044a165bac04df15c2332e259af05a2b3563d8cffdd9b2d88c85e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->