### PR TITLE
fix(release): rehearse package-set signing before the tag depends on it

### DIFF
--- a/.changeset/package-set-offline-verify.md
+++ b/.changeset/package-set-offline-verify.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Publish again: sign the package-set manifest in the Sigstore bundle format and verify it against an explicit trusted root, so the release's offline verification no longer reaches for the network and blocks npm publish (v3.19.0 never reached the registry, which broke every `install.sh` host).

--- a/.github/workflows/red-package-set-smoke.yml
+++ b/.github/workflows/red-package-set-smoke.yml
@@ -1,0 +1,118 @@
+name: red-package-set-smoke
+
+# Rehearse the release's package-set signing recipe BEFORE a tag depends on it.
+#
+# red-publish.yml signs the package-set manifest keylessly and then proves the
+# downloaded verifier works with the network gone. That step first ran for real
+# on v3.19.0 and failed, which blocked npm publish and broke every installer
+# that materialises the release packages. Nothing on a pull request had ever
+# exercised real cosign: the workspace contract test drives a fake. This
+# workflow signs a fixture manifest under its own OIDC identity and runs the
+# exact offline verifier the release runs, so a recipe regression fails the PR
+# instead of the release.
+
+on:
+  pull_request:
+    paths:
+      - scripts/build-package-set.mjs
+      - scripts/verify-package-set.mjs
+      - scripts/test-package-set-contract.sh
+      - .github/workflows/red-package-set-smoke.yml
+      - .github/workflows/red-publish.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  smoke:
+    # Fork pull requests carry no OIDC token, so keyless signing cannot run there.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
+
+      - name: Build and sign a fixture package set
+        env:
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          printf 'alpha payload\n' >dist/alpha.bin
+          printf 'beta payload\n' >dist/beta.bin
+          cp scripts/verify-package-set.mjs dist/verify-package-set.mjs
+          node scripts/build-package-set.mjs \
+            --source-commit "$SOURCE_COMMIT" \
+            --out dist/package-set.manifest.json \
+            --asset dist/alpha.bin \
+            --asset dist/beta.bin \
+            --asset dist/verify-package-set.mjs
+          cosign version
+          cosign sign-blob \
+            --yes \
+            --bundle dist/package-set.manifest.sigstore.json \
+            dist/package-set.manifest.json
+          echo "--- bundle shape"
+          node -e 'const b=require("./dist/package-set.manifest.sigstore.json"); console.log(Object.keys(b))'
+          echo "--- sigstore cache after signing"
+          ls -laR "$HOME/.sigstore" 2>&1 | head -60 || true
+
+      - name: Offline verify (release recipe)
+        env:
+          IDENTITY: ^https://github\.com/${{ github.repository }}/\.github/workflows/red-package-set-smoke\.yml@refs/.+$
+        run: |
+          set -euo pipefail
+          echo "--- environment seen under sudo"
+          sudo --preserve-env=HOME env | grep -E '^(HOME|USER|PATH)=' || true
+          sudo --preserve-env=HOME unshare --net -- \
+            "$(command -v node)" scripts/verify-package-set.mjs \
+              --manifest dist/package-set.manifest.json \
+              --bundle dist/package-set.manifest.sigstore.json \
+              --cosign-bin "$(command -v cosign)" \
+              --certificate-identity-regexp "$IDENTITY"
+
+      - name: Diagnostics when the release recipe fails
+        if: failure()
+        env:
+          IDENTITY: ^https://github\.com/${{ github.repository }}/\.github/workflows/red-package-set-smoke\.yml@refs/.+$
+        run: |
+          set +e
+          echo "=== A. same verifier, network on, no sudo"
+          node scripts/verify-package-set.mjs \
+            --manifest dist/package-set.manifest.json \
+            --bundle dist/package-set.manifest.sigstore.json \
+            --cosign-bin "$(command -v cosign)" \
+            --certificate-identity-regexp "$IDENTITY"
+          echo "exit=$?"
+          echo "=== B. same verifier, network on, under sudo"
+          sudo --preserve-env=HOME "$(command -v node)" scripts/verify-package-set.mjs \
+            --manifest dist/package-set.manifest.json \
+            --bundle dist/package-set.manifest.sigstore.json \
+            --cosign-bin "$(command -v cosign)" \
+            --certificate-identity-regexp "$IDENTITY"
+          echo "exit=$?"
+          echo "=== C. cosign directly, offline, no sudo, verbose"
+          cosign verify-blob --verbose --offline \
+            --bundle dist/package-set.manifest.sigstore.json \
+            --certificate-identity-regexp "$IDENTITY" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            dist/package-set.manifest.json
+          echo "exit=$?"
+          echo "=== D. cosign directly, offline, netns, verbose"
+          sudo --preserve-env=HOME unshare --net -- "$(command -v cosign)" verify-blob --verbose --offline \
+            --bundle dist/package-set.manifest.sigstore.json \
+            --certificate-identity-regexp "$IDENTITY" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            dist/package-set.manifest.json
+          echo "exit=$?"
+          echo "=== E. cert SAN"
+          node -e 'const b=require("./dist/package-set.manifest.sigstore.json"); process.stdout.write(Buffer.from(b.cert,"base64").toString())' | openssl x509 -noout -text | grep -A2 -i "subject alternative\|Issuer:" || true

