### PR TITLE
fix: #3974 The release emits a signed package-set manifest from current artifacts

### DIFF
--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -6,7 +6,8 @@ name: red-publish
 # reviewed Version Packages PR. THIS workflow owns everything downstream of the
 # tag and nothing upstream of it:
 #
-#   1. Build every plugin/runtime bundle + checksum manifest at the tagged tree.
+#   1. Build every plugin/runtime bundle and the signed package-set manifest at
+#      the tagged tree.
 #   2. Pack the npm package, run the REAL packaged client against the packed
 #      tarball as a producer/consumer contract check, publish, and smoke the
 #      published package from the registry.
@@ -219,6 +220,10 @@ jobs:
         if: steps.target.outputs.publish == 'true'
         run: scripts/test-red-release-reddb-assets-contract.sh
 
+      - name: Test package-set contract
+        if: steps.target.outputs.publish == 'true'
+        run: scripts/test-package-set-contract.sh
+
       - name: Test agent metadata fixtures
         if: steps.target.outputs.publish == 'true'
         run: scripts/test-validate-agent-metadata.sh
@@ -241,6 +246,13 @@ jobs:
           REDDB_SKIP_POSTINSTALL: "1"
         run: pnpm install --frozen-lockfile
 
+      # The package set is a separate workstation acquisition contract, not a
+      # return to the removed per-bundle client signatures from ADR 0091.
+      # Pin the signer installer like every other third-party workflow action.
+      - name: Install cosign
+        if: steps.target.outputs.publish == 'true'
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
+
       # The tag is the contract. The release engine wrote every version surface
       # when it made the Version PR, so a tag that disagrees with the tree means
       # someone tagged by hand at the wrong commit — fail before publishing
@@ -262,9 +274,9 @@ jobs:
           echo "tag and tree agree on ${VERSION}"
 
       # ADR 0091: the plugin bundles are distributed over npm with npm's own
-      # tarball shasum/provenance for integrity — the client no longer verifies a
-      # hand-rolled sigstore manifest signature, so cosign is not installed and
-      # manifests are not signed.
+      # tarball shasum/provenance for integrity. Their old per-bundle signature
+      # channel stays retired; the package-set signature below authenticates the
+      # complete workstation release contract instead.
 
       # ADR 0039: the two committed, dependency-free entrypoints —
       # plugins/dev/hooks/red-fetch.mjs (fetch role) and
@@ -652,6 +664,61 @@ jobs:
           set -euo pipefail
           pnpm package
 
+      # The first package-set contract covers the workstation artifacts the
+      # tagged tree can produce coherently today. Plugin payloads and host
+      # projections remain in the source snapshot named by SOURCE_COMMIT;
+      # Gemini/Hermes completeness is added by later Spec #3973 slices.
+      - name: Build, sign, and offline-verify package set
+        if: steps.target.outputs.publish == 'true'
+        env:
+          SOURCE_COMMIT: ${{ steps.target.outputs.sha }}
+          VERSION: ${{ steps.target.outputs.version }}
+        run: |
+          set -euo pipefail
+          cp scripts/verify-package-set.mjs dist/verify-package-set.mjs
+          workstation_assets=(
+            "dist/vscode-extension-red-skills-${VERSION}.vsix"
+            dist/herdr-plugin-red-skills.bundle.min.mjs
+            dist/dev.bundle.min.mjs
+            dist/dev.manifest.json
+            dist/redskilled-mcp.bundle.min.mjs
+            dist/code-nav.bundle.min.mjs
+            dist/code-nav.manifest.json
+            dist/opencode-host.bundle.min.mjs
+            dist/opencode-host.generated.tgz
+            dist/memory.bundle.min.mjs
+            dist/memory-mcp.bundle.min.mjs
+            dist/memory-runtime-manifest.json
+            dist/brain.bundle.min.mjs
+            dist/brain-mcp.bundle.min.mjs
+            dist/brain-runtime-manifest.json
+            dist/rsp.bundle.min.mjs
+            dist/rsp-core.bundle.min.mjs
+            dist/redskilled.bundle.min.mjs
+            dist/verify-package-set.mjs
+          )
+          build_args=()
+          for asset in "${workstation_assets[@]}"; do
+            build_args+=(--asset "$asset")
+          done
+          node scripts/build-package-set.mjs \
+            --source-commit "$SOURCE_COMMIT" \
+            --out dist/package-set.manifest.json \
+            "${build_args[@]}"
+          cosign sign-blob \
+            --yes \
+            --bundle dist/package-set.manifest.sigstore.json \
+            dist/package-set.manifest.json
+
+          # Signing needs Fulcio/Rekor; verification does not. Enter a fresh
+          # network namespace after signing so this smoke proves the downloaded
+          # manifest, bundle, verifier, and payloads are sufficient by themselves.
+          sudo --preserve-env=HOME unshare --net -- \
+            "$(command -v node)" scripts/verify-package-set.mjs \
+              --manifest dist/package-set.manifest.json \
+              --bundle dist/package-set.manifest.sigstore.json \
+              --cosign-bin "$(command -v cosign)"
+
       # ADR 0091: npm is the ONLY client transport. Stage the built bundles into
       # the packaging/npm package, pnpm pack it, then run the REAL client resolver
       # (the packaged bin) against the packed tarball as a producer/consumer
