### PR TITLE
fix: #3977 The release publishes the complete RedSkills workstation package set

### DIFF
--- a/.github/workflows/red-package-set-smoke.yml
+++ b/.github/workflows/red-package-set-smoke.yml
@@ -16,6 +16,8 @@ on:
     paths:
       - scripts/build-package-set.mjs
       - scripts/verify-package-set.mjs
+      - scripts/expand-package-set.mjs
+      - scripts/workstation-package-set.mjs
       - scripts/test-package-set-contract.sh
       - .github/workflows/red-package-set-smoke.yml
       - .github/workflows/red-publish.yml

--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -696,10 +696,58 @@ jobs:
           set -euo pipefail
           pnpm package
 
-      # The first package-set contract covers the workstation artifacts the
-      # tagged tree can produce coherently today. Plugin payloads and host
-      # projections remain in the source snapshot named by SOURCE_COMMIT;
-      # Gemini/Hermes completeness is added by later Spec #3973 slices.
+      # The payloads a workstation installs that are not a runtime bundle: the
+      # four plugin definition trees every host registers, the canonical
+      # marketplace projections, the generated Gemini extension (#3975), the
+      # Hermes skills installer (#3976), and the Zellij dashboard integration.
+      # Each host generator ships BESIDE its output, so an operator whose
+      # network is gone can re-generate and re-validate from the expanded tree
+      # instead of being told to fetch the repository that produced it.
+      - name: Build workstation payloads
+        if: steps.target.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          # The plugin list is never spelled here: it comes from the same
+          # enumeration the signed set derives from, which the contract test
+          # holds against the plugin tree itself. A fifth plugin gets a payload
+          # by existing, not by someone remembering this loop.
+          while IFS= read -r payload; do
+            plugin="${payload#dist/plugin-}"
+            plugin="${plugin%.payload.tgz}"
+            [ -f "plugins/$plugin/.claude-plugin/plugin.json" ] || {
+              echo "::error::declared plugin payload has no plugin tree: plugins/$plugin" >&2
+              exit 1
+            }
+            tar -czf "$payload" "plugins/$plugin"
+          done < <(node scripts/workstation-package-set.mjs --plugin-payloads)
+          tar -czf dist/marketplace-manifests.tgz \
+            .claude-plugin/marketplace.json \
+            .agents/plugins/marketplace.json \
+            .gemini-plugin/marketplace.json
+          tar -czf dist/zellij-dashboard.tgz -C apps zellij-plugin-dashboard
+          # Generate the self-contained Gemini dev extension from this tree's
+          # plugin payload plus the bundles built above, and run the
+          # generated-path validator BEFORE the bytes can enter the signed set:
+          # an extension that fails validation must never become a signed
+          # artifact an operator trusts.
+          rm -rf dist/gemini
+          node scripts/build-gemini-extension.mjs --root . --output dist/gemini/dev
+          node scripts/validate-gemini-extension.mjs --extension dist/gemini/dev
+          tar -czf dist/gemini-extension.tgz -C dist gemini
+          cp scripts/build-gemini-extension.mjs dist/build-gemini-extension.mjs
+          cp scripts/validate-gemini-extension.mjs dist/validate-gemini-extension.mjs
+          cp scripts/install-hermes-skills.mjs dist/install-hermes-skills.mjs
+          cp scripts/expand-package-set.mjs dist/expand-package-set.mjs
+          cp scripts/workstation-package-set.mjs dist/workstation-package-set.mjs
+
+      # The package set is the COMPLETE workstation release contract (Spec
+      # #3973): every payload a machine needs to install RedSkills with no
+      # network, correlated to one source commit and authenticated by one
+      # signature. The membership list is not written here — it is derived from
+      # scripts/workstation-package-set.mjs, the one enumeration
+      # scripts/test-package-set-contract.sh pins, because two hand-kept bash
+      # arrays in this file is exactly how a payload lands in the upload and
+      # not in the signed set.
       - name: Build, sign, and offline-verify package set
         if: steps.target.outputs.publish == 'true'
         env:
@@ -708,27 +756,11 @@ jobs:
         run: |
           set -euo pipefail
           cp scripts/verify-package-set.mjs dist/verify-package-set.mjs
-          workstation_assets=(
-            "dist/vscode-extension-red-skills-${VERSION}.vsix"
-            dist/herdr-plugin-red-skills.bundle.min.mjs
-            dist/dev.bundle.min.mjs
-            dist/dev.manifest.json
-            dist/redskilled-mcp.bundle.min.mjs
-            dist/code-nav.bundle.min.mjs
-            dist/code-nav.manifest.json
-            dist/opencode-host.bundle.min.mjs
-            dist/opencode-host.generated.tgz
-            dist/memory.bundle.min.mjs
-            dist/memory-mcp.bundle.min.mjs
-            dist/memory-runtime-manifest.json
-            dist/brain.bundle.min.mjs
-            dist/brain-mcp.bundle.min.mjs
-            dist/brain-runtime-manifest.json
-            dist/rsp.bundle.min.mjs
-            dist/rsp-core.bundle.min.mjs
-            dist/redskilled.bundle.min.mjs
-            dist/verify-package-set.mjs
-          )
+          mapfile -t workstation_assets < <(node scripts/workstation-package-set.mjs --version "$VERSION")
+          [ "${#workstation_assets[@]}" -gt 0 ] || {
+            echo "::error::the workstation package set resolved to no assets" >&2
+            exit 1
+          }
           build_args=()
           for asset in "${workstation_assets[@]}"; do
             build_args+=(--asset "$asset")
