### PR TITLE
chore: changeset for the skills-only plugin fix (3.19.2)

### DIFF
--- a/.changeset/skills-only-plugin-ships-no-bundle.md
+++ b/.changeset/skills-only-plugin-ships-no-bundle.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Publish and install again: a skills-only plugin (`internal`) ships no runtime bundle, so the release's tarball boundary check and the installer stop demanding one — the v3.19.1 publish died on that check, and the fix lives in the tagged tree.


### PR DESCRIPTION
`red-publish` checks out the **tagged** tree, so the #3988 fix (`check-npm-tarball-boundaries.mjs`, `install.sh`) never reaches the `v3.19.1` publish — run 32097141636 fails identically. This changeset cuts 3.19.2, whose tree carries every fix (#3985, #3987, #3988).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789617652&installation_model_id=20659&pr_number=3989&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3989&signature=a28c8d8a3e0c2e1678473f028c472fb1b3cd7d28df0a141a4e706adeff3e52f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->