@@ -862,10 +929,10 @@ jobs:
           major="v${NEXT#v}"
           major="${major%%.*}"
 
-          # ADR 0091: the client resolves bundles over npm; these Release assets
-          # are kept as an INERT backup artifact the client never reads. No
-          # sigstore signatures are uploaded (client signature verification
-          # removed).
+          # ADR 0091: the client resolves individual bundles over npm; those
+          # assets remain inert backups. The package-set manifest is a distinct
+          # workstation contract and carries one Sigstore bundle for the whole
+          # declared set.
           # Two of these are not an inert backup: the `.vsix` and the herdr
           # bundle are the ONLY way either companion surface is installed on a
           # machine without this monorepo (issue #3060).
@@ -892,6 +959,9 @@ jobs:
             dist/rsp.bundle.min.mjs
             dist/rsp-core.bundle.min.mjs
             dist/redskilled.bundle.min.mjs
+            dist/package-set.manifest.json
+            dist/package-set.manifest.sigstore.json
+            dist/verify-package-set.mjs
           )
           # The Release standard owns the Release; this job only ever attaches to
           # it. Two owners would race over one object: the engine re-reads the

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Test canary channel promotion contract
         run: scripts/test-afk-promote-channel.sh
 
-      # These two ran only inside red-publish.yml, which is to say only at
+      # These contracts once ran only inside red-publish.yml, which is to say only at
       # publish time — after the last chance to fix anything. That is how a
       # refactor deleted five scripts the publish workflow calls and no check
       # went red: the only thing that reads the publish workflow was the publish
@@ -116,6 +116,9 @@ jobs:
 
       - name: Test red-release reddb asset contract
         run: scripts/test-red-release-reddb-assets-contract.sh
+
+      - name: Test package-set contract
+        run: scripts/test-package-set-contract.sh
 
       # ADR 0139: a changeset that cannot resolve does not get skipped — it
       # throws and abandons the whole release plan, so one bad file fails every

