### PR TITLE
fix: #4008 protocol-acp: one package for ACP compat, wire major, socket transport and _redskills/* schemas

### DIFF
--- a/.changeset/protocol-acp-shared-wire.md
+++ b/.changeset/protocol-acp-shared-wire.md
@@ -1,0 +1,10 @@
+---
+"@reddb-io/protocol-acp": minor
+"@reddb-io/redskilled": patch
+"@reddb-io/dev": patch
+---
+The shared RedSkills ACP wire moves into one package, `@reddb-io/protocol-acp`:
+ACP v1/v2 compat and draft-revision gating, the RedSkills wire major, the local
+Unix-socket / Named Pipe transport, and the `_redskills/*` method registry. The
+daemon and the stateless adapters import it instead of carrying private copies,
+and a grep-pinned ownership guard refuses a re-grown copy.

--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -143,6 +143,7 @@ release:
     - { path: packages/build-info/package.json, format: npm }
     - { path: packages/cdp-driver/package.json, format: npm }
     - { path: packages/github/package.json, format: npm }
+    - { path: packages/protocol-acp/package.json, format: npm }
     - { path: packages/red-castle/package.json, format: npm }
     - { path: packages/redskilled-render/package.json, format: npm }
     - { path: packages/shared/package.json, format: npm }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ red-skills/                         ← repo root + marketplace
 │   ├── shared/                     ← CLI args, bundle-fetch, entrypoint (ADR 0034)
 │   ├── build-info/                 ← shared build metadata helpers
 │   ├── github/                     ← the one budget-aware GitHub client: cardinality routing, asked balance, cache (ADR 0132)
+│   ├── protocol-acp/               ← the shared ACP wire: v1/v2 compat, the RedSkills wire major, socket transport, `_redskills/*` methods (ADR 0148/0153)
 │   ├── cdp-driver/, browser-bridge/ ← browser transport
 │   └── red-castle/                 ← vendored AFK execution substrate source (@reddb-io/red-castle, ADR 0061/0101)
 ├── dist/                           ← generated release bundles and manifests

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -23,6 +23,7 @@
     "@reddb-io/brand-tokens": "workspace:*",
     "@reddb-io/build-info": "workspace:*",
     "@reddb-io/github": "workspace:*",
+    "@reddb-io/protocol-acp": "workspace:*",
     "@reddb-io/red-castle": "workspace:*",
     "@reddb-io/redskilled": "workspace:*",
     "@reddb-io/redskilled-render": "workspace:*",