--- a/.github/workflows/red-package-set-smoke.yml
+++ b/.github/workflows/red-package-set-smoke.yml
@@ -61,18 +61,15 @@ jobs:
             --yes \
             --bundle dist/package-set.manifest.sigstore.json \
             dist/package-set.manifest.json
-          echo "--- bundle shape"
-          node -e 'const b=require("./dist/package-set.manifest.sigstore.json"); console.log(Object.keys(b))'
-          echo "--- sigstore cache after signing"
-          ls -laR "$HOME/.sigstore" 2>&1 | head -60 || true
+          # Same as the release: prime the TUF trust-root cache verify-blob
+          # reads, while the network is still up.
+          cosign initialize
 
       - name: Offline verify (release recipe)
         env:
           IDENTITY: ^https://github\.com/${{ github.repository }}/\.github/workflows/red-package-set-smoke\.yml@refs/.+$
         run: |
           set -euo pipefail
-          echo "--- environment seen under sudo"
-          sudo --preserve-env=HOME env | grep -E '^(HOME|USER|PATH)=' || true
           sudo --preserve-env=HOME unshare --net -- \
             "$(command -v node)" scripts/verify-package-set.mjs \
               --manifest dist/package-set.manifest.json \

--- a/.github/workflows/red-package-set-smoke.yml
+++ b/.github/workflows/red-package-set-smoke.yml
@@ -59,11 +59,14 @@ jobs:
           cosign version
           cosign sign-blob \
             --yes \
+            --new-bundle-format \
             --bundle dist/package-set.manifest.sigstore.json \
             dist/package-set.manifest.json
-          # Same as the release: prime the TUF trust-root cache verify-blob
-          # reads, while the network is still up.
+          # Same as the release: fetch and cache the Sigstore trust root while
+          # the network is still up; the offline verify hands it over by path.
           cosign initialize
+          trusted_root="$HOME/.sigstore/root/tuf-repo-cdn.sigstore.dev/targets/trusted_root.json"
+          [ -f "$trusted_root" ] || { echo "cosign initialize did not cache $trusted_root" >&2; exit 1; }
 
       - name: Offline verify (release recipe)
         env:
@@ -75,7 +78,21 @@ jobs:
               --manifest dist/package-set.manifest.json \
               --bundle dist/package-set.manifest.sigstore.json \
               --cosign-bin "$(command -v cosign)" \
+              --trusted-root "$HOME/.sigstore/root/tuf-repo-cdn.sigstore.dev/targets/trusted_root.json" \
               --certificate-identity-regexp "$IDENTITY"
+
+      # A verifier without --trusted-root is what an ordinary workstation runs:
+      # cosign resolves the trust root through TUF over the network.
+      - name: Online verify (workstation default)
+        env:
+          IDENTITY: ^https://github\.com/${{ github.repository }}/\.github/workflows/red-package-set-smoke\.yml@refs/.+$
+        run: |
+          set -euo pipefail
+          node scripts/verify-package-set.mjs \
+            --manifest dist/package-set.manifest.json \
+            --bundle dist/package-set.manifest.sigstore.json \
+            --cosign-bin "$(command -v cosign)" \
+            --certificate-identity-regexp "$IDENTITY"
 
       - name: Diagnostics when the release recipe fails
         if: failure()
@@ -83,33 +100,21 @@ jobs:
           IDENTITY: ^https://github\.com/${{ github.repository }}/\.github/workflows/red-package-set-smoke\.yml@refs/.+$
         run: |
           set +e
