### PR TITLE
fix(opencode-host): disambiguate skill names claimed by more than one plugin

### DIFF
--- a/.changeset/opencode-skill-name-collisions.md
+++ b/.changeset/opencode-skill-name-collisions.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+OpenCode/RedCode: a skill name claimed by more than one plugin (`memory:view` and `brain:view`) is installed as `<plugin>-<name>` for every claimant instead of the later plugin silently overwriting the earlier one.

--- a/apps/opencode-host/src/emit.ts
+++ b/apps/opencode-host/src/emit.ts
@@ -11,11 +11,12 @@
  * All file IO is concentrated here so the planner modules stay pure
  * and the CLI is a thin caller.
  */
-import { mkdirSync, symlinkSync, writeFileSync, copyFileSync } from "node:fs";
+import { mkdirSync, symlinkSync, writeFileSync, copyFileSync, readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { buildProviderBlock, type OpencodeConfig } from "./provider-block.js";
 import {
   planAllSkills,
+  renameSkillFrontmatter,
   type PlanResult,
 } from "./skills-to-opencode.js";
 import { planPluginHooks, type HookPlan } from "./hooks-to-events.js";
@@ -105,7 +106,11 @@ export function writeEmit(plan: EmitPlan, options: EmitOptions): void {
     for (const sp of skills.plans) {
       const target = join(pluginRoot, ".opencode", sp.target);
       mkdirSync(dirname(target), { recursive: true });
-      if (options.copySkills) {
+      if (sp.renamedFrom) {
+        // A collision-renamed skill cannot be a symlink: opencode reads the
+        // name from the frontmatter, so the copy carries the new one.
+        writeFileSync(target, renameSkillFrontmatter(readFileSync(sp.source, "utf8"), sp.name), "utf8");
+      } else if (options.copySkills) {
         copyFileSync(sp.source, target);
       } else {
         const rel = relative(dirname(target), sp.source);

--- a/apps/opencode-host/src/skills-to-opencode.ts
+++ b/apps/opencode-host/src/skills-to-opencode.ts
@@ -27,6 +27,11 @@ export interface SkillPlan {
   name: string;
   /** The bucket the source came from (`engineering`, `knowledge`, …). */
   bucket: string;
+  /** Set when the flat name collided with another plugin's skill and the
+   *  plan was disambiguated to `<plugin>-<name>`: the source's frontmatter
+   *  `name:` (the original) must be rewritten in the emitted copy, because
+   *  opencode keys skills by frontmatter name, not by directory. */
+  renamedFrom?: string;
 }
 
 /** A validation error from the planner. */
@@ -243,5 +248,45 @@ export function planAllSkills(
   pluginsRoot: string,
   plugins: string[],
 ): { plugin: string; result: PlanResult }[] {
-  return plugins.map((plugin) => ({ plugin, result: planPluginSkills(pluginsRoot, plugin) }));
+  const planned = plugins.map((plugin) => ({ plugin, result: planPluginSkills(pluginsRoot, plugin) }));
+  disambiguateCollisions(planned);
+  return planned;
+}
+
+/**
+ * OpenCode's skill namespace is flat: Claude's `memory:view` and `brain:view`
+ * would both land as `view`, and the later one silently overwrote the earlier
+ * (the global installer only logged a "duplicate skipped" note). Every skill
+ * whose flat name is claimed by more than one plugin is renamed
+ * `<plugin>-<name>` — all parties, not just the loser, so the result does not
+ * depend on plugin order — and marked `renamedFrom` so the emitter rewrites
+ * the frontmatter name in a copy. Names claimed once are untouched.
+ */
+export function disambiguateCollisions(planned: { plugin: string; result: PlanResult }[]): void {
+  const claimants = new Map<string, Set<string>>();
+  for (const { plugin, result } of planned) {
+    for (const plan of result.plans) {
+      if (!claimants.has(plan.name)) claimants.set(plan.name, new Set());
+      claimants.get(plan.name)!.add(plugin);
+    }
+  }
+  for (const { plugin, result } of planned) {
+    for (const plan of result.plans) {
+      if ((claimants.get(plan.name)?.size ?? 0) < 2) continue;
+      const renamed = `${plugin}-${plan.name}`;
+      plan.renamedFrom = plan.name;
+      plan.name = renamed;
+      plan.target = `skills/${renamed}/SKILL.md`;
+    }
+    result.plans.sort((a, b) => a.target.localeCompare(b.target));
+  }
+}
+
+/** Rewrite the frontmatter `name:` of a source SKILL.md for a renamed plan. */
+export function renameSkillFrontmatter(text: string, renamed: string): string {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return text;
+  const block = match[1]!;
+  const rewritten = block.replace(/^name:.*$/m, `name: ${renamed}`);
+  return text.replace(block, rewritten);
 }

--- a/apps/opencode-host/tests/skills-to-opencode.test.ts
+++ b/apps/opencode-host/tests/skills-to-opencode.test.ts
@@ -9,8 +9,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   listSkillFiles,
   parseFrontmatter,
+  planAllSkills,
   planPluginSkills,
   planSkill,
+  renameSkillFrontmatter,
   skillRelativeParts,
 } from "../src/skills-to-opencode.js";
 
@@ -154,5 +156,44 @@ describe("planPluginSkills", () => {
     expect(result.plans.map((p) => p.name).sort()).toEqual(["afk", "ship"]);
     expect(result.errors.length).toBe(1);
     expect(result.errors[0]!.code).toBe("name-not-valid");
+  });
+});
+
+describe("planAllSkills (flat-namespace collisions across plugins)", () => {
+  function writePluginSkill(plugin: string, name: string, body: string, bucket = "core"): void {
+    const dir = join(root, plugin, "skills", bucket, name);
+    require("node:fs").mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "SKILL.md"), body, "utf8");
+  }
+
+  it("renames every claimant of a shared name to <plugin>-<name> and leaves unique names alone", () => {
+    writePluginSkill("memory", "view", "---\nname: view\ndescription: Open the Memory graph.\n---\n");
+    writePluginSkill("brain", "view", "---\nname: view\ndescription: Open the Brain graph.\n---\n");
+    writePluginSkill("memory", "store", "---\nname: store\ndescription: Save a fact.\n---\n");
+    const planned = planAllSkills(root, ["memory", "brain"]);
+    const memory = planned.find((p) => p.plugin === "memory")!.result.plans;
+    const brain = planned.find((p) => p.plugin === "brain")!.result.plans;
+    expect(memory.map((p) => p.name).sort()).toEqual(["memory-view", "store"]);
+    expect(brain.map((p) => p.name)).toEqual(["brain-view"]);
+    const memoryView = memory.find((p) => p.name === "memory-view")!;
+    expect(memoryView.target).toBe("skills/memory-view/SKILL.md");
+    expect(memoryView.renamedFrom).toBe("view");
+    expect(memory.find((p) => p.name === "store")!.renamedFrom).toBeUndefined();
+  });
+
+  it("does not depend on plugin order", () => {
+    writePluginSkill("memory", "view", "---\nname: view\ndescription: a\n---\n");
+    writePluginSkill("brain", "view", "---\nname: view\ndescription: b\n---\n");
+    const forward = planAllSkills(root, ["memory", "brain"]).flatMap((p) => p.result.plans.map((s) => s.name)).sort();
+    const backward = planAllSkills(root, ["brain", "memory"]).flatMap((p) => p.result.plans.map((s) => s.name)).sort();
+    expect(forward).toEqual(["brain-view", "memory-view"]);
+    expect(backward).toEqual(forward);
+  });
+
+  it("rewrites only the frontmatter name in the emitted copy", () => {
+    const text = "---\nname: view\ndescription: Open the graph named view.\n---\n\n# view\n\nRun `/view`.\n";
+    expect(renameSkillFrontmatter(text, "brain-view")).toBe(
+      "---\nname: brain-view\ndescription: Open the graph named view.\n---\n\n# view\n\nRun `/view`.\n",
+    );
   });
 });


