### PR TITLE
fix: #3972 Redcode host uses native LSP instead of a second navigator stack

### DIFF
--- a/apps/code-nav/README.md
+++ b/apps/code-nav/README.md
@@ -49,8 +49,26 @@ defaults):
 CODE_NAV_SERVERS='{"clangd":{"command":"clangd","args":[],"extensions":[".c",".cpp",".h"],"languageId":"cpp"}}'
 ```
 
-`CODE_NAV_ROOT` sets the workspace root (defaults to the process cwd, which Claude
-Code sets to the project directory).
+## Workspace root
+
+The root the language servers index follows the **opened project**, not the
+plugin the launcher lives in. Precedence:
+
+1. `CODE_NAV_ROOT` — the operator's own word, obeyed as written.
+2. The project the host announces: `RED_SKILLS_PROJECT_ROOT`,
+   `CLAUDE_PROJECT_DIR`, `CODEX_PROJECT_DIR`, `OPENCODE_PROJECT_DIR`.
+3. The process cwd.
+
+A candidate that is recognisably a plugin installation — it carries a plugin
+manifest, sits in a host's plugin cache, or is the plugin root the host itself
+announced — is skipped at steps 2 and 3. The navigator is launched from a script
+inside the installed plugin, so an unguarded cwd indexed the plugin instead of
+the repository and every lookup answered "not found" as if a language server
+were missing. When the plugin directory is genuinely all that is left, the root
+is used anyway and the ready line on stderr says so, naming `CODE_NAV_ROOT` as
+the fix.
+
+The ready line carries both: `navigator MCP ready (root=…, root-source=…, languages=…)`.
 
 ## Build
 

--- a/apps/code-nav/src/cli-args.ts
+++ b/apps/code-nav/src/cli-args.ts
@@ -111,7 +111,11 @@ Options:
   -h, --help       show this help
 
 Environment:
-  CODE_NAV_ROOT     workspace root the language servers index (default: cwd)
+  CODE_NAV_ROOT     workspace root the language servers index. Absent, the root
+                    follows the project the host announces (RED_SKILLS_PROJECT_ROOT,
+                    CLAUDE_PROJECT_DIR, CODEX_PROJECT_DIR, OPENCODE_PROJECT_DIR),
+                    then the cwd. A plugin installation directory is never the
+                    root unless nothing else is available.
   CODE_NAV_SERVERS  JSON registry overriding the default language servers, e.g.
                     '{"go":{"command":"gopls","args":[],"extensions":[".go"],"languageId":"go"}}'
 

--- a/apps/code-nav/src/index.ts
+++ b/apps/code-nav/src/index.ts
@@ -29,6 +29,7 @@ import {
   type ServerSpec,
 } from "./config.js";
 import { LspSession, uriToRelative } from "./lsp.js";
+import { resolveWorkspaceRoot } from "./workspace-root.js";
 
 const posShape = {
   file: z.string().describe("Workspace-relative path to the source file."),
@@ -39,6 +40,10 @@ const posShape = {
 interface Navigator {
   server: McpServer;
   root: string;
+  /** Where the root came from; `cwd` means nothing announced a project. */
+  rootSource: string;
+  /** Set when the root fell back to a plugin installation directory. */
+  rootWarning?: string;
   languages: string[];
   dispose: () => void;
 }
@@ -49,7 +54,9 @@ interface Navigator {
  * path — the registry is the first thing a version answer must not depend on.
  */
 function createNavigator(): Navigator {
-  const root = process.env.CODE_NAV_ROOT ?? process.cwd();
+  // The opened project, not the plugin the launcher happens to live in.
+  const resolution = resolveWorkspaceRoot();
+  const root = resolution.root;
   const servers = loadServers();
   const extIndex = buildExtensionIndex(servers);
 
@@ -209,6 +216,8 @@ function createNavigator(): Navigator {
   return {
     server,
     root,
+    rootSource: resolution.source,
+    ...(resolution.warning === undefined ? {} : { rootWarning: resolution.warning }),
     languages: Object.keys(servers),
     dispose: () => {
       for (const s of sessions.values()) s.dispose();
@@ -251,8 +260,11 @@ async function serve(): Promise<void> {
   }
   const transport = new StdioServerTransport();
   await navigator.server.connect(transport);
+  if (navigator.rootWarning !== undefined) {
+    process.stderr.write(`navigator: ${navigator.rootWarning}\n`);
+  }
   process.stderr.write(
-    `navigator MCP ready (root=${navigator.root}, languages=${navigator.languages.join(",")})\n`,
+    `navigator MCP ready (root=${navigator.root}, root-source=${navigator.rootSource}, languages=${navigator.languages.join(",")})\n`,
   );
 }
 

--- a/apps/code-nav/src/workspace-root.ts
+++ b/apps/code-nav/src/workspace-root.ts
@@ -1,0 +1,123 @@
+/**
+ * workspace-root.ts — which tree the language servers index.
+ *
+ * The navigator is launched BY a host, from a launcher script that lives in
+ * the plugin installation directory, and hosts differ on what the child's cwd
+ * ends up being: a marketplace cache, `~/.claude/plugins/...`, or the emitted
+ * opencode entry's baked `cwd: <plugins-root>`. Taking `process.cwd()` as the
+ * workspace root therefore indexed the PLUGIN — every `goto_definition` in the
+ * user's own repo answered "no definition found", and the failure looked like
+ * a missing language server rather than a wrong root.
+ *
+ * The root follows the OPENED PROJECT: the operator's explicit override first,
+ * then the project directory the host itself announces, and only then the cwd.
+ * A candidate that is recognisably a plugin installation is refused at every
+ * step, because a plugin tree is never the thing the user asked to navigate.
+ * When the cwd is all that is left AND it is the plugin, the resolution says so
+ * — a wrong root that announces itself is debuggable; a silent one is not.
+ */
+import { existsSync } from "node:fs";
+import { join, resolve, sep } from "node:path";
+
+/**
+ * Env vars that carry the opened project, in precedence order. Mirrors
+ * `resolveMcpProjectRoot` in apps/dev so one answer does not disagree with the
+ * other about which repo the agent is working in.
+ */
+export const PROJECT_ROOT_ENV_VARS = [
+  "CODE_NAV_ROOT",
+  "RED_SKILLS_PROJECT_ROOT",
+  "CLAUDE_PROJECT_DIR",
+  "CODEX_PROJECT_DIR",
+  "OPENCODE_PROJECT_DIR",
+] as const;
+
+/**
+ * Env vars that carry the PLUGIN installation, never the project. Read only to
+ * recognise a cwd that is the plugin — never as a root candidate.
+ */
+const PLUGIN_ROOT_ENV_VARS = ["CLAUDE_PLUGIN_ROOT", "CODEX_PLUGIN_ROOT"] as const;
+
+/** Manifest files that mark a directory as an installed plugin. */
+const PLUGIN_MANIFESTS = [
+  join(".claude-plugin", "plugin.json"),
+  join(".codex-plugin", "plugin.json"),
+  join(".gemini-plugin", "plugin.json"),
+];
+
+/** Path fragments of the well-known host plugin caches. */
+const PLUGIN_CACHE_FRAGMENTS = [
+  join(".claude", "plugins"),
+  join(".codex", "plugins"),
+  join(".codex", ".tmp", "marketplaces"),
+  join(".gemini", "plugins"),
+];
+
+function withinPluginCache(path: string): boolean {
+  const padded = `${path}${sep}`;
+  return PLUGIN_CACHE_FRAGMENTS.some((fragment) => padded.includes(`${sep}${fragment}${sep}`));
+}
+
+/**
+ * True when `path` is a plugin installation rather than a project: it carries a
+ * plugin manifest, sits inside a host's plugin cache, or IS the plugin root the
+ * host announced.
+ */
+export function isPluginInstallDir(
+  path: string,
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  const abs = resolve(path);
+  for (const key of PLUGIN_ROOT_ENV_VARS) {
+    const declared = (env[key] ?? "").trim();
+    if (declared !== "" && resolve(declared) === abs) return true;
+  }
+  if (withinPluginCache(abs)) return true;
+  return PLUGIN_MANIFESTS.some((manifest) => existsSync(join(abs, manifest)));
+}
+
+/** Where the workspace root came from, and whether it is trustworthy. */
+export interface WorkspaceRootResolution {
+  /** The absolute directory the language servers index. */
+  root: string;
+  /** The env var that supplied it, or `"cwd"` when nothing announced one. */
+  source: (typeof PROJECT_ROOT_ENV_VARS)[number] | "cwd";
+  /** Set when the only candidate left was a plugin installation. */
+  warning?: string;
+}
+
+/**
+ * Resolve the workspace root the language servers index.
+ *
+ * Precedence: an explicit project env var (first one set and usable), then the
+ * cwd. A plugin installation directory is skipped wherever it appears — except
+ * as the last resort, where returning the cwd at least keeps the server
+ * answering, with a warning naming the env var that would fix it.
+ */
+export function resolveWorkspaceRoot(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  cwd: string = process.cwd(),
+): WorkspaceRootResolution {
+  for (const key of PROJECT_ROOT_ENV_VARS) {
+    const declared = (env[key] ?? "").trim();
+    if (declared === "") continue;
+    const abs = resolve(declared);
+    // CODE_NAV_ROOT is the operator's own word and is obeyed as written; the
+    // host-announced vars are guessed on our behalf and get the plugin check.
+    if (key === "CODE_NAV_ROOT" || !isPluginInstallDir(abs, env)) {
+      return { root: abs, source: key };
+    }
+  }
+  const fallback = resolve(cwd);
+  if (isPluginInstallDir(fallback, env)) {
+    return {
+      root: fallback,
+      source: "cwd",
+      warning:
+        `workspace root fell back to the plugin installation at ${fallback} — ` +
+        `no project directory was announced. Set CODE_NAV_ROOT to the repository ` +
+        `you want indexed.`,
+    };
+  }
+  return { root: fallback, source: "cwd" };
+}

--- a/apps/code-nav/tests/workspace-root.test.ts
+++ b/apps/code-nav/tests/workspace-root.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for the workspace-root resolution (issue #3972).
+ *
+ * The regression this pins: the navigator is launched from a script inside the
+ * plugin installation, so `process.cwd()` was frequently the PLUGIN and every
+ * navigation answered against the wrong tree. The standalone integration test
+ * at the bottom is the real proof — it spawns the binary the way a host does
+ * (cwd = the plugin install) and reads the root off the ready line.
+ */
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { isPluginInstallDir, resolveWorkspaceRoot } from "../src/workspace-root.js";
+
+const REPO = resolve(__dirname, "../../..");
+const ENTRY = resolve(REPO, "apps/code-nav/src/index.ts");
+
+// pnpm's isolated layout keeps the bin package-local; a hoisted install puts it
+// at the repo root. Same discovery the cli-smoke suite uses.
+const TSX = [
+  resolve(REPO, "apps/code-nav/node_modules/.bin/tsx"),
+  resolve(REPO, "node_modules/.bin/tsx"),
+].find((candidate) => existsSync(candidate));
+
+let scratch: string;
+let project: string;
+let pluginInstall: string;
+
+beforeAll(() => {
+  // realpath: the temp dir is a symlink on some platforms, and the child
+  // process reports the resolved cwd — the two must be comparable.
+  scratch = realpathSync(mkdtempSync(join(tmpdir(), "code-nav-root-")));
+  project = join(scratch, "my-repo");
+  pluginInstall = join(scratch, "installed", "dev");
+  mkdirSync(join(project, "src"), { recursive: true });
+  writeFileSync(join(project, "src", "a.ts"), "export const a = 1;\n", "utf8");
+  mkdirSync(join(pluginInstall, ".claude-plugin"), { recursive: true });
+  writeFileSync(
+    join(pluginInstall, ".claude-plugin", "plugin.json"),
+    JSON.stringify({ name: "dev", version: "0.0.0" }),
+    "utf8",
+  );
+});
+
+afterAll(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+describe("isPluginInstallDir", () => {
+  it("recognises a directory carrying a plugin manifest", () => {
+    expect(isPluginInstallDir(pluginInstall, {})).toBe(true);
+    expect(isPluginInstallDir(project, {})).toBe(false);
+  });
+
+  it("recognises the plugin root the host announced", () => {
+    expect(isPluginInstallDir(project, { CLAUDE_PLUGIN_ROOT: project })).toBe(true);
+    expect(isPluginInstallDir(project, { CODEX_PLUGIN_ROOT: project })).toBe(true);
+  });
+
+  it("recognises the well-known host plugin caches by path", () => {
+    expect(isPluginInstallDir("/home/u/.claude/plugins/cache/red-skills/dev", {})).toBe(true);
+    expect(isPluginInstallDir("/home/u/.codex/plugins/cache/red-skills/dev", {})).toBe(true);
+    expect(
+      isPluginInstallDir("/home/u/.codex/.tmp/marketplaces/red-skills/plugins/dev", {}),
+    ).toBe(true);
+    expect(isPluginInstallDir("/home/u/work/red-skills", {})).toBe(false);
+  });
+});
+
+describe("resolveWorkspaceRoot", () => {
+  it("obeys CODE_NAV_ROOT as written", () => {
+    const r = resolveWorkspaceRoot({ CODE_NAV_ROOT: project }, pluginInstall);
+    expect(r.root).toBe(project);
+    expect(r.source).toBe("CODE_NAV_ROOT");
+  });
+
+  it("follows the project the host announces over the cwd", () => {
+    for (const key of [
+      "RED_SKILLS_PROJECT_ROOT",
+      "CLAUDE_PROJECT_DIR",
+      "CODEX_PROJECT_DIR",
+      "OPENCODE_PROJECT_DIR",
+    ]) {
+      const r = resolveWorkspaceRoot({ [key]: project }, pluginInstall);
+      expect(r.root).toBe(project);
+      expect(r.source).toBe(key);
+    }
+  });
+
+  it("prefers CODE_NAV_ROOT over a host-announced project", () => {
+    const r = resolveWorkspaceRoot(
+      { CODE_NAV_ROOT: project, CLAUDE_PROJECT_DIR: pluginInstall },
+      scratch,
+    );
+    expect(r.root).toBe(project);
+  });
+
+  it("skips a host-announced directory that is really the plugin install", () => {
+    const r = resolveWorkspaceRoot(
+      { CLAUDE_PROJECT_DIR: pluginInstall, CODEX_PROJECT_DIR: project },
+      scratch,
+    );
+    expect(r.root).toBe(project);
+    expect(r.source).toBe("CODEX_PROJECT_DIR");
+  });
+
+  it("falls back to the cwd when nothing announces a project", () => {
+    const r = resolveWorkspaceRoot({}, project);
+    expect(r.root).toBe(project);
+    expect(r.source).toBe("cwd");
+    expect(r.warning).toBeUndefined();
+  });
+
+  it("warns when the only candidate left is the plugin installation", () => {
+    const r = resolveWorkspaceRoot({}, pluginInstall);
+    expect(r.root).toBe(pluginInstall);
+    expect(r.warning).toMatch(/plugin installation/);
+    expect(r.warning).toMatch(/CODE_NAV_ROOT/);
+  });
+
+  it("ignores an empty or whitespace-only announcement", () => {
+    const r = resolveWorkspaceRoot({ CLAUDE_PROJECT_DIR: "   " }, project);
+    expect(r.root).toBe(project);
+    expect(r.source).toBe("cwd");
+  });
+});
+
+/**
+ * The integration proof: launch the navigator the way a host does — cwd inside
+ * the plugin installation — and read the workspace root back off the ready
+ * line it writes to stderr. Nothing here needs a language server: the sessions
+ * are opened lazily on the first tool call.
+ */
+function launchAndReadRoot(
+  cwd: string,
+  env: Record<string, string>,
+): Promise<{ root: string; source: string; stderr: string }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    if (TSX === undefined) {
+      rejectPromise(new Error("tsx not installed; run `pnpm install`"));
+      return;
+    }
+    const child = spawn(TSX, [ENTRY], {
+      cwd,
+      env: {
+        ...process.env,
+        // Strip any project announcement the surrounding test runner exported,
+        // so the case under test is the only thing deciding.
+        CODE_NAV_ROOT: undefined,
+        RED_SKILLS_PROJECT_ROOT: undefined,
+        CLAUDE_PROJECT_DIR: undefined,
+        CODEX_PROJECT_DIR: undefined,
+        OPENCODE_PROJECT_DIR: undefined,
+        CLAUDE_PLUGIN_ROOT: undefined,
+        CODEX_PLUGIN_ROOT: undefined,
+        ...env,
+      } as NodeJS.ProcessEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+      const match = stderr.match(/navigator MCP ready \(root=(.+?), root-source=(.+?),/);
+      if (match) {
+        child.kill("SIGKILL");
+        resolvePromise({ root: match[1]!, source: match[2]!, stderr });
+      }
+    });
+    child.on("error", (err) => {
+      child.kill("SIGKILL");
+      rejectPromise(err);
+    });
+    child.on("exit", () => {
+      if (!/navigator MCP ready/.test(stderr)) {
+        rejectPromise(new Error(`navigator exited before it was ready:\n${stderr}`));
+      }
+    });
+  });
+}
+
+describe("standalone navigator (integration)", () => {
+  it("indexes the opened project, not the plugin installation it launched from", async () => {
+    const observed = await launchAndReadRoot(pluginInstall, { CLAUDE_PROJECT_DIR: project });
+    expect(observed.root).toBe(project);
+    expect(observed.root).not.toBe(pluginInstall);
+    expect(observed.source).toBe("CLAUDE_PROJECT_DIR");
+  }, 60_000);
+
+  it("says so on stderr when the plugin installation is all it has", async () => {
+    const observed = await launchAndReadRoot(pluginInstall, {});
+    expect(observed.root).toBe(pluginInstall);
+    expect(observed.stderr).toMatch(/plugin installation/);
+  }, 60_000);
+});

--- a/apps/opencode-host/README.md
+++ b/apps/opencode-host/README.md
@@ -177,6 +177,26 @@ extend the same source-of-truth to skills and hooks, so a user running
 `opencode .` on a reddb.io repo sees the same model, the same 56
 skills, and the same lifecycle hooks Claude Code and Codex see.
 
+## Semantic navigation is the host's when the host has an LSP
+
+RedCode runs a language-server stack natively. Projecting the `navigator` MCP
+onto it would birth a **second** stack over the same tree — double the memory,
+double the indexing wall-clock, and two answers that can disagree while both
+look authoritative. So `--host redcode` omits `navigator` from the emitted
+`mcp:` block entirely (the entry is dropped, not emitted `enabled: false`: an
+entry carrying the launcher command is one flag away from the duplicate it
+exists to prevent), and the generator says on stdout what it deferred and why.
+
+The deferral is conditional on the native authority actually being available.
+`--host opencode`, Claude Code, and Codex have no LSP of their own and keep
+`navigator`; `--host redcode --no-native-lsp` puts it back for a RedCode install
+whose native LSP is switched off. Every other MCP the plugins ship is untouched
+— RedCode still receives `redskilled` and `rsp`.
+
+The rule lives in `src/semantic-authority.ts` as a host table plus the operator
+override, so the standalone Slice 1 file and the Slice 2 dist tree defer the
+same way instead of each emit path re-deciding.
+
 ## Hook coverage notes
 
 OpenCode does not expose a Claude-style `SubagentStop` event in the plugin

--- a/apps/opencode-host/src/cli-args.ts
+++ b/apps/opencode-host/src/cli-args.ts
@@ -14,6 +14,7 @@ import {
   UnknownCommandError,
   type FlagSchema,
 } from "@reddb-io/shared/args.js";
+import { HOST_TARGETS, isHostTarget, type HostTarget } from "./semantic-authority.js";
 
 /** The command set. `generate` is the only verb, and the default one. */
 export type OpencodeHostCommand = "generate";
@@ -23,6 +24,11 @@ const FLAGS = {
   out: { kind: "value", aliases: ["o"], coerce: (raw: string) => raw },
   "out-dir": { kind: "value", aliases: ["d"], coerce: (raw: string) => raw },
   "plugins-root": { kind: "value", aliases: ["p"], coerce: (raw: string) => raw },
+  host: { kind: "value", coerce: (raw: string) => raw },
+  // Which stack answers "where is this symbol defined?". Defaults from the
+  // host table; `--no-native-lsp` is how a RedCode install with its LSP
+  // switched off asks for the navigator projection back.
+  "native-lsp": { kind: "boolean" },
   plugin: { kind: "value", type: "array", coerce: (raw: string) => raw },
   // Negation is the contract's (`--no-slice-2`); `--with-slice-2` stays as the
   // spelling earlier callers used.
@@ -42,6 +48,10 @@ export interface OpencodeHostArgs {
   /** Slice 2: write the dist tree under this directory. */
   outDir: string;
   pluginsRoot: string;
+  /** The OpenCode-compatible host the tree is emitted for. */
+  host: HostTarget;
+  /** `--native-lsp` / `--no-native-lsp`; absent, the host table decides. */
+  nativeLsp: boolean | undefined;
   showHelp: boolean;
   showVersion: boolean;
   /** `--json`: print the structured build info instead of the version line. */
@@ -99,12 +109,20 @@ export function parseOpencodeHostArgs(argv: readonly string[]): OpencodeHostArgs
   }
 
   const { values } = parsed;
+  const host = values.host ?? "opencode";
+  if (!isHostTarget(host)) {
+    throw new OpencodeHostUsageError(
+      `unsupported --host '${host}'; expected one of: ${HOST_TARGETS.join(", ")}`,
+    );
+  }
   return {
     command: routed.command,
     configPath: values.config ?? "./.red/config.yaml",
     outPath: values.out ?? "./opencode.json",
     outDir: values["out-dir"] ?? "./dist/opencode",
     pluginsRoot: values["plugins-root"] ?? "./plugins",
+    host,
+    nativeLsp: values["native-lsp"],
     showHelp: values.help ?? false,
     showVersion: values.version ?? false,
     versionJson: values.json ?? false,
@@ -123,7 +141,7 @@ Slice 1: opencode.json (provider block) at <out>
 Slice 2: dist tree at <out-dir>/<plugin>/{opencode.json, .opencode/...}
 
 Usage:
-  opencode-host [generate] [--config <path>] [--out <path>] [--out-dir <path>] [--plugins-root <path>] [--plugin <name>] [--copy] [--print] [--no-slice-2]
+  opencode-host [generate] [--config <path>] [--out <path>] [--out-dir <path>] [--plugins-root <path>] [--host <host>] [--plugin <name>] [--copy] [--print] [--no-slice-2]
   opencode-host --version [--json]
   opencode-host --help
 
@@ -132,6 +150,9 @@ Options:
   -o, --out <path>           Slice 1: path to write opencode.json (default: ./opencode.json)
   -d, --out-dir <path>       Slice 2: dist root (default: ./dist/opencode)
   -p, --plugins-root <path>  path to the plugins/ tree (default: ./plugins)
+      --host <host>          OpenCode-compatible host: opencode | redcode (default: opencode)
+      --native-lsp           the host answers navigation natively (default: redcode only)
+      --no-native-lsp        the host has no LSP of its own — publish navigator
       --plugin <name>        emit only this plugin (repeatable; Slice 2 only)
       --copy                 copy SKILL.md instead of symlinking
       --with-slice-2         emit the Slice 2 dist tree (default; kept for compatibility)
@@ -150,6 +171,9 @@ Notes:
   - The ADR 0067 strict opt-in gate applies: plugins.dev.enabled: true must be set.
   - Slice 1 (--out) is unaffected by --plugin/--no-slice-2; it is the standalone
     provider-block JSON file.
+  - A host with native LSP (redcode) omits the navigator MCP rather than
+    birthing a second language-server stack over the same tree. --no-native-lsp
+    puts it back.
   - Planner errors (bad name, missing frontmatter) are reported on stderr but
     do NOT fail the build. The events the generator can map are emitted.
 `;

