### PR TITLE
fix(install-opencode): prune stale entries of the previous manifest on re-install

### DIFF
--- a/.changeset/install-opencode-prunes-stale-manifest.md
+++ b/.changeset/install-opencode-prunes-stale-manifest.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+OpenCode/RedCode re-install prunes what the previous install recorded and this one no longer produces (a renamed or removed skill, a hook module that stopped shipping) instead of leaving it loaded beside its successor.

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -159,8 +159,37 @@ record_manifest() {
   printf '%s\n' "$path" >> "$MANIFEST_TMP"
 }
 
+# A re-install replaces the manifest wholesale, so anything the PREVIOUS
+# install recorded and this one did not reproduce — a skill renamed or
+# removed upstream, a hook module that stopped shipping — would linger on the
+# host forever, still loaded next to its successor (a stale `view` beside
+# `memory-view`, 3.19.4). Prune those entries before the new manifest lands;
+# only paths under the manifest's own root are ever touched.
+prune_stale_manifest_paths() {
+  previous="$1"
+  next="$2"
+  allowed_root="$(dirname "$previous")"
+  [ -f "$previous" ] || return 0
+  while IFS= read -r path || [ -n "$path" ]; do
+    case "$path" in
+      ""|\#*) continue ;;
+    esac
+    grep -qxF -- "$path" "$next" && continue
+    case "$path" in
+      "$allowed_root"/*)
+        if [ -e "$path" ] || [ -L "$path" ]; then
+          run_rm "$path"
+          log "pruned stale $path (recorded by the previous install, not produced by this one)"
+        fi
+        ;;
+      *) log "(note) skipped stale manifest path outside $allowed_root: $path" ;;
+    esac
+  done < "$previous"
+}
+
 finish_manifest() {
   [ -n "$MANIFEST_TMP" ] || return 0
+  prune_stale_manifest_paths "$MANIFEST_FILE" "$MANIFEST_TMP"
   mv "$MANIFEST_TMP" "$MANIFEST_FILE"
   log "wrote uninstall manifest $MANIFEST_FILE"
 }

--- a/scripts/test-install-redcode-host.sh
+++ b/scripts/test-install-redcode-host.sh
@@ -45,6 +45,21 @@ HOME="$HOME_DIR" XDG_CONFIG_HOME="$XDG_DIR" \
   "$FIXTURE/scripts/install-opencode.sh" --global --host opencode >/dev/null
 test -f "$XDG_DIR/opencode/plugins/redskills-dev-example.ts"
 
+# A re-install prunes what the previous install recorded and this one no
+# longer produces (a skill renamed upstream), and leaves user files alone.
+mv "$FIXTURE/dist/opencode/dev/.opencode/skills/example" "$FIXTURE/dist/opencode/dev/.opencode/skills/renamed"
+mkdir -p "$XDG_DIR/redcode/skills/mine"
+printf '# Mine
+' > "$XDG_DIR/redcode/skills/mine/SKILL.md"
+HOME="$HOME_DIR" XDG_CONFIG_HOME="$XDG_DIR" \
+  "$FIXTURE/scripts/install-opencode.sh" --global --host redcode >/dev/null
+test -f "$XDG_DIR/redcode/skills/renamed/SKILL.md"
+test ! -e "$XDG_DIR/redcode/skills/example"
+test -f "$XDG_DIR/redcode/skills/mine/SKILL.md"
+grep -qxF "$XDG_DIR/redcode/skills/renamed" "$XDG_DIR/redcode/redskills-install-manifest.txt"
+! grep -qxF "$XDG_DIR/redcode/skills/example" "$XDG_DIR/redcode/redskills-install-manifest.txt"
+mv "$FIXTURE/dist/opencode/dev/.opencode/skills/renamed" "$FIXTURE/dist/opencode/dev/.opencode/skills/example"
+
 HOME="$HOME_DIR" XDG_CONFIG_HOME="$XDG_DIR" \
   "$FIXTURE/scripts/install-opencode.sh" --uninstall --global --host redcode >/dev/null
 test ! -e "$XDG_DIR/redcode/plugins/redskills-dev-example.ts"


### PR DESCRIPTION
Found while verifying 3.19.4 on the real hosts: `memory-view`/`brain-view` landed, but the pre-rename `skills/view` from 3.19.3 stayed on disk — a re-install wrote a fresh manifest and never looked at the previous one, so anything renamed or removed upstream lingered forever, still loaded beside its successor.

- `install-opencode.sh`: `finish_manifest` prunes every path the previous manifest recorded that the new install did not, restricted to the manifest's own root (`$XDG_CONFIG_HOME/<host>` or the project `.opencode/`); user files untouched.
- `test-install-redcode-host.sh`: re-install after an upstream rename removes the old skill, keeps the new one and a user's own skill, and the manifest reflects it.
- Changeset (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789648483&installation_model_id=20659&pr_number=4000&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4000&signature=a9fa85393f104e0836e1165d9c0d4eb688d76cac9cbcfa92065e33f7f357094d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->