-          echo "=== A. same verifier, network on, no sudo"
-          node scripts/verify-package-set.mjs \
-            --manifest dist/package-set.manifest.json \
-            --bundle dist/package-set.manifest.sigstore.json \
-            --cosign-bin "$(command -v cosign)" \
-            --certificate-identity-regexp "$IDENTITY"
-          echo "exit=$?"
-          echo "=== B. same verifier, network on, under sudo"
-          sudo --preserve-env=HOME "$(command -v node)" scripts/verify-package-set.mjs \
-            --manifest dist/package-set.manifest.json \
-            --bundle dist/package-set.manifest.sigstore.json \
-            --cosign-bin "$(command -v cosign)" \
-            --certificate-identity-regexp "$IDENTITY"
-          echo "exit=$?"
-          echo "=== C. cosign directly, offline, no sudo, verbose"
+          echo "=== cosign directly, verbose, network on"
           cosign verify-blob --verbose --offline \
             --bundle dist/package-set.manifest.sigstore.json \
             --certificate-identity-regexp "$IDENTITY" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             dist/package-set.manifest.json
           echo "exit=$?"
-          echo "=== D. cosign directly, offline, netns, verbose"
+          echo "=== cosign directly, verbose, network namespace, explicit trusted root"
           sudo --preserve-env=HOME unshare --net -- "$(command -v cosign)" verify-blob --verbose --offline \
             --bundle dist/package-set.manifest.sigstore.json \
             --certificate-identity-regexp "$IDENTITY" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --trusted-root "$HOME/.sigstore/root/tuf-repo-cdn.sigstore.dev/targets/trusted_root.json" \
             dist/package-set.manifest.json
           echo "exit=$?"
-          echo "=== E. cert SAN"
-          node -e 'const b=require("./dist/package-set.manifest.sigstore.json"); process.stdout.write(Buffer.from(b.cert,"base64").toString())' | openssl x509 -noout -text | grep -A2 -i "subject alternative\|Issuer:" || true
+          echo "=== bundle shape and sigstore cache"
+          node -e 'const b=require("./dist/package-set.manifest.sigstore.json"); console.log(Object.keys(b), b.mediaType)'
+          ls -laR "$HOME/.sigstore" 2>&1 | head -60 || true

--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -710,9 +710,16 @@ jobs:
             --bundle dist/package-set.manifest.sigstore.json \
             dist/package-set.manifest.json
 
-          # Signing needs Fulcio/Rekor; verification does not. Enter a fresh
-          # network namespace after signing so this smoke proves the downloaded
-          # manifest, bundle, verifier, and payloads are sufficient by themselves.
+          # Verification needs no Fulcio/Rekor round-trip, but it does need the
+          # Sigstore TUF trust roots (Rekor and Fulcio public keys). Signing
+          # caches only sigstore-go's trusted_root.json; verify-blob on this
+          # bundle shape reads the older TUF cache (tuf.db + targets/), which
+          # is empty until `cosign initialize` fills it — the v3.19.0 publish
+          # died on exactly that inside the network namespace. Initialize
+          # while the network is up, then drop it: the smoke proves the
+          # downloaded manifest, bundle, verifier, payloads, and a primed
+          # trust-root cache are sufficient by themselves.
+          cosign initialize
           sudo --preserve-env=HOME unshare --net -- \
             "$(command -v node)" scripts/verify-package-set.mjs \
               --manifest dist/package-set.manifest.json \

--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -705,26 +705,35 @@ jobs:
             --source-commit "$SOURCE_COMMIT" \
             --out dist/package-set.manifest.json \
             "${build_args[@]}"
+          # The Sigstore bundle format (--new-bundle-format) carries the
+          # certificate, signature, and Rekor entry with its inclusion proof,
+          # so verification needs no Fulcio/Rekor round-trip. The one input a
+          # bundle cannot carry is the Sigstore trust root (Fulcio, Rekor and
+          # CT log keys): cosign fetches it through TUF, verified against its
+          # embedded root. `cosign initialize` does that fetch while the
+          # network is still up and caches trusted_root.json; the offline
+          # verify below hands that file over explicitly. The legacy bundle
+          # shape could never be verified with the network gone — its trust
+          # roots come from an older TUF store nothing in cosign 2.5 primes —
+          # which is how the v3.19.0 publish died inside the network namespace.
           cosign sign-blob \
             --yes \