--- a/apps/opencode-host/src/emit.ts
+++ b/apps/opencode-host/src/emit.ts
@@ -22,6 +22,11 @@ import {
 import { planPluginHooks, type HookPlan } from "./hooks-to-events.js";
 import { planPluginMcp, type McpPlan, type McpEntry } from "./mcp-passthrough.js";
 import { planPluginStatusline, type StatuslinePlan } from "./statusline.js";
+import {
+  applySemanticAuthority,
+  resolveSemanticAuthority,
+  type SemanticAuthority,
+} from "./semantic-authority.js";
 
 /** A single plugin's planned output. */
 export interface PluginEmit {
@@ -30,12 +35,16 @@ export interface PluginEmit {
   skills: PlanResult;
   hooks: HookPlan[];
   mcp: McpPlan[];
+  /** MCP names left to the host's own LSP (ADR 0075; issue #3972). */
+  deferredMcp: string[];
   statusline: StatuslinePlan[];
 }
 
 /** Top-level emit plan for one or more plugins. */
 export interface EmitPlan {
   byPlugin: PluginEmit[];
+  /** Who owns semantic navigation for the host this plan targets. */
+  semanticAuthority: SemanticAuthority;
 }
 
 export interface EmitOptions {
@@ -52,6 +61,8 @@ export interface EmitOptions {
   copySkills?: boolean;
   /** Generator version string (printed in the install manifest). */
   version: string;
+  /** Who owns semantic navigation. Default: a bare opencode host (no native LSP). */
+  semanticAuthority?: SemanticAuthority;
 }
 
 /**
@@ -63,20 +74,28 @@ export function planEmit(input: {
   plugins: string[];
   configText: string;
   env: Readonly<Record<string, string | undefined>>;
+  /** Default: a bare opencode host, which has no LSP of its own. */
+  semanticAuthority?: SemanticAuthority;
 }): EmitPlan {
+  const semanticAuthority = input.semanticAuthority ?? resolveSemanticAuthority("opencode");
   const skillPlan = planAllSkills(input.pluginsRoot, input.plugins);
   const byPlugin: PluginEmit[] = input.plugins.map((plugin) => {
     const skills = skillPlan.find((s) => s.plugin === plugin)?.result ?? { plans: [], errors: [] };
     const hooks = planPluginHooks(input.pluginsRoot, plugin);
-    const mcp = planPluginMcp(input.pluginsRoot, plugin);
+    // A host that answers navigation natively never receives the navigator
+    // launcher, so nothing in the emitted tree can birth a second stack.
+    const { plans: mcp, deferred: deferredMcp } = applySemanticAuthority(
+      planPluginMcp(input.pluginsRoot, plugin),
+      semanticAuthority,
+    );
     const statusline = planPluginStatusline(input.pluginsRoot, plugin);
     const provider = buildProviderBlock({
       configText: input.configText,
       env: input.env,
     });
-    return { plugin, provider, skills, hooks, mcp, statusline };
+    return { plugin, provider, skills, hooks, mcp, deferredMcp, statusline };
   });
-  return { byPlugin };
+  return { byPlugin, semanticAuthority };
 }
 
 /**

--- a/apps/opencode-host/src/generate.ts
+++ b/apps/opencode-host/src/generate.ts
@@ -44,6 +44,11 @@ import {
 import { planEmit, writeEmit } from "./emit.js";
 import { listPluginDirs } from "./plugin-discovery.js";
 import { planPluginMcp, type McpPlan, type McpEntry } from "./mcp-passthrough.js";
+import {
+  applySemanticAuthority,
+  resolveSemanticAuthority,
+  type SemanticAuthority,
+} from "./semantic-authority.js";
 
 /** Collect MCP plans from every plugin for the standalone Slice 1
  *  `opencode.json` (the user wants one `mcp:` block that includes
@@ -52,11 +57,18 @@ import { planPluginMcp, type McpPlan, type McpEntry } from "./mcp-passthrough.js
 function collectMcpForStandalone(
   pluginsRoot: string,
   plugins: string[],
-): { mcps: McpPlan[]; warnings: string[] } {
+  authority: SemanticAuthority,
+): { mcps: McpPlan[]; warnings: string[]; deferred: string[] } {
   const mcps: McpPlan[] = [];
   const warnings: string[] = [];
+  const deferred: string[] = [];
   for (const p of plugins) {
-    for (const plan of planPluginMcp(pluginsRoot, p)) {
+    // A host with its own LSP never sees the navigator launcher: the whole
+    // point of the deferral is that no emitted entry can birth a second
+    // language-server stack over the tree the host already indexes.
+    const applied = applySemanticAuthority(planPluginMcp(pluginsRoot, p), authority);
+    for (const name of applied.deferred) deferred.push(name);
+    for (const plan of applied.plans) {
       mcps.push(plan);
       for (const w of plan.warnings) warnings.push(`[${p}] ${w}`);
     }
@@ -69,7 +81,7 @@ function collectMcpForStandalone(
     seen.add(m.name);
     return true;
   });
-  return { mcps: deduped, warnings };
+  return { mcps: deduped, warnings, deferred: [...new Set(deferred)] };
 }
 
 function mcpPlansToObject(plans: McpPlan[]): Record<string, McpEntry> {
@@ -156,8 +168,13 @@ function main(argv: ReadonlyArray<string>): void {
   // Discover plugins first so the standalone file can include every
   // MCP the user has installed. (Slice 2 also calls listPluginDirs
   // — the call is cheap, just a stat per directory.)
+  const semanticAuthority = resolveSemanticAuthority(args.host, args.nativeLsp);
   const discoveredForMcp = listPluginDirs(pluginsRootAbs);
-  const standaloneMcp = collectMcpForStandalone(pluginsRootAbs, discoveredForMcp.map((d) => d.name));
+  const standaloneMcp = collectMcpForStandalone(
+    pluginsRootAbs,
+    discoveredForMcp.map((d) => d.name),
+    semanticAuthority,
+  );
   const standaloneJson: Record<string, unknown> = { ...config };
   if (standaloneMcp.mcps.length > 0) {
     standaloneJson.mcp = mcpPlansToObject(standaloneMcp.mcps);
@@ -199,6 +216,14 @@ function main(argv: ReadonlyArray<string>): void {
     process.stderr.write(`opencode-host: mcp warning — ${w}\n`);
   }
 
+  // Say what was deferred and why: a missing MCP the operator never asked
+  // about reads as a broken install rather than a deliberate one.
+  if (standaloneMcp.deferred.length > 0) {
+    process.stdout.write(
+      `opencode-host: ${standaloneMcp.deferred.join(", ")} deferred to ${semanticAuthority.host} native LSP (--no-native-lsp to publish it anyway)\n`,
+    );
+  }
+
   if (!args.slice2) {
     process.stdout.write(
       `opencode-host: wrote ${args.outPath} (slice 1+3; provider=${active ?? "openrouter"} via precedence, model=${config.model}, mcps=${standaloneMcp.mcps.length})\n`,
@@ -224,6 +249,7 @@ function main(argv: ReadonlyArray<string>): void {
     plugins,
     configText,
     env: process.env,
+    semanticAuthority,
   });
 
   try {
@@ -236,6 +262,7 @@ function main(argv: ReadonlyArray<string>): void {
       env: process.env,
       copySkills: args.copySkills,
       version: buildVersion,
+      semanticAuthority,
     });
   } catch (err) {
     process.stderr.write(

--- a/apps/opencode-host/src/semantic-authority.ts
+++ b/apps/opencode-host/src/semantic-authority.ts
@@ -1,0 +1,101 @@
+/**
+ * semantic-authority.ts — who answers "where is this symbol defined?" for a
+ * generated host surface.
+ *
+ * The navigator MCP exists because Claude Code, Codex, and a bare OpenCode
+ * have no semantic index of their own: it spawns `typescript-language-server`,
+ * `gopls`, `rust-analyzer` and friends and speaks LSP on the agent's behalf.
+ * RedCode already runs that stack natively, so projecting navigator onto it
+ * births a SECOND language server over the same tree and the same files —
+ * double the memory, double the indexing wall-clock, and two answers that can
+ * disagree while both look authoritative.
+ *
+ * The rule is stated once here, as a table plus an operator override, so every
+ * emit path (the standalone Slice 1 file and the Slice 2 dist tree) defers the
+ * same way rather than each caller re-deciding. Deferral is CONDITIONAL on the
+ * native authority actually being available: a RedCode install whose native
+ * LSP is switched off keeps navigator, because the alternative is a host with
+ * no semantic navigation at all.
+ */
+import type { McpPlan } from "./mcp-passthrough.js";
+
+/** The OpenCode-compatible hosts the generator emits for. */
+export const HOST_TARGETS = ["opencode", "redcode"] as const;
+
+export type HostTarget = (typeof HOST_TARGETS)[number];
+
+/**
+ * Hosts that ship their own LSP stack. `true` means the host answers
+ * navigation natively, so a navigator projection would be the duplicate.
+ */
+const NATIVE_SEMANTIC_HOSTS: Record<HostTarget, boolean> = {
+  opencode: false,
+  redcode: true,
+};
+
+/**
+ * MCP servers whose whole job is semantic navigation over a language-server
+ * stack. Named rather than pattern-matched: a host with native LSP defers
+ * exactly these and keeps every other MCP the plugins ship.
+ */
+export const NAVIGATOR_MCP_NAMES: readonly string[] = ["navigator"];
+
+/** True when `name` is a navigator-class MCP a native LSP already answers. */
+export function isNavigatorMcp(name: string): boolean {
+  return NAVIGATOR_MCP_NAMES.includes(name);
+}
+
+/** True when `value` names a host the generator knows how to emit for. */
+export function isHostTarget(value: string): value is HostTarget {
+  return (HOST_TARGETS as readonly string[]).includes(value);
+}
+
+/** Who owns semantic navigation for one generated host surface. */
+export interface SemanticAuthority {
+  host: HostTarget;
+  /** True when the host's own LSP answers navigation for the opened tree. */
+  nativeLsp: boolean;
+}
+
+/**
+ * Resolve the authority for `host`. `override` is the operator's explicit
+ * `--native-lsp` / `--no-native-lsp`; absent, the host table decides.
+ */
+export function resolveSemanticAuthority(
+  host: HostTarget,
+  override?: boolean,
+): SemanticAuthority {
+  return { host, nativeLsp: override ?? NATIVE_SEMANTIC_HOSTS[host] };
+}
+
+/** True when navigator must be left to the host's own LSP. */
+export function defersNavigation(authority: SemanticAuthority): boolean {
+  return authority.nativeLsp;
+}
+
+/** The plans that survive, plus the names deferred to the host's own LSP. */
+export interface AppliedAuthority {
+  plans: McpPlan[];
+  /** MCP names dropped because the host answers them natively. */
+  deferred: string[];
+}
+
+/**
+ * Drop the navigator-class plans a native-LSP host already answers. The plan
+ * is omitted rather than emitted `enabled: false`: an entry that carries the
+ * launcher command is one flag away from birthing the duplicate stack, and the
+ * generated file is regenerated on every install anyway.
+ */
+export function applySemanticAuthority(
+  plans: readonly McpPlan[],
+  authority: SemanticAuthority,
+): AppliedAuthority {
+  if (!defersNavigation(authority)) return { plans: [...plans], deferred: [] };
+  const kept: McpPlan[] = [];
+  const deferred: string[] = [];
+  for (const plan of plans) {
+    if (isNavigatorMcp(plan.name)) deferred.push(plan.name);
+    else kept.push(plan);
+  }
+  return { plans: kept, deferred };
+}

--- a/apps/opencode-host/tests/cli-args.test.ts
+++ b/apps/opencode-host/tests/cli-args.test.ts
@@ -20,6 +20,8 @@ describe("parseOpencodeHostArgs", () => {
       outPath: "./opencode.json",
       outDir: "./dist/opencode",
       pluginsRoot: "./plugins",
+      host: "opencode",
+      nativeLsp: undefined,
       showHelp: false,
       showVersion: false,
       versionJson: false,
@@ -28,6 +30,18 @@ describe("parseOpencodeHostArgs", () => {
       pluginFilter: null,
       slice2: true,
     });
+  });
+
+  it("parses the host and the native-LSP override", () => {
+    expect(parseOpencodeHostArgs(["--host", "redcode"]).host).toBe("redcode");
+    expect(parseOpencodeHostArgs(["--host=redcode"]).host).toBe("redcode");
+    expect(parseOpencodeHostArgs(["--native-lsp"]).nativeLsp).toBe(true);
+    expect(parseOpencodeHostArgs(["--no-native-lsp"]).nativeLsp).toBe(false);
+  });
+
+  it("rejects a host it cannot emit for, naming the ones it can", () => {
+    expect(() => parseOpencodeHostArgs(["--host", "vscode"])).toThrow(OpencodeHostUsageError);
+    expect(() => parseOpencodeHostArgs(["--host", "vscode"])).toThrow(/opencode, redcode/);
   });
 
   it("routes the explicit `generate` command and still parses its flags", () => {

--- a/apps/opencode-host/tests/generate-cli.test.ts
+++ b/apps/opencode-host/tests/generate-cli.test.ts
@@ -220,6 +220,60 @@ describe("opencode-host generate (CLI smoke)", () => {
     }
   });
 
+  it("defers navigator to the host's native LSP for --host redcode (#3972)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "opencode-host-"));
+    const config = join(dir, "config.yaml");
+    const out = join(dir, "opencode.json");
+    writeFileSync(config, "plugins:\n  dev:\n    enabled: true\n", "utf8");
+    try {
+      // The real plugins tree is the source: navigator is the MCP under test
+      // and the fixture tree ships no .mcp.json.
+      const realPlugins = resolve(REPO, "plugins");
+
+      const redcode = runGenerate(
+        ["--config", config, "--plugins-root", realPlugins, "--out", out, "--host", "redcode", "--no-slice-2"],
+        {},
+      );
+      expect(redcode.status).toBe(0);
+      const redcodeJson = readFileSync(out, "utf8");
+      const redcodeMcp = JSON.parse(redcodeJson.slice(redcodeJson.indexOf("{"))).mcp as Record<string, unknown>;
+      expect(Object.keys(redcodeMcp)).not.toContain("navigator");
+      expect(Object.keys(redcodeMcp)).toContain("redskilled");
+      expect(redcode.stdout).toMatch(/navigator deferred to redcode native LSP/);
+
+      const opencode = runGenerate(
+        ["--config", config, "--plugins-root", realPlugins, "--out", out, "--host", "opencode", "--no-slice-2"],
+        {},
+      );
+      expect(opencode.status).toBe(0);
+      const opencodeJson = readFileSync(out, "utf8");
+      const opencodeMcp = JSON.parse(opencodeJson.slice(opencodeJson.indexOf("{"))).mcp as Record<string, unknown>;
+      expect(Object.keys(opencodeMcp)).toContain("navigator");
+      expect(opencode.stdout).not.toMatch(/deferred/);
+
+      const noNative = runGenerate(
+        [
+          "--config", config, "--plugins-root", realPlugins, "--out", out,
+          "--host", "redcode", "--no-native-lsp", "--no-slice-2",
+        ],
+        {},
+      );
+      expect(noNative.status).toBe(0);
+      const noNativeJson = readFileSync(out, "utf8");
+      const noNativeMcp = JSON.parse(noNativeJson.slice(noNativeJson.indexOf("{"))).mcp as Record<string, unknown>;
+      expect(Object.keys(noNativeMcp)).toContain("navigator");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an unknown --host with a non-zero exit naming the ones it emits for", () => {
+    const r = runGenerate(["--host", "vscode"], {});
+    expect([1, 2]).toContain(r.status);
+    expect(r.stderr).toMatch(/unsupported --host 'vscode'/);
+    expect(r.stderr).toMatch(/opencode, redcode/);
+  });
+
   it("emits the Slice 2 dist tree by default and allows opting out", () => {
     const dir = mkdtempSync(join(tmpdir(), "opencode-host-"));
     const config = join(dir, "config.yaml");

--- a/apps/opencode-host/tests/semantic-authority.test.ts
+++ b/apps/opencode-host/tests/semantic-authority.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the native-LSP deferral (issue #3972).
+ *
+ * Three claims are under test:
+ *   1. The rule itself: navigator is dropped when — and only when — the host
+ *      answers navigation natively.
+ *   2. The generated fixtures: a `--host redcode` tree omits navigator while a
+ *      `--host opencode` tree still publishes it.
+ *   3. Process birth: nothing in the RedCode composition names a command that
+ *      would spawn a language server, so the deferral is not one flag away
+ *      from the duplicate stack it exists to prevent.
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  applySemanticAuthority,
+  defersNavigation,
+  isHostTarget,
+  isNavigatorMcp,
+  resolveSemanticAuthority,
+} from "../src/semantic-authority.js";
+import { planEmit } from "../src/emit.js";
+import type { McpPlan } from "../src/mcp-passthrough.js";
+
+const REPO = resolve(__dirname, "../../..");
+const REAL_PLUGINS = resolve(REPO, "plugins");
+
+/** The language servers the navigator spawns (apps/code-nav/src/config.ts). */
+const LANGUAGE_SERVER_COMMANDS = [
+  "typescript-language-server",
+  "gopls",
+  "rust-analyzer",
+  "pyright-langserver",
+];
+
+function plan(name: string, command: string[]): McpPlan {
+  return { name, entry: { type: "local", command, enabled: true }, warnings: [] };
+}
+
+describe("semantic authority (the rule)", () => {
+  it("gives redcode native LSP and a bare opencode none", () => {
+    expect(resolveSemanticAuthority("redcode").nativeLsp).toBe(true);
+    expect(resolveSemanticAuthority("opencode").nativeLsp).toBe(false);
+  });
+
+  it("obeys an explicit override in both directions", () => {
+    expect(resolveSemanticAuthority("redcode", false).nativeLsp).toBe(false);
+    expect(resolveSemanticAuthority("opencode", true).nativeLsp).toBe(true);
+  });
+
+  it("defers navigation only when native authority is available", () => {
+    expect(defersNavigation(resolveSemanticAuthority("redcode"))).toBe(true);
+    expect(defersNavigation(resolveSemanticAuthority("redcode", false))).toBe(false);
+    expect(defersNavigation(resolveSemanticAuthority("opencode"))).toBe(false);
+  });
+
+  it("names the navigator MCP and nothing else", () => {
+    expect(isNavigatorMcp("navigator")).toBe(true);
+    expect(isNavigatorMcp("redskilled")).toBe(false);
+    expect(isNavigatorMcp("rsp")).toBe(false);
+  });
+
+  it("rejects a host it does not know how to emit for", () => {
+    expect(isHostTarget("opencode")).toBe(true);
+    expect(isHostTarget("redcode")).toBe(true);
+    expect(isHostTarget("vscode")).toBe(false);
+  });
+
+  it("drops only the navigator plan, keeping every other MCP", () => {
+    const plans = [
+      plan("navigator", ["bash", "/x/code-nav-mcp.sh"]),
+      plan("redskilled", ["bash", "/x/redskilled-mcp.sh"]),
+      plan("rsp", ["node", "/x/rsp.mjs", "mcp"]),
+    ];
+    const applied = applySemanticAuthority(plans, resolveSemanticAuthority("redcode"));
+    expect(applied.plans.map((p) => p.name)).toEqual(["redskilled", "rsp"]);
+    expect(applied.deferred).toEqual(["navigator"]);
+  });
+
+  it("keeps every plan when the host has no LSP of its own", () => {
+    const plans = [plan("navigator", ["bash", "/x/code-nav-mcp.sh"])];
+    const applied = applySemanticAuthority(plans, resolveSemanticAuthority("opencode"));
+    expect(applied.plans.map((p) => p.name)).toEqual(["navigator"]);
+    expect(applied.deferred).toEqual([]);
+  });
+});
+
+describe("host generation fixtures (the emitted tree)", () => {
+  const CONFIG = "plugins:\n  dev:\n    enabled: true\n";
+
+  function emit(host: "opencode" | "redcode", nativeLsp?: boolean): Record<string, unknown> {
+    const outRoot = mkdtempSync(join(tmpdir(), "semantic-authority-"));
+    try {
+      const emitPlan = planEmit({
+        pluginsRoot: REAL_PLUGINS,
+        plugins: ["dev"],
+        configText: CONFIG,
+        env: {},
+        semanticAuthority: resolveSemanticAuthority(host, nativeLsp),
+      });
+      mkdirSync(outRoot, { recursive: true });
+      // Only the opencode.json matters here; write it from the plan directly
+      // so the fixture stays about the MCP block, not symlink portability.
+      const dev = emitPlan.byPlugin.find((p) => p.plugin === "dev")!;
+      const json: Record<string, unknown> = { ...dev.provider };
+      if (dev.mcp.length > 0) {
+        json.mcp = Object.fromEntries(dev.mcp.map((m) => [m.name, m.entry]));
+      }
+      const path = join(outRoot, "opencode.json");
+      writeFileSync(path, JSON.stringify(json, null, 2) + "\n", "utf8");
+      return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    } finally {
+      rmSync(outRoot, { recursive: true, force: true });
+    }
+  }
+
+  it("omits navigator from the redcode composition", () => {
+    const mcp = emit("redcode").mcp as Record<string, unknown>;
+    expect(Object.keys(mcp)).not.toContain("navigator");
+    // The deferral is scoped: RedCode still receives the MCPs it has no
+    // native answer for.
+    expect(Object.keys(mcp)).toContain("redskilled");
+  });
+
+  it("publishes navigator to a non-redcode host", () => {
+    const mcp = emit("opencode").mcp as Record<string, unknown>;
+    expect(Object.keys(mcp)).toContain("navigator");
+    expect(Object.keys(mcp)).toContain("redskilled");
+  });
+
+  it("publishes navigator to redcode when its native LSP is switched off", () => {
+    const mcp = emit("redcode", false).mcp as Record<string, unknown>;
+    expect(Object.keys(mcp)).toContain("navigator");
+  });
+
+  it("records what it deferred, so a missing MCP is explained", () => {
+    const emitPlan = planEmit({
+      pluginsRoot: REAL_PLUGINS,
+      plugins: ["dev"],
+      configText: CONFIG,
+      env: {},
+      semanticAuthority: resolveSemanticAuthority("redcode"),
+    });
+    expect(emitPlan.semanticAuthority).toEqual({ host: "redcode", nativeLsp: true });
+    expect(emitPlan.byPlugin[0]!.deferredMcp).toEqual(["navigator"]);
+  });
+
+  it("defaults to a bare opencode host when no authority is passed", () => {
+    const emitPlan = planEmit({
+      pluginsRoot: REAL_PLUGINS,
+      plugins: ["dev"],
+      configText: CONFIG,
+      env: {},
+    });
+    expect(emitPlan.semanticAuthority).toEqual({ host: "opencode", nativeLsp: false });
+    expect(emitPlan.byPlugin[0]!.mcp.map((m) => m.name)).toContain("navigator");
+  });
+});
+
+describe("process birth (nothing spawns a second language server)", () => {
+  const CONFIG = "plugins:\n  dev:\n    enabled: true\n";
+
+  function commandsFor(host: "opencode" | "redcode"): string[] {
+    const emitPlan = planEmit({
+      pluginsRoot: REAL_PLUGINS,
+      plugins: ["dev", "memory", "brain"],
+      configText: CONFIG,
+      env: {},
+      semanticAuthority: resolveSemanticAuthority(host),
+    });
+    return emitPlan.byPlugin.flatMap((p) => p.mcp.flatMap((m) => m.entry.command));
+  }
+
+  it("names no navigator launcher in the redcode composition", () => {
+    const commands = commandsFor("redcode");
+    expect(commands.length).toBeGreaterThan(0);
+    for (const token of commands) {
+      expect(token).not.toMatch(/code-nav/);
+      expect(token).not.toMatch(/red-skills-code-nav/);
+    }
+  });
+
+  it("names no language-server binary in the redcode composition", () => {
+    const commands = commandsFor("redcode");
+    for (const token of commands) {
+      for (const server of LANGUAGE_SERVER_COMMANDS) {
+        expect(token).not.toContain(server);
+      }
+    }
+  });
+
+  it("does name the navigator launcher for a host without native LSP", () => {
+    // The negative above is only evidence if the positive holds: a projection
+    // that dropped navigator everywhere would pass the redcode assertions for
+    // the wrong reason.
+    const commands = commandsFor("opencode");
+    expect(commands.some((token) => /code-nav/.test(token))).toBe(true);
+  });
+});

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -369,7 +369,9 @@ fi
 if [ -f "$PREGENERATED_TREE_MARKER" ]; then
   log "using release-generated dist tree under $OUT_DIR"
 else
-  GEN_ARGS=(--config "$CONFIG_PATH" --plugins-root "$PLUGINS_ROOT" --out-dir "$OUT_DIR")
+  # The host is passed through: a host with its own LSP (redcode) gets the
+  # navigator MCP deferred instead of a second language-server stack.
+  GEN_ARGS=(--config "$CONFIG_PATH" --plugins-root "$PLUGINS_ROOT" --out-dir "$OUT_DIR" --host "$HOST")
   [ "$COPY" = "true" ] && GEN_ARGS+=(--copy)
 
   log "generating dist tree under $OUT_DIR"


### PR DESCRIPTION
Automated AFK landing for #3972. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3972

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789687986&installation_model_id=20659&pr_number=4035&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4035&signature=09e609b2c35168a9d97a3334de4f149547b3859f8ad9f8e45c397a2a80164ef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->