### PR DESCRIPTION
## Why

Item 2b of the install follow-ups. OpenCode/RedCode have a flat skill namespace; `memory:view` and `brain:view` both land as `view`, and the later plugin silently overwrote the earlier — the global installer only logged `(note) duplicate skill view from brain skipped`. Today `view` is the only collision, but nothing prevented the next one.

## What

- `skills-to-opencode.ts`: `planAllSkills` renames **every** claimant of a shared flat name to `<plugin>-<name>` (all parties, so plugin order does not decide who keeps the bare name), marks `renamedFrom`, and leaves names claimed once untouched. `renameSkillFrontmatter` rewrites only the frontmatter `name:`.
- `emit.ts`: a renamed plan is written as a copy with the new frontmatter name (opencode keys skills by frontmatter, so a symlink would still register as `view`).
- Tests: rename + untouched, order-independence, frontmatter-only rewrite.
- Changeset (patch).

Against the live materialised 3.19.3 tree: `brain/.opencode/skills/brain-view/SKILL.md` (`name: brain-view`) and `memory/.opencode/skills/memory-view/SKILL.md` (`name: memory-view`); 69 skills, 0 warnings.

Note: `install-opencode.sh`'s duplicate guard stays as a safety net; after this change it should never fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789647368&installation_model_id=20659&pr_number=3997&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3997&signature=a19b1fe62ab42c3154e762bbe42068edc2f844676d1c420306e4d4032e587eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->