### PR TITLE
docs: install one-liner rides v3; say what the red-release environment gates

### DIFF
--- a/.changeset/install-one-liner-rides-v3.md
+++ b/.changeset/install-one-liner-rides-v3.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Docs: the install one-liner in `docs/INSTALL.md` and the opencode-host README rides the `v3` major ref like the root README.

--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -51,9 +51,11 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Repository settings protect the red-release environment with required
-    # reviewers. Approval happens before this job can build, publish assets, or
-    # move the matching major tag.
+    # The job runs in the red-release environment so repository settings CAN
+    # gate it with required reviewers; this file does not enforce that, and as
+    # of 2026-08-18 the environment carries no protection rules — merging the
+    # Version PR publishes to npm without a further approval. Whoever wants a
+    # human gate configures it on the environment, not here.
     environment:
       name: red-release
     steps:

--- a/apps/opencode-host/README.md
+++ b/apps/opencode-host/README.md
@@ -76,7 +76,7 @@ latest RedSkills release, detects `opencode` and `redcode` alongside Claude Code
 and Codex, and invokes the adapter for every host present:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v3/scripts/install.sh | bash
 ```
 
 That path installs OpenCode under `~/.config/opencode/`, RedCode under

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -48,7 +48,7 @@ is enough:
 
 ```bash
 # re-run the one-liner: it detects the Directory source and re-registers it
-curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v3/scripts/install.sh | bash
 
 # or repoint by hand
 claude plugin marketplace remove red-skills


### PR DESCRIPTION
Items 2c and 3 of the install follow-ups.

- `docs/INSTALL.md`, `apps/opencode-host/README.md`: the curl one-liner pointed at the `v1` major ref; the root README already says `v3`.
- `red-publish.yml`: the comment claimed required reviewers protect the `red-release` environment. `gh api repos/reddb-io/red-skills/environments/red-release` → `protection_rules: []`, so merging the Version PR publishes to npm directly (which is how 3.19.1–3.19.3 shipped tonight). The comment now says exactly that and where a human gate belongs if one is wanted — a repository setting, not this file. Configuring the gate itself is a maintainer decision I did not take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/3998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789647539&installation_model_id=20659&pr_number=3998&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F3998&signature=254d6e6b9864ccb298d2f114d9e96ae8a4c0e45d0a5975302c03c14b5c1a0d90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->