--- a/scripts/build-package-set.mjs
+++ b/scripts/build-package-set.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const PACKAGE_SET_SCHEMA = "red.package-set.v1";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function assertCommit(value, label = "source commit") {
+  if (!/^[0-9a-f]{40}$/.test(value)) {
+    throw new Error(`${label} must be a lowercase 40-character git commit`);
+  }
+}
+
+export function packageSetIdentityBytes(identity) {
+  return Buffer.from(`${JSON.stringify(identity)}\n`);
+}
+
+/**
+ * Build the deterministic package-set manifest model. The identity deliberately
+ * carries no build time, release URL, or input ordering: the source commit and
+ * exact local artifact bytes are the complete identity.
+ */
+export function createPackageSet({ sourceCommit, artifacts }) {
+  assertCommit(sourceCommit);
+  if (!Array.isArray(artifacts) || artifacts.length === 0) {
+    throw new Error("at least one --asset is required");
+  }
+
+  const declared = artifacts.map((input) => {
+    const path = resolve(typeof input === "string" ? input : input.path);
+    const artifactCommit = typeof input === "string" ? sourceCommit : (input.sourceCommit ?? sourceCommit);
+    assertCommit(artifactCommit, `source commit for ${basename(path)}`);
+    const info = statSync(path);
+    if (!info.isFile()) throw new Error(`artifact is not a regular file: ${path}`);
+    const bytes = readFileSync(path);
+    return {
+      name: basename(path),
+      sourceCommit: artifactCommit,
+      size: info.size,
+      sha256: sha256(bytes),
+    };
+  });
+
+  declared.sort((left, right) => left.name.localeCompare(right.name, "en"));
+  for (let index = 1; index < declared.length; index += 1) {
+    if (declared[index - 1].name === declared[index].name) {
+      throw new Error(`duplicate artifact name: ${declared[index].name}`);
+    }
+  }
+
+  const identity = {
+    schema: PACKAGE_SET_SCHEMA,
+    sourceCommit,
+    artifacts: declared,
+  };
+  return {
+    ...identity,
+    wholeSetDigest: sha256(packageSetIdentityBytes(identity)),
+  };
+}
+
+export function encodePackageSet(manifest) {
+  return Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function parseArgs(argv) {
+  const options = { assets: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+    if (argument === "--asset" && value) {
+      options.assets.push(value);
+      index += 1;
+    } else if (argument === "--source-commit" && value) {
+      options.sourceCommit = value;
+      index += 1;
+    } else if (argument === "--out" && value) {
+      options.out = value;
+      index += 1;
+    } else {
+      throw new Error(`unknown or incomplete argument: ${argument}`);
+    }
+  }
+  if (!options.sourceCommit) throw new Error("--source-commit is required");
+  if (!options.out) throw new Error("--out is required");
+  return options;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const manifest = createPackageSet({
+    sourceCommit: options.sourceCommit,
+    artifacts: options.assets,
+  });
+  const out = resolve(options.out);
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, encodePackageSet(manifest));
+  process.stdout.write(`${manifest.wholeSetDigest}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`package-set build failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/test-package-set-contract.sh
+++ b/scripts/test-package-set-contract.sh
@@ -16,6 +16,40 @@ pass() {
   printf 'PASS: %s\n' "$*"
 }
 
+WORKFLOW=".github/workflows/red-publish.yml"
+
+line_of_step() {
+  local step="$1"
+  grep -nF -- "- name: $step" "$WORKFLOW" | head -n1 | cut -d: -f1
+}
+
+contract_line="$(line_of_step "Test package-set contract" || true)"
+build_line="$(line_of_step "Build, sign, and offline-verify package set" || true)"
+release_line="$(line_of_step "GitHub Release" || true)"
+[ -n "$contract_line" ] || fail "release workflow must run the focused package-set contract"
+[ -n "$build_line" ] || fail "release workflow must build and verify the package set"
+[ -n "$release_line" ] || fail "release workflow must publish GitHub assets"
+[ "$contract_line" -lt "$build_line" ] && [ "$build_line" -lt "$release_line" ] ||
+  fail "package-set contract, build, and release upload must run in order"
+
+grep -qF 'uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac' "$WORKFLOW" ||
+  fail "release workflow must install cosign from the pinned v3 commit"
+grep -qF 'node scripts/build-package-set.mjs' "$WORKFLOW" ||
+  fail "release workflow must use the deterministic package-set producer"
+grep -qF 'SOURCE_COMMIT: ${{ steps.target.outputs.sha }}' "$WORKFLOW" ||
+  fail "package-set identity must use the resolved release tag commit"
+grep -qF 'cosign sign-blob' "$WORKFLOW" && grep -qF 'dist/package-set.manifest.sigstore.json' "$WORKFLOW" ||
+  fail "release workflow must sign the package-set manifest into a Sigstore bundle"
+grep -qF 'unshare --net' "$WORKFLOW" && grep -qF 'scripts/verify-package-set.mjs' "$WORKFLOW" ||
+  fail "release workflow must smoke the verifier with network access blocked"
+for asset in \
+  dist/package-set.manifest.json \
+  dist/package-set.manifest.sigstore.json \
+  dist/verify-package-set.mjs; do
+  grep -qF "$asset" "$WORKFLOW" || fail "release upload must carry $asset"
+done
+pass "release workflow builds, signs, verifies, and uploads the package set"
+
 source_commit="1111111111111111111111111111111111111111"
 other_commit="2222222222222222222222222222222222222222"
 mkdir -p "$tmp/assets" "$tmp/bin"

--- a/scripts/test-package-set-contract.sh
+++ b/scripts/test-package-set-contract.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+pass() {
+  printf 'PASS: %s\n' "$*"
+}
+
+source_commit="1111111111111111111111111111111111111111"
+other_commit="2222222222222222222222222222222222222222"
+mkdir -p "$tmp/assets" "$tmp/bin"
+printf 'alpha payload\n' >"$tmp/assets/alpha.bin"
+printf 'beta payload\n' >"$tmp/assets/beta.bin"
+
+# The fake is a deterministic stand-in for cosign's offline verify-blob
+# boundary. It deliberately refuses any invocation without --offline, checks
+# the pinned workflow identity/issuer, and authenticates the exact manifest
+# bytes against the fixture bundle. The release smoke exercises real cosign.
+cat >"$tmp/bin/cosign" <<'EOF'
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+if (args[0] !== "verify-blob" || !args.includes("--offline")) process.exit(20);
+const value = (flag) => {
+  const index = args.indexOf(flag);
+  return index >= 0 ? args[index + 1] : undefined;
+};
+if (value("--certificate-oidc-issuer") !== "https://token.actions.githubusercontent.com") process.exit(21);
+const identity = value("--certificate-identity-regexp") ?? "";
+if (!identity.includes("red-publish\\.yml") || !identity.includes("refs/tags/v")) process.exit(22);
+const bundle = JSON.parse(readFileSync(value("--bundle"), "utf8"));
+const manifest = readFileSync(args.at(-1));
+const digest = createHash("sha256").update(manifest).digest("hex");
+process.exit(bundle.sha256 === digest ? 0 : 23);
+EOF
+chmod +x "$tmp/bin/cosign"
+
+sign_fixture() {
+  local manifest="$1" bundle="$2"
+  node --input-type=module - "$manifest" "$bundle" <<'EOF'
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+const [, , manifest, bundle] = process.argv;
+const sha256 = createHash("sha256").update(readFileSync(manifest)).digest("hex");
+writeFileSync(bundle, `${JSON.stringify({ sha256 })}\n`);
+EOF
+}
+
+build() {
+  local commit="$1" out="$2"
+  shift 2
+  node scripts/build-package-set.mjs \
+    --source-commit "$commit" \
+    --out "$out" \
+    "$@"
+}
+
+verify() {
+  local manifest="$1" bundle="$2"
+  node scripts/verify-package-set.mjs \
+    --manifest "$manifest" \
+    --bundle "$bundle" \
+    --cosign-bin "$tmp/bin/cosign"
+}
+
+build "$source_commit" "$tmp/first.json" \
+  --asset "$tmp/assets/beta.bin" \
+  --asset "$tmp/assets/alpha.bin"
+build "$source_commit" "$tmp/second.json" \
+  --asset "$tmp/assets/alpha.bin" \
+  --asset "$tmp/assets/beta.bin"
+cmp -s "$tmp/first.json" "$tmp/second.json" || fail "identical inputs must produce identical manifest bytes"
+pass "identical inputs produce identical manifest bytes"
+
+first_digest="$(node -p "require('$tmp/first.json').wholeSetDigest")"
+printf 'alpha payload changed\n' >"$tmp/assets/alpha.bin"
+build "$source_commit" "$tmp/payload-changed.json" \
+  --asset "$tmp/assets/alpha.bin" \
+  --asset "$tmp/assets/beta.bin"
+payload_digest="$(node -p "require('$tmp/payload-changed.json').wholeSetDigest")"
+[ "$first_digest" != "$payload_digest" ] || fail "payload changes must change the whole-set digest"
+pass "payload changes alter the whole-set digest"
+
+printf 'alpha payload\n' >"$tmp/assets/alpha.bin"
+build "$other_commit" "$tmp/commit-changed.json" \
+  --asset "$tmp/assets/alpha.bin" \
+  --asset "$tmp/assets/beta.bin"
+commit_digest="$(node -p "require('$tmp/commit-changed.json').wholeSetDigest")"
+[ "$first_digest" != "$commit_digest" ] || fail "source commit changes must change the whole-set digest"
+pass "source commit changes alter the whole-set digest"
+
+cp "$tmp/first.json" "$tmp/assets/package-set.manifest.json"
+sign_fixture "$tmp/assets/package-set.manifest.json" "$tmp/assets/package-set.manifest.sigstore.json"
+verify "$tmp/assets/package-set.manifest.json" "$tmp/assets/package-set.manifest.sigstore.json" >/dev/null
+pass "valid local package set verifies"
+
+printf '{"sha256":"%064d"}\n' 0 >"$tmp/assets/invalid.sigstore.json"
+if verify "$tmp/assets/package-set.manifest.json" "$tmp/assets/invalid.sigstore.json" >/dev/null 2>&1; then
+  fail "invalid signature must be refused"
+fi
+pass "invalid signature is refused"
+
+printf 'alpha payload corrupted\n' >"$tmp/assets/alpha.bin"
+if verify "$tmp/assets/package-set.manifest.json" "$tmp/assets/package-set.manifest.sigstore.json" >/dev/null 2>&1; then
+  fail "checksum mismatch must be refused"
+fi
+pass "checksum mismatch is refused"
+printf 'alpha payload\n' >"$tmp/assets/alpha.bin"
+
+mv "$tmp/assets/beta.bin" "$tmp/assets/beta.missing"
+if verify "$tmp/assets/package-set.manifest.json" "$tmp/assets/package-set.manifest.sigstore.json" >/dev/null 2>&1; then
+  fail "missing asset must be refused"
+fi
+pass "missing asset is refused"
+mv "$tmp/assets/beta.missing" "$tmp/assets/beta.bin"
+
+node --input-type=module - "$tmp/assets/package-set.manifest.json" "$other_commit" <<'EOF'
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+const [, , path, otherCommit] = process.argv;
+const manifest = JSON.parse(readFileSync(path, "utf8"));
+manifest.artifacts[0].sourceCommit = otherCommit;
+const identity = {
+  schema: manifest.schema,
+  sourceCommit: manifest.sourceCommit,
+  artifacts: manifest.artifacts,
+};
+manifest.wholeSetDigest = createHash("sha256").update(`${JSON.stringify(identity)}\n`).digest("hex");
+writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+EOF
+sign_fixture "$tmp/assets/package-set.manifest.json" "$tmp/assets/cross-commit.sigstore.json"
+if verify "$tmp/assets/package-set.manifest.json" "$tmp/assets/cross-commit.sigstore.json" >/dev/null 2>&1; then
+  fail "cross-commit artifact must be refused"
+fi
+pass "cross-commit artifact is refused"
+
+# A path escape must never let a signed manifest read outside its local asset
+# directory. Re-signing proves the refusal is the package-set boundary, not an
+# incidental signature failure.
+cp "$tmp/first.json" "$tmp/assets/package-set.manifest.json"
+node --input-type=module - "$tmp/assets/package-set.manifest.json" <<'EOF'
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+const path = process.argv[2];
+const manifest = JSON.parse(readFileSync(path, "utf8"));
+manifest.artifacts[0].name = "../alpha.bin";
+const identity = {
+  schema: manifest.schema,
+  sourceCommit: manifest.sourceCommit,
+  artifacts: manifest.artifacts,
+};
+manifest.wholeSetDigest = createHash("sha256").update(`${JSON.stringify(identity)}\n`).digest("hex");
+writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+EOF
+sign_fixture "$tmp/assets/package-set.manifest.json" "$tmp/assets/path-escape.sigstore.json"
+if verify "$tmp/assets/package-set.manifest.json" "$tmp/assets/path-escape.sigstore.json" >/dev/null 2>&1; then
+  fail "asset path escape must be refused"
+fi
+pass "asset path escape is refused"
+
+if grep -Eq 'fetch\(|https?\.request|node:(http|https|net|tls|dns)' scripts/verify-package-set.mjs; then
+  fail "offline verifier must not contain a network client"
+fi
+pass "verifier has no network client and requires cosign offline mode"

--- a/scripts/test-package-set-contract.sh
+++ b/scripts/test-package-set-contract.sh
@@ -17,6 +17,7 @@ pass() {
 }
 
 WORKFLOW=".github/workflows/red-publish.yml"
+WORKSPACE_CI=".github/workflows/red-workspace-ci.yml"
 
 line_of_step() {
   local step="$1"
@@ -49,6 +50,9 @@ for asset in \
   grep -qF "$asset" "$WORKFLOW" || fail "release upload must carry $asset"
 done
 pass "release workflow builds, signs, verifies, and uploads the package set"
+grep -qF 'run: scripts/test-package-set-contract.sh' "$WORKSPACE_CI" ||
+  fail "workspace CI must run the package-set contract before merge"
+pass "workspace CI runs the package-set contract before merge"
 
 source_commit="1111111111111111111111111111111111111111"
 other_commit="2222222222222222222222222222222222222222"

--- a/scripts/verify-package-set.mjs
+++ b/scripts/verify-package-set.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const SCHEMA = "red.package-set.v1";
+const COMMIT = /^[0-9a-f]{40}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const EXPECTED_KEYS = ["schema", "sourceCommit", "artifacts", "wholeSetDigest"];
+const EXPECTED_ARTIFACT_KEYS = ["name", "sourceCommit", "size", "sha256"];
+const GITHUB_ISSUER = "https://token.actions.githubusercontent.com";
+const RELEASE_IDENTITY =
+  "^https://github\\.com/reddb-io/red-skills/\\.github/workflows/red-publish\\.yml@refs/heads/main$" +
+  "|^https://github\\.com/reddb-io/red-skills/\\.github/workflows/red-publish\\.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$";
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function sameKeys(value, expected) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    JSON.stringify(Object.keys(value)) === JSON.stringify(expected)
+  );
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function verifySignature({ manifestPath, bundlePath, cosignBin }) {
+  if (!existsSync(bundlePath)) fail("signature bundle is missing");
+  const result = spawnSync(
+    cosignBin,
+    [
+      "verify-blob",
+      "--offline",
+      "--bundle",
+      bundlePath,
+      "--certificate-identity-regexp",
+      RELEASE_IDENTITY,
+      "--certificate-oidc-issuer",
+      GITHUB_ISSUER,
+      manifestPath,
+    ],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  if (result.error) fail(`signature verifier could not run: ${result.error.message}`);
+  if (result.status !== 0) fail("manifest signature is invalid");
+}
+
+function parseAndValidateManifest(manifestPath) {
+  const bytes = readFileSync(manifestPath);
+  let manifest;
+  try {
+    manifest = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    fail("manifest is not valid JSON");
+  }
+  if (!sameKeys(manifest, EXPECTED_KEYS)) fail("manifest shape or key order is not canonical");
+  if (manifest.schema !== SCHEMA) fail(`unsupported manifest schema: ${String(manifest.schema)}`);
+  if (!COMMIT.test(manifest.sourceCommit)) fail("manifest source commit is invalid");
+  if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length === 0) {
+    fail("manifest must declare at least one artifact");
+  }
+  if (!SHA256.test(manifest.wholeSetDigest)) fail("whole-set digest is invalid");
+
+  let priorName = "";
+  for (const artifact of manifest.artifacts) {
+    if (!sameKeys(artifact, EXPECTED_ARTIFACT_KEYS)) fail("artifact shape or key order is not canonical");
+    if (
+      typeof artifact.name !== "string" ||
+      artifact.name.length === 0 ||
+      artifact.name === "." ||
+      artifact.name === ".." ||
+      basename(artifact.name) !== artifact.name
+    ) {
+      fail("artifact name must be one local basename");
+    }
+    if (priorName && priorName.localeCompare(artifact.name, "en") >= 0) {
+      fail("artifact names must be unique and sorted");
+    }
+    priorName = artifact.name;
+    if (artifact.sourceCommit !== manifest.sourceCommit) {
+      fail(`artifact ${artifact.name} belongs to a different source commit`);
+    }
+    if (!Number.isSafeInteger(artifact.size) || artifact.size < 0) {
+      fail(`artifact ${artifact.name} has an invalid size`);
+    }
+    if (!SHA256.test(artifact.sha256)) fail(`artifact ${artifact.name} has an invalid checksum`);
+  }
+
+  const identity = {
+    schema: manifest.schema,
+    sourceCommit: manifest.sourceCommit,
+    artifacts: manifest.artifacts,
+  };
+  const expectedDigest = sha256(Buffer.from(`${JSON.stringify(identity)}\n`));
+  if (manifest.wholeSetDigest !== expectedDigest) fail("whole-set digest does not match the manifest identity");
+  const canonicalBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+  if (!bytes.equals(canonicalBytes)) fail("manifest bytes are not canonical");
+  return manifest;
+}
+
+function verifyArtifacts(manifest, manifestPath) {
+  const root = dirname(manifestPath);
+  for (const artifact of manifest.artifacts) {
+    const path = join(root, artifact.name);
+    if (!existsSync(path)) fail(`declared artifact is missing: ${artifact.name}`);
+    const info = statSync(path);
+    if (!info.isFile()) fail(`declared artifact is not a regular file: ${artifact.name}`);
+    if (info.size !== artifact.size) fail(`artifact size mismatch: ${artifact.name}`);
+    if (sha256(readFileSync(path)) !== artifact.sha256) fail(`artifact checksum mismatch: ${artifact.name}`);
+  }
+}
+
+function parseArgs(argv) {
+  const options = { cosignBin: "cosign" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+    if (argument === "--manifest" && value) {
+      options.manifestPath = resolve(value);
+      index += 1;
+    } else if (argument === "--bundle" && value) {
+      options.bundlePath = resolve(value);
+      index += 1;
+    } else if (argument === "--cosign-bin" && value) {
+      options.cosignBin = value;
+      index += 1;
+    } else {
+      fail(`unknown or incomplete argument: ${argument}`);
+    }
+  }
+  if (!options.manifestPath) fail("--manifest is required");
+  if (!options.bundlePath) fail("--bundle is required");
+  return options;
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  if (!existsSync(options.manifestPath)) fail("manifest is missing");
+  verifySignature(options);
+  const manifest = parseAndValidateManifest(options.manifestPath);
+  verifyArtifacts(manifest, options.manifestPath);
+  process.stdout.write(`verified package set ${manifest.wholeSetDigest}\n`);
+} catch (error) {
+  process.stderr.write(`package-set verification failed: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Automated AFK landing for #3974. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3974

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789574758&installation_model_id=20659&pr_number=3980&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3980&signature=de97b791e5c0ec93f8bd697a162a0d1355f820d8edaefd0a6873d64b672e3d74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->