+            --new-bundle-format \
             --bundle dist/package-set.manifest.sigstore.json \
             dist/package-set.manifest.json
-
-          # Verification needs no Fulcio/Rekor round-trip, but it does need the
-          # Sigstore TUF trust roots (Rekor and Fulcio public keys). Signing
-          # caches only sigstore-go's trusted_root.json; verify-blob on this
-          # bundle shape reads the older TUF cache (tuf.db + targets/), which
-          # is empty until `cosign initialize` fills it — the v3.19.0 publish
-          # died on exactly that inside the network namespace. Initialize
-          # while the network is up, then drop it: the smoke proves the
-          # downloaded manifest, bundle, verifier, payloads, and a primed
-          # trust-root cache are sufficient by themselves.
           cosign initialize
+          trusted_root="$HOME/.sigstore/root/tuf-repo-cdn.sigstore.dev/targets/trusted_root.json"
+          [ -f "$trusted_root" ] || { echo "cosign initialize did not cache $trusted_root" >&2; exit 1; }
+
+          # Enter a fresh network namespace so this smoke proves the downloaded
+          # manifest, bundle, verifier, payloads, and a trust root the operator
+          # already holds are sufficient by themselves.
           sudo --preserve-env=HOME unshare --net -- \
             "$(command -v node)" scripts/verify-package-set.mjs \
               --manifest dist/package-set.manifest.json \
               --bundle dist/package-set.manifest.sigstore.json \
-              --cosign-bin "$(command -v cosign)"
+              --cosign-bin "$(command -v cosign)" \
+              --trusted-root "$trusted_root"
 
       # ADR 0091: npm is the ONLY client transport. Stage the built bundles into
       # the packaging/npm package, pnpm pack it, then run the REAL client resolver

--- a/scripts/test-package-set-contract.sh
+++ b/scripts/test-package-set-contract.sh
@@ -43,15 +43,21 @@ grep -qF 'cosign sign-blob' "$WORKFLOW" && grep -qF 'dist/package-set.manifest.s
   fail "release workflow must sign the package-set manifest into a Sigstore bundle"
 grep -qF 'unshare --net' "$WORKFLOW" && grep -qF 'scripts/verify-package-set.mjs' "$WORKFLOW" ||
   fail "release workflow must smoke the verifier with network access blocked"
-# verify-blob reads the legacy TUF cache (tuf.db + targets/), which signing
-# does not populate; without a prime step the offline smoke reaches for the
-# network and fails (v3.19.0). The prime must precede the network drop.
+# The legacy bundle shape reads trust roots from an older TUF store nothing in
+# cosign 2.5 primes, so its offline verify always reached for the network and
+# failed (v3.19.0). The Sigstore bundle format plus an explicit trusted root,
+# fetched by `cosign initialize` BEFORE the network drop, is the recipe.
+grep -qF -- '--new-bundle-format' "$WORKFLOW" ||
+  fail "release workflow must sign in the Sigstore bundle format"
 initialize_line="$(grep -nF 'cosign initialize' "$WORKFLOW" | head -n1 | cut -d: -f1)"
 unshare_line="$(grep -nF 'unshare --net' "$WORKFLOW" | head -n1 | cut -d: -f1)"
 [ -n "$initialize_line" ] && [ "$initialize_line" -lt "$unshare_line" ] ||
   fail "release workflow must run 'cosign initialize' before dropping the network"
+grep -qF -- '--trusted-root "$trusted_root"' "$WORKFLOW" ||
+  fail "release offline verify must hand the verifier the cached trusted root"
 SMOKE=".github/workflows/red-package-set-smoke.yml"
-grep -qF 'cosign sign-blob' "$SMOKE" && grep -qF 'cosign initialize' "$SMOKE" &&
+grep -qF 'cosign sign-blob' "$SMOKE" && grep -qF -- '--new-bundle-format' "$SMOKE" &&
+  grep -qF 'cosign initialize' "$SMOKE" && grep -qF -- '--trusted-root' "$SMOKE" &&
   grep -qF 'unshare --net' "$SMOKE" && grep -qF 'scripts/verify-package-set.mjs' "$SMOKE" ||
   fail "pull-request smoke must rehearse the release's real cosign sign + offline verify recipe"
 for asset in \

