### PR TITLE
fix: #4014 go_dispatch on the daemon, and the control-plane method registry split by domain

### DIFF
--- a/.changeset/go-dispatch-on-the-daemon.md
+++ b/.changeset/go-dispatch-on-the-daemon.md
@@ -1,0 +1,16 @@
+---
+"@reddb-io/protocol-acp": minor
+"@reddb-io/redskilled": minor
+---
+
+`_redskills/go_dispatch(demand)` lands on the daemon: one call mints the
+disposable Ticket into the isolated go lane, admits a Worker against exactly
+that Ticket, and answers with the Worker id. Its schema — params, answer and
+the validator that refuses a caller-named lane, Ticket or budget — is published
+from `@reddb-io/protocol-acp`.
+
+The control plane's `_redskills/*` bindings become data. Each domain (host,
+Project control, GitHub, credential budgets, go) declares its own bindings and
+the fragment it advertises on `initialize`; one table composes them and both
+ACP dialects register from it, replacing two hand-kept `.onRequest` chains and
+two copies of the capability block. A layout test pins one module per domain.

--- a/apps/redskilled/src/acp-budget.ts
+++ b/apps/redskilled/src/acp-budget.ts
@@ -7,6 +7,10 @@ import {
   type RedskilledGithubHostBudgetProjection,
   type RedskilledGithubProjectBudgetProjection,
 } from "./github-gateway.js";
+import {
+  redskillsAcpMethod,
+  type RedskillsAcpMethodDomain,
+} from "./acp-method-registry.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 import { RedskilledGithubCredentialProfileError } from "./github-credential-profiles.js";
 
@@ -77,4 +81,43 @@ export const emptyBudgetParams: (value: unknown) => EmptyParams = emptyRedskills
 function budgetGateway(gateway: RedskilledGithubGateway | undefined): RedskilledGithubBudgetGateway | null {
   if (gateway == null || !("projectBudget" in gateway) || !("hostBudget" in gateway)) return null;
   return gateway as RedskilledGithubBudgetGateway;
+}
+
+export interface AcpBudgetDomainDeps {
+  readonly gateway: RedskilledGithubGatewayRegistration | undefined;
+  readonly scopedProject: () => AcpProjectWorkspace;
+  /** Explicit endpoint authority; ordinary project ACP stays false. */
+  readonly hostAdministration: boolean;
+}
+
+/**
+ * The `budget` domain: what one Project may observe of its own credential
+ * spend, plus the host-wide projection an administrative endpoint may read.
+ *
+ * The host method is advertised only where it is answerable. A connection that
+ * sees `host_budgets` in the capability block and is then refused for lacking
+ * authority learned nothing it could act on; one that never sees it knows the
+ * endpoint it dialed is not the administrative one.
+ */
+export function budgetMethodDomain(deps: AcpBudgetDomainDeps): RedskillsAcpMethodDomain {
+  const readProjectBudget = bindAcpProjectGithubBudget(deps.gateway, deps.scopedProject);
+  const readHostBudget = bindAcpHostGithubBudget(deps.gateway, deps.hostAdministration);
+  return {
+    domain: "budget",
+    bindings: [
+      redskillsAcpMethod(REDSKILLED_PROJECT_BUDGET_METHOD, emptyBudgetParams, readProjectBudget),
+      redskillsAcpMethod(REDSKILLED_HOST_BUDGET_METHOD, emptyBudgetParams, readHostBudget),
+    ],
+    ...(deps.gateway == null ? {} : {
+      capability: {
+        credentialBudgets: {
+          version: 1,
+          methods: [
+            REDSKILLED_PROJECT_BUDGET_METHOD,
+            ...(deps.hostAdministration ? [REDSKILLED_HOST_BUDGET_METHOD] : []),
+          ],
+        },
+      },
+    }),
+  };
 }

