### PR TITLE
fix: #4011 Ordered Worker ids: fixed-width base62 of the birth epoch-ms

### DIFF
--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -18,7 +18,6 @@
  * verdict" is a property of this function instead of a convention every future
  * call site has to remember.
  */
-import { randomInt } from "node:crypto";
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
@@ -156,24 +155,67 @@ export interface LaunchWorkerOptions {
   readonly openLog?: boolean;
 }
 
-const HOST_WORKER_ID_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-const HOST_WORKER_ID_RANDOM_LENGTH = 4;
-const HOST_WORKER_ID_SPACE = HOST_WORKER_ID_ALPHABET.length ** HOST_WORKER_ID_RANDOM_LENGTH;
+/**
+ * The alphabet is in ASCII order on purpose — `'0' < 'A' < 'a'` byte-wise — so a
+ * plain lexicographic sort of two fixed-width ids is a sort by birth instant.
+ * That is the whole point of the encoding: `sort` on a directory listing is a
+ * timeline, and pruning births older than a cutoff is a prefix scan.
+ */
+const HOST_WORKER_ID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+const HOST_WORKER_ID_WIDTH = 7;
+/**
+ * The first birth instant that no longer fits the width — 62^7 ms after the
+ * epoch, some time in 2081. An id allowed to grow a character would sort BEFORE
+ * every shorter one, which is the one failure the fixed width exists to refuse,
+ * so the encoder throws rather than widening.
+ */
+const HOST_WORKER_ID_CEILING = HOST_WORKER_ID_ALPHABET.length ** HOST_WORKER_ID_WIDTH;
 