--- a/scripts/test-package-set-contract.sh
+++ b/scripts/test-package-set-contract.sh
@@ -43,6 +43,17 @@ grep -qF 'cosign sign-blob' "$WORKFLOW" && grep -qF 'dist/package-set.manifest.s
   fail "release workflow must sign the package-set manifest into a Sigstore bundle"
 grep -qF 'unshare --net' "$WORKFLOW" && grep -qF 'scripts/verify-package-set.mjs' "$WORKFLOW" ||
   fail "release workflow must smoke the verifier with network access blocked"
+# verify-blob reads the legacy TUF cache (tuf.db + targets/), which signing
+# does not populate; without a prime step the offline smoke reaches for the
+# network and fails (v3.19.0). The prime must precede the network drop.
+initialize_line="$(grep -nF 'cosign initialize' "$WORKFLOW" | head -n1 | cut -d: -f1)"
+unshare_line="$(grep -nF 'unshare --net' "$WORKFLOW" | head -n1 | cut -d: -f1)"
+[ -n "$initialize_line" ] && [ "$initialize_line" -lt "$unshare_line" ] ||
+  fail "release workflow must run 'cosign initialize' before dropping the network"
+SMOKE=".github/workflows/red-package-set-smoke.yml"
+grep -qF 'cosign sign-blob' "$SMOKE" && grep -qF 'cosign initialize' "$SMOKE" &&
+  grep -qF 'unshare --net' "$SMOKE" && grep -qF 'scripts/verify-package-set.mjs' "$SMOKE" ||
+  fail "pull-request smoke must rehearse the release's real cosign sign + offline verify recipe"
 for asset in \
   dist/package-set.manifest.json \
   dist/package-set.manifest.sigstore.json \

--- a/scripts/verify-package-set.mjs
+++ b/scripts/verify-package-set.mjs
@@ -32,7 +32,7 @@ function fail(message) {
   throw new Error(message);
 }
 