--- a/apps/dev/src/core/declared-wait-guard.ts
+++ b/apps/dev/src/core/declared-wait-guard.ts
@@ -81,13 +81,14 @@ export interface DeclaredWait {
 /**
  * The engine trees the guard enumerates.
  *
- * Scoped to the two packages that hold the orchestrator and its substrate,
- * because those are the waits a stalled AFK run is stuck inside. A tree added
- * here is a tree whose waits must all be declared in the same slice.
+ * Scoped to the trees that hold the orchestrator, its substrate and the shared
+ * ACP wire, because those are the waits a stalled AFK run is stuck inside. A
+ * tree added here is a tree whose waits must all be declared in the same slice.
  */
 export const WAIT_SCAN_ROOTS: readonly string[] = [
   "apps/dev/src",
   "apps/redskilled/src",
+  "packages/protocol-acp",
   "packages/shared/kill-tree.ts",
   "packages/red-castle/src",
 ];
@@ -698,7 +699,7 @@ export const DECLARED_WAITS: readonly DeclaredWait[] = [
     heartbeat: { silent: "a two-second host drain followed immediately by replacement or bounded refusal" },
   },
   {
-    path: "apps/redskilled/src/acp-socket.ts",
+    path: "packages/protocol-acp/transport.ts",
     fn: "connectWithDeadline",
     subject: "the daemon ACP socket or assigned native Worker ACP socket accepting a local connection",
     deadline: "the caller's `timeoutMs`, 10 seconds for both public and Worker rendezvous",

--- a/apps/dev/tests/acp-adapter-ownership-guard.test.ts
+++ b/apps/dev/tests/acp-adapter-ownership-guard.test.ts
@@ -1,6 +1,8 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+
+import { REDSKILLS_ACP_METHOD_NAMES } from "@reddb-io/protocol-acp";
 
 const ADAPTERS = [
   "src/mcp-server.ts",
@@ -38,5 +40,88 @@ describe("ACP adapter ownership guard", () => {
     expect(source).toContain("endpoint.acpSocketPath");
     expect(source).not.toMatch(/endpoint\.(?:socketPath|leasePath|eventLanePath|machineClaimPath)/);
     expect(source).not.toMatch(/from ["'].+protocol\.js["']/);
+  });
+});
+
+// The shared wire is ONE package (ADR 0148, issue #4008). A private copy of ACP
+// compat, the wire major, the socket transport or a `_redskills/*` method name
+// does not fail to compile — it fails at run time, on the far side of a socket,
+// against a peer that read the other copy. So the copies are refused by grep.
+const WIRE_PACKAGE = resolve(__dirname, "..", "..", "..", "packages", "protocol-acp");
+
+/** Every source tree that must IMPORT the shared wire rather than restate it. */
+const WIRE_CONSUMERS = [
+  resolve(__dirname, "..", "src"),
+  resolve(__dirname, "..", "..", "redskilled", "src"),
+] as const;
+
+/**
+ * A re-grown copy, paired with the export that already answers it.
+ *
+ * Each pattern matches a DEFINITION, never a use: `REDSKILLS_WIRE_MAJOR` may be
+ * read anywhere, and only `REDSKILLS_WIRE_MAJOR =` declares a second one.
+ */
+const WIRE_COPIES = [
+  { pattern: /\bACP_PROTOCOL_VERSION\s*=/, owner: "compat.ts ACP_PROTOCOL_VERSION" },
+  { pattern: /\bACP_V2_DRAFT_REVISION\s*=\s*["'`]/, owner: "compat.ts ACP_V2_DRAFT_REVISION" },
+  { pattern: /\bREDSKILLS_WIRE_MAJOR\s*=\s*\d/, owner: "compat.ts REDSKILLS_WIRE_MAJOR" },
+  { pattern: /function\s+requireCompatibleWireMajor\b/, owner: "compat.ts requireCompatibleWireMajor" },
+  { pattern: /function\s+requireSupportedV2Revision\b/, owner: "compat.ts requireSupportedV2Revision" },
+  { pattern: /function\s+translateV1SessionUpdateToV2\b/, owner: "compat.ts translateV1SessionUpdateToV2" },
+  { pattern: /function\s+socketStream\b/, owner: "transport.ts socketStream" },
+  { pattern: /function\s+bindWorkerRendezvous\b/, owner: "transport.ts bindWorkerRendezvous" },
+  { pattern: /function\s+connectWithDeadline\b/, owner: "transport.ts connectWithDeadline" },
+  { pattern: /function\s+removeAcpEndpoint\b/, owner: "transport.ts removeAcpEndpoint" },
+] as const;
+
+function sourceFiles(root: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) found.push(...sourceFiles(path));
+    else if (entry.name.endsWith(".ts")) found.push(path);
+  }
+  return found;
+}
+
+describe("shared ACP wire ownership guard (#4008)", () => {
+  it("keeps ACP compat, the wire major and the socket transport in @reddb-io/protocol-acp", () => {
+    const violations: string[] = [];
+    for (const root of WIRE_CONSUMERS) {
+      for (const path of sourceFiles(root)) {
+        const source = readFileSync(path, "utf8");
+        for (const rule of WIRE_COPIES) {
+          if (rule.pattern.test(source)) {
+            violations.push(`${path.slice(path.indexOf("apps/"))}: private copy of ${rule.owner}`);
+          }
+        }
+      }
+    }
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  it("spells every `_redskills/*` method name only in the shared registry", () => {
+    const literal = /["'`]_redskills\/[a-z_]+["'`]/;
+    const violations: string[] = [];
+    for (const root of WIRE_CONSUMERS) {
+      for (const path of sourceFiles(root)) {
+        if (literal.test(readFileSync(path, "utf8"))) {
+          violations.push(`${path.slice(path.indexOf("apps/"))}: _redskills/* literal outside the registry`);
+        }
+      }
+    }
+    expect(violations, violations.join("\n")).toEqual([]);
+    expect(REDSKILLS_ACP_METHOD_NAMES.length).toBeGreaterThan(0);
+  });
+
+  it("serves the daemon and the adapters from one copy of the wire", () => {
+    for (const module of ["compat.ts", "methods.ts", "transport.ts"]) {
+      expect(readFileSync(join(WIRE_PACKAGE, module), "utf8").length).toBeGreaterThan(0);
+    }
+    const controlPlane = readFileSync(
+      resolve(__dirname, "..", "..", "redskilled", "src", "acp-control-plane.ts"),
+      "utf8",
+    );
+    expect(controlPlane).toContain('from "@reddb-io/protocol-acp"');
   });
 });

--- a/apps/dev/tests/declared-wait-guard.test.ts
+++ b/apps/dev/tests/declared-wait-guard.test.ts
@@ -96,6 +96,7 @@ describe("the live engine declares every wait it holds (#3024)", () => {
     expect(WAIT_SCAN_ROOTS).toEqual([
       "apps/dev/src",
       "apps/redskilled/src",
+      "packages/protocol-acp",
       "packages/shared/kill-tree.ts",
       "packages/red-castle/src",
     ]);

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -56,6 +56,7 @@
     "@agentclientprotocol/sdk": "1.3.0",
     "@reddb-io/build-info": "workspace:*",
     "@reddb-io/github": "workspace:*",
+    "@reddb-io/protocol-acp": "workspace:*",
     "@reddb-io/red-castle": "workspace:*",
     "@reddb-io/redskilled-render": "workspace:*",
     "@reddb-io/shared": "workspace:*",

--- a/apps/redskilled/src/acp-budget.ts
+++ b/apps/redskilled/src/acp-budget.ts
@@ -1,4 +1,5 @@
 import { RequestError } from "@agentclientprotocol/sdk";
+import { REDSKILLS_ACP_METHODS, emptyRedskillsParams } from "@reddb-io/protocol-acp";
 import {
   type RedskilledGithubBudgetGateway,
   type RedskilledGithubGateway,
@@ -9,8 +10,8 @@ import {
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 import { RedskilledGithubCredentialProfileError } from "./github-credential-profiles.js";
 
-export const REDSKILLED_PROJECT_BUDGET_METHOD = "_redskills/project_budget";
-export const REDSKILLED_HOST_BUDGET_METHOD = "_redskills/host_budgets";
+export const REDSKILLED_PROJECT_BUDGET_METHOD = REDSKILLS_ACP_METHODS.projectBudget;
+export const REDSKILLED_HOST_BUDGET_METHOD = REDSKILLS_ACP_METHODS.hostBudgets;
 
 type EmptyParams = Record<string, never>;
 
@@ -69,12 +70,9 @@ export function bindAcpHostGithubBudget(
 }
 
 /** Both budget methods accept exactly an empty object; authority is never caller-named. */
-export function emptyBudgetParams(value: unknown): EmptyParams {
-  if (value == null || typeof value !== "object" || Array.isArray(value) || Object.keys(value).length !== 0) {
-    throw RequestError.invalidParams({}, "credential-budget requests accept no caller-controlled authority fields");
-  }
-  return {};
-}
+export const emptyBudgetParams: (value: unknown) => EmptyParams = emptyRedskillsParams(
+  "credential-budget requests accept no caller-controlled authority fields",
+);
 
 function budgetGateway(gateway: RedskilledGithubGateway | undefined): RedskilledGithubBudgetGateway | null {
   if (gateway == null || !("projectBudget" in gateway) || !("hostBudget" in gateway)) return null;

--- a/apps/redskilled/src/acp-child-agent.ts
+++ b/apps/redskilled/src/acp-child-agent.ts
@@ -14,7 +14,7 @@ import {
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
 import type { AcpEndpoint } from "./acp-agent-catalog.js";
-import { ACP_PROTOCOL_VERSION, REDSKILLS_WIRE_MAJOR } from "./acp-compat.js";
+import { ACP_PROTOCOL_VERSION, REDSKILLS_WIRE_MAJOR } from "@reddb-io/protocol-acp";
 import { createChildAcpSpinEpisode, type ChildAcpSpinEpisode } from "./acp-child-spin.js";
 import type { SpinPattern } from "@reddb-io/red-castle/engine/spin-evaluator";
 

--- a/apps/redskilled/src/acp-client.ts
+++ b/apps/redskilled/src/acp-client.ts
@@ -16,7 +16,7 @@ import {
 } from "@agentclientprotocol/sdk";
 import { ensureRedskilledDaemon } from "./client.js";
 import { resolveRedskilledClientEndpoint } from "./client-rendezvous.js";
-import { REDSKILLS_WIRE_MAJOR } from "./acp-compat.js";
+import { REDSKILLS_ACP_METHODS, REDSKILLS_WIRE_MAJOR } from "@reddb-io/protocol-acp";
 import { resolveRedskilledPaths, type RedskilledPaths } from "./paths.js";
 import type { ProjectStatusContext } from "./project-control.js";
 
@@ -67,9 +67,9 @@ export interface ConnectRedskillsProjectAcpOptions {
 }
 
 const PROJECT_CONTROL_METHOD = {
-  drain: "_redskills/project_drain",
-  stop: "_redskills/project_stop",
-  status: "_redskills/project_status",
+  drain: REDSKILLS_ACP_METHODS.projectDrain,
+  stop: REDSKILLS_ACP_METHODS.projectStop,
+  status: REDSKILLS_ACP_METHODS.projectStatus,
 } as const;
 
 /** Connect a public adapter to redskilled through ACP and no private daemon wire. */

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -26,19 +26,18 @@ import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import {
   ACP_PROTOCOL_VERSION,
   ACP_V2_DRAFT_REVISION,
+  REDSKILLS_ACP_METHODS,
   REDSKILLS_WIRE_MAJOR,
-  requireCompatibleWireMajor,
-  requireSupportedV2Revision,
-  translateV1SessionUpdateToV2,
-} from "./acp-compat.js";
-import {
   closeServer,
   connectWithDeadline,
   listen,
   removeAcpEndpoint,
+  requireCompatibleWireMajor,
+  requireSupportedV2Revision,
   socketStream,
+  translateV1SessionUpdateToV2,
   withTimeout,
-} from "./acp-socket.js";
+} from "@reddb-io/protocol-acp";
 import {
   REDSKILLED_GITHUB_UPDATE_METHOD,
   bindAcpGithubReaderUpdates,
@@ -115,7 +114,7 @@ import { admitNativeAcpWorker } from "./acp-native-worker.js";
 export { runNativeAcpWorker } from "./acp-native-worker.js";
 import { runAcpWorkflowTurn } from "./acp-workflow-turn.js";
 
-export { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "./acp-compat.js";
+export { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "@reddb-io/protocol-acp";
 
 interface PublicSession {
   readonly request: NewSessionRequest;
@@ -404,7 +403,7 @@ async function servePublicConnection(
     })
     // Compatibility spelling, but deliberately a Project projection. Ordinary
     // ACP socket access is not an administrative capability.
-    .onRequest("_redskills/host_state", emptyParams, scopedState)
+    .onRequest(REDSKILLS_ACP_METHODS.hostState, emptyParams, scopedState)
     .onRequest(PROJECT_CONTROL_METHODS[0], emptyParams, () => mutateProjectControl("drain"))
     .onRequest(PROJECT_CONTROL_METHODS[1], emptyParams, () => mutateProjectControl("stop"))
     .onRequest(PROJECT_CONTROL_METHODS[2], emptyParams, readProjectControl)
@@ -532,7 +531,7 @@ async function servePublicConnection(
         ...(params._meta == null ? {} : { _meta: params._meta }),
       });
     })
-    .onRequest("_redskills/host_state", emptyParams, scopedState)
+    .onRequest(REDSKILLS_ACP_METHODS.hostState, emptyParams, scopedState)
     .onRequest(PROJECT_CONTROL_METHODS[0], emptyParams, () => mutateProjectControl("drain"))
     .onRequest(PROJECT_CONTROL_METHODS[1], emptyParams, () => mutateProjectControl("stop"))
     .onRequest(PROJECT_CONTROL_METHODS[2], emptyParams, readProjectControl)

--- a/apps/redskilled/src/acp-github.ts
+++ b/apps/redskilled/src/acp-github.ts
@@ -1,5 +1,6 @@
 import { RequestError } from "@agentclientprotocol/sdk";
 import { GithubBackpressureError } from "@reddb-io/github";
+import { REDSKILLS_ACP_METHODS } from "@reddb-io/protocol-acp";
 import {
   RedskilledGithubAuthorityError,
   type RedskilledGithubGatewayRegistration,
@@ -18,7 +19,7 @@ type GithubReadParams = { readonly read: RedskilledGithubRead };
 type GithubWriteParams = RedskilledGithubWriteRequest;
 type GithubCustodyHandoffParams = RedskilledGithubCustodyHandoff;
 
-export const REDSKILLED_GITHUB_UPDATE_METHOD = "_redskills/github_update";
+export const REDSKILLED_GITHUB_UPDATE_METHOD = REDSKILLS_ACP_METHODS.githubUpdate;
 
 export interface AcpGithubUpdateObserver {
   close(): void;

--- a/apps/redskilled/src/acp-native-worker.ts
+++ b/apps/redskilled/src/acp-native-worker.ts
@@ -21,17 +21,15 @@ import { WorkflowChildAgent } from "./acp-child-agent.js";
 import {
   ACP_PROTOCOL_VERSION,
   REDSKILLS_WIRE_MAJOR,
-  requireCompatibleWireMajor,
-} from "./acp-compat.js";
-import {
   abortableDelay,
   bindWorkerRendezvous,
   connectWithDeadline,
   removeAcpEndpoint,
+  requireCompatibleWireMajor,
   socketStream,
   waitForAbort,
   withTimeout,
-} from "./acp-socket.js";
+} from "@reddb-io/protocol-acp";
 import {
   notifySessionRecovery,
   providerSessionEvidenceFromMeta,

--- a/apps/redskilled/src/acp-worker-budget-grace.ts
+++ b/apps/redskilled/src/acp-worker-budget-grace.ts
@@ -1,7 +1,8 @@
 import type { RedskilledGithubWriteRequest } from "./github-write.js";
+import { REDSKILLS_ACP_METHODS } from "@reddb-io/protocol-acp";
 
 /** ACP control delivered to a Worker after the daemon records its budget verdict. */
-export const REDSKILLED_WORKER_BUDGET_GRACE_METHOD = "_redskills/worker_budget_grace";
+export const REDSKILLED_WORKER_BUDGET_GRACE_METHOD = REDSKILLS_ACP_METHODS.workerBudgetGrace;
 
 export interface WorkerBudgetGraceControl {
   readonly version: 1;

--- a/apps/redskilled/src/acp-worker-lifecycle.ts
+++ b/apps/redskilled/src/acp-worker-lifecycle.ts
@@ -7,7 +7,7 @@ import {
   type PromptResponse,
 } from "@agentclientprotocol/sdk";
 import type { AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
-import { removeAcpEndpoint } from "./acp-socket.js";
+import { removeAcpEndpoint } from "@reddb-io/protocol-acp";
 
 export interface ActiveWorkflowWorker {
   readonly workerId: string;

--- a/apps/redskilled/src/github-custody.ts
+++ b/apps/redskilled/src/github-custody.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import { REDSKILLS_ACP_METHODS } from "@reddb-io/protocol-acp";
 import type {
   RedskilledGithubCredential,
   RedskilledGithubProjectAuthority,
@@ -44,7 +45,7 @@ export interface RedskilledGithubCustodyFault {
   readonly threshold_ms: number;
   readonly age_ms: number;
   readonly repair: {
-    readonly method: "_redskills/github_custody_handoff";
+    readonly method: typeof REDSKILLS_ACP_METHODS.githubCustodyHandoff;
     readonly params: RedskilledGithubCustodyHandoff;
   };
 }
@@ -309,7 +310,7 @@ function publicRecord(
       threshold_ms: threshold,
       age_ms: Math.max(0, age),
       repair: {
-        method: "_redskills/github_custody_handoff",
+        method: REDSKILLS_ACP_METHODS.githubCustodyHandoff,
         params: {
           pull_request: record.pull_request,
           owner_ticket: record.owner_ticket,

--- a/apps/redskilled/src/github-gateway.ts
+++ b/apps/redskilled/src/github-gateway.ts
@@ -11,6 +11,7 @@ import {
   type GithubLimitFact,
 } from "@reddb-io/github";
 import { isDeepStrictEqual } from "node:util";
+import { REDSKILLS_ACP_METHODS } from "@reddb-io/protocol-acp";
 import {
   githubCredentialScopeRefusal,
 } from "./github-credential-profiles.js";
@@ -80,9 +81,9 @@ export {
   type RedskilledGithubWriteUpstreamInput,
 } from "./github-write.js";
 
-export const REDSKILLED_GITHUB_READ_METHOD = "_redskills/github_read";
-export const REDSKILLED_GITHUB_WRITE_METHOD = "_redskills/github_write";
-export const REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD = "_redskills/github_custody_handoff";
+export const REDSKILLED_GITHUB_READ_METHOD = REDSKILLS_ACP_METHODS.githubRead;
+export const REDSKILLED_GITHUB_WRITE_METHOD = REDSKILLS_ACP_METHODS.githubWrite;
+export const REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD = REDSKILLS_ACP_METHODS.githubCustodyHandoff;
 
 export type {
   RedskilledGithubCustodyFault,

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -6,6 +6,7 @@ import {
   type AgentConnection,
 } from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
+import { REDSKILLS_ACP_METHODS } from "@reddb-io/protocol-acp";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
 import type { RedskilledDemandOutcome } from "./demand-loop.js";
 import type { RedskilledHostState } from "./host-state.js";
@@ -13,9 +14,9 @@ import type { AcpProjectWorkspace } from "./project-workspace.js";
 import { REDSKILLED_QUEUE_STALENESS_MS } from "./queue-discovery.js";
 
 export const PROJECT_CONTROL_METHODS = [
-  "_redskills/project_drain",
-  "_redskills/project_stop",
-  "_redskills/project_status",
+  REDSKILLS_ACP_METHODS.projectDrain,
+  REDSKILLS_ACP_METHODS.projectStop,
+  REDSKILLS_ACP_METHODS.projectStatus,
 ] as const;
 
 export type ProjectControlOperation = "drain" | "stop";

--- a/apps/redskilled/tests/acp-control-plane-layout.test.ts
+++ b/apps/redskilled/tests/acp-control-plane-layout.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const sourceRoot = join(__dirname, "..", "src");
+const wirePackage = join(__dirname, "..", "..", "..", "packages", "protocol-acp");
 
 describe("the ACP control-plane module boundary", () => {
   it("keeps the public control plane at or below its headroom target", async () => {
@@ -11,17 +12,18 @@ describe("the ACP control-plane module boundary", () => {
     expect(source.split("\n").length - 1).toBeLessThanOrEqual(700);
   });
 
-  it("keeps compatibility negotiation and socket plumbing in domain modules", async () => {
-    const [controlPlane, compatibility, socket] = await Promise.all([
+  it("takes compatibility negotiation and socket plumbing from the shared wire package", async () => {
+    const [controlPlane, compatibility, transport] = await Promise.all([
       readFile(join(sourceRoot, "acp-control-plane.ts"), "utf8"),
-      readFile(join(sourceRoot, "acp-compat.ts"), "utf8"),
-      readFile(join(sourceRoot, "acp-socket.ts"), "utf8"),
+      readFile(join(wirePackage, "compat.ts"), "utf8"),
+      readFile(join(wirePackage, "transport.ts"), "utf8"),
     ]);
 
-    expect(controlPlane).toContain('from "./acp-compat.js"');
-    expect(controlPlane).toContain('from "./acp-socket.js"');
+    expect(controlPlane).toContain('from "@reddb-io/protocol-acp"');
+    expect(controlPlane).not.toContain('from "./acp-compat.js"');
+    expect(controlPlane).not.toContain('from "./acp-socket.js"');
     expect(compatibility).toContain("requireCompatibleWireMajor");
-    expect(socket).toContain("connectWithDeadline");
+    expect(transport).toContain("connectWithDeadline");
   });
 
   it("keeps child-stream semantics in the Workflow Worker", async () => {

--- a/apps/redskilled/tests/acp-project-status.test.ts
+++ b/apps/redskilled/tests/acp-project-status.test.ts
@@ -7,7 +7,7 @@ import { client, methods, type ClientConnection } from "@agentclientprotocol/sdk
 import { afterEach, describe, expect, it } from "vitest";
 import type { RedskillsProjectStatusSnapshot } from "../src/acp-client.js";
 import { startRedskillsAcpControlPlane } from "../src/acp-control-plane.js";
-import { socketStream } from "../src/acp-socket.js";
+import { socketStream } from "@reddb-io/protocol-acp";
 import { resolveRedskilledPaths } from "../src/paths.js";
 import { resolveAcpProjectIdentity } from "../src/project-workspace.js";
 

--- a/apps/redskilled/tests/github-custody.test.ts
+++ b/apps/redskilled/tests/github-custody.test.ts
@@ -13,7 +13,7 @@ import {
   type RedskilledGithubCustodyStatus,
 } from "../src/github-gateway.js";
 import { startRedskillsAcpControlPlane } from "../src/acp-control-plane.js";
-import { socketStream } from "../src/acp-socket.js";
+import { socketStream } from "@reddb-io/protocol-acp";
 import { resolveRedskilledPaths } from "../src/paths.js";
 
 const roots: string[] = [];

--- a/apps/redskilled/tests/github-gateway.test.ts
+++ b/apps/redskilled/tests/github-gateway.test.ts
@@ -23,7 +23,7 @@ import {
 import { bindAcpProjectGithubRead } from "../src/acp-github.js";
 import { decode } from "@reddb-io/toon";
 import { startRedskillsAcpControlPlane } from "../src/acp-control-plane.js";
-import { socketStream } from "../src/acp-socket.js";
+import { socketStream } from "@reddb-io/protocol-acp";
 import { resolveRedskilledPaths } from "../src/paths.js";
 
 const PROJECT: RedskilledGithubProjectAuthority = {

--- a/packages/protocol-acp/README.md
+++ b/packages/protocol-acp/README.md
@@ -1,0 +1,53 @@
+# @reddb-io/protocol-acp
+
+The shared RedSkills ACP wire, in one package. ADR 0148 (the shared wire moves
+out of the daemon), ADR 0145 §2–3 and §7 (v1/v2 compat, the wire major, the
+local transport), ADR 0153 (the name).
+
+## Why it exists
+
+ACP is the sole agent protocol through the RedSkills control and execution chain
+(ADR 0145). That chain has at least three bodies — the `redskilled` daemon, the
+Worker, and the stateless MCP/CLI adapters — and every one of them sits on the
+same socket speaking the same four things:
+
+1. **Which ACP contract is in force.** ACP v2 draft revisions share
+   `protocolVersion: 2` while changing incompatibly, so the number on the wire
+   does not identify the contract; the revision names itself in
+   `_meta.redskills`.
+2. **Which RedSkills wire major is in force.** An independent axis: two peers
+   can agree on ACP and still be forbidden to exchange workflow traffic.
+3. **How the local endpoint is bound.** One control endpoint per authority —
+   Unix socket on Linux, Named Pipe on Windows — differing in exactly one
+   observable way, that a Unix socket leaves a filesystem node the next bind
+   must remove.
+4. **What the `_redskills/*` methods are called.**
+
+Each of those is an *agreement between two processes*, which makes a private
+copy the worst possible place to keep it: a second spelling does not fail to
+compile, it fails at run time, on the far side of a socket, on the platform the
+author does not use. This package is the single spelling.
+
+## What is NOT here
+
+The body-versus-control cut of ADR 0148 holds. This package moves bytes and
+names methods; it decides nothing. Admission, budget policy, the GitHub
+gateway, Project control state, session journalling, placement — all stay with
+the authority that owns them. A validator lives here only when its rule is pure
+protocol (`emptyRedskillsParams`: this method accepts exactly `{}`), never when
+it encodes what an authority permits.
+
+## Modules
+
+| Module | What it owns |
+| --- | --- |
+| `compat.ts` | `ACP_PROTOCOL_VERSION`, `ACP_V2_DRAFT_REVISION`, `REDSKILLS_WIRE_MAJOR`, the two gates that refuse an incompatible peer, and the v1 → v2 session-update translation. |
+| `transport.ts` | Binding, connecting, streaming and tearing down the local ACP endpoint on both platforms. |
+| `methods.ts` | The `_redskills/*` registry and the params shape shared by the methods that take none. |
+
+## Ownership guard
+
+`apps/dev/tests/acp-adapter-ownership-guard.test.ts` greps the daemon and
+adapter sources for a re-grown copy of any of the four agreements above, and
+for a `_redskills/*` literal spelled outside this package's registry. It runs in
+every gate through `pnpm -C apps/dev test:invariants`.

--- a/packages/protocol-acp/compat.ts
+++ b/packages/protocol-acp/compat.ts
@@ -1,3 +1,14 @@
+// compat — ACP v1/v2 negotiation and the RedSkills wire major (ADR 0145 §2-3).
+//
+// ACP v2 draft revisions share `protocolVersion: 2` while changing
+// incompatibly, so the number on the wire is not enough to tell two peers
+// apart; every revision RedSkills ships names itself in `_meta.redskills`. The
+// RedSkills wire major is a SECOND, independent axis: two peers can agree on
+// ACP and still disagree on RedSkills workflow traffic.
+//
+// This module is the one home of both answers. A private copy in the daemon or
+// in an adapter is how the two ends of one socket come to disagree about what
+// they just negotiated.
 import { RequestError, type SessionNotification } from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 

--- a/packages/protocol-acp/index.ts
+++ b/packages/protocol-acp/index.ts
@@ -1,0 +1,9 @@
+// @reddb-io/protocol-acp — the shared RedSkills ACP wire (ADR 0148).
+//
+// One package the daemon, the Worker and the stateless adapters all import, so
+// the two ends of any RedSkills socket negotiate against the same answers:
+// ACP v1/v2 compat and draft-revision gating, the RedSkills wire major, the
+// local Unix-socket / Named Pipe transport, and the `_redskills/*` methods.
+export * from "./compat.js";
+export * from "./methods.js";
+export * from "./transport.js";

--- a/packages/protocol-acp/methods.ts
+++ b/packages/protocol-acp/methods.ts
@@ -1,0 +1,73 @@
+// methods — the `_redskills/*` extension surface, named once (ADR 0145 §1).
+//
+// An extension method is a STRING on a socket, so a literal spelled at the
+// server and re-spelled at the client is two independent chances to be wrong,
+// and a rename touches whichever copies the renamer happened to grep. The
+// registry below is the single spelling; every caller and every handler reads
+// its name from here.
+//
+// What lives here is the WIRE: the method names, their direction, and the
+// param shapes that are pure protocol. What a method DOES — admission, budget
+// policy, the GitHub gateway, Project control state — stays with the authority
+// that owns it, per ADR 0148's body-versus-control cut.
+import { RequestError } from "@agentclientprotocol/sdk";
+
+/** Every RedSkills extension method is namespaced; ACP core owns the rest. */
+export const REDSKILLS_ACP_METHOD_NAMESPACE = "_redskills/";
+
+/**
+ * The `_redskills/*` methods, keyed by the name callers use in code.
+ *
+ * Adding a method is one entry here plus its handler; a literal spelled
+ * anywhere else is the drift the grep-pinned ownership guard refuses.
+ */
+export const REDSKILLS_ACP_METHODS = {
+  hostState: "_redskills/host_state",
+  hostBudgets: "_redskills/host_budgets",
+  projectDrain: "_redskills/project_drain",
+  projectStop: "_redskills/project_stop",
+  projectStatus: "_redskills/project_status",
+  projectBudget: "_redskills/project_budget",
+  githubRead: "_redskills/github_read",
+  githubWrite: "_redskills/github_write",
+  githubUpdate: "_redskills/github_update",
+  githubCustodyHandoff: "_redskills/github_custody_handoff",
+  workerBudgetGrace: "_redskills/worker_budget_grace",
+} as const;
+
+/** Any name the registry declares. */
+export type RedskillsAcpMethod = (typeof REDSKILLS_ACP_METHODS)[keyof typeof REDSKILLS_ACP_METHODS];
+
+/** The declared names, for advertisement and for conformance sweeps. */
+export const REDSKILLS_ACP_METHOD_NAMES: readonly RedskillsAcpMethod[] =
+  Object.values(REDSKILLS_ACP_METHODS);
+
+export function isRedskillsAcpMethod(method: string): method is RedskillsAcpMethod {
+  return (REDSKILLS_ACP_METHOD_NAMES as readonly string[]).includes(method);
+}
+
+/** The params of a method that takes none. Authority is never caller-named. */
+export type RedskillsAcpEmptyParams = Record<string, never>;
+
+/**
+ * Build the params validator for a method that accepts EXACTLY `{}`.
+ *
+ * An empty-params method is the shape most likely to be waved through with a
+ * loose `value ?? {}`, and waving it through is how a caller smuggles a
+ * Project, a credential profile or a host operation into a request whose whole
+ * point is that it names none. `detail` states, per method, what the caller may
+ * not name.
+ */
+export function emptyRedskillsParams(
+  detail: string,
+): (value: unknown) => RedskillsAcpEmptyParams {
+  return (value: unknown): RedskillsAcpEmptyParams => {
+    if (
+      value == null || typeof value !== "object" || Array.isArray(value) ||
+      Object.keys(value).length !== 0
+    ) {
+      throw RequestError.invalidParams({}, detail);
+    }
+    return {};
+  };
+}

--- a/packages/protocol-acp/package.json
+++ b/packages/protocol-acp/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@reddb-io/protocol-acp",
+  "version": "3.19.5",
+  "private": true,
+  "type": "module",
+  "description": "The shared RedSkills ACP wire (ADR 0148, ADR 0145 §2-3, ADR 0153): ACP v1/v2 compat and draft-revision gating, the RedSkills wire major, the Unix-socket / Named Pipe local transport, and the `_redskills/*` method schemas. Depended on by the daemon, the Worker and the stateless adapters.",
+  "license": "Apache-2.0",
+  "exports": {
+    ".": "./index.ts",
+    "./compat.js": "./compat.ts",
+    "./methods.js": "./methods.ts",
+    "./transport.js": "./transport.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@agentclientprotocol/sdk": "1.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/protocol-acp/transport.ts
+++ b/packages/protocol-acp/transport.ts
@@ -1,3 +1,13 @@
+// transport — the reconnectable local ACP endpoint (ADR 0145 §7).
+//
+// One control endpoint per authority: a Unix socket on Linux, a Named Pipe on
+// Windows. The two differ in exactly one observable way — a Unix socket leaves
+// a filesystem node behind that the next bind must remove, a Named Pipe dies
+// with its server handle — and that difference is spelled ONCE here, in
+// `removeAcpEndpoint`. A second copy is a Windows-only bug nobody sees on the
+// machine that wrote it.
+//
+// Transport changes no method and no ownership: everything here moves bytes.
 import { rm } from "node:fs/promises";
 import { connect, createServer, type Server, type Socket } from "node:net";
 import { Readable, Writable } from "node:stream";

--- a/packages/protocol-acp/tsconfig.json
+++ b/packages/protocol-acp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       '@reddb-io/github':
         specifier: workspace:*
         version: link:../../packages/github
+      '@reddb-io/protocol-acp':
+        specifier: workspace:*
+        version: link:../../packages/protocol-acp
       '@reddb-io/red-castle':
         specifier: workspace:*
         version: link:../../packages/red-castle
@@ -354,6 +357,9 @@ importers:
       '@reddb-io/github':
         specifier: workspace:*
         version: link:../../packages/github
+      '@reddb-io/protocol-acp':
+        specifier: workspace:*
+        version: link:../../packages/protocol-acp
       '@reddb-io/red-castle':
         specifier: workspace:*
         version: link:../../packages/red-castle
@@ -565,6 +571,19 @@ importers:
       '@reddb-io/toon':
         specifier: 'catalog:'
         version: 0.26.2
+
+  packages/protocol-acp:
+    dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: 1.3.0
+        version: 1.3.0(zod@4.4.3)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   packages/red-castle:
     dependencies:


### PR DESCRIPTION
Automated AFK landing for #4008. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #4008

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789690101&installation_model_id=20659&pr_number=4038&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4038&signature=b5b111f85e09be476f8dc49e41b88d333afdda537aa9f5b9bdc264589eff3112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->