### PR TITLE
fix(release): a skills-only plugin ships no runtime bundle

### DIFF
--- a/scripts/check-npm-tarball-boundaries.mjs
+++ b/scripts/check-npm-tarball-boundaries.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 const MEMORY_TOKENIZER_ASSET = "memory-tokenizer.asset.cjs";
@@ -113,6 +113,10 @@ function pluginManifests(root) {
     .sort((left, right) => left.name.localeCompare(right.name));
 }
 
+function pluginHasRuntime(root, pluginName) {
+  return existsSync(join(root, "apps", pluginName, "package.json"));
+}
+
 function checkPlugins(root, tarballsDir) {
   const tarballs = readdirSync(tarballsDir).filter((entry) => entry.endsWith(".tgz"));
   for (const plugin of pluginManifests(root)) {
@@ -128,7 +132,16 @@ function checkPlugins(root, tarballsDir) {
       (entry) => entry.startsWith("package/skills/") && entry.endsWith("/SKILL.md"),
     );
     if (!skill) throw new Error(`${packageName} tarball carries no published skills`);
-    requireEntry(listing, `package/dist/${plugin.name}.bundle.min.mjs`, packageName);
+    // A plugin carries its runtime bundle iff it has a runtime app
+    // (apps/<name>); `internal` is skills-only, and demanding a bundle nothing
+    // builds refused the v3.19.1 publish. The inverse is refused too, so a
+    // stray bundle cannot ride a skills-only package.
+    const bundle = `package/dist/${plugin.name}.bundle.min.mjs`;
+    if (pluginHasRuntime(root, plugin.name)) {
+      requireEntry(listing, bundle, packageName);
+    } else if (listing.includes(bundle)) {
+      throw new Error(`${packageName} is skills-only but its tarball carries ${bundle}`);
+    }
     if (plugin.name === "memory") {
       requireEntry(listing, `package/dist/${MEMORY_TOKENIZER_ASSET}`, packageName);
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,6 +98,16 @@ die() {
   exit 1
 }
 
+# plugin_has_runtime <plugin> <runtime plugins...>
+plugin_has_runtime() {
+  local plugin="$1" candidate
+  shift
+  for candidate in "$@"; do
+    [[ "$candidate" == "$plugin" ]] && return 0
+  done
+  return 1
+}
+
 quote_cmd() {
   local out="" arg
   for arg in "$@"; do
@@ -206,7 +216,11 @@ prepare_source() {
   mkdir -p "$versions_dir"
 
   local tmp core package_dir package_version plugin bundle resolved_version dest
+  # Every marketplace plugin is materialised; only the ones with a runtime app
+  # (apps/<plugin> in the repo) carry dist/<plugin>.bundle.min.mjs. `internal`
+  # is skills-only, so requiring its bundle refused every install (v3.19.1).
   local -a plugins=(dev memory brain internal)
+  local -a runtime_plugins=(dev memory brain)
   local -a specs=("@reddb-io/red-skills@$npm_version")
   for plugin in "${plugins[@]}"; do
     specs+=("@reddb-io/red-skills-$plugin@$npm_version")
@@ -234,7 +248,9 @@ prepare_source() {
     package_dir="$tmp/node_modules/@reddb-io/red-skills-$plugin"
     bundle="$package_dir/dist/$plugin.bundle.min.mjs"
     [[ -f "$package_dir/package.json" ]] || die "npm did not materialise @reddb-io/red-skills-$plugin"
-    [[ -f "$bundle" ]] || die "@reddb-io/red-skills-$plugin package is missing dist/$plugin.bundle.min.mjs"
+    if plugin_has_runtime "$plugin" "${runtime_plugins[@]}"; then
+      [[ -f "$bundle" ]] || die "@reddb-io/red-skills-$plugin package is missing dist/$plugin.bundle.min.mjs"
+    fi
     package_version="$(node -e 'process.stdout.write(require(process.argv[1]).version || "")' "$package_dir/package.json")"
     [[ "$package_version" == "$resolved_version" ]] \
       || die "npm resolved @reddb-io/red-skills-$plugin@$package_version, expected $resolved_version"
@@ -251,7 +267,9 @@ prepare_source() {
       package_dir="$tmp/node_modules/@reddb-io/red-skills-$plugin"
       bundle="$package_dir/dist/$plugin.bundle.min.mjs"
       cp -R "$package_dir" "$dest.tmp/plugins/$plugin"
-      cp "$bundle" "$dest.tmp/dist/$plugin.bundle.min.mjs"
+      if plugin_has_runtime "$plugin" "${runtime_plugins[@]}"; then
+        cp "$bundle" "$dest.tmp/dist/$plugin.bundle.min.mjs"
+      fi
     done
     mv "$dest.tmp" "$dest"
   else

--- a/scripts/test-install-release-assets.sh
+++ b/scripts/test-install-release-assets.sh
@@ -29,19 +29,27 @@ test -f "$root/dist/opencode-host.bundle.min.mjs"
 for plugin in dev memory brain internal; do
   test -f "$root/plugins/$plugin/package.json"
   test -f "$root/plugins/$plugin/skills/example/SKILL.md"
+done
+for plugin in dev memory brain; do
   test -f "$root/dist/$plugin.bundle.min.mjs"
 done
+test ! -e "$root/dist/internal.bundle.min.mjs"
 test ! -e "$root/apps"
 test ! -e "$root/packages"
 INSTALL_OPENCODE
 chmod +x "$core/scripts/install-opencode.sh"
 
+# `internal` is skills-only: its package ships no runtime bundle, and the
+# installer must materialise it without demanding one.
 for plugin in dev memory brain internal; do
   package="$packages/red-skills-$plugin"
-  mkdir -p "$package/skills/example" "$package/dist"
+  mkdir -p "$package/skills/example"
   printf '{"name":"@reddb-io/red-skills-%s","version":"9.9.9"}\n' "$plugin" >"$package/package.json"
   printf '# Example\n' >"$package/skills/example/SKILL.md"
-  printf '%s bundle\n' "$plugin" >"$package/dist/$plugin.bundle.min.mjs"
+  if [ "$plugin" != internal ]; then
+    mkdir -p "$package/dist"
+    printf '%s bundle\n' "$plugin" >"$package/dist/$plugin.bundle.min.mjs"
+  fi
 done
 
 # npm installs the local fixture packages into the same node_modules shape as
@@ -109,8 +117,11 @@ test -f "$version/.agents/plugins/marketplace.json"
 test -f "$version/dist/opencode-host.bundle.min.mjs"
 for plugin in dev memory brain internal; do
   test -f "$version/plugins/$plugin/skills/example/SKILL.md"
+done
+for plugin in dev memory brain; do
   test -f "$version/dist/$plugin.bundle.min.mjs"
 done
+test ! -e "$version/dist/internal.bundle.min.mjs"
 test ! -e "$version/apps"
 test ! -e "$version/packages"
 test -f "$tmp/install/current/plugins/dev/skills/example/SKILL.md"

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -181,13 +181,19 @@ cp packaging/npm/package.json "$core_tree/package.json"
 tar -czf "$contract_fixture/core.tgz" -C "$contract_fixture/core-tree" package
 
 first_plugin=""
+skills_only_plugin=""
 while IFS= read -r plugin_json; do
   plugin="$(node -p "require('./${plugin_json}').name")"
   [ -n "$first_plugin" ] || first_plugin="$plugin"
   plugin_tree="$contract_fixture/plugin-$plugin/package"
   mkdir -p "$plugin_tree/skills/core/example" "$plugin_tree/dist"
   : > "$plugin_tree/skills/core/example/SKILL.md"
-  : > "$plugin_tree/dist/$plugin.bundle.min.mjs"
+  # Only a plugin with a runtime app carries a bundle; `internal` is skills-only.
+  if [ -f "apps/$plugin/package.json" ]; then
+    : > "$plugin_tree/dist/$plugin.bundle.min.mjs"
+  else
+    skills_only_plugin="$plugin"
+  fi
   if [ "$plugin" = "memory" ]; then
     : > "$plugin_tree/dist/memory-tokenizer.asset.cjs"
   fi
@@ -236,6 +242,27 @@ fi
 plugin_tree="$contract_fixture/plugin-$first_plugin/package"
 tar -czf "$plugin_tarballs/reddb-io-red-skills-$first_plugin-9.9.9.tgz" \
   -C "$contract_fixture/plugin-$first_plugin" package
+
+# A skills-only plugin (no apps/<name>) ships no runtime bundle: demanding one
+# refused the v3.19.1 publish, and a stray bundle riding it is refused too.
+[ -n "$skills_only_plugin" ] || fail "fixture expects at least one skills-only plugin (internal)"
+[ "$first_plugin" != "$skills_only_plugin" ] || fail "missing-bundle mutation must target a runtime plugin"
+stray_bundle_tree="$contract_fixture/stray-bundle/package"
+mkdir -p "$stray_bundle_tree/skills/core/example" "$stray_bundle_tree/dist"
+: > "$stray_bundle_tree/skills/core/example/SKILL.md"
+: > "$stray_bundle_tree/dist/$skills_only_plugin.bundle.min.mjs"
+tar -czf "$plugin_tarballs/reddb-io-red-skills-$skills_only_plugin-9.9.9.tgz" \
+  -C "$contract_fixture/stray-bundle" package
+if node scripts/check-npm-tarball-boundaries.mjs \
+  --root "$ROOT" \
+  --core "$contract_fixture/core.tgz" \
+  --plugins "$plugin_tarballs" >/dev/null 2>&1; then
+  fail "skills-only plugin tarball carrying a runtime bundle must fail the publish contract"
+else
+  pass "skills-only plugin tarball carrying a runtime bundle fails the publish contract"
+fi
+tar -czf "$plugin_tarballs/reddb-io-red-skills-$skills_only_plugin-9.9.9.tgz" \
+  -C "$contract_fixture/plugin-$skills_only_plugin" package
 
 bad_core_tree="$contract_fixture/bad-core/package"
 mkdir -p "$contract_fixture/bad-core"


### PR DESCRIPTION
## Why

The dispatched `red-publish` for `v3.19.1` (run 32096427365) passed sign/verify (#3985) and the release-engine bundle (#3987) and then died in the pack step:

```
@reddb-io/red-skills-internal tarball missing package/dist/internal.bundle.min.mjs
```

`internal` is a skills-only plugin — there is no `apps/internal`, nothing builds a bundle for it — but `check-npm-tarball-boundaries.mjs` (#3957) demanded `dist/<plugin>.bundle.min.mjs` for every plugin manifest, and `scripts/install.sh` (#3945) demanded the same when materialising, so even a published 3.19.1 would have been refused by the installer.

## What

- `check-npm-tarball-boundaries.mjs`: a plugin carries its bundle **iff** `apps/<name>/package.json` exists; a skills-only package carrying a stray bundle is refused too.
- `install.sh`: require/copy the bundle only for runtime plugins (`dev`, `memory`, `brain`); `internal` materialises as skills.
- Tests: `test-install-release-assets.sh` fixture ships `internal` without a bundle and asserts none is materialised; `test-red-release-npm-publish-contract.sh` fixture derives bundles from `apps/<name>` and adds the stray-bundle mutation.

Verified locally by emulating the publish pack step end to end (root `pnpm bundle` + `bundle:mcp`, `pi:packages:build`, per-plugin pack, `prepare.mjs`, core pack, boundary check, packaged `redskilled-mcp --help`, rsp and release bins): green.

## After merge

`gh workflow run red-publish.yml -f tag=v3.19.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789617067&installation_model_id=20659&pr_number=3988&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3988&signature=d5e94296876b3555e059effa2fb9406f8129035b49af8ae8540f9b33d7d7d156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->