### PR TITLE
fix(release): build the release engine bundle before packing npm

### DIFF
--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -628,6 +628,22 @@ jobs:
           set -euo pipefail
           pnpm bundle
 
+      # The release engine ships as dist/release.bundle.min.mjs behind the
+      # packaged `red-skills-release` bin. Every prior publish staged the bin
+      # and skipped the bundle ("release.bundle.min.mjs not built; skipping"),
+      # so the shim resolved nothing; the tarball boundary check now refuses a
+      # bin whose bundle is absent (#3957) and the v3.19.1 publish died on it.
+      - name: Build release engine bundle
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/release
+        env:
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          pnpm bundle
+
       # The two companion surfaces that read the daemon are installed by hand
       # rather than resolved by a launcher, so a release is the ONLY place they
       # can come from (issue #3060). Both were complete in source and absent from

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -42,6 +42,7 @@ assert_before() {
 
 verify_line="$(line_of_step "Verify the tag matches the tree")"
 pack_line="$(line_of_step "Pack npm package + producer/consumer contract check")"
+release_bundle_line="$(line_of_step "Build release engine bundle" || true)"
 publish_line="$(line_of_step "Publish to npm")"
 smoke_line="$(line_of_step "Smoke published npm package from registry")"
 release_line="$(line_of_step "GitHub Release")"
@@ -55,6 +56,17 @@ assert_before "tag/tree verification" "$verify_line" "pack/contract check" "$pac
 assert_before "pack/contract check" "$pack_line" "publish" "$publish_line"
 assert_before "publish" "$publish_line" "registry smoke" "$smoke_line"
 assert_before "registry smoke" "$smoke_line" "GitHub release" "$release_line"
+
+# Every bundle packaging/npm/scripts/prepare.mjs stages must have a producer
+# step ahead of the pack: prepare skips a missing bundle with a warning, the
+# bin shim still ships, and the tarball boundary check then fails the publish
+# on a bundle nothing built (release.bundle.min.mjs, v3.19.1). Guard the one
+# that was missing by name and position.
+[ -n "$release_bundle_line" ] || fail "release workflow must build the release engine bundle (apps/release pnpm bundle)"
+assert_before "release engine bundle build" "$release_bundle_line" "pack/contract check" "$pack_line"
+grep -qF 'working-directory: apps/release' "$WORKFLOW" ||
+  fail "release engine bundle must be built from apps/release so pnpm bundle emits dist/release.bundle.min.mjs"
+pass "release engine bundle is built before the pack"
 
 # That the version surfaces agree with EACH OTHER is the version-train
 # invariant, run on every PR by the release engine's own gate. What this


### PR DESCRIPTION
## Why

The dispatched `red-publish` for `v3.19.1` (run 32095758969) got past the fixed sign/verify step (#3985) and died at **Pack npm package + producer/consumer contract check**:

```
prepare: release.bundle.min.mjs not built (looked for release.bundle.min.mjs); skipping
...
core npm tarball missing package/dist/release.bundle.min.mjs
```

`packaging/npm/package.json` ships the `red-skills-release` bin and `prepare.mjs` stages `release.bundle.min.mjs`, but the workflow never built it — every previous publish shipped a bin shim that resolved nothing. The tarball boundary check (#3957) now correctly refuses that, so the publish blocks until the bundle is built.

## What

- `red-publish.yml`: add **Build release engine bundle** (`apps/release` → `pnpm bundle` → `dist/release.bundle.min.mjs`) ahead of the pack, same shape as the rsp/redskilled steps.
- `test-red-release-npm-publish-contract.sh`: require that step, by name and position, before the pack.

Verified locally: `apps/release pnpm bundle` emits a 354k bundle that answers `--version`.

## After merge

`gh workflow run red-publish.yml -f tag=v3.19.1` (v3.19.0's tail was reconciled by moving `v3` to its commit, so v3.19.1 is the oldest pending release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789616321&installation_model_id=20659&pr_number=3987&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3987&signature=fba590864b1f3ed8b39d92fc635baa65e87b9d68b90f9c0e6cb3bafc49463657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->