-/** Mint the host's short, human-facing Worker handle without colliding with a live Worker. */
+/**
+ * Encode a birth instant as the host's Worker id (ADR 0149 §3).
+ *
+ * Fixed-width, zero-padded base62: compact, no character that needs escaping in
+ * a path or a shell, and **its own birth time** — a reader that holds only the
+ * name still knows when the Worker was born and which of two came first.
+ */
+export function encodeHostWorkerId(epochMs: number): string {
+  if (!Number.isFinite(epochMs) || epochMs < 0 || epochMs >= HOST_WORKER_ID_CEILING) {
+    throw new RedskilledWorkerSpecError(
+      `redskilled cannot encode a Worker id for birth instant ${epochMs}: only 0 <= ms < ` +
+        `${HOST_WORKER_ID_CEILING} fits ${HOST_WORKER_ID_WIDTH} base62 characters`,
+    );
+  }
+  const base = HOST_WORKER_ID_ALPHABET.length;
+  let remaining = Math.floor(epochMs);
+  let workerId = "";
+  for (let index = 0; index < HOST_WORKER_ID_WIDTH; index += 1) {
+    workerId = HOST_WORKER_ID_ALPHABET[remaining % base]! + workerId;
+    remaining = Math.floor(remaining / base);
+  }
+  return workerId;
+}
+
+/**
+ * Mint the host's Worker handle: the birth epoch in milliseconds, base62.
+ *
+ * **A collision walks the birth instant forward by 1 ms rather than redrawing.**
+ * Two Workers born inside one millisecond still have to come out in the order
+ * they were born, and a redraw — the random `h`+4 scheme this replaced — would
+ * return an id that sorts wherever chance put it. The walk terminates because
+ * the live set is finite and each step is strictly larger than the last.
+ */
 export function mintHostWorkerId(
   liveWorkerIds: Iterable<string>,
-  draw: (maxExclusive: number) => number = randomInt,
+  now: () => number = Date.now,
 ): string {
   const live = new Set(liveWorkerIds);
-  for (let attempt = 0; attempt < HOST_WORKER_ID_SPACE; attempt += 1) {
-    let workerId = "h";
-    for (let index = 0; index < HOST_WORKER_ID_RANDOM_LENGTH; index += 1) {
-      workerId += HOST_WORKER_ID_ALPHABET[draw(HOST_WORKER_ID_ALPHABET.length)]!;
-    }
-    if (!live.has(workerId)) return workerId;
+  let bornAtMs = Math.floor(now());
+  let workerId = encodeHostWorkerId(bornAtMs);
+  while (live.has(workerId)) {
+    bornAtMs += 1;
+    workerId = encodeHostWorkerId(bornAtMs);
   }
-  throw new RedskilledWorkerSpecError("redskilled exhausted the host Worker id space");
+  return workerId;
 }
 
 /** What preparing a Worker's log actually did, and what to say when it failed. */

--- a/apps/redskilled/tests/registration-log-path.test.ts
+++ b/apps/redskilled/tests/registration-log-path.test.ts
@@ -172,7 +172,7 @@ describe("the daemon writes its own facts into a registration's log path", () =>
     expect(tick.granted).toHaveLength(1);
     const spec = launched[0]!.spec;
     const workerId = tick.granted[0]!.worker_id;
-    expect(workerId).toMatch(/^h[A-Z0-9]{4}$/);
+    expect(workerId).toMatch(/^[0-9A-Za-z]{7}$/);
     expect(spec.log_path).toBe(`${workspace}/.red/tmp/workers/${workerId}/worker.log.toonl`);
     // The record the surfaces read carries it too — the whole point of stating it.
     expect(daemon.hostState().workers[0]!.log_path).toBe(spec.log_path);

--- a/apps/redskilled/tests/worker-birth.test.ts
+++ b/apps/redskilled/tests/worker-birth.test.ts
@@ -10,6 +10,7 @@ import { isRedskilledWorkerView } from "../src/host-state.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "../src/paths.js";
 import { evaluateWorkerAdmission, UNBOUNDED_HOST_CEILING } from "../src/admission.js";
 import {
+  encodeHostWorkerId,
   launchWorker,
   mintHostWorkerId,
   RedskilledWorkerSpecError,
@@ -59,8 +60,7 @@ describe("worker birth through the socket", () => {
 
     expect(isRedskilledWorkerView(started.worker)).toBe(true);
     expect(started.worker.project_label).toBe("acme/widgets");
-    expect(started.worker.worker_id).toMatch(/^h[A-Z0-9]{4}$/);
-    expect(started.worker.worker_id).toHaveLength(5);
+    expect(started.worker.worker_id).toMatch(/^[0-9A-Za-z]{7}$/);
     expect(started.worker.pid).toBeGreaterThan(0);
     expect(started.worker.workspace_path).toBe(workspace);
 
@@ -161,15 +161,61 @@ describe("worker birth through the socket", () => {
 });
 
 describe("host-minted Worker ids", () => {
-  it("retries a collision against the live set and stays short", () => {
-    const draws = [0, 0, 0, 0, 0, 0, 0, 1];
-    const workerId = mintHostWorkerId(["hAAAA", "wVWHA"], () => draws.shift()!);
+  // ADR 0149 §3: the id IS the birth instant, so the order is readable from the
+  // name and a prune is a prefix scan.
+  const FIXED_WIDTH_BASE62 = /^[0-9A-Za-z]{7}$/;
 
-    expect(workerId).toBe("hAAAB");
-    expect(workerId).toHaveLength(5);
-    expect(workerId.startsWith("h")).toBe(true);
-    expect(workerId.startsWith("w")).toBe(false);
-    expect(draws).toEqual([]);
+  it("mints fixed-width base62 ids that sort lexicographically by birth", () => {
+    const first = mintHostWorkerId([]);
+    const second = mintHostWorkerId([first]);
+
+    expect(first).toMatch(FIXED_WIDTH_BASE62);
+    expect(second).toMatch(FIXED_WIDTH_BASE62);
+    // Strictly less, not merely different: two Workers born inside one
+    // millisecond still have to come out in the order they were born.
+    expect(first < second).toBe(true);
+  });
+
+  it("walks the birth instant forward by 1 ms until the id is not a live one", () => {
+    const bornAtMs = 1_770_000_000_000;
+    const taken = [encodeHostWorkerId(bornAtMs), encodeHostWorkerId(bornAtMs + 1)];
+
+    const workerId = mintHostWorkerId([...taken, "wVWHA"], () => bornAtMs);
+
+    expect(workerId).toBe(encodeHostWorkerId(bornAtMs + 2));
+    expect(taken).not.toContain(workerId);
+    expect(workerId).toMatch(FIXED_WIDTH_BASE62);
+  });
+
+  it("never returns a live id however crowded the millisecond is", () => {
+    const bornAtMs = 1_770_000_000_000;
+    const live = new Set(
+      Array.from({ length: 64 }, (_unused, offset) => encodeHostWorkerId(bornAtMs + offset)),
+    );
+
+    const workerId = mintHostWorkerId(live, () => bornAtMs);
+
+    expect(live.has(workerId)).toBe(false);
+    expect(workerId).toBe(encodeHostWorkerId(bornAtMs + 64));
+  });
+
+  it("encodes the birth epoch so a byte-order sort is a birth-order sort", () => {
+    const instants = [0, 1, 61, 62, 3_843, 1_770_000_000_000, 1_770_000_000_001];
+    const ids = instants.map(encodeHostWorkerId);
+
+    expect(ids[0]).toBe("0000000");
+    expect(ids[1]).toBe("0000001");
+    expect(ids[2]).toBe("000000z");
+    expect(ids[3]).toBe("0000010");
+    expect(ids.every((id) => FIXED_WIDTH_BASE62.test(id))).toBe(true);
+    expect([...ids].sort()).toEqual(ids);
+  });
+
+  it("refuses a birth instant that does not fit the fixed width", () => {
+    // 62^7 ms after the epoch — the first instant a 7-character id would have to
+    // grow for, which would silently break the sort it exists to provide.
+    expect(() => encodeHostWorkerId(62 ** 7)).toThrow(RedskilledWorkerSpecError);
+    expect(() => encodeHostWorkerId(-1)).toThrow(RedskilledWorkerSpecError);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #4011. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #4011

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789693792&installation_model_id=20659&pr_number=4042&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4042&signature=2fd16ee18f1c0b03f1b0c6e80e5c39378f890d834ab84a4f0f5aef75608ac301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->