### PR TITLE
fix: #3968 /go: Corrigir o gerador apps/opencode-host/src/hooks-to-events.ts para que mú

### DIFF
--- a/apps/opencode-host/src/hooks-to-events.ts
+++ b/apps/opencode-host/src/hooks-to-events.ts
@@ -349,7 +349,13 @@ function sideEffectCases(input: {
         `        const __stdout = await __runHook(${JSON.stringify(inner)}, ${input.payloadExpression});`,
         input.contextSink ? `        const __ctx = __extractContext(__stdout); if (__ctx) ${input.contextSink};` : "",
       ].filter(Boolean).join("\n");
-      if (!input.toolExpression) return run;
+      if (!input.toolExpression) {
+        return [
+          "      {",
+          run,
+          "      }",
+        ].join("\n");
+      }
       return [
         `      if (${matcherToRegex(g.matcher)}.test(${input.toolExpression})) {`,
         run,

--- a/apps/opencode-host/tests/hooks-to-events.test.ts
+++ b/apps/opencode-host/tests/hooks-to-events.test.ts
@@ -6,6 +6,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import ts from "typescript";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   isRspRewriteHook,
@@ -229,6 +230,46 @@ describe("planPluginHooks (real claude.hooks.json shape)", () => {
     expect(stop.source).toContain("hook_event_name: __sourceEvent");
     expect(stop.source).toContain("transcript_text");
     expect(stop.source).toContain("sessionApi.messages");
+  });
+
+  it("emits lexically valid Stop bindings for the Codex and Claude adapter commands", () => {
+    writeHookFile("codex.hooks.json", {
+      hooks: {
+        Stop: [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: `sh -c 'tmp="$(mktemp)"; trap "rm -f \\"$tmp\\"" EXIT; timeout "${"$"}{RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}" cat >"$tmp" 2>/dev/null || true; timeout "${"$"}{RED_SKILLS_HOOK_TIMEOUT_S:-3s}" node "${"$"}{CODEX_PLUGIN_ROOT}/scripts/bootstrap.mjs" hook Stop --runner codex <"$tmp" || printf "{}"'`,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    writeHookFile("claude.hooks.json", {
+      hooks: {
+        Stop: [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: `sh -c 'timeout "${"$"}{RED_SKILLS_HOOK_TIMEOUT_S:-3s}" node "${"$"}{CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" hook Stop --runner claude || printf "{}"'`,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const stop = planPluginHooks(root, "dev").find((plan) => plan.sourceEvent === "Stop")!;
+    const compiled = ts.transpileModule(stop.source, {
+      compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+    });
+
+    expect(stop.source).toContain("--runner codex");
+    expect(stop.source).toContain("--runner claude");
+    expect(() => Function(compiled.outputText)).not.toThrow();
   });
 
   it("maps PreCompact to experimental.session.compacting", () => {


### PR DESCRIPTION
Automated AFK landing for #3968. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3968

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789560548&installation_model_id=20659&pr_number=3969&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3969&signature=9501aa819b2e4984c0d34c659485805888a4d69a8305396a20aebb87b6ff6e24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->