--- a/apps/redskilled/src/acp-connection-methods.ts
+++ b/apps/redskilled/src/acp-connection-methods.ts
@@ -1,0 +1,156 @@
+// acp-connection-methods — the `_redskills/*` surface one connection binds.
+//
+// Declared ONCE and registered onto both dialects. The domains themselves are
+// dialect-blind: a Project status projection is the same answer whether v1 or
+// v2 asked. Only `go_dispatch` differs, and only in how the Worker it admits
+// frames its narration for the caller — so that is the one thing the two
+// tables are built with different arguments for.
+import { randomUUID } from "node:crypto";
+import {
+  methods,
+  type AgentContext,
+  type AgentConnection,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk";
+import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
+import { translateV1SessionUpdateToV2 } from "@reddb-io/protocol-acp";
+
+import { budgetMethodDomain } from "./acp-budget.js";
+import type { PublicSession } from "./acp-control-plane.js";
+import type { AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
+import { githubMethodDomain } from "./acp-github.js";
+import { createGoWorkerAdmission } from "./acp-go-admission.js";
+import {
+  createAcpGithubGoTicketTracker,
+  goDispatchMethodDomain,
+  type GoWorkerAdmission,
+} from "./acp-go-dispatch.js";
+import { hostStateMethodDomain } from "./acp-host-methods.js";
+import {
+  redskillsAcpMethodTable,
+  type RedskillsAcpMethodTable,
+} from "./acp-method-registry.js";
+import type { ActiveWorkflowWorker } from "./acp-worker-lifecycle.js";
+import type { AcpSessionJournal } from "./acp-session-journal.js";
+import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
+import type { RedskilledPaths } from "./paths.js";
+import { projectControlMethodDomain, type ProjectControlOperation } from "./project-control.js";
+import type { AcpProjectWorkspace } from "./project-workspace.js";
+import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
+
+export interface ConnectionMethodDeps {
+  readonly paths: RedskilledPaths;
+  readonly startWorker: (spec: RedskilledWorkerSpec) => LaunchedWorker;
+  readonly githubGateway: RedskilledGithubGatewayRegistration | undefined;
+  readonly hostAdministration: boolean;
+  readonly sessionJournal: AcpSessionJournal;
+  readonly sessions: Map<string, PublicSession>;
+  readonly active: Map<string, ActiveWorkflowWorker>;
+  /** The Project projection this connection may read. Throws when unbound. */
+  readonly scopedState: () => unknown;
+  /** The Project this connection bound. Throws when none has. */
+  readonly scopedProject: () => AcpProjectWorkspace;
+  readonly mutateProjectControl: (operation: ProjectControlOperation) => Promise<unknown>;
+  readonly readProjectStatus: () => Promise<unknown>;
+  /** Observe the reader the first GitHub read resolves, to stream its updates. */
+  readonly onGithubReader: (reader: unknown) => void;
+  /** Resolve one permission decision under this connection's durable policy. */
+  readonly permission: (
+    sessionId: string,
+    request: RequestPermissionRequest,
+    project: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>,
+  ) => Promise<RequestPermissionResponse>;
+}
+
+export interface ConnectionMethodTables {
+  readonly v1: RedskillsAcpMethodTable;
+  readonly v2: RedskillsAcpMethodTable;
+}
+
+/** Compose this connection's domains, once per dialect. */
+export function connectionMethodTables(deps: ConnectionMethodDeps): ConnectionMethodTables {
+  const table = (admit: GoAdmit): RedskillsAcpMethodTable => redskillsAcpMethodTable([
+    hostStateMethodDomain({ scopedState: deps.scopedState }),
+    projectControlMethodDomain({
+      mutate: deps.mutateProjectControl,
+      read: deps.readProjectStatus,
+    }),
+    githubMethodDomain({
+      gateway: deps.githubGateway,
+      scopedProject: deps.scopedProject,
+      onReader: deps.onGithubReader,
+    }),
+    budgetMethodDomain({
+      gateway: deps.githubGateway,
+      scopedProject: deps.scopedProject,
+      hostAdministration: deps.hostAdministration,
+    }),
+    goDispatchMethodDomain({
+      tracker: createAcpGithubGoTicketTracker(deps.githubGateway, deps.scopedProject),
+      admit,
+    }),
+  ]);
+  return { v1: table(admitThroughV1(deps)), v2: table(admitThroughV2(deps)) };
+}
+
+type GoAdmit = (
+  dispatch: AcpTargetedDispatchIntent,
+  context: { readonly client: unknown },
+) => Promise<GoWorkerAdmission>;
+
+/**
+ * The caller's connection is reachable only from inside a handler, so the
+ * admission is bound around the context the request arrived with. The cast is
+ * the registry's erasure being undone by the dialect that erased it.
+ */
+function admitThroughV1(deps: ConnectionMethodDeps): GoAdmit {
+  return async (dispatch, context) => {
+    const upstream = context.client as AgentContext;
+    return await goAdmission(deps, {
+      forward: () => upstream.notify.bind(upstream) as AgentConnection["client"]["notify"],
+      permission: (request) => upstream.request(methods.client.session.requestPermission, request),
+    })(dispatch);
+  };
+}
+
+function admitThroughV2(deps: ConnectionMethodDeps): GoAdmit {
+  return async (dispatch, context) => {
+    const upstream = context.client as acpV2.AgentContext;
+    const messageId = randomUUID();
+    return await goAdmission(deps, {
+      forward: (sessionId) => (async (_method: unknown, notice: SessionNotification) => {
+        const update = translateV1SessionUpdateToV2(notice.update, messageId);
+        if (update == null) return;
+        await upstream.notify(acpV2.methods.client.session.update, {
+          sessionId,
+          update,
+          _meta: notice._meta,
+        });
+      }) as AgentConnection["client"]["notify"],
+      permission: async (request) => await upstream.request(
+        acpV2.methods.client.session.requestPermission,
+        request as unknown as acpV2.RequestPermissionRequest,
+      ) as unknown as RequestPermissionResponse,
+    })(dispatch);
+  };
+}
+
+interface GoDialect {
+  readonly forward: (sessionId: string) => AgentConnection["client"]["notify"];
+  readonly permission: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>;
+}
+
+function goAdmission(deps: ConnectionMethodDeps, dialect: GoDialect) {
+  return createGoWorkerAdmission({
+    paths: deps.paths,
+    startWorker: deps.startWorker,
+    sessionJournal: deps.sessionJournal,
+    sessions: deps.sessions,
+    active: deps.active,
+    project: deps.scopedProject,
+    forward: dialect.forward,
+    permission: (sessionId, request) => deps.permission(sessionId, request, dialect.permission),
+  });
+}

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -26,7 +26,6 @@ import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import {
   ACP_PROTOCOL_VERSION,
   ACP_V2_DRAFT_REVISION,
-  REDSKILLS_ACP_METHODS,
   REDSKILLS_WIRE_MAJOR,
   closeServer,
   connectWithDeadline,
@@ -39,24 +38,11 @@ import {
   withTimeout,
 } from "@reddb-io/protocol-acp";
 import {
-  REDSKILLED_GITHUB_UPDATE_METHOD,
   bindAcpGithubReaderUpdates,
-  bindAcpProjectGithubCustodyHandoff,
   bindAcpProjectGithubCustodyStatus,
-  bindAcpProjectGithubRead,
-  bindAcpProjectGithubWrite,
-  githubCustodyHandoffParams,
-  githubReadParams,
-  githubWriteParams,
   type AcpGithubUpdateObserver,
 } from "./acp-github.js";
-import {
-  bindAcpHostGithubBudget,
-  bindAcpProjectGithubBudget,
-  emptyBudgetParams,
-  REDSKILLED_HOST_BUDGET_METHOD,
-  REDSKILLED_PROJECT_BUDGET_METHOD,
-} from "./acp-budget.js";
+import { connectionMethodTables } from "./acp-connection-methods.js";
 import {
   acpSessionJournalPath,
   createAcpSessionJournal as createDurableAcpSessionJournal,
@@ -68,19 +54,13 @@ import {
   notifyV2AcpRetakeEvidence,
 } from "./acp-retake-evidence.js";
 import type { RedskilledHostState } from "./host-state.js";
-import {
-  REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD,
-  REDSKILLED_GITHUB_READ_METHOD,
-  REDSKILLED_GITHUB_WRITE_METHOD,
-  type RedskilledGithubGatewayRegistration,
-} from "./github-gateway.js";
+import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
 import type { RedskilledPaths } from "./paths.js";
 import {
   applyProjectControl,
   coreProjectOperation,
   createProjectControlStore,
   notifyV1ProjectControl,
-  PROJECT_CONTROL_METHODS,
   projectStatusSnapshot,
   projectControlStorePath,
   runV2ProjectControlTurn,
@@ -116,7 +96,7 @@ import { runAcpWorkflowTurn } from "./acp-workflow-turn.js";
 
 export { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "@reddb-io/protocol-acp";
 
-interface PublicSession {
+export interface PublicSession {
   readonly request: NewSessionRequest;
   readonly project: AcpProjectWorkspace;
   readonly dispatchJournal: AcpDispatchJournal;
@@ -231,15 +211,6 @@ async function servePublicConnection(
   };
   const mutateProjectControl = (operation: ProjectControlOperation) =>
     applyProjectControl(scopedProject(), operation, projectControls, persistProjectControls);
-  const readGithub = bindAcpProjectGithubRead(options.githubGateway, scopedProject, (reader) => {
-    if (githubObserver != null || githubNotify == null) return;
-    githubObserver = Promise.resolve(bindAcpGithubReaderUpdates(
-      reader,
-      (method, update) => githubNotify!(method, update),
-    ));
-  });
-  const writeGithub = bindAcpProjectGithubWrite(options.githubGateway, scopedProject);
-  const handoffGithubCustody = bindAcpProjectGithubCustodyHandoff(options.githubGateway, scopedProject);
   const readGithubCustody = bindAcpProjectGithubCustodyStatus(options.githubGateway, scopedProject);
   const readProjectStatus = async (project: AcpProjectWorkspace) => {
     const control = projectStatusSnapshot(
@@ -251,10 +222,34 @@ async function servePublicConnection(
     const mergeCustody = await readGithubCustody();
     return mergeCustody == null ? control : { ...control, merge_custody: mergeCustody };
   };
-  const readProjectControl = () => readProjectStatus(scopedProject());
-  const readProjectBudget = bindAcpProjectGithubBudget(options.githubGateway, scopedProject);
-  const readHostBudget = bindAcpHostGithubBudget(options.githubGateway, options.hostAdministration === true);
-  const emptyParams = () => ({});
+
+  const { v1: v1Methods, v2: v2Methods } = connectionMethodTables({
+    paths: options.paths,
+    startWorker: options.startWorker,
+    githubGateway: options.githubGateway,
+    hostAdministration: options.hostAdministration === true,
+    sessionJournal,
+    sessions,
+    active,
+    scopedState,
+    scopedProject,
+    mutateProjectControl,
+    readProjectStatus: () => readProjectStatus(scopedProject()),
+    onGithubReader: (reader) => {
+      if (githubObserver != null || githubNotify == null) return;
+      githubObserver = Promise.resolve(bindAcpGithubReaderUpdates(
+        reader,
+        (method, update) => githubNotify!(method, update),
+      ));
+    },
+    permission: (sessionId, request, project) => resolvePermission(
+      sessionJournal,
+      sessionId,
+      request,
+      () => attached,
+      project,
+    ),
+  });
 
   const v1App = agent({ name: "RedSkills" })
     .onRequest(methods.agent.initialize, ({ params }) => {
@@ -269,25 +264,7 @@ async function servePublicConnection(
           redskills: {
             wireMajor: REDSKILLS_WIRE_MAJOR,
             workerBacked: true,
-            projectControl: { version: 1, methods: PROJECT_CONTROL_METHODS },
-            ...(options.githubGateway == null ? {} : {
-              githubGateway: {
-                version: 1,
-                methods: [
-                  REDSKILLED_GITHUB_READ_METHOD,
-                  REDSKILLED_GITHUB_WRITE_METHOD,
-                  REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD,
-                ],
-                notifications: [REDSKILLED_GITHUB_UPDATE_METHOD],
-              },
-              credentialBudgets: {
-                version: 1,
-                methods: [
-                  REDSKILLED_PROJECT_BUDGET_METHOD,
-                  ...(options.hostAdministration === true ? [REDSKILLED_HOST_BUDGET_METHOD] : []),
-                ],
-              },
-            }),
+            ...v1Methods.capabilities,
           },
         },
       };
@@ -400,18 +377,10 @@ async function servePublicConnection(
         sessionId: worker.downstreamSessionId,
         ...(params._meta == null ? {} : { _meta: params._meta }),
       });
-    })
-    // Compatibility spelling, but deliberately a Project projection. Ordinary
-    // ACP socket access is not an administrative capability.
-    .onRequest(REDSKILLS_ACP_METHODS.hostState, emptyParams, scopedState)
-    .onRequest(PROJECT_CONTROL_METHODS[0], emptyParams, () => mutateProjectControl("drain"))
-    .onRequest(PROJECT_CONTROL_METHODS[1], emptyParams, () => mutateProjectControl("stop"))
-    .onRequest(PROJECT_CONTROL_METHODS[2], emptyParams, readProjectControl)
-    .onRequest(REDSKILLED_GITHUB_READ_METHOD, githubReadParams, readGithub)
-    .onRequest(REDSKILLED_GITHUB_WRITE_METHOD, githubWriteParams, writeGithub)
-    .onRequest(REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD, githubCustodyHandoffParams, handoffGithubCustody)
-    .onRequest(REDSKILLED_PROJECT_BUDGET_METHOD, emptyBudgetParams, readProjectBudget)
-    .onRequest(REDSKILLED_HOST_BUDGET_METHOD, emptyBudgetParams, readHostBudget);
+    });
+  for (const binding of v1Methods.bindings) {
+    v1App.onRequest(binding.method, binding.params, binding.handle);
+  }
 
   const v2Turns = new Map<string, Promise<void>>();
   const v2App = acpV2.agent({ name: "RedSkills" })
@@ -427,25 +396,7 @@ async function servePublicConnection(
             wireMajor: REDSKILLS_WIRE_MAJOR,
             workerBacked: true,
             acpDraftRevision: ACP_V2_DRAFT_REVISION,
-            projectControl: { version: 1, methods: PROJECT_CONTROL_METHODS },
-            ...(options.githubGateway == null ? {} : {
-              githubGateway: {
-                version: 1,
-                methods: [
-                  REDSKILLED_GITHUB_READ_METHOD,
-                  REDSKILLED_GITHUB_WRITE_METHOD,
-                  REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD,
-                ],
-                notifications: [REDSKILLED_GITHUB_UPDATE_METHOD],
-              },
-              credentialBudgets: {
-                version: 1,
-                methods: [
-                  REDSKILLED_PROJECT_BUDGET_METHOD,
-                  ...(options.hostAdministration === true ? [REDSKILLED_HOST_BUDGET_METHOD] : []),
-                ],
-              },
-            }),
+            ...v2Methods.capabilities,
           },
         },
       };
@@ -530,16 +481,10 @@ async function servePublicConnection(
         sessionId: worker.downstreamSessionId,
         ...(params._meta == null ? {} : { _meta: params._meta }),
       });
-    })
-    .onRequest(REDSKILLS_ACP_METHODS.hostState, emptyParams, scopedState)
-    .onRequest(PROJECT_CONTROL_METHODS[0], emptyParams, () => mutateProjectControl("drain"))
-    .onRequest(PROJECT_CONTROL_METHODS[1], emptyParams, () => mutateProjectControl("stop"))
-    .onRequest(PROJECT_CONTROL_METHODS[2], emptyParams, readProjectControl)
-    .onRequest(REDSKILLED_GITHUB_READ_METHOD, githubReadParams, readGithub)
-    .onRequest(REDSKILLED_GITHUB_WRITE_METHOD, githubWriteParams, writeGithub)
-    .onRequest(REDSKILLED_GITHUB_CUSTODY_HANDOFF_METHOD, githubCustodyHandoffParams, handoffGithubCustody)
-    .onRequest(REDSKILLED_PROJECT_BUDGET_METHOD, emptyBudgetParams, readProjectBudget)
-    .onRequest(REDSKILLED_HOST_BUDGET_METHOD, emptyBudgetParams, readHostBudget);
+    });
+  for (const binding of v2Methods.bindings) {
+    v2App.onRequest(binding.method, binding.params, binding.handle);
+  }
 
   const connection = acpV2.agentProtocolRouter()
     .withV1(v1App)