-function verifySignature({ manifestPath, bundlePath, cosignBin }) {
+function verifySignature({ manifestPath, bundlePath, cosignBin, identityRegexp }) {
   if (!existsSync(bundlePath)) fail("signature bundle is missing");
   const result = spawnSync(
     cosignBin,
@@ -42,7 +42,7 @@ function verifySignature({ manifestPath, bundlePath, cosignBin }) {
       "--bundle",
       bundlePath,
       "--certificate-identity-regexp",
-      RELEASE_IDENTITY,
+      identityRegexp,
       "--certificate-oidc-issuer",
       GITHUB_ISSUER,
       manifestPath,
@@ -50,7 +50,13 @@ function verifySignature({ manifestPath, bundlePath, cosignBin }) {
     { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
   );
   if (result.error) fail(`signature verifier could not run: ${result.error.message}`);
-  if (result.status !== 0) fail("manifest signature is invalid");
+  if (result.status !== 0) {
+    // cosign's own reason is the only thing that separates "wrong signer",
+    // "tampered manifest", and "verifier could not reach its trust roots";
+    // swallowing it left the v3.19.0 release log with a bare "invalid".
+    const detail = `${result.stderr ?? ""}${result.stdout ?? ""}`.trim();
+    fail(`manifest signature is invalid${detail ? `: ${detail}` : ""}`);
+  }
 }
 
 function parseAndValidateManifest(manifestPath) {
@@ -119,7 +125,7 @@ function verifyArtifacts(manifest, manifestPath) {
 }
 
 function parseArgs(argv) {
-  const options = { cosignBin: "cosign" };
+  const options = { cosignBin: "cosign", identityRegexp: RELEASE_IDENTITY };
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     const value = argv[index + 1];
@@ -131,6 +137,12 @@ function parseArgs(argv) {
       index += 1;
     } else if (argument === "--cosign-bin" && value) {
       options.cosignBin = value;
+      index += 1;
+    } else if (argument === "--certificate-identity-regexp" && value) {
+      // Smoke/test override only: the release verifier default pins the
+      // red-publish workflow identity. A pull-request smoke signs under its
+      // own workflow ref and must say so explicitly to be accepted.
+      options.identityRegexp = value;
       index += 1;
     } else {
       fail(`unknown or incomplete argument: ${argument}`);

--- a/scripts/verify-package-set.mjs
+++ b/scripts/verify-package-set.mjs
@@ -32,8 +32,9 @@ function fail(message) {
   throw new Error(message);
 }
 
-function verifySignature({ manifestPath, bundlePath, cosignBin, identityRegexp }) {
+function verifySignature({ manifestPath, bundlePath, cosignBin, identityRegexp, trustedRootPath }) {
   if (!existsSync(bundlePath)) fail("signature bundle is missing");
+  if (trustedRootPath && !existsSync(trustedRootPath)) fail("trusted root is missing");
   const result = spawnSync(
     cosignBin,
     [
@@ -45,6 +46,12 @@ function verifySignature({ manifestPath, bundlePath, cosignBin, identityRegexp }
       identityRegexp,
       "--certificate-oidc-issuer",
       GITHUB_ISSUER,
+      // The Sigstore trust roots (Fulcio, Rekor, CT log keys) are the one input
+      // the bundle cannot carry. cosign fetches them through TUF, verified
+      // against its embedded root, when no --trusted-root is given; a host with
+      // no network passes the trusted_root.json a prior `cosign initialize`
+      // cached.
+      ...(trustedRootPath ? ["--trusted-root", trustedRootPath] : []),
       manifestPath,
     ],
     { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
@@ -137,6 +144,9 @@ function parseArgs(argv) {
       index += 1;
     } else if (argument === "--cosign-bin" && value) {
       options.cosignBin = value;
+      index += 1;
+    } else if (argument === "--trusted-root" && value) {
+      options.trustedRootPath = resolve(value);
       index += 1;
     } else if (argument === "--certificate-identity-regexp" && value) {
       // Smoke/test override only: the release verifier default pins the


### PR DESCRIPTION
## Why

`red-publish` for `v3.19.0` failed at **Build, sign, and offline-verify package set** with a bare `package-set verification failed: manifest signature is invalid` (run 32083981388; the hourly retry fails the same way). Publish is upstream of npm, so npm still serves `3.18.12` — the old Pi-only package shape — while `scripts/install.sh` (post #3945/#3974) requires `@reddb-io/red-skills-<plugin>` to carry `dist/<plugin>.bundle.min.mjs`. Result: `install.sh` dies with `@reddb-io/red-skills-dev package is missing dist/dev.bundle.min.mjs` for every host (opencode, redcode, claude, codex).

## Cause (reproduced by the new smoke, run 32092819986)

cosign v2.5.2 `sign-blob` caches only sigstore-go's `trusted_root.json`. `verify-blob --offline` on the **legacy** bundle shape resolves Rekor/Fulcio keys through the older TUF store (`tuf.db` + `targets/`), which nothing in cosign 2.5 primes — not even `cosign initialize` (run 32092913182 proves it: initialize returns early once the mirror serves `trusted_root.json`). Inside `unshare --net` that path reaches for `tuf-repo-cdn.sigstore.dev` and dies with `network is unreachable`. The verifier swallowed that stderr, so the release log said only "invalid".

## What

- `scripts/verify-package-set.mjs`: print cosign's own reason on failure; accept `--trusted-root <file>` (pass-through; without it cosign resolves the Sigstore trust root through TUF over the network, the ordinary workstation path) and `--certificate-identity-regexp` (default unchanged: the pinned red-publish identity; a PR smoke signs under its own workflow ref).
- `red-publish.yml`: sign with `--new-bundle-format` (cert + signature + Rekor entry with inclusion proof travel in the bundle); `cosign initialize` while the network is up; offline verify hands the cached `trusted_root.json` over by path.
- `red-package-set-smoke.yml` (new): on PRs touching the recipe, keyless-sign a fixture manifest and run the exact `sudo unshare --net` verifier the release runs, plus the online default. Green on run 32093117601 (both offline and online verify).
- `test-package-set-contract.sh`: ratchets `--new-bundle-format`, `cosign initialize` before the network drop, `--trusted-root` on the release verify, and the smoke's presence.
- Changeset (`@reddb-io/red-skills` patch): the `v3.19.0` tag's tree carries the pre-fix verifier (no `--trusted-root`), so the hourly retry cannot complete that tag even under the fixed workflow definition; a `v3.19.1` release publishes the fix itself and the resolver then treats `v3.19.0` as stale, not pending.

## After merge

1. red-release opens the Version PR for 3.19.1 → merge → tag → red-publish (now green through the sign/verify step) → npm gets the bundle-carrying package set.
2. `install.sh --only opencode,redcode` (and claude/codex) materialises again.

Refs #3974

🤖 Generated with [Claude Code](https://claude.com/claude-code)