### PR TITLE
fix(release): drop empty changeset

### DIFF
--- a/.changeset/zellij-dashboard-plugin.md
+++ b/.changeset/zellij-dashboard-plugin.md
@@ -1,4 +1,0 @@
----
----
-
-Add the Zellij dashboard plugin: a layout and two launcher scripts that put the fleet, host, and GitHub-spend surfaces in one tab. Ships no package — it composes the existing `red-skills-dev` and `red-skills-redskilled` binaries — so it bumps no version.


### PR DESCRIPTION
Remove the package-less Zellij dashboard changeset that the release parser rejects. The feature explicitly ships no package and therefore needs no version entry.\n\nValidation: `node .github/red-skills/release.bundle.mjs status --root .` now parses all 19 pending changes and computes 3.19.0.\n\nUnblocks the Version PR and the signed package-set release needed by AFK Actions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789603751&installation_model_id=20659&pr_number=3983&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3983&signature=d4ed41a1a7b6ff232ae483a6f2ea2f106fa0b33b5cfb13418e2ce8e9269ad22c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->