--- a/apps/redskilled/src/acp-dispatch-intent.ts
+++ b/apps/redskilled/src/acp-dispatch-intent.ts
@@ -1,6 +1,12 @@
 /** Exact governed intent retained by redskilled across Workflow Worker replacement. */
 export type AcpWorkerKind = "afk" | "go" | "scout";
 
+/** The isolated lane every `go` dispatch selects — never `ready-for-agent`. */
+export const GO_DISPATCH_LANE = "lane:go";
+
+/** The isolated lane every read-only `scout` dispatch selects. */
+export const SCOUT_DISPATCH_LANE = "lane:scout";
+
 export interface AcpTargetedDispatchIntent {
   readonly version: 1;
   readonly workerKind: AcpWorkerKind;
@@ -67,7 +73,9 @@ function validateTargetedDispatch(value: unknown): AcpTargetedDispatchIntent {
   }
   const lane = typeof selector.lane === "string" ? selector.lane.trim() : "";
   if (lane === "") throw new Error("a targeted ACP dispatch requires an explicit selector lane");
-  const requiredLane = workerKind === "go" ? "lane:go" : workerKind === "scout" ? "lane:scout" : undefined;
+  const requiredLane = workerKind === "go"
+    ? GO_DISPATCH_LANE
+    : workerKind === "scout" ? SCOUT_DISPATCH_LANE : undefined;
   if (requiredLane != null && lane !== requiredLane) {
     throw new Error(`Worker kind ${workerKind} requires selector lane ${requiredLane}`);
   }

--- a/apps/redskilled/src/acp-github.ts
+++ b/apps/redskilled/src/acp-github.ts
@@ -12,6 +12,10 @@ import {
   type RedskilledGithubUpdate,
   type RedskilledGithubWriteRequest,
 } from "./github-gateway.js";
+import {
+  redskillsAcpMethod,
+  type RedskillsAcpMethodDomain,
+} from "./acp-method-registry.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 import { RedskilledGithubCredentialProfileError } from "./github-credential-profiles.js";
 
@@ -20,6 +24,14 @@ type GithubWriteParams = RedskilledGithubWriteRequest;
 type GithubCustodyHandoffParams = RedskilledGithubCustodyHandoff;
 
 export const REDSKILLED_GITHUB_UPDATE_METHOD = REDSKILLS_ACP_METHODS.githubUpdate;
+
+export interface AcpGithubDomainDeps {
+  readonly gateway: RedskilledGithubGatewayRegistration | undefined;
+  /** The Project this ACP connection bound; every method is scoped to it. */
+  readonly scopedProject: () => AcpProjectWorkspace;
+  /** Observe the reader the first read resolves, to stream its updates. */
+  readonly onReader?: (reader: unknown) => void;
+}
 
 export interface AcpGithubUpdateObserver {
   close(): void;
@@ -300,4 +312,44 @@ export function githubCustodyHandoffParams(value: unknown): GithubCustodyHandoff
     );
   }
   return params as unknown as GithubCustodyHandoffParams;
+}
+
+/**
+ * The `github` domain: the Project-bound gateway's three request methods and
+ * the one notification it advertises.
+ *
+ * The domain is only present when the daemon actually registered a gateway.
+ * Advertising the methods with no gateway behind them would answer every call
+ * with the same authorization refusal, which reads to a client as "your
+ * credentials are wrong" when the truth is "this daemon has no forge at all".
+ */
+export function githubMethodDomain(deps: AcpGithubDomainDeps): RedskillsAcpMethodDomain {
+  const readGithub = bindAcpProjectGithubRead(deps.gateway, deps.scopedProject, deps.onReader);
+  const writeGithub = bindAcpProjectGithubWrite(deps.gateway, deps.scopedProject);
+  const handoffCustody = bindAcpProjectGithubCustodyHandoff(deps.gateway, deps.scopedProject);
+  return {
+    domain: "github",
+    bindings: [
+      redskillsAcpMethod(REDSKILLS_ACP_METHODS.githubRead, githubReadParams, readGithub),
+      redskillsAcpMethod(REDSKILLS_ACP_METHODS.githubWrite, githubWriteParams, writeGithub),
+      redskillsAcpMethod(
+        REDSKILLS_ACP_METHODS.githubCustodyHandoff,
+        githubCustodyHandoffParams,
+        handoffCustody,
+      ),
+    ],
+    ...(deps.gateway == null ? {} : {
+      capability: {
+        githubGateway: {
+          version: 1,
+          methods: [
+            REDSKILLS_ACP_METHODS.githubRead,
+            REDSKILLS_ACP_METHODS.githubWrite,
+            REDSKILLS_ACP_METHODS.githubCustodyHandoff,
+          ],
+          notifications: [REDSKILLED_GITHUB_UPDATE_METHOD],
+        },
+      },
+    }),
+  };
 }