@@ -759,13 +791,21 @@ jobs:
 
           # Enter a fresh network namespace so this smoke proves the downloaded
           # manifest, bundle, verifier, payloads, and a trust root the operator
-          # already holds are sufficient by themselves.
+          # already holds are sufficient by themselves. The expander runs from
+          # dist/ rather than scripts/ because the DOWNLOADED copies are what an
+          # operator has; it verifies the signature, refuses an incomplete or
+          # developer-only set, expands every archive payload, and drives the
+          # Gemini and Hermes local surfaces through their own validators.
+          expansion="$(mktemp -d)"
           sudo --preserve-env=HOME unshare --net -- \
-            "$(command -v node)" scripts/verify-package-set.mjs \
+            "$(command -v node)" dist/expand-package-set.mjs \
               --manifest dist/package-set.manifest.json \
               --bundle dist/package-set.manifest.sigstore.json \
+              --into "$expansion" \
+              --version "$VERSION" \
               --cosign-bin "$(command -v cosign)" \
               --trusted-root "$trusted_root"
+          sudo rm -rf "$expansion"
 
       # ADR 0091: npm is the ONLY client transport. Stage the built bundles into
       # the packaging/npm package, pnpm pack it, then run the REAL client resolver
@@ -984,33 +1024,16 @@ jobs:
           # Two of these are not an inert backup: the `.vsix` and the herdr
           # bundle are the ONLY way either companion surface is installed on a
           # machine without this monorepo (issue #3060).
-          assets=(
-            "dist/vscode-extension-red-skills-${NEXT#v}.vsix"
-            dist/herdr-plugin-red-skills.bundle.min.mjs
-            dist/dev.bundle.min.mjs
-            dist/dev.manifest.json
-            dist/redskilled-mcp.bundle.min.mjs
-            dist/code-nav.bundle.min.mjs
-            dist/code-nav.manifest.json
-            dist/benchmark-memory.bundle.min.mjs
-            dist/benchmark-memory.manifest.json
-            dist/opencode-host.bundle.min.mjs
-            dist/opencode-host.generated.tgz
-            dist/benchmark-code-understanding.bundle.min.mjs
-            dist/benchmark-code-understanding.manifest.json
-            dist/memory.bundle.min.mjs
-            dist/memory-mcp.bundle.min.mjs
-            dist/memory-runtime-manifest.json
-            dist/brain.bundle.min.mjs
-            dist/brain-mcp.bundle.min.mjs
-            dist/brain-runtime-manifest.json
-            dist/rsp.bundle.min.mjs
-            dist/rsp-core.bundle.min.mjs
-            dist/redskilled.bundle.min.mjs
-            dist/package-set.manifest.json
-            dist/package-set.manifest.sigstore.json
-            dist/verify-package-set.mjs
-          )
+          # Derived from the same enumeration that decides the signed set, so a
+          # new payload cannot land in one array and be forgotten in the other.
+          # `--github-release` adds what the workstation set deliberately
+          # excludes: the benchmark evidence this repository publishes for its
+          # own measurements, and the signed manifest plus its Sigstore bundle.
+          mapfile -t assets < <(node scripts/workstation-package-set.mjs --github-release --version "${NEXT#v}")
+          [ "${#assets[@]}" -gt 0 ] || {
+            echo "::error::the release asset set resolved to no files" >&2
+            exit 1
+          }
           # The Release standard owns the Release; this job only ever attaches to
           # it. Two owners would race over one object: the engine re-reads the
           # Release it created and refuses a body it did not write, so a Release

