### PR TITLE
chore(afk): allowlist the maintainer in the trust gate

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -8,6 +8,8 @@ plugins:
     lock:
       primary-branch: true       # primary-checkout branch-switch guard
     afk:
+      trust-gate:
+        allowlist: filipeforattini
       setup:
         - pnpm install --frozen-lockfile
       # Local AFK validation reproves workspace types and repo invariants inside


### PR DESCRIPTION
Lands the `trust-gate.allowlist` entry that had been carried uncommitted in the primary checkout.

Without it the trust gate holds every Ticket authored by the maintainer for summon. Carrying it dirty made `.red/config.yaml` a tracked dirty path, and once #4008 added `packages/protocol-acp` to the release version surfaces in the same file, the AFK boot probe refused the local trunk fast-forward on dirt-collision — 27 Workers died at boot in a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789691731&installation_model_id=20659&pr_number=4041&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4041&signature=662ac1babaf4ab90be70df107803b99ccfb72df5ede4ebf2382d70ed1c70a249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->