--- a/apps/redskilled/src/acp-go-admission.ts
+++ b/apps/redskilled/src/acp-go-admission.ts
@@ -1,0 +1,85 @@
+// acp-go-admission — how the `go_dispatch` extension method gets a Worker.
+//
+// The method answers with a Worker id, so something must admit one. A `/go`
+// dispatch arrives as a bare request rather than inside a prompt turn, so it
+// has no session to attach to and mints its own: the Worker's narration has to
+// reach the client SOMEWHERE, and a Worker admitted against no session is one
+// nobody can watch, cancel, or read a permission prompt from.
+//
+// The dialect-shaped parts — how an update is framed, how a permission request
+// is projected — stay with the caller, because that is the one thing v1 and v2
+// genuinely differ about here.
+import { randomUUID } from "node:crypto";
+import type {
+  AgentConnection,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+} from "@agentclientprotocol/sdk";
+
+import type { PublicSession } from "./acp-control-plane.js";
+import { createAcpSessionJournal as createAcpDispatchJournal } from "./acp-dispatch-intent.js";
+import type { AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
+import type { GoWorkerAdmission } from "./acp-go-dispatch.js";
+import { admitNativeAcpWorker } from "./acp-native-worker.js";
+import type { ActiveWorkflowWorker } from "./acp-worker-lifecycle.js";
+import type { AcpSessionJournal } from "./acp-session-journal.js";
+import type { RedskilledPaths } from "./paths.js";
+import type { AcpProjectWorkspace } from "./project-workspace.js";
+import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
+
+export interface GoWorkerAdmissionDeps {
+  readonly paths: RedskilledPaths;
+  readonly startWorker: (spec: RedskilledWorkerSpec) => LaunchedWorker;
+  readonly sessionJournal: AcpSessionJournal;
+  /** This connection's public sessions; a dispatch mints one of its own. */
+  readonly sessions: Map<string, PublicSession>;
+  readonly active: Map<string, ActiveWorkflowWorker>;
+  /** The Project that bound this connection. Throws when none has. */
+  readonly project: () => AcpProjectWorkspace;
+  /** Frame this Worker's updates in the dialect the caller is speaking. */
+  readonly forward: (sessionId: string) => AgentConnection["client"]["notify"];
+  /** Ask the caller for a permission decision, in its own dialect. */
+  readonly permission: (
+    sessionId: string,
+    request: RequestPermissionRequest,
+  ) => Promise<RequestPermissionResponse>;
+}
+
+/**
+ * Admit one Worker for a minted Ticket, on a session minted with it.
+ *
+ * The session is registered BEFORE admission so that a Worker which starts
+ * narrating immediately has somewhere to narrate to, and the Worker is tracked
+ * in `active` after it so that connection teardown reaps it like any other.
+ */
+export function createGoWorkerAdmission(deps: GoWorkerAdmissionDeps) {
+  return async (dispatch: AcpTargetedDispatchIntent): Promise<GoWorkerAdmission> => {
+    const project = deps.project();
+    const sessionId = randomUUID();
+    const session: PublicSession = {
+      request: { cwd: project.workspacePath, mcpServers: [] },
+      project,
+      dispatchJournal: createAcpDispatchJournal(),
+    };
+    await deps.sessionJournal.create(sessionId, project);
+    deps.sessions.set(sessionId, session);
+    let worker: ActiveWorkflowWorker;
+    try {
+      worker = await admitNativeAcpWorker(
+        { paths: deps.paths, startWorker: deps.startWorker },
+        deps.sessionJournal,
+        session,
+        sessionId,
+        deps.forward(sessionId),
+        (request) => deps.permission(sessionId, request),
+        false,
+        dispatch,
+      );
+    } catch (error) {
+      deps.sessions.delete(sessionId);
+      throw error;
+    }
+    deps.active.set(sessionId, worker);
+    return { worker_id: worker.workerId, session_id: sessionId };
+  };
+}

--- a/apps/redskilled/src/acp-go-dispatch.ts
+++ b/apps/redskilled/src/acp-go-dispatch.ts
@@ -1,0 +1,203 @@
+// acp-go-dispatch — the daemon side of the `go_dispatch` method (ADR 0150 §3).
+//
+// `/go` becomes thin here. The client sends a demand; the daemon mints the
+// disposable Ticket in the isolated go lane, admits one Worker against exactly
+// that Ticket, and answers with the Worker id. Nothing in the sequence reads a
+// client checkout, which is the whole point: the boot phases `/go` used to run
+// project-side become daemon admission or they die (ADR 0144 §5).
+//
+// The Ticket is minted into `lane:go` and NEVER into `ready-for-agent`, so the
+// running drain cannot claim a Ticket a dedicated Worker already owns.
+import { RequestError } from "@agentclientprotocol/sdk";
+import {
+  GO_DISPATCH_SCHEMA,
+  REDSKILLS_ACP_METHODS,
+  goDispatchParams,
+  type GoDispatchAnswer,
+  type GoDispatchParams,
+} from "@reddb-io/protocol-acp";
+
+import { randomUUID } from "node:crypto";
+
+import { GO_DISPATCH_LANE, type AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
+import { bindAcpProjectGithubWrite } from "./acp-github.js";
+import {
+  redskillsAcpMethod,
+  type RedskillsAcpMethodContext,
+  type RedskillsAcpMethodDomain,
+} from "./acp-method-registry.js";
+import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
+import type { AcpProjectWorkspace } from "./project-workspace.js";
+
+export { GO_DISPATCH_LANE };
+export const REDSKILLED_GO_DISPATCH_METHOD = REDSKILLS_ACP_METHODS.goDispatch;
+
+/** The disposable Ticket one demand becomes. */
+export interface GoTicketSpec {
+  readonly title: string;
+  readonly body: string;
+  /** The isolated go lane, and nothing that would put it in the drain's queue. */
+  readonly labels: readonly string[];
+}
+
+/**
+ * The Ticket tracker, as the daemon needs it and no wider.
+ *
+ * A port rather than the gateway itself: `go_dispatch` needs a Ticket number
+ * and a way to take it back, and a handler that could reach the whole forge
+ * client would be one refactor away from doing the rest of `/go` here too.
+ */
+export interface GoTicketTracker {
+  mint(spec: GoTicketSpec): Promise<number>;
+  /** Take the Ticket back when no Worker was born to own it. Optional: a
+   * tracker with no close authority is better than a silent pretend-close. */
+  dispose?(ticket: number): Promise<void>;
+}
+
+/** What admission reports back about the Worker it just admitted. */
+export interface GoWorkerAdmission {
+  readonly worker_id: string;
+  /** The public ACP session carrying this Worker's updates, when it has one. */
+  readonly session_id?: string;
+}
+
+export interface AcpGoDispatchDeps {
+  readonly tracker: GoTicketTracker;
+  /** Admit exactly one Worker against the minted Ticket. */
+  admit(
+    dispatch: AcpTargetedDispatchIntent,
+    context: RedskillsAcpMethodContext<GoDispatchParams>,
+  ): Promise<GoWorkerAdmission>;
+}
+
+/**
+ * Build the disposable Ticket for a demand.
+ *
+ * The only routing label is the isolated go lane. The body says what the
+ * Ticket is, because a human who finds it in the tracker three weeks later
+ * needs to know it was minted by a dispatch and closes with its PR.
+ */
+export function buildGoTicket(demand: string): GoTicketSpec {
+  const text = demand.trim();
+  if (text === "") throw RequestError.invalidParams({}, "go_dispatch requires a non-empty demand");
+  const headline = (text.split("\n", 1)[0] ?? "").trim();
+  return {
+    title: `/go: ${headline.slice(0, 72) || "dispatch"}`,
+    body: [
+      "## Demand",
+      "",
+      text,
+      "",
+      "---",
+      "",
+      `🤖 Disposable dispatch Ticket, minted by \`${REDSKILLS_ACP_METHODS.goDispatch}\` into the`,
+      `isolated \`${GO_DISPATCH_LANE}\` lane — never \`ready-for-agent\`, so the running drain`,
+      "cannot claim it. Its dedicated Worker owns it, and it closes with that Worker's PR.",
+    ].join("\n"),
+    labels: [GO_DISPATCH_LANE],
+  };
+}
+
+/**
+ * Bind `go_dispatch` to a tracker and an admission authority.
+ *
+ * Mint, then admit, then answer — and if admission refuses, take the Ticket
+ * back before the refusal reaches the caller. A minted Ticket whose Worker was
+ * never born is litter no one is watching for: it carries no `ready-for-agent`,
+ * so the drain will not clear it, and it names a lane no human reads.
+ */
+export function bindAcpGoDispatch(deps: AcpGoDispatchDeps) {
+  return async (context: RedskillsAcpMethodContext<GoDispatchParams>): Promise<GoDispatchAnswer> => {
+    const spec = buildGoTicket(context.params.demand);
+    const ticket = await deps.tracker.mint(spec);
+    if (!Number.isInteger(ticket) || ticket <= 0) {
+      throw new Error(`the Ticket tracker answered ${String(ticket)} instead of a Ticket number`);
+    }
+    const dispatch: AcpTargetedDispatchIntent = {
+      version: 1,
+      workerKind: "go",
+      ticket,
+      selector: { kind: "issues", numbers: [ticket], lane: GO_DISPATCH_LANE },
+    };
+    let admission: GoWorkerAdmission;
+    try {
+      admission = await deps.admit(dispatch, context);
+    } catch (error) {
+      try {
+        await deps.tracker.dispose?.(ticket);
+      } catch (disposeError) {
+        throw new AggregateError(
+          [error, disposeError],
+          `Worker admission failed and disposable Ticket #${ticket} could not be closed`,
+        );
+      }
+      throw error;
+    }
+    return {
+      version: 1,
+      worker_id: admission.worker_id,
+      ticket,
+      lane: GO_DISPATCH_LANE,
+      ...(admission.session_id == null ? {} : { session_id: admission.session_id }),
+    };
+  };
+}
+
+/** The go domain: one method, validated against the published wire schema. */
+export function goDispatchMethodDomain(deps: AcpGoDispatchDeps): RedskillsAcpMethodDomain {
+  return {
+    domain: "go",
+    bindings: [redskillsAcpMethod(REDSKILLS_ACP_METHODS.goDispatch, goDispatchParams, bindAcpGoDispatch(deps))],
+    capability: {
+      goDispatch: {
+        version: GO_DISPATCH_SCHEMA.version,
+        methods: [REDSKILLS_ACP_METHODS.goDispatch],
+        lane: GO_DISPATCH_LANE,
+      },
+    },
+  };
+}
+
+/**
+ * The production tracker: the Project-bound GitHub gateway, and nothing else.
+ *
+ * `dispose` is deliberately ABSENT. The daemon's write authority opens Tickets
+ * and publishes comments; it cannot yet close one, and a `dispose` that
+ * published "never mind" while leaving the Ticket open would report a cleanup
+ * that did not happen. The minted Ticket carries only the isolated go lane and
+ * never `ready-for-agent`, so an orphan is inert rather than claimable — it
+ * waits for a human, which is the honest state until closure is a write kind.
+ */
+export function createAcpGithubGoTicketTracker(
+  gateway: RedskilledGithubGatewayRegistration | undefined,
+  scopedProject: () => AcpProjectWorkspace,
+): GoTicketTracker {
+  const write = bindAcpProjectGithubWrite(gateway, scopedProject);
+  return {
+    async mint(spec: GoTicketSpec): Promise<number> {
+      const answer = await write({
+        params: {
+          idempotency_key: `go-dispatch:${randomUUID()}`,
+          write: {
+            kind: "issue-publication",
+            title: spec.title,
+            body: spec.body,
+            labels: [...spec.labels],
+          },
+        },
+      });
+      return ticketNumber(answer.value);
+    },
+  };
+}
+
+/** Read the Ticket number out of the tracker's own answer, or refuse. */
+function ticketNumber(value: unknown): number {
+  const number = value != null && typeof value === "object"
+    ? (value as { readonly number?: unknown }).number
+    : undefined;
+  if (!Number.isInteger(number) || Number(number) <= 0) {
+    throw new Error("the Ticket tracker published no Ticket number for this dispatch");
+  }
+  return Number(number);
+}

--- a/apps/redskilled/src/acp-host-methods.ts
+++ b/apps/redskilled/src/acp-host-methods.ts
@@ -1,0 +1,29 @@
+// acp-host-methods — the `host` `_redskills/*` domain.
+//
+// One method, and its name is a compatibility spelling: `host_state`
+// answers a PROJECT projection, not the host's. Ordinary access to the public
+// ACP socket is not an administrative capability, so what a connection reads is
+// scoped to the Project that bound it — the host-wide facts live behind the
+// budget domain's explicitly administrative endpoint.
+import { REDSKILLS_ACP_METHODS } from "@reddb-io/protocol-acp";
+
+import {
+  acpNoParams,
+  redskillsAcpMethod,
+  type RedskillsAcpMethodDomain,
+} from "./acp-method-registry.js";
+
+export const REDSKILLED_HOST_STATE_METHOD = REDSKILLS_ACP_METHODS.hostState;
+
+export interface AcpHostStateDeps {
+  /** The Project projection this connection is allowed to read. */
+  scopedState: () => unknown;
+}
+
+/** The host domain: the Project-scoped state projection, and nothing wider. */
+export function hostStateMethodDomain(deps: AcpHostStateDeps): RedskillsAcpMethodDomain {
+  return {
+    domain: "host",
+    bindings: [redskillsAcpMethod(REDSKILLED_HOST_STATE_METHOD, acpNoParams, () => deps.scopedState())],
+  };
+}

--- a/apps/redskilled/src/acp-method-registry.ts
+++ b/apps/redskilled/src/acp-method-registry.ts
@@ -1,0 +1,145 @@
+// acp-method-registry — one table, one module per `_redskills/*` domain.
+//
+// The control plane used to bind every extension method itself, twice: once on
+// the v1 app and once on the v2 app, as two hand-kept chains of `.onRequest`.
+// Two chains is the shape a method goes missing from — a binding added to one
+// and forgotten on the other is a method that answers on one dialect and 404s
+// on the other, and nothing fails until a peer that speaks the other dialect
+// asks. So the bindings become DATA: each domain module declares its own, the
+// table composes them, and both dialects are registered from the same list.
+//
+// A domain also declares the `_meta.redskills` fragment it contributes to
+// `initialize`, because advertising a method the endpoint does not bind (and
+// binding one it never advertises) are the same drift in the other direction.
+import { REDSKILLS_ACP_METHODS, type RedskillsAcpMethod } from "@reddb-io/protocol-acp";
+
+/** The context an extension handler is given. Params are already validated. */
+export interface RedskillsAcpMethodContext<Params = unknown> {
+  readonly params: Params;
+  /** The peer on the other end of THIS connection, in its own dialect. */
+  readonly client: unknown;
+}
+
+/** One method: its name, its params validator, and the handler behind it. */
+export interface RedskillsAcpMethodBinding {
+  readonly method: RedskillsAcpMethod;
+  readonly params: (value: unknown) => unknown;
+  readonly handle: (context: RedskillsAcpMethodContext) => unknown;
+}
+
+/** Every `_redskills/*` domain the daemon knows, control-plane served or not. */
+export type RedskillsAcpMethodDomainName = "host" | "project" | "github" | "budget" | "go" | "worker";
+
+/** One domain's contribution: its bindings and what `initialize` advertises. */
+export interface RedskillsAcpMethodDomain {
+  readonly domain: RedskillsAcpMethodDomainName;
+  readonly bindings: readonly RedskillsAcpMethodBinding[];
+  /** Merged into `_meta.redskills` on `initialize`; absent when nothing is advertised. */
+  readonly capability?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Declare one method binding.
+ *
+ * The helper exists for its TYPES: `params` narrows `unknown` to the handler's
+ * shape exactly once, here, so a domain module writes an ordinary typed handler
+ * and the table stores an erased one. Without it every domain would restate the
+ * same cast, which is the same as having no validator at all.
+ */
+export function redskillsAcpMethod<Params, Result>(
+  method: RedskillsAcpMethod,
+  params: (value: unknown) => Params,
+  handle: (context: RedskillsAcpMethodContext<Params>) => Result,
+): RedskillsAcpMethodBinding {
+  return {
+    method,
+    params,
+    handle: handle as (context: RedskillsAcpMethodContext) => unknown,
+  };
+}
+
+/**
+ * Params of a method whose whole request is its name.
+ *
+ * Deliberately permissive where the strict `emptyRedskillsParams` is not: these
+ * methods have accepted any object since they existed, and tightening them is a
+ * wire change owed its own slice, not a side effect of moving the binding.
+ */
+export const acpNoParams = (): Record<string, never> => ({});
+
+/** The composed control-plane surface: what to bind, and what to advertise. */
+export interface RedskillsAcpMethodTable {
+  readonly bindings: readonly RedskillsAcpMethodBinding[];
+  readonly capabilities: Readonly<Record<string, unknown>>;
+  readonly domains: readonly RedskillsAcpMethodDomainName[];
+}
+
+/**
+ * Compose the declared domains into the one table both dialects register from.
+ *
+ * A method claimed twice is refused at composition, not at request time: two
+ * handlers for one name means whichever domain registered last silently wins,
+ * and the loser's authority checks never run.
+ */
+export function redskillsAcpMethodTable(
+  domains: readonly RedskillsAcpMethodDomain[],
+): RedskillsAcpMethodTable {
+  const bindings: RedskillsAcpMethodBinding[] = [];
+  const claimed = new Map<string, RedskillsAcpMethodDomainName>();
+  let capabilities: Record<string, unknown> = {};
+  for (const domain of domains) {
+    for (const binding of domain.bindings) {
+      const holder = claimed.get(binding.method);
+      if (holder != null) {
+        throw new Error(`${binding.method} is claimed by both the ${holder} and ${domain.domain} ACP domains`);
+      }
+      claimed.set(binding.method, domain.domain);
+      bindings.push(binding);
+    }
+    if (domain.capability != null) capabilities = { ...capabilities, ...domain.capability };
+  }
+  return { bindings, capabilities, domains: domains.map((domain) => domain.domain) };
+}
+
+/**
+ * The module that owns each domain, and the method keys it owns.
+ *
+ * Declared here rather than discovered, so `apps/redskilled/tests/acp-control-plane-layout.test.ts`
+ * can pin ONE module per domain and refuse a method with no home. `served`
+ * states whether the public control plane binds the domain: `worker_budget_grace`
+ * travels daemon → Worker and is answered by the Worker, so it has an owner and
+ * no control-plane binding.
+ */
+export interface RedskillsAcpMethodDomainDeclaration {
+  readonly domain: RedskillsAcpMethodDomainName;
+  /** Repo-relative module, under `apps/redskilled/src/`, that owns the domain. */
+  readonly module: string;
+  /** Keys of `REDSKILLS_ACP_METHODS` this domain owns. */
+  readonly methods: readonly (keyof typeof REDSKILLS_ACP_METHODS)[];
+  /** True when the public control plane binds this domain's methods. */
+  readonly served: boolean;
+}
+
+export const REDSKILLS_ACP_METHOD_DOMAINS: readonly RedskillsAcpMethodDomainDeclaration[] = [
+  { domain: "host", module: "acp-host-methods.ts", methods: ["hostState"], served: true },
+  {
+    domain: "project",
+    module: "project-control.ts",
+    methods: ["projectDrain", "projectStop", "projectStatus"],
+    served: true,
+  },
+  {
+    domain: "github",
+    module: "acp-github.ts",
+    methods: ["githubRead", "githubWrite", "githubUpdate", "githubCustodyHandoff"],
+    served: true,
+  },
+  { domain: "budget", module: "acp-budget.ts", methods: ["projectBudget", "hostBudgets"], served: true },
+  { domain: "go", module: "acp-go-dispatch.ts", methods: ["goDispatch"], served: true },
+  {
+    domain: "worker",
+    module: "acp-worker-budget-grace.ts",
+    methods: ["workerBudgetGrace"],
+    served: false,
+  },
+];

--- a/apps/redskilled/src/github-outbox.ts
+++ b/apps/redskilled/src/github-outbox.ts
@@ -248,21 +248,37 @@ function validateWrite(write: RedskilledGithubWrite): RedskilledGithubWrite {
     return { kind: "pull-request", head, base, title, body };
   }
   if (write.kind === "issue-publication") {
-    requireOnlyKeys(write, ["kind", "issue", "title", "body"]);
+    requireOnlyKeys(write, ["kind", "issue", "title", "body", "labels"]);
     const body = typeof write.body === "string" ? write.body : refuse("an Issue publication needs a body");
     if (write.issue != null) {
       if (!Number.isSafeInteger(write.issue) || write.issue <= 0 || write.title != null) {
         return refuse("an Issue comment needs one positive Issue number and no title");
       }
+      if (write.labels != null) return refuse("an Issue comment carries no labels");
       return { kind: "issue-publication", issue: write.issue, body };
     }
+    const labels = validateLabels(write.labels);
     return {
       kind: "issue-publication",
       title: nonEmpty(write.title, "a new Issue publication needs a title"),
       body,
+      ...(labels.length === 0 ? {} : { labels }),
     };
   }
   return refuse("Project authority permits only repository push, pull request, and Issue publication writes");
+}
+
+/** Labels are routing, so each one must be a real, single, non-empty name. */
+function validateLabels(value: unknown): readonly string[] {
+  if (value == null) return [];
+  if (!Array.isArray(value)) return refuse("Issue labels must be a list of label names");
+  return value.map((entry) => {
+    const name = typeof entry === "string" ? entry.trim() : "";
+    if (name === "" || name.includes(",") || name.includes("\n")) {
+      return refuse("an Issue label must be one non-empty label name");
+    }
+    return name;
+  });
 }
 
 function validateBranchRef(value: unknown, label: string): string {

--- a/apps/redskilled/src/github-write.ts
+++ b/apps/redskilled/src/github-write.ts
@@ -24,6 +24,15 @@ export type RedskilledGithubWrite =
       readonly issue?: number;
       readonly title?: string;
       readonly body: string;
+      /**
+       * Labels stamped on a NEWLY opened Ticket.
+       *
+       * A lane label decides who may claim the Ticket, so stamping it in the
+       * SAME call that opens the Ticket is what keeps the window shut: a Ticket
+       * opened unlabelled and labelled a round-trip later is claimable by
+       * whoever lists the queue in between.
+       */
+      readonly labels?: readonly string[];
     };
 
 export interface RedskilledGithubWriteRequest {
@@ -120,7 +129,11 @@ function apiWriteRequest(
   return {
     lookup: `repos/${repository}/issues?state=all&per_page=100`,
     path: `repos/${repository}/issues`,
-    body: { title: write.title, body: marked(write.body) },
+    body: {
+      title: write.title,
+      body: marked(write.body),
+      ...(write.labels == null || write.labels.length === 0 ? {} : { labels: [...write.labels] }),
+    },
   };
 }
 

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -8,6 +8,11 @@ import {
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import { REDSKILLS_ACP_METHODS } from "@reddb-io/protocol-acp";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import {
+  acpNoParams,
+  redskillsAcpMethod,
+  type RedskillsAcpMethodDomain,
+} from "./acp-method-registry.js";
 import type { RedskilledDemandOutcome } from "./demand-loop.js";
 import type { RedskilledHostState } from "./host-state.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
@@ -378,4 +383,30 @@ function record(value: unknown): Record<string, unknown> | undefined {
   return value != null && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
     : undefined;
+}
+
+export interface AcpProjectControlDomainDeps {
+  /** Apply drain or stop to the Project this connection bound. */
+  mutate: (operation: ProjectControlOperation) => Promise<unknown>;
+  /** Read the Project's control status, custody included when observable. */
+  read: () => Promise<unknown>;
+}
+
+/**
+ * The `project` domain: drain, stop, and the status projection.
+ *
+ * Order matters and is pinned by {@link PROJECT_CONTROL_METHODS}: the same
+ * array is what `initialize` advertises, so a method bound here and missing
+ * there would be a capability a client cannot discover.
+ */
+export function projectControlMethodDomain(deps: AcpProjectControlDomainDeps): RedskillsAcpMethodDomain {
+  return {
+    domain: "project",
+    bindings: [
+      redskillsAcpMethod(PROJECT_CONTROL_METHODS[0], acpNoParams, () => deps.mutate("drain")),
+      redskillsAcpMethod(PROJECT_CONTROL_METHODS[1], acpNoParams, () => deps.mutate("stop")),
+      redskillsAcpMethod(PROJECT_CONTROL_METHODS[2], acpNoParams, () => deps.read()),
+    ],
+    capability: { projectControl: { version: 1, methods: PROJECT_CONTROL_METHODS } },
+  };
 }

--- a/apps/redskilled/tests/acp-control-plane-layout.test.ts
+++ b/apps/redskilled/tests/acp-control-plane-layout.test.ts
@@ -2,6 +2,10 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { REDSKILLS_ACP_METHODS, REDSKILLS_ACP_METHOD_NAMES } from "@reddb-io/protocol-acp";
+
+import { REDSKILLS_ACP_METHOD_DOMAINS } from "../src/acp-method-registry.js";
+
 const sourceRoot = join(__dirname, "..", "src");
 const wirePackage = join(__dirname, "..", "..", "..", "packages", "protocol-acp");
 
@@ -36,5 +40,71 @@ describe("the ACP control-plane module boundary", () => {
     expect(controlPlane).not.toMatch(/evaluateSpin|createChildAcpSpinEpisode|SpinPattern/);
     expect(workflowTurn).not.toMatch(/evaluateSpin|createChildAcpSpinEpisode|SpinPattern/);
     expect(childAgent).toContain("createChildAcpSpinEpisode");
+  });
+});
+
+// One module per method domain (#4014). The control plane used to bind every
+// `_redskills/*` method itself, twice, which meant every new method landed in
+// the same file as every old one — and a slice adding a method could not be
+// written without touching the file every other slice was touching.
+describe("the `_redskills/*` method domains", () => {
+  it("gives every declared method exactly one owning domain", () => {
+    const owners = new Map<string, string>();
+    for (const domain of REDSKILLS_ACP_METHOD_DOMAINS) {
+      for (const key of domain.methods) {
+        const method = REDSKILLS_ACP_METHODS[key];
+        expect(owners.get(method), `${method} is claimed twice`).toBeUndefined();
+        owners.set(method, domain.domain);
+      }
+    }
+    expect([...owners.keys()].sort()).toEqual([...REDSKILLS_ACP_METHOD_NAMES].sort());
+  });
+
+  it("gives every domain its own module, and no two domains the same one", () => {
+    const modules = REDSKILLS_ACP_METHOD_DOMAINS.map((domain) => domain.module);
+
+    expect(new Set(modules).size).toBe(modules.length);
+    expect(new Set(REDSKILLS_ACP_METHOD_DOMAINS.map((entry) => entry.domain)).size)
+      .toBe(REDSKILLS_ACP_METHOD_DOMAINS.length);
+  });
+
+  it("spells each domain's method keys in that domain's module and nowhere else", async () => {
+    const sources = new Map<string, string>();
+    for (const domain of REDSKILLS_ACP_METHOD_DOMAINS) {
+      sources.set(domain.module, await readFile(join(sourceRoot, domain.module), "utf8"));
+    }
+
+    const misplaced: string[] = [];
+    for (const domain of REDSKILLS_ACP_METHOD_DOMAINS) {
+      for (const key of domain.methods) {
+        const spelling = `REDSKILLS_ACP_METHODS.${key}`;
+        if (!sources.get(domain.module)!.includes(spelling)) {
+          misplaced.push(`${domain.module} never names ${spelling}`);
+        }
+        for (const [module, source] of sources) {
+          if (module === domain.module || !source.includes(spelling)) continue;
+          misplaced.push(`${module} names ${spelling}, owned by the ${domain.domain} domain`);
+        }
+      }
+    }
+    expect(misplaced, misplaced.join("\n")).toEqual([]);
+  });
+
+  it("keeps the control plane out of the binding business entirely", async () => {
+    const controlPlane = await readFile(join(sourceRoot, "acp-control-plane.ts"), "utf8");
+
+    expect(controlPlane).not.toMatch(/REDSKILLS_ACP_METHODS\./);
+    expect(controlPlane).toContain("connectionMethodTables");
+  });
+
+  it("binds every control-plane-served domain onto both dialects", async () => {
+    const composed = await readFile(join(sourceRoot, "acp-connection-methods.ts"), "utf8");
+
+    for (const domain of REDSKILLS_ACP_METHOD_DOMAINS.filter((entry) => entry.served)) {
+      const specifier = `from "./${domain.module.replace(/\.ts$/, ".js")}"`;
+      expect(composed, `the ${domain.domain} domain is never composed`).toContain(specifier);
+    }
+    expect(composed).toContain("v1: table(");
+    expect(composed).toContain("v2: table(");
   });
 });

--- a/apps/redskilled/tests/acp-go-dispatch.test.ts
+++ b/apps/redskilled/tests/acp-go-dispatch.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GO_DISPATCH_SCHEMA,
+  REDSKILLS_ACP_METHODS,
+  goDispatchParams,
+} from "@reddb-io/protocol-acp";
+
+import {
+  bindAcpGoDispatch,
+  buildGoTicket,
+  goDispatchMethodDomain,
+  GO_DISPATCH_LANE,
+  type GoTicketSpec,
+} from "../src/acp-go-dispatch.js";
+import type { AcpTargetedDispatchIntent } from "../src/acp-dispatch-intent.js";
+
+/** A tracker that records what was minted instead of reaching a forge. */
+function stubTracker() {
+  const minted: { ticket: number; spec: GoTicketSpec }[] = [];
+  const disposed: number[] = [];
+  let next = 4100;
+  return {
+    minted,
+    disposed,
+    async mint(spec: GoTicketSpec): Promise<number> {
+      const ticket = next++;
+      minted.push({ ticket, spec });
+      return ticket;
+    },
+    async dispose(ticket: number): Promise<void> {
+      disposed.push(ticket);
+    },
+  };
+}
+
+describe("_redskills/go_dispatch", () => {
+  it("mints the Ticket in the go lane and answers with the admitted Worker id", async () => {
+    const tracker = stubTracker();
+    const admitted: AcpTargetedDispatchIntent[] = [];
+    const dispatch = bindAcpGoDispatch({
+      tracker,
+      admit: async (intent) => {
+        admitted.push(intent);
+        return { worker_id: "host:W4014", session_id: "session-4014" };
+      },
+    });
+
+    const answer = await dispatch({ params: { demand: "teach the daemon to dispatch /go" }, client: undefined });
+
+    expect(answer).toEqual({
+      version: 1,
+      worker_id: "host:W4014",
+      ticket: 4100,
+      lane: GO_DISPATCH_LANE,
+      session_id: "session-4014",
+    });
+    expect(tracker.minted).toHaveLength(1);
+    expect(tracker.minted[0]!.spec.labels).toContain(GO_DISPATCH_LANE);
+    expect(tracker.minted[0]!.spec.labels).not.toContain("ready-for-agent");
+    expect(tracker.minted[0]!.spec.body).toContain("teach the daemon to dispatch /go");
+    expect(admitted).toEqual([{
+      version: 1,
+      workerKind: "go",
+      ticket: 4100,
+      selector: { kind: "issues", numbers: [4100], lane: GO_DISPATCH_LANE },
+    }]);
+  });
+
+  it("disposes the minted Ticket when admission fails, so no Ticket outlives its Worker", async () => {
+    const tracker = stubTracker();
+    const dispatch = bindAcpGoDispatch({
+      tracker,
+      admit: async () => {
+        throw new Error("no host capacity");
+      },
+    });
+
+    await expect(dispatch({ params: { demand: "a demand nothing can admit" }, client: undefined }))
+      .rejects.toThrow(/no host capacity/);
+    expect(tracker.minted.map((entry) => entry.ticket)).toEqual([4100]);
+    expect(tracker.disposed).toEqual([4100]);
+  });
+
+  it("refuses an empty demand before anything is minted", async () => {
+    const tracker = stubTracker();
+    const dispatch = bindAcpGoDispatch({
+      tracker,
+      admit: async () => ({ worker_id: "never" }),
+    });
+
+    await expect(dispatch({ params: { demand: "   " }, client: undefined })).rejects.toThrow(/demand/);
+    expect(tracker.minted).toEqual([]);
+  });
+
+  it("builds a disposable Ticket that names the demand and only the go lane", () => {
+    const spec = buildGoTicket("rename the drain\nand keep the ledger");
+
+    expect(spec.title).toBe("/go: rename the drain");
+    expect(spec.labels).toEqual([GO_DISPATCH_LANE]);
+    expect(spec.body).toContain("rename the drain");
+  });
+
+  it("publishes its schema from the protocol package and validates params against it", () => {
+    expect(GO_DISPATCH_SCHEMA.method).toBe(REDSKILLS_ACP_METHODS.goDispatch);
+    expect(REDSKILLS_ACP_METHODS.goDispatch).toBe("_redskills/go_dispatch");
+    expect(GO_DISPATCH_SCHEMA.params.required).toEqual(["demand"]);
+
+    expect(goDispatchParams({ demand: "ship it" })).toEqual({ demand: "ship it" });
+    expect(() => goDispatchParams({})).toThrow();
+    expect(() => goDispatchParams({ demand: "ship it", ticket: 7 })).toThrow();
+  });
+
+  it("registers exactly the go domain's method", () => {
+    const domain = goDispatchMethodDomain({
+      tracker: stubTracker(),
+      admit: async () => ({ worker_id: "host:W1" }),
+    });
+
+    expect(domain.domain).toBe("go");
+    expect(domain.bindings.map((binding) => binding.method)).toEqual([REDSKILLS_ACP_METHODS.goDispatch]);
+  });
+});

--- a/packages/protocol-acp/README.md
+++ b/packages/protocol-acp/README.md
@@ -44,6 +44,7 @@ it encodes what an authority permits.
 | `compat.ts` | `ACP_PROTOCOL_VERSION`, `ACP_V2_DRAFT_REVISION`, `REDSKILLS_WIRE_MAJOR`, the two gates that refuse an incompatible peer, and the v1 → v2 session-update translation. |
 | `transport.ts` | Binding, connecting, streaming and tearing down the local ACP endpoint on both platforms. |
 | `methods.ts` | The `_redskills/*` registry and the params shape shared by the methods that take none. |
+| `go-dispatch.ts` | The `go_dispatch` params, answer, published schema and params validator. |
 
 ## Ownership guard
 

--- a/packages/protocol-acp/go-dispatch.ts
+++ b/packages/protocol-acp/go-dispatch.ts
@@ -1,0 +1,118 @@
+// go-dispatch — the wire shape of `_redskills/go_dispatch` (ADR 0150 §3).
+//
+// `/go` used to be a client PROGRAM: mint a disposable Ticket with `gh`,
+// compose an engine argv, spawn the Worker. Every one of those steps read the
+// human's checkout — the input ADR 0144 §5 forbids — so the method replaces the
+// program with ONE call: the daemon mints the Ticket, admits the Worker, and
+// answers with the Worker id. The client carries a demand and nothing else.
+//
+// What lives here is the WIRE and only the wire: what a caller may name, what
+// it may read back, and the published schema both ends validate against. Which
+// lane the Ticket is minted into, which tracker mints it, and which Worker is
+// admitted stay with the daemon, per ADR 0148's body-versus-control cut.
+import { RequestError } from "@agentclientprotocol/sdk";
+
+import { REDSKILLS_ACP_METHODS } from "./methods.js";
+
+/**
+ * Everything a `/go` caller may name.
+ *
+ * Exactly one field, deliberately: a demand. Lane, tracker, Worker kind,
+ * budget and placement are the daemon's verdicts, and a params shape that let
+ * a caller name one of them would be a client boot phase wearing a wire.
+ */
+export interface GoDispatchParams {
+  readonly demand: string;
+}
+
+/** What one accepted `go_dispatch` produced. */
+export interface GoDispatchAnswer {
+  readonly version: 1;
+  /** The admitted Worker, named by the daemon that admitted it. */
+  readonly worker_id: string;
+  /** The Ticket the daemon minted for this demand. */
+  readonly ticket: number;
+  /** The lane label the Ticket was minted into. */
+  readonly lane: string;
+  /** The public ACP session carrying this Worker's updates, when it has one. */
+  readonly session_id?: string;
+}
+
+/**
+ * Longest demand the wire accepts.
+ *
+ * A demand becomes the body of a Ticket a forge must accept, so an unbounded
+ * one fails on the far side of the daemon, after the mint has been attempted.
+ * Refusing it here fails closed, in the caller's own error.
+ */
+export const GO_DISPATCH_DEMAND_MAX_LENGTH = 16_000;
+
+/** The published params schema; the daemon and every client read this one. */
+export const GO_DISPATCH_PARAMS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["demand"],
+  properties: {
+    demand: {
+      type: "string",
+      minLength: 1,
+      maxLength: GO_DISPATCH_DEMAND_MAX_LENGTH,
+      description: "The one-off demand this dispatch exists to satisfy.",
+    },
+  },
+} as const;
+
+/** The published answer schema. */
+export const GO_DISPATCH_ANSWER_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["version", "worker_id", "ticket", "lane"],
+  properties: {
+    version: { const: 1 },
+    worker_id: { type: "string", minLength: 1 },
+    ticket: { type: "integer", minimum: 1 },
+    lane: { type: "string", minLength: 1 },
+    session_id: { type: "string", minLength: 1 },
+  },
+} as const;
+
+/** The whole published contract of `_redskills/go_dispatch`, in one value. */
+export const GO_DISPATCH_SCHEMA = {
+  version: 1,
+  method: REDSKILLS_ACP_METHODS.goDispatch,
+  params: GO_DISPATCH_PARAMS_SCHEMA,
+  answer: GO_DISPATCH_ANSWER_SCHEMA,
+} as const;
+
+/**
+ * Validate `_redskills/go_dispatch` params against the published schema.
+ *
+ * `additionalProperties: false` is enforced rather than described: a caller
+ * that smuggles a `lane`, a `ticket` or a `runner` past this validator is
+ * naming a daemon verdict, and a silently ignored field reads to its author as
+ * a field that worked.
+ */
+export function goDispatchParams(value: unknown): GoDispatchParams {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw RequestError.invalidParams({}, "go_dispatch requires an object naming exactly a demand");
+  }
+  const named = Object.keys(value);
+  const unknownFields = named.filter((key) => key !== "demand");
+  if (unknownFields.length > 0) {
+    throw RequestError.invalidParams(
+      { unknown_fields: unknownFields },
+      "go_dispatch accepts no caller-named lane, Ticket, Worker kind or budget",
+    );
+  }
+  const demand = (value as { readonly demand?: unknown }).demand;
+  if (typeof demand !== "string" || demand.trim() === "") {
+    throw RequestError.invalidParams({}, "go_dispatch requires a non-empty demand");
+  }
+  if (demand.length > GO_DISPATCH_DEMAND_MAX_LENGTH) {
+    throw RequestError.invalidParams(
+      { max_length: GO_DISPATCH_DEMAND_MAX_LENGTH },
+      "go_dispatch refuses a demand longer than a Ticket body can carry",
+    );
+  }
+  return { demand };
+}