--- a/scripts/expand-package-set.mjs
+++ b/scripts/expand-package-set.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+// Expand and check a downloaded workstation package set with the network gone
+// (Spec #3973, Ticket #3977).
+//
+// scripts/verify-package-set.mjs answers "are these bytes the signed ones?".
+// That is necessary and not sufficient: a set can be perfectly signed and still
+// be missing the plugin payload a host must register, or carry a tarball packed
+// from the wrong directory so it expands somewhere nobody looks. This expander
+// answers the operator's actual question — "can this machine, with no network,
+// install RedSkills from what it downloaded?" — by verifying the signature,
+// expanding every archive payload, asserting each materialises what the
+// enumeration declares, and driving the Gemini and Hermes local surfaces
+// through their own validators against the expanded tree.
+//
+// It holds no network client BY CONSTRUCTION and shells out to `tar` and to the
+// released scripts sitting beside the manifest; scripts/test-package-set-contract.sh
+// greps this file for a network client the same way it greps the verifier.
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { DEVELOPER_ONLY_ARTIFACTS, archivePayloads, workstationAssets } from "./workstation-package-set.mjs";
+
+const VSIX = /^vscode-extension-red-skills-[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?\.vsix$/;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(command, args, label) {
+  const result = spawnSync(command, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  if (result.error) fail(`${label} could not run: ${result.error.message}`);
+  if (result.status !== 0) {
+    const detail = `${result.stderr ?? ""}${result.stdout ?? ""}`.trim();
+    fail(`${label} failed${detail ? `: ${detail}` : ""}`);
+  }
+  return result.stdout ?? "";
+}
+
+/**
+ * The declared set is what an expansion owes. A missing payload is the failure
+ * this whole exercise exists to catch; a developer-only artifact inside the
+ * signed set is the opposite failure and just as wrong, because it makes the
+ * workstation contract mean whatever the last release happened to build.
+ */
+function assertCompleteSet(manifest, version) {
+  const present = new Set(manifest.artifacts.map((artifact) => artifact.name));
+  const missing = [];
+  for (const asset of workstationAssets(version || "0.0.0")) {
+    const name = basename(asset);
+    if (asset.includes("vscode-extension-red-skills-") && !version) {
+      if (![...present].some((candidate) => VSIX.test(candidate))) missing.push("vscode-extension-red-skills-<version>.vsix");
+      continue;
+    }
+    if (!present.has(name)) missing.push(name);
+  }
+  if (missing.length > 0) fail(`package set is missing workstation payload(s): ${missing.join(", ")}`);
+
+  const developerOnly = DEVELOPER_ONLY_ARTIFACTS.map((artifact) => basename(artifact.asset)).filter((name) => present.has(name));
+  if (developerOnly.length > 0) {
+    fail(`package set carries developer-only artifact(s): ${developerOnly.join(", ")}`);
+  }
+}
+
+function expandArchives(manifest, root, into, version) {
+  const present = new Set(manifest.artifacts.map((artifact) => artifact.name));
+  for (const payload of archivePayloads(version || "0.0.0")) {
+    const name = basename(payload.asset);
+    if (!present.has(name)) fail(`archive payload is missing from the manifest: ${name}`);
+    // `-p` keeps the mode bits a host reads (the Gemini hook must stay
+    // executable); `--no-same-owner` refuses to chown, which is both what an
+    // operator expanding into their own tree wants and the only thing that
+    // works inside a rootless namespace.
+    run("tar", ["-xzf", join(root, name), "-p", "--no-same-owner", "-C", into], `expanding ${name}`);
+    for (const expected of payload.expandsTo) {
+      if (!existsSync(join(into, expected))) fail(`${name} did not materialise ${expected}`);
+    }
+  }
+}
+
+/**
+ * Generated-path validation for the two local host surfaces added by #3975 and
+ * #3976. Both run against the EXPANDED tree, not the repository, so a payload
+ * that expands into an unusable shape fails here rather than on a workstation.
+ */
+function checkLocalHostSurfaces(root, into) {
+  run("node", [join(root, "validate-gemini-extension.mjs"), "--extension", join(into, "gemini", "dev")], "Gemini extension validation");
+
+  const hermesHome = mkdtempSync(join(into, ".hermes-home-"));
+  try {
+    const installer = join(root, "install-hermes-skills.mjs");
+    run("node", [installer, "--install", "--source", into, "--home", hermesHome], "Hermes skills install");
+    run("node", [installer, "--verify", "--source", into, "--home", hermesHome], "Hermes skills verify");
+    run("node", [installer, "--uninstall", "--home", hermesHome], "Hermes skills uninstall");
+  } finally {
+    rmSync(hermesHome, { recursive: true, force: true });
+  }
+}
+
+function parseArgs(argv) {
+  const options = { version: "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+    const flags = {
+      "--manifest": "manifestPath",
+      "--bundle": "bundlePath",
+      "--into": "into",
+      "--verifier": "verifierPath",
+      "--cosign-bin": "cosignBin",
+      "--trusted-root": "trustedRootPath",
+      "--certificate-identity-regexp": "identityRegexp",
+      "--version": "version",
+    };
+    const key = flags[argument];
+    if (!key || !value) fail(`unknown or incomplete argument: ${argument}`);
+    options[key] = key === "cosignBin" || key === "identityRegexp" || key === "version" ? value : resolve(value);
+    index += 1;
+  }
+  if (!options.manifestPath) fail("--manifest is required");
+  if (!options.bundlePath) fail("--bundle is required");
+  if (!options.into) fail("--into is required");
+  return options;
+}
+
+function verifySignedBytes(options, root) {
+  const verifier = options.verifierPath ?? join(root, "verify-package-set.mjs");
+  if (!existsSync(verifier)) fail(`verifier is missing: ${verifier}`);
+  const args = [verifier, "--manifest", options.manifestPath, "--bundle", options.bundlePath];
+  if (options.cosignBin) args.push("--cosign-bin", options.cosignBin);
+  if (options.trustedRootPath) args.push("--trusted-root", options.trustedRootPath);
+  if (options.identityRegexp) args.push("--certificate-identity-regexp", options.identityRegexp);
+  run(process.execPath, args, "package-set verification");
+}
+
+export function expandPackageSet(options) {
+  const root = dirname(options.manifestPath);
+  verifySignedBytes(options, root);
+  const manifest = JSON.parse(readFileSync(options.manifestPath, "utf8"));
+  assertCompleteSet(manifest, options.version);
+  mkdirSync(options.into, { recursive: true });
+  expandArchives(manifest, root, options.into, options.version);
+  checkLocalHostSurfaces(root, options.into);
+  return manifest;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const manifest = expandPackageSet(parseArgs(process.argv.slice(2)));
+    process.stdout.write(`expanded and checked package set ${manifest.wholeSetDigest}\n`);
+  } catch (error) {
+    process.stderr.write(`package-set expansion failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/test-package-set-contract.sh
+++ b/scripts/test-package-set-contract.sh
@@ -43,6 +43,13 @@ grep -qF 'cosign sign-blob' "$WORKFLOW" && grep -qF 'dist/package-set.manifest.s
   fail "release workflow must sign the package-set manifest into a Sigstore bundle"
 grep -qF 'unshare --net' "$WORKFLOW" && grep -qF 'scripts/verify-package-set.mjs' "$WORKFLOW" ||
   fail "release workflow must smoke the verifier with network access blocked"
+# Verifying the bytes is not expanding the set. The network-denied smoke must
+# run the EXPANDER — from dist/, the copy an operator downloads — so a payload
+# that is signed but unusable (a tarball packed from the wrong directory, a
+# Gemini extension that fails generated-path validation, a Hermes source tree
+# with no plugins/dev) fails the release rather than the workstation.
+grep -qF '"$(command -v node)" dist/expand-package-set.mjs' "$WORKFLOW" ||
+  fail "release offline smoke must expand the set through the released expander"
 # The legacy bundle shape reads trust roots from an older TUF store nothing in
 # cosign 2.5 primes, so its offline verify always reached for the network and
 # failed (v3.19.0). The Sigstore bundle format plus an explicit trusted root,
@@ -60,13 +67,14 @@ grep -qF 'cosign sign-blob' "$SMOKE" && grep -qF -- '--new-bundle-format' "$SMOK
   grep -qF 'cosign initialize' "$SMOKE" && grep -qF -- '--trusted-root' "$SMOKE" &&
   grep -qF 'unshare --net' "$SMOKE" && grep -qF 'scripts/verify-package-set.mjs' "$SMOKE" ||
   fail "pull-request smoke must rehearse the release's real cosign sign + offline verify recipe"
-for asset in \
-  dist/package-set.manifest.json \
-  dist/package-set.manifest.sigstore.json \
-  dist/verify-package-set.mjs; do
-  grep -qF "$asset" "$WORKFLOW" || fail "release upload must carry $asset"
-done
-pass "release workflow builds, signs, verifies, and uploads the package set"
+# Neither the signed set nor the upload may hand-keep its own list of dist
+# paths: two arrays in one file is how a payload lands in one and is forgotten
+# in the other. Both derive from scripts/workstation-package-set.mjs.
+grep -qF 'mapfile -t workstation_assets < <(node scripts/workstation-package-set.mjs --version "$VERSION")' "$WORKFLOW" ||
+  fail "the signed package set must derive its members from the workstation enumeration"
+grep -qF 'mapfile -t assets < <(node scripts/workstation-package-set.mjs --github-release --version "${NEXT#v}")' "$WORKFLOW" ||
+  fail "the release upload must derive its assets from the workstation enumeration"
+pass "release workflow builds, signs, expands, and uploads the derived package set"
 grep -qF 'run: scripts/test-package-set-contract.sh' "$WORKSPACE_CI" ||
   fail "workspace CI must run the package-set contract before merge"
 pass "workspace CI runs the package-set contract before merge"
@@ -229,3 +237,249 @@ if grep -Eq 'fetch\(|https?\.request|node:(http|https|net|tls|dns)' scripts/veri
   fail "offline verifier must not contain a network client"
 fi
 pass "verifier has no network client and requires cosign offline mode"
+
+if grep -Eq 'fetch\(|https?\.request|node:(http|https|net|tls|dns)' scripts/expand-package-set.mjs; then
+  fail "offline expander must not contain a network client"
+fi
+pass "expander has no network client"
+
+# --- the complete workstation package set (Ticket #3977) ---------------------
+#
+# This literal list is the CONTRACT. It is written out here rather than imported
+# from scripts/workstation-package-set.mjs on purpose: an enumeration that
+# validates itself validates nothing, and a payload added to or dropped from the
+# release must be restated by whoever changed it. `--version 9.9.9` resolves the
+# one version-stamped asset without pinning this test to a release.
+expected_workstation=(
+  dist/plugin-dev.payload.tgz
+  dist/plugin-memory.payload.tgz
+  dist/plugin-brain.payload.tgz
+  dist/plugin-internal.payload.tgz
+  dist/marketplace-manifests.tgz
+  dist/opencode-host.bundle.min.mjs
+  dist/opencode-host.generated.tgz
+  dist/gemini-extension.tgz
+  dist/build-gemini-extension.mjs
+  dist/validate-gemini-extension.mjs
+  dist/install-hermes-skills.mjs
+  dist/dev.bundle.min.mjs
+  dist/dev.manifest.json
+  dist/redskilled-mcp.bundle.min.mjs
+  dist/code-nav.bundle.min.mjs
+  dist/code-nav.manifest.json
+  dist/memory.bundle.min.mjs
+  dist/memory-mcp.bundle.min.mjs
+  dist/memory-runtime-manifest.json
+  dist/brain.bundle.min.mjs
+  dist/brain-mcp.bundle.min.mjs
+  dist/brain-runtime-manifest.json
+  dist/rsp.bundle.min.mjs
+  dist/rsp-core.bundle.min.mjs
+  dist/redskilled.bundle.min.mjs
+  dist/herdr-plugin-red-skills.bundle.min.mjs
+  dist/vscode-extension-red-skills-9.9.9.vsix
+  dist/zellij-dashboard.tgz
+  dist/verify-package-set.mjs
+  dist/expand-package-set.mjs
+  dist/workstation-package-set.mjs
+)
+mapfile -t declared_workstation < <(node scripts/workstation-package-set.mjs --version 9.9.9)
+if ! diff -u \
+  <(printf '%s\n' "${expected_workstation[@]}" | sort) \
+  <(printf '%s\n' "${declared_workstation[@]}" | sort) >"$tmp/workstation.diff"; then
+  cat "$tmp/workstation.diff" >&2
+  fail "the workstation package set drifted from the declared contract"
+fi
+pass "the workstation package set matches the declared contract"
+
+# The plugin payloads follow the plugin TREE, not a memory of it: a fifth plugin
+# must get a payload by existing. The enumeration is static so the expander can
+# read it on a machine with no checkout, so CI is where the two are tied.
+mapfile -t declared_plugin_payloads < <(node scripts/workstation-package-set.mjs --plugin-payloads)
+mapfile -t tree_plugin_payloads < <(
+  find plugins -mindepth 3 -maxdepth 3 -path '*/.claude-plugin/plugin.json' |
+    sed -E 's#^plugins/([^/]+)/.*#dist/plugin-\1.payload.tgz#'
+)
+if ! diff -u \
+  <(printf '%s\n' "${declared_plugin_payloads[@]}" | sort) \
+  <(printf '%s\n' "${tree_plugin_payloads[@]}" | sort) >"$tmp/plugins.diff"; then
+  cat "$tmp/plugins.diff" >&2
+  fail "the declared plugin payloads drifted from the plugin tree"
+fi
+pass "every plugin in the tree has a declared payload"
+
+# Every workstation-installable KIND the Ticket names must be represented. A
+# list that still parses while a whole category quietly vanished is the failure
+# an enumeration is supposed to make impossible.
+require_member() {
+  local label="$1" asset="$2"
+  printf '%s\n' "${declared_workstation[@]}" | grep -qxF "$asset" ||
+    fail "the workstation package set carries no $label ($asset)"
+}
+require_member "dev plugin payload" dist/plugin-dev.payload.tgz
+require_member "memory plugin payload" dist/plugin-memory.payload.tgz
+require_member "brain plugin payload" dist/plugin-brain.payload.tgz
+require_member "internal plugin payload" dist/plugin-internal.payload.tgz
+require_member "marketplace projection" dist/marketplace-manifests.tgz
+require_member "Gemini local surface" dist/gemini-extension.tgz
+require_member "Gemini generated-path validator" dist/validate-gemini-extension.mjs
+require_member "Hermes local surface" dist/install-hermes-skills.mjs
+require_member "redskilled daemon" dist/redskilled.bundle.min.mjs
+require_member "Herdr plugin" dist/herdr-plugin-red-skills.bundle.min.mjs
+require_member "VS Code extension" dist/vscode-extension-red-skills-9.9.9.vsix
+require_member "Zellij integration" dist/zellij-dashboard.tgz
+require_member "offline expander" dist/expand-package-set.mjs
+pass "every declared workstation payload kind is present"
+
+# Developer-only artifacts are the opposite failure: an addition that makes the
+# workstation contract mean whatever the last release happened to build.
+mapfile -t developer_only < <(node scripts/workstation-package-set.mjs --developer-only)
+for artifact in \
+  dist/benchmark-memory.bundle.min.mjs \
+  dist/benchmark-memory.manifest.json \
+  dist/benchmark-code-understanding.bundle.min.mjs \
+  dist/benchmark-code-understanding.manifest.json \
+  dist/release.bundle.min.mjs; do
+  printf '%s\n' "${developer_only[@]}" | grep -qxF "$artifact" ||
+    fail "$artifact must stay declared developer-only"
+done
+for artifact in "${developer_only[@]}"; do
+  if printf '%s\n' "${declared_workstation[@]}" | grep -qxF "$artifact"; then
+    fail "developer-only artifact is inside the workstation package set: $artifact"
+  fi
+done
+pass "developer-only artifacts stay out of the workstation package set"
+
+# The upload is a superset: it also carries the published developer-only
+# evidence and the signed manifest with its Sigstore bundle.
+mapfile -t release_assets < <(node scripts/workstation-package-set.mjs --github-release --version 9.9.9)
+for asset in "${declared_workstation[@]}" dist/package-set.manifest.json dist/package-set.manifest.sigstore.json; do
+  printf '%s\n' "${release_assets[@]}" | grep -qxF "$asset" || fail "release upload must carry $asset"
+done
+if printf '%s\n' "${release_assets[@]}" | grep -qxF dist/release.bundle.min.mjs; then
+  fail "the release engine bundle travels inside the npm package, not the GitHub Release"
+fi
+pass "the GitHub Release upload is the workstation set plus its declared extras"
+
+# The npm and Pi transports keep their existing public contracts: this package
+# set references them, it does not replace them (Ticket #3977).
+for entry in \
+  scripts/build-gemini-extension.mjs \
+  scripts/validate-gemini-extension.mjs \
+  scripts/install-hermes-skills.mjs; do
+  node -e '
+    const files = require("./packaging/npm/package.json").files;
+    if (!files.includes(process.argv[1])) {
+      console.error(`packaging/npm/package.json no longer ships ${process.argv[1]}`);
+      process.exit(1);
+    }
+  ' "$entry" || fail "the npm transport must keep shipping $entry"
+done
+pass "the npm transport keeps its Gemini and Hermes public contract"
+
+# --- network-denied expansion of a complete set (Ticket #3977) ---------------
+#
+# The release proves this inside `unshare --net` with real cosign. Here the same
+# expander runs against a REAL fixture set — the actual plugin trees, the actual
+# generated Gemini extension, the actual Hermes installer — with the runtime
+# bundles stubbed, so a payload that expands into an unusable shape fails the
+# pull request instead of the workstation. Network denial uses a rootless
+# namespace when the host allows one; the expander holds no network client
+# either way, which the grep above pins.
+fixture="$tmp/source"
+set_dir="$tmp/set"
+expanded="$tmp/expanded"
+mkdir -p "$fixture/dist" "$set_dir" "$expanded"
+ln -s "$ROOT/plugins" "$fixture/plugins"
+for stub in code-nav-mcp redskilled-mcp rsp; do
+  printf 'stub %s bundle\n' "$stub" >"$fixture/dist/$stub.bundle.min.mjs"
+done
+
+node scripts/build-gemini-extension.mjs --root "$fixture" --output "$tmp/gemini/dev"
+node scripts/validate-gemini-extension.mjs --extension "$tmp/gemini/dev" >/dev/null
+tar -czf "$set_dir/gemini-extension.tgz" -C "$tmp" gemini
+for plugin in dev memory brain internal; do
+  tar -czf "$set_dir/plugin-$plugin.payload.tgz" -C "$ROOT" "plugins/$plugin"
+done
+tar -czf "$set_dir/marketplace-manifests.tgz" -C "$ROOT" \
+  .claude-plugin/marketplace.json \
+  .agents/plugins/marketplace.json \
+  .gemini-plugin/marketplace.json
+tar -czf "$set_dir/zellij-dashboard.tgz" -C "$ROOT/apps" zellij-plugin-dashboard
+mkdir -p "$tmp/opencode-source/dist/opencode"
+printf 'stub opencode projection\n' >"$tmp/opencode-source/dist/opencode/.release-generated"
+tar -czf "$set_dir/opencode-host.generated.tgz" -C "$tmp/opencode-source" dist/opencode
+for script in \
+  verify-package-set.mjs \
+  expand-package-set.mjs \
+  workstation-package-set.mjs \
+  build-gemini-extension.mjs \
+  validate-gemini-extension.mjs \
+  install-hermes-skills.mjs; do
+  cp "scripts/$script" "$set_dir/$script"
+done
+mapfile -t fixture_assets < <(node scripts/workstation-package-set.mjs --version 9.9.9)
+build_args=()
+for asset in "${fixture_assets[@]}"; do
+  name="$(basename "$asset")"
+  [ -e "$set_dir/$name" ] || printf 'stub %s\n' "$name" >"$set_dir/$name"
+  build_args+=(--asset "$set_dir/$name")
+done
+build "$source_commit" "$set_dir/package-set.manifest.json" "${build_args[@]}" >/dev/null
+sign_fixture "$set_dir/package-set.manifest.json" "$set_dir/package-set.manifest.sigstore.json"
+
+expand() {
+  local into="$1"
+  local -a command=(
+    node "$set_dir/expand-package-set.mjs"
+    --manifest "$set_dir/package-set.manifest.json"
+    --bundle "$set_dir/package-set.manifest.sigstore.json"
+    --into "$into"
+    --version 9.9.9
+    --cosign-bin "$tmp/bin/cosign"
+  )
+  if unshare -rn true >/dev/null 2>&1; then
+    unshare -rn -- "${command[@]}"
+  else
+    printf 'NOTE: this host allows no rootless network namespace; expanding without one\n'
+    "${command[@]}"
+  fi
+}
+
+expand "$expanded" >/dev/null
+for materialised in \
+  plugins/dev/.claude-plugin/plugin.json \
+  plugins/memory/.claude-plugin/plugin.json \
+  plugins/brain/.claude-plugin/plugin.json \
+  plugins/internal/package.json \
+  .claude-plugin/marketplace.json \
+  gemini/dev/gemini-extension.json \
+  zellij-plugin-dashboard/layouts/red-dashboard.kdl \
+  dist/opencode/.release-generated; do
+  [ -e "$expanded/$materialised" ] || fail "expansion did not materialise $materialised"
+done
+pass "a complete package set expands and checks its host surfaces with no network"
+
+# An omitted workstation payload must be refused at expansion time too, not only
+# in CI: the operator holding the download is the last reader who can notice.
+incomplete="$tmp/incomplete"
+mkdir -p "$incomplete/set"
+cp "$set_dir"/* "$incomplete/set/" 2>/dev/null || true
+rm -f "$incomplete/set/plugin-memory.payload.tgz"
+short_args=()
+for asset in "${fixture_assets[@]}"; do
+  name="$(basename "$asset")"
+  if [ "$name" = "plugin-memory.payload.tgz" ]; then continue; fi
+  short_args+=(--asset "$incomplete/set/$name")
+done
+build "$source_commit" "$incomplete/set/package-set.manifest.json" "${short_args[@]}" >/dev/null
+sign_fixture "$incomplete/set/package-set.manifest.json" "$incomplete/set/package-set.manifest.sigstore.json"
+if node "$incomplete/set/expand-package-set.mjs" \
+  --manifest "$incomplete/set/package-set.manifest.json" \
+  --bundle "$incomplete/set/package-set.manifest.sigstore.json" \
+  --into "$tmp/incomplete-expanded" \
+  --version 9.9.9 \
+  --cosign-bin "$tmp/bin/cosign" >/dev/null 2>&1; then
+  fail "a set missing a workstation payload must be refused"
+fi
+pass "a set missing a workstation payload is refused"

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -471,6 +471,11 @@ fi
 # The standalone installer downloads the RSP bundle into the source snapshot
 # used by OpenCode. Building it only for the npm tarball is insufficient: the
 # GitHub Release upload list is the installer's public artifact contract.
+#
+# That list is no longer written in the workflow — it is derived from
+# scripts/workstation-package-set.mjs (#3977) — so this reads the derivation and
+# separately pins that the step still uses it. Grepping the step's own text
+# would pass on an empty upload.
 github_release_step="$(mktemp)"
 trap 'rm -f "$github_release_step"' EXIT
 awk '
@@ -478,8 +483,10 @@ awk '
   in_step && /^      - name:/ && $0 != "      - name: GitHub Release" { exit }
   in_step { print }
 ' "$WORKFLOW" >"$github_release_step"
-if grep -qF 'dist/rsp.bundle.min.mjs' "$github_release_step" &&
-   grep -qF 'dist/rsp-core.bundle.min.mjs' "$github_release_step"; then
+release_assets="$(node scripts/workstation-package-set.mjs --github-release --version 0.0.0)"
+if grep -qF 'node scripts/workstation-package-set.mjs --github-release' "$github_release_step" &&
+   printf '%s\n' "$release_assets" | grep -qxF 'dist/rsp.bundle.min.mjs' &&
+   printf '%s\n' "$release_assets" | grep -qxF 'dist/rsp-core.bundle.min.mjs'; then
   pass "GitHub Release publishes the RSP launcher and core consumed by the installer"
 else
   fail "GitHub Release must upload both RSP boundary assets for standalone installs"

--- a/scripts/workstation-package-set.mjs
+++ b/scripts/workstation-package-set.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+
+// The declared workstation package set (Spec #3973, Ticket #3977).
+//
+// A RedSkills release attaches two kinds of artifact to one GitHub Release:
+// what a WORKSTATION installs, and what only this repository's own developers
+// consume. Both used to be hand-kept bash arrays inside red-publish.yml — one
+// for the signed package set, one for the upload — so a new payload landed in
+// whichever array its author happened to edit. That drift is invisible until an
+// operator expands the set on a machine with no network and finds a host with
+// no plugin payload to register.
+//
+// This module is the ONE enumeration. The release workflow derives both arrays
+// from it, and scripts/test-package-set-contract.sh pins it against an
+// independent literal list, so adding or dropping a payload is a deliberate
+// two-file change rather than a silent omission.
+
+import { fileURLToPath } from "node:url";
+
+/**
+ * One workstation-installable payload.
+ *
+ * `asset` is the dist path the release builds; `{version}` is substituted with
+ * the release version. `expandsTo` names the paths an archive payload
+ * materialises relative to an expansion root — the expander asserts them, so a
+ * tarball packed from the wrong `-C` fails the release instead of the operator.
+ */
+export const WORKSTATION_PAYLOADS = [
+  // The four plugin definition trees every host registers. Without them a
+  // network-denied expansion yields runtimes with nothing to run.
+  { asset: "dist/plugin-dev.payload.tgz", kind: "plugin-payload", expandsTo: ["plugins/dev"] },
+  { asset: "dist/plugin-memory.payload.tgz", kind: "plugin-payload", expandsTo: ["plugins/memory"] },
+  { asset: "dist/plugin-brain.payload.tgz", kind: "plugin-payload", expandsTo: ["plugins/brain"] },
+  { asset: "dist/plugin-internal.payload.tgz", kind: "plugin-payload", expandsTo: ["plugins/internal"] },
+
+  // Canonical host projections and the generators that produce them. The Claude
+  // manifest is the source; the Codex and Gemini manifests are its projections.
+  {
+    asset: "dist/marketplace-manifests.tgz",
+    kind: "host-projection",
+    expandsTo: [".claude-plugin/marketplace.json", ".agents/plugins/marketplace.json", ".gemini-plugin/marketplace.json"],
+  },
+  { asset: "dist/opencode-host.bundle.min.mjs", kind: "host-generator" },
+  { asset: "dist/opencode-host.generated.tgz", kind: "host-projection", expandsTo: ["dist/opencode"] },
+  // Gemini (#3975): the generated extension is shipped already built AND the
+  // generator plus its generated-path validator ride along, so an operator can
+  // re-generate and re-validate from the expanded plugin payloads offline.
+  { asset: "dist/gemini-extension.tgz", kind: "host-projection", expandsTo: ["gemini/dev"] },
+  { asset: "dist/build-gemini-extension.mjs", kind: "host-generator" },
+  { asset: "dist/validate-gemini-extension.mjs", kind: "host-generator" },
+  // Hermes (#3976): the installer reads `<source>/plugins/dev`, which the dev
+  // plugin payload above materialises.
+  { asset: "dist/install-hermes-skills.mjs", kind: "host-generator" },
+
+  // Runtime bundles, each with the checksum manifest its dynamic fetch verifies.
+  { asset: "dist/dev.bundle.min.mjs", kind: "runtime-bundle" },
+  { asset: "dist/dev.manifest.json", kind: "runtime-bundle" },
+  { asset: "dist/redskilled-mcp.bundle.min.mjs", kind: "runtime-bundle" },
+  { asset: "dist/code-nav.bundle.min.mjs", kind: "runtime-bundle" },
+  { asset: "dist/code-nav.manifest.json", kind: "runtime-bundle" },
+  { asset: "dist/memory.bundle.min.mjs", kind: "runtime-bundle" },
+  { asset: "dist/memory-mcp.bundle.min.mjs", kind: "runtime-bundle" },
+  { asset: "dist/memory-runtime-manifest.json", kind: "runtime-bundle" },
+  { asset: "dist/brain.bundle.min.mjs", kind: "runtime-bundle" },
+  { asset: "dist/brain-mcp.bundle.min.mjs", kind: "runtime-bundle" },
+  { asset: "dist/brain-runtime-manifest.json", kind: "runtime-bundle" },
+  { asset: "dist/rsp.bundle.min.mjs", kind: "runtime-bundle" },
+  { asset: "dist/rsp-core.bundle.min.mjs", kind: "runtime-bundle" },
+
+  // The host-scoped daemon (ADR 0130).
+  { asset: "dist/redskilled.bundle.min.mjs", kind: "daemon" },
+
+  // Companion surfaces installed by hand rather than resolved by a launcher, so
+  // the release is the only place they can come from (#3060).
+  { asset: "dist/herdr-plugin-red-skills.bundle.min.mjs", kind: "companion-surface" },
+  { asset: "dist/vscode-extension-red-skills-{version}.vsix", kind: "companion-surface" },
+  { asset: "dist/zellij-dashboard.tgz", kind: "terminal-integration", expandsTo: ["zellij-plugin-dashboard"] },
+
+  // Everything a network-denied expansion needs to check itself.
+  { asset: "dist/verify-package-set.mjs", kind: "verifier-input" },
+  { asset: "dist/expand-package-set.mjs", kind: "verifier-input" },
+  // The expander reads this enumeration to know what an expansion owes, so the
+  // completeness check travels with the set instead of living only in CI.
+  { asset: "dist/workstation-package-set.mjs", kind: "verifier-input" },
+];
+
+/**
+ * Artifacts the release builds that the workstation set must NEVER carry.
+ * `published` says whether the GitHub Release still attaches the file: the
+ * benchmarks are downloadable evidence for this repository's own measurements,
+ * and the release engine bundle travels only inside the npm package.
+ */
+export const DEVELOPER_ONLY_ARTIFACTS = [
+  { asset: "dist/benchmark-memory.bundle.min.mjs", published: true },
+  { asset: "dist/benchmark-memory.manifest.json", published: true },
+  { asset: "dist/benchmark-code-understanding.bundle.min.mjs", published: true },
+  { asset: "dist/benchmark-code-understanding.manifest.json", published: true },
+  { asset: "dist/release.bundle.min.mjs", published: false },
+];
+
+/** The signed manifest and its Sigstore bundle: attached, never members of the set they describe. */
+export const PACKAGE_SET_SIGNATURE_ASSETS = ["dist/package-set.manifest.json", "dist/package-set.manifest.sigstore.json"];
+
+const VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+
+function resolveAsset(asset, version) {
+  if (!asset.includes("{version}")) return asset;
+  if (!version) throw new Error(`--version is required to resolve ${asset}`);
+  return asset.replaceAll("{version}", version);
+}
+
+/** The complete workstation package set, in declaration order. */
+export function workstationAssets(version) {
+  return WORKSTATION_PAYLOADS.map((payload) => resolveAsset(payload.asset, version));
+}
+
+/** The plugin definition payloads, one per plugin the marketplace ships. */
+export function pluginPayloads() {
+  return WORKSTATION_PAYLOADS.filter((payload) => payload.kind === "plugin-payload").map((payload) => payload.asset);
+}
+
+/** The archive payloads, with the paths each one must materialise. */
+export function archivePayloads(version) {
+  return WORKSTATION_PAYLOADS.filter((payload) => Array.isArray(payload.expandsTo)).map((payload) => ({
+    asset: resolveAsset(payload.asset, version),
+    expandsTo: payload.expandsTo,
+  }));
+}
+
+/** Every file the tag's GitHub Release attaches. */
+export function githubReleaseAssets(version) {
+  return [
+    ...workstationAssets(version),
+    ...DEVELOPER_ONLY_ARTIFACTS.filter((artifact) => artifact.published).map((artifact) => artifact.asset),
+    ...PACKAGE_SET_SIGNATURE_ASSETS,
+  ];
+}
+
+function parseArgs(argv) {
+  const options = { mode: "workstation", version: "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--version") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--version requires a value");
+      if (!VERSION.test(value)) throw new Error(`--version must be a bare semver, got ${JSON.stringify(value)}`);
+      options.version = value;
+      index += 1;
+      continue;
+    }
+    if (
+      argument === "--workstation" ||
+      argument === "--developer-only" ||
+      argument === "--github-release" ||
+      argument === "--archives" ||
+      argument === "--plugin-payloads"
+    ) {
+      options.mode = argument.slice(2);
+      continue;
+    }
+    throw new Error(`unknown or incomplete argument: ${argument}`);
+  }
+  return options;
+}
+
+export function render(options) {
+  if (options.mode === "developer-only") return DEVELOPER_ONLY_ARTIFACTS.map((artifact) => artifact.asset);
+  if (options.mode === "github-release") return githubReleaseAssets(options.version);
+  if (options.mode === "plugin-payloads") return pluginPayloads();
+  if (options.mode === "archives") {
+    return archivePayloads(options.version).map((payload) => `${payload.asset}\t${payload.expandsTo.join(",")}`);
+  }
+  return workstationAssets(options.version);
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const lines = render(parseArgs(argv));
+  process.stdout.write(lines.length === 0 ? "" : `${lines.join("\n")}\n`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`workstation package set failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
Automated AFK landing for #3977. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #3977

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789689296&installation_model_id=20659&pr_number=4037&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4037&signature=475cf95682b2826e9eb651203e5f4c040061d2f0b1fff3a6cd315471a8600b93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->