### PR TITLE
fix(opencode-host): resolve MCP launchers against the generating tree first

### DIFF
--- a/.changeset/opencode-mcp-plugin-root-first.md
+++ b/.changeset/opencode-mcp-plugin-root-first.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+OpenCode/RedCode MCP entries (navigator, redskilled, rsp) now resolve against the tree the install generates from — the materialised package set or the checkout — instead of a Codex marketplace cache that happened to exist; the rsp launcher chain names the package set's `bin/rsp.mjs`.

--- a/apps/opencode-host/src/mcp-passthrough.ts
+++ b/apps/opencode-host/src/mcp-passthrough.ts
@@ -97,18 +97,22 @@ export function resolveScriptPath(
   const candidates = [
     join(pluginsRoot, plugin, relativeScriptPath),
     join(pluginsRoot, plugin, "hooks", relativeScriptPath.split("/").pop() ?? ""),
+    // The tree that owns `plugins/` (a checkout or the installer's
+    // materialised package set): `$root/dist/rsp.bundle.min.mjs` in the
+    // source chain names a repo-root bundle, not a plugin-root one.
+    join(pluginsRoot, "..", relativeScriptPath),
     join(pluginsRoot, "..", "..", ".codex", ".tmp", "marketplaces", "red-skills", "plugins", plugin, relativeScriptPath),
     join(homedir(), ".codex", "plugins", "cache", "red-skills", plugin, relativeScriptPath),
   ];
   // The .codex cache path is `<cache>/<plugin>/*/<relativeScriptPath>`;
   // walk one level deep into the cache dir and pick the first hit.
-  for (const c of candidates.slice(0, 2)) {
+  for (const c of candidates.slice(0, 3)) {
     if (existsSync(c)) return { path: c, candidate: c };
   }
-  // Codexa cache: glob one level (best-effort; not as robust as the
+  // Codex cache: glob one level (best-effort; not as robust as the
   // source's shell glob, but the dev checkout path is the common
   // case and the build-time check is a warning, not a fail-closed).
-  for (const c of candidates.slice(2)) {
+  for (const c of candidates.slice(3)) {
     if (existsSync(c)) return { path: c, candidate: c };
   }
   return { path: null, candidate: candidates[0] ?? null };
@@ -212,16 +216,20 @@ function rewriteShC(
     }
   }
 
-  let resolvedPath = resolveHomeScriptPath(body);
-  if (!resolvedPath) {
-    for (const rel of candidates) {
-      const { path } = resolveScriptPath(pluginsRoot, plugin, rel);
-      if (path) {
-        resolvedPath = path;
-        break;
-      }
+  // The tree being generated FROM wins. The explicit `$HOME/...` launchers
+  // in the source chain are fallbacks for hosts that never materialised a
+  // tree; consulting them first baked a Codex marketplace cache path into
+  // every OpenCode install that happened to have one, and the MCP died the
+  // day that cache was cleaned.
+  let resolvedPath: string | null = null;
+  for (const rel of candidates) {
+    const { path } = resolveScriptPath(pluginsRoot, plugin, rel);
+    if (path) {
+      resolvedPath = path;
+      break;
     }
   }
+  if (!resolvedPath) resolvedPath = resolveHomeScriptPath(body);
 
   if (!resolvedPath) {
     warnings.push(

--- a/apps/opencode-host/tests/mcp-passthrough.test.ts
+++ b/apps/opencode-host/tests/mcp-passthrough.test.ts
@@ -68,18 +68,18 @@ describe("resolveScriptPath (Slice 3 search order)", () => {
 
 describe("resolveHomeScriptPath", () => {
   it("resolves a launcher installed under the user's home", () => {
-    writeFile("home/.red-skills/current/packaging/npm/bin/rsp.mjs", "console.log(1)");
+    writeFile("home/.red-skills/current/bin/rsp.mjs", "console.log(1)");
     const body =
-      'if [ -f "$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs" ]; then exec node "$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs" mcp; fi';
+      'if [ -f "$HOME/.red-skills/current/bin/rsp.mjs" ]; then exec node "$HOME/.red-skills/current/bin/rsp.mjs" mcp; fi';
 
     expect(resolveHomeScriptPath(body, join(root, "home"))).toBe(
-      join(root, "home/.red-skills/current/packaging/npm/bin/rsp.mjs"),
+      join(root, "home/.red-skills/current/bin/rsp.mjs"),
     );
   });
 
   it("keeps the mcp argument before a shell command separator", () => {
-    writeFile("home/.red-skills/current/packaging/npm/bin/rsp.mjs", "console.log(1)");
-    const launcher = join(root, "home/.red-skills/current/packaging/npm/bin/rsp.mjs");
+    writeFile("home/.red-skills/current/bin/rsp.mjs", "console.log(1)");
+    const launcher = join(root, "home/.red-skills/current/bin/rsp.mjs");
     const previousHome = process.env.HOME;
     process.env.HOME = join(root, "home");
     try {
@@ -87,11 +87,59 @@ describe("resolveHomeScriptPath", () => {
         command: "sh",
         args: [
           "-c",
-          'if [ -f "$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs" ]; then exec node "$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs" mcp; fi',
+          'if [ -f "$HOME/.red-skills/current/bin/rsp.mjs" ]; then exec node "$HOME/.red-skills/current/bin/rsp.mjs" mcp; fi',
         ],
       });
       expect(warnings).toEqual([]);
       expect(entry.command).toEqual(["node", launcher, "mcp"]);
+    } finally {
+      process.env.HOME = previousHome;
+    }
+  });
+});
+
+describe("rewriteServer prefers the tree it generates from", () => {
+  it("resolves against the plugin root before an explicit $HOME launcher elsewhere", () => {
+    // Both exist: the plugin's own launcher and a stale Codex marketplace
+    // cache the source chain names as a last resort. The emitted command must
+    // point at the plugin root — the cache is the fallback, not the answer.
+    writeFile("dev/hooks/redskilled-mcp.sh", "echo hi");
+    writeFile("home/.codex/.tmp/marketplaces/red-skills/plugins/dev/hooks/redskilled-mcp.sh", "echo stale");
+    const previousHome = process.env.HOME;
+    process.env.HOME = join(root, "home");
+    try {
+      const { entry, warnings } = rewriteServer(root, "dev", "redskilled", {
+        command: "sh",
+        args: [
+          "-c",
+          'root="${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}"; for launcher in "$root/hooks/redskilled-mcp.sh" "$HOME/.codex/.tmp/marketplaces/red-skills/plugins/dev/hooks/redskilled-mcp.sh"; do if [ -f "$launcher" ]; then exec bash "$launcher"; fi; done; exit 1',
+        ],
+      });
+      expect(warnings).toEqual([]);
+      expect(entry.command).toEqual(["bash", join(root, "dev/hooks/redskilled-mcp.sh")]);
+    } finally {
+      process.env.HOME = previousHome;
+    }
+  });
+
+  it("resolves a repo-root bundle ($root/dist/…) against the tree that owns plugins/", () => {
+    // In the materialised package set the rsp bundle sits beside plugins/, not
+    // inside the dev plugin; the plugin-root candidate misses and the tree
+    // root must be tried before any $HOME or Codex-cache fallback.
+    writeFile("tree/dist/rsp.bundle.min.mjs", "console.log(1)");
+    writeFile("tree/plugins/dev/.mcp.json", "{}");
+    const previousHome = process.env.HOME;
+    process.env.HOME = join(root, "home");
+    try {
+      const { entry, warnings } = rewriteServer(join(root, "tree/plugins"), "dev", "rsp", {
+        command: "sh",
+        args: [
+          "-c",
+          'root="${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}"; for bundle in "$PWD/dist/rsp.bundle.min.mjs" "$root/dist/rsp.bundle.min.mjs" "$HOME/.red-skills/current/bin/rsp.mjs"; do if [ -f "$bundle" ]; then exec node "$bundle" mcp; fi; done; exit 1',
+        ],
+      });
+      expect(warnings).toEqual([]);
+      expect(entry.command).toEqual(["node", join(root, "tree/dist/rsp.bundle.min.mjs"), "mcp"]);
     } finally {
       process.env.HOME = previousHome;
     }
@@ -188,7 +236,7 @@ describe("planPluginMcp against the real source tree", () => {
   it("keeps the installed RedSkills rsp launcher in the runtime fallback chain", () => {
     const raw = readMcpJson(REAL_PLUGINS, "dev")!;
     const body = raw.mcpServers!.rsp!.args![1]!;
-    expect(body).toContain('$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs');
+    expect(body).toContain('$HOME/.red-skills/current/bin/rsp.mjs');
   });
 
   it("plans the memory plugin's red-memory and red-ui MCPs", () => {

--- a/packaging/pi/dev/.mcp.json
+++ b/packaging/pi/dev/.mcp.json
@@ -18,7 +18,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if command -v rsp >/dev/null 2>&1; then exec rsp mcp; fi; for bundle in \"$PWD/dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\" \"$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs\" \"$HOME/.codex/.tmp/marketplaces/red-skills/packaging/npm/bin/rsp.mjs\"; do if [ -f \"$bundle\" ]; then exec node \"$bundle\" mcp; fi; done; printf 'rsp: could not locate rsp MCP launcher\\n' >&2; exit 1"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if command -v rsp >/dev/null 2>&1; then exec rsp mcp; fi; for bundle in \"$PWD/dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\" \"$HOME/.red-skills/current/bin/rsp.mjs\" \"$HOME/.codex/.tmp/marketplaces/red-skills/packaging/npm/bin/rsp.mjs\"; do if [ -f \"$bundle\" ]; then exec node \"$bundle\" mcp; fi; done; printf 'rsp: could not locate rsp MCP launcher\\n' >&2; exit 1"
       ]
     }
   }

--- a/plugins/dev/.mcp.json
+++ b/plugins/dev/.mcp.json
@@ -18,7 +18,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if command -v rsp >/dev/null 2>&1; then exec rsp mcp; fi; for bundle in \"$PWD/dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\" \"$HOME/.red-skills/current/packaging/npm/bin/rsp.mjs\" \"$HOME/.codex/.tmp/marketplaces/red-skills/packaging/npm/bin/rsp.mjs\"; do if [ -f \"$bundle\" ]; then exec node \"$bundle\" mcp; fi; done; printf 'rsp: could not locate rsp MCP launcher\\n' >&2; exit 1"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if command -v rsp >/dev/null 2>&1; then exec rsp mcp; fi; for bundle in \"$PWD/dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\" \"$HOME/.red-skills/current/bin/rsp.mjs\" \"$HOME/.codex/.tmp/marketplaces/red-skills/packaging/npm/bin/rsp.mjs\"; do if [ -f \"$bundle\" ]; then exec node \"$bundle\" mcp; fi; done; printf 'rsp: could not locate rsp MCP launcher\\n' >&2; exit 1"
       ]
     }
   }


### PR DESCRIPTION
## Why

Item 2a of the install follow-ups. `~/.config/opencode/opencode.jsonc` carried `navigator`, `redskilled` and `rsp` pointing at `~/.codex/.tmp/marketplaces/red-skills/...`: `rewriteServer` tried the source chain's explicit `$HOME/...` launchers before the plugin root, so a Codex cache that happened to exist won over the tree the install was generating from. Clean that cache and three MCPs die in OpenCode/RedCode.

## What

- `mcp-passthrough.ts`: plugin-root candidates first (plugin dir → plugin `hooks/` → the tree that owns `plugins/`, for repo-root bundles like `$root/dist/rsp.bundle.min.mjs`), then `$HOME` launchers, then the Codex caches. Two tests pin it (stale cache present + plugin root present → plugin root; repo-root bundle resolves through the owning tree).
- `plugins/dev/.mcp.json` (+ pi mirror): the rsp chain names the package set's `bin/rsp.mjs` instead of the retired `packaging/npm/bin/rsp.mjs`.
- Changeset (patch).

Against the live materialised 3.19.3 tree the generator now emits all six MCPs under `~/.red-skills/current/…` (`plugins/dev/hooks/code-nav-mcp.sh`, `…/redskilled-mcp.sh`, `dist/rsp.bundle.min.mjs`, memory/brain `scripts/bootstrap.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789647224&installation_model_id=20659&pr_number=3996&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3996&signature=4e2ea9c350e85d727101353e27a557fa3126e737fb1d7c9f88cbbe0ebb19b3a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->