--- a/packages/protocol-acp/index.ts
+++ b/packages/protocol-acp/index.ts
@@ -5,5 +5,6 @@
 // ACP v1/v2 compat and draft-revision gating, the RedSkills wire major, the
 // local Unix-socket / Named Pipe transport, and the `_redskills/*` methods.
 export * from "./compat.js";
+export * from "./go-dispatch.js";
 export * from "./methods.js";
 export * from "./transport.js";

--- a/packages/protocol-acp/methods.ts
+++ b/packages/protocol-acp/methods.ts
@@ -33,6 +33,7 @@ export const REDSKILLS_ACP_METHODS = {
   githubUpdate: "_redskills/github_update",
   githubCustodyHandoff: "_redskills/github_custody_handoff",
   workerBudgetGrace: "_redskills/worker_budget_grace",
+  goDispatch: "_redskills/go_dispatch",
 } as const;
 
 /** Any name the registry declares. */

--- a/packages/protocol-acp/package.json
+++ b/packages/protocol-acp/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./index.ts",
     "./compat.js": "./compat.ts",
+    "./go-dispatch.js": "./go-dispatch.ts",
     "./methods.js": "./methods.ts",
     "./transport.js": "./transport.ts"
   },


### PR DESCRIPTION
Automated AFK landing for #4014. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #4014

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789696981&installation_model_id=20659&pr_number=4044&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4044&signature=ef8b57ef26bfd5622032a53ad719103616615dd013ba8d0bac1ac0b105d2bccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->