### PR TITLE
resume: #4021

### DIFF
--- a/.changeset/worktree-add-through-the-daemon.md
+++ b/.changeset/worktree-add-through-the-daemon.md
@@ -1,0 +1,19 @@
+---
+"@reddb-io/protocol-acp": minor
+"@reddb-io/redskilled": minor
+---
+
+`_redskills/worktree_add` creates the human's interactive worktree, and
+`_redskills/worktree_list` becomes the one inventory that shows it (ADR 0150
+§4). The daemon fetches the Project's registered trunk and forks the worktree
+from that REMOTE ref into the client checkout's manual lane, closing the way a
+hand-typed `git worktree add <dir> <branch>` resolves the LOCAL ref and builds
+on a stale tip.
+
+The inventory answers from both authorities at once: git's own list for the
+worktrees that hang off the registered checkout — each judged `checkout`,
+`interactive`, `worker` or `unregistered` — and the daemon's host state for the
+Workers, whose worktrees live in its own storage and are invisible to the
+checkout. A checkout the daemon holds no registration for is refused with a
+typed `checkout-not-registered` reason rather than a sentence, because a client
+that must regex a message is a client that cannot branch on the answer.

--- a/apps/dev/tests/worktree-lane-doctor.test.ts
+++ b/apps/dev/tests/worktree-lane-doctor.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  interactiveWorktreeDirectory,
+  REDSKILLED_INTERACTIVE_WORKTREE_LANE,
+} from "@reddb-io/redskilled/acp-worktree";
+import {
   auditWorktreeLanes,
   parseWorktreePorcelain,
   REGISTERED_WORKTREE_LANES,
@@ -73,5 +77,30 @@ describe("auditWorktreeLanes — every worktree lives in a lane we own", () => {
       { path: "/repo", branch: "refs/heads/main" },
       { path: "/repo/.red/tmp/worktrees/manual/slug" },
     ]);
+  });
+});
+
+// The daemon creates the interactive worktree now (ADR 0150 §4, issue #4021),
+// and it creates it in the human's own checkout — the one place the dev command
+// proxy and this doctor both govern. So the lane it writes into is pinned HERE
+// rather than trusted: a daemon that started landing worktrees in a lane nobody
+// registered would be refused by the proxy in a human's checkout, at the moment
+// they asked for a worktree, with nothing in the gate having said so.
+describe("the daemon's interactive lane is a lane this repo registers", () => {
+  it("lands worktree_add in a registered lane under .red/tmp/", () => {
+    expect(REGISTERED_WORKTREE_LANES).toContain(REDSKILLED_INTERACTIVE_WORKTREE_LANE);
+    expect(interactiveWorktreeDirectory("4021-worktree-add")).toBe(
+      ".red/tmp/worktrees/manual/4021-worktree-add",
+    );
+  });
+
+  it("is judged registered by the doctor that reads git's own inventory", () => {
+    const report = auditWorktreeLanes(ROOT, [
+      { path: ROOT },
+      { path: `${ROOT}/${interactiveWorktreeDirectory("4021-worktree-add")}` },
+    ]);
+
+    expect(report.verdict).toBe("ok");
+    expect(report.findings).toEqual([]);
   });
 });

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./acp-client": "./src/acp-client.ts",
     "./acp-agent-catalog": "./src/acp-agent-catalog.ts",
+    "./acp-worktree": "./src/acp-worktree.ts",
     "./cli": "./src/cli.ts",
     "./client": "./src/client.ts",
     "./daemon": "./src/daemon.ts",

--- a/apps/redskilled/src/acp-connection-methods.ts
+++ b/apps/redskilled/src/acp-connection-methods.ts
@@ -33,8 +33,14 @@ import {
   type RedskillsAcpMethodTable,
 } from "./acp-method-registry.js";
 import type { ActiveWorkflowWorker } from "./acp-worker-lifecycle.js";
+import {
+  worktreeMethodDomain,
+  type RedskilledRegisteredCheckout,
+  type RedskilledWorkerWorktree,
+} from "./acp-worktree.js";
 import type { AcpSessionJournal } from "./acp-session-journal.js";
 import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
+import type { RedskilledHostState } from "./host-state.js";
 import type { RedskilledPaths } from "./paths.js";
 import { projectControlMethodDomain, type ProjectControlOperation } from "./project-control.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
@@ -52,6 +58,8 @@ export interface ConnectionMethodDeps {
   readonly scopedState: () => unknown;
   /** The Project this connection bound. Throws when none has. */
   readonly scopedProject: () => AcpProjectWorkspace;
+  /** The daemon's own state, read for the registration a worktree stands on. */
+  readonly hostState: () => RedskilledHostState;
   readonly mutateProjectControl: (operation: ProjectControlOperation) => Promise<unknown>;
   readonly readProjectStatus: () => Promise<unknown>;
   /** Observe the reader the first GitHub read resolves, to stream its updates. */
@@ -91,8 +99,47 @@ export function connectionMethodTables(deps: ConnectionMethodDeps): ConnectionMe
       tracker: createAcpGithubGoTicketTracker(deps.githubGateway, deps.scopedProject),
       admit,
     }),
+    worktreeMethodDomain({
+      registeredCheckout: () => registeredCheckout(deps),
+      workerWorktrees: () => workerWorktrees(deps),
+    }),
   ]);
   return { v1: table(admitThroughV1(deps)), v2: table(admitThroughV2(deps)) };
+}
+
+/**
+ * The registration this connection's checkout stands on, or nothing.
+ *
+ * Absence is an ordinary answer here rather than a throw, because it is the
+ * one the worktree domain turns into its typed `checkout-not-registered`
+ * refusal — a caller told "no registration" can register, while a caller told
+ * "internal error" cannot.
+ */
+function registeredCheckout(deps: ConnectionMethodDeps): RedskilledRegisteredCheckout | undefined {
+  const project = deps.scopedProject();
+  const registration = deps.hostState().registrations
+    ?.find((entry) => entry.project_label === project.projectLabel);
+  if (registration == null) return undefined;
+  return {
+    project_label: project.projectLabel,
+    checkout_root: project.checkoutRoot,
+    ...(registration.trunk == null ? {} : { trunk: registration.trunk }),
+  };
+}
+
+/**
+ * This Project's Worker worktrees, as the daemon knows them.
+ *
+ * `workspace_path` is carried verbatim — the daemon stores what it was given
+ * and interprets nothing, so the inventory reports the execution root the
+ * Worker was born with rather than a path composed from a layout the daemon
+ * would have had to learn.
+ */
+function workerWorktrees(deps: ConnectionMethodDeps): readonly RedskilledWorkerWorktree[] {
+  const project = deps.scopedProject();
+  return deps.hostState().workers
+    .filter((worker) => worker.project_label === project.projectLabel)
+    .map((worker) => ({ worker_id: worker.worker_id, path: worker.workspace_path }));
 }
 
 type GoAdmit = (

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -233,6 +233,7 @@ async function servePublicConnection(
     active,
     scopedState,
     scopedProject,
+    hostState: options.hostState,
     mutateProjectControl,
     readProjectStatus: () => readProjectStatus(scopedProject()),
     onGithubReader: (reader) => {

--- a/apps/redskilled/src/acp-method-registry.ts
+++ b/apps/redskilled/src/acp-method-registry.ts
@@ -28,7 +28,14 @@ export interface RedskillsAcpMethodBinding {
 }
 
 /** Every `_redskills/*` domain the daemon knows, control-plane served or not. */
-export type RedskillsAcpMethodDomainName = "host" | "project" | "github" | "budget" | "go" | "worker";
+export type RedskillsAcpMethodDomainName =
+  | "host"
+  | "project"
+  | "github"
+  | "budget"
+  | "go"
+  | "worktree"
+  | "worker";
 
 /** One domain's contribution: its bindings and what `initialize` advertises. */
 export interface RedskillsAcpMethodDomain {
@@ -136,6 +143,12 @@ export const REDSKILLS_ACP_METHOD_DOMAINS: readonly RedskillsAcpMethodDomainDecl
   },
   { domain: "budget", module: "acp-budget.ts", methods: ["projectBudget", "hostBudgets"], served: true },
   { domain: "go", module: "acp-go-dispatch.ts", methods: ["goDispatch"], served: true },
+  {
+    domain: "worktree",
+    module: "acp-worktree.ts",
+    methods: ["worktreeAdd", "worktreeList"],
+    served: true,
+  },
   {
     domain: "worker",
     module: "acp-worker-budget-grace.ts",

--- a/apps/redskilled/src/acp-worktree.ts
+++ b/apps/redskilled/src/acp-worktree.ts
@@ -1,0 +1,297 @@
+// acp-worktree — the daemon side of `worktree_add` and `worktree_list` (ADR 0150 §4).
+//
+// The interactive Working mode is the one a human returns to, so its worktree
+// stays under the client checkout's manual lane rather than moving into the
+// daemon's own storage. What moves is WHO creates it: the daemon, into a lane
+// it names, forked from a trunk it fetched — not a hand-typed `git worktree
+// add` whose base resolves to a LOCAL ref that can trail the remote, which is
+// how work gets built on a stale tip and only the refused push says so.
+//
+// `worktree_list` is the other half, and the reason the pair is one slice: an
+// interactive worktree lives in the client checkout and a Worker's lives in the
+// daemon's storage (ADR 0149), so before this there was no single question that
+// could be asked about both. Two half-inventories is the shape a worktree is
+// forgotten in.
+import { execFile } from "node:child_process";
+import {
+  REDSKILLS_ACP_METHODS,
+  WORKTREE_REFUSAL_REASONS,
+  WORKTREE_SCHEMA,
+  emptyRedskillsParams,
+  worktreeAddParams,
+  worktreeRefusal,
+  type WorktreeAddAnswer,
+  type WorktreeAddParams,
+  type WorktreeEntry,
+  type WorktreeKind,
+  type WorktreeListAnswer,
+} from "@reddb-io/protocol-acp";
+
+import {
+  redskillsAcpMethod,
+  type RedskillsAcpMethodContext,
+  type RedskillsAcpMethodDomain,
+} from "./acp-method-registry.js";
+import type { RedskilledTrunk } from "./project-registration.js";
+
+const GIT_TIMEOUT_MS = 30_000;
+
+/**
+ * The lane an interactive worktree lands in.
+ *
+ * `manual` and nothing else, because it is the ONE lane ADR 0098 registers for
+ * work a human returns to — and `apps/dev/tests/worktree-lane-doctor.test.ts`
+ * pins this constant against that registry, so a daemon that started writing
+ * into a lane the dev command proxy refuses fails in the gate rather than in a
+ * human's checkout.
+ */
+export const REDSKILLED_INTERACTIVE_WORKTREE_LANE = "manual";
+
+/** Where every registered worktree lane lives, relative to the checkout root. */
+export const REDSKILLED_WORKTREE_LANE_ROOT = ".red/tmp/worktrees";
+
+/** The Worker workspace lanes, whose worktree is the leaf `worktree` directory. */
+const WORKER_WORKTREE_LANES = ["workers", "go-workers", "scout-workers"] as const;
+
+/** Repo-relative directory an interactive worktree for `slug` lands in. */
+export function interactiveWorktreeDirectory(slug: string): string {
+  return `${REDSKILLED_WORKTREE_LANE_ROOT}/${REDSKILLED_INTERACTIVE_WORKTREE_LANE}/${slug}`;
+}
+
+/**
+ * The checkout a connection may create an interactive worktree in.
+ *
+ * Registration is the precondition rather than a nicety: the daemon learns a
+ * Project's trunk remote and branch from its REGISTRATION, so a checkout it
+ * holds no registration for is one it cannot name a fresh base in. Refusing it
+ * by name beats forking off a guess.
+ */
+export interface RedskilledRegisteredCheckout {
+  readonly project_label: string;
+  /** The client checkout root, as the connection's own git evidence reports it. */
+  readonly checkout_root: string;
+  /** The Project's git coordinates; absent on a registration too old to state them. */
+  readonly trunk?: RedskilledTrunk;
+}
+
+/** One Worker worktree the daemon coordinates, as host state reports it. */
+export interface RedskilledWorkerWorktree {
+  readonly worker_id: string;
+  readonly path: string;
+}
+
+export interface AcpWorktreeDeps {
+  /**
+   * The registered checkout behind this connection, or `undefined` when the
+   * daemon holds no registration for the Project the connection bound.
+   */
+  readonly registeredCheckout: () => RedskilledRegisteredCheckout | undefined;
+  /** The Worker worktrees the daemon owns for that Project. */
+  readonly workerWorktrees: () => readonly RedskilledWorkerWorktree[];
+  /** Run git in a directory. Injected so the domain is testable without a repo. */
+  readonly git?: (cwd: string, args: readonly string[]) => Promise<string>;
+}
+
+/** The registered checkout, or the typed refusal that names the repair. */
+function requireRegisteredCheckout(deps: AcpWorktreeDeps): RedskilledRegisteredCheckout {
+  const checkout = deps.registeredCheckout();
+  if (checkout == null) {
+    throw worktreeRefusal(
+      WORKTREE_REFUSAL_REASONS.checkoutNotRegistered,
+      "redskilled holds no registration for this checkout's Project, so it can name neither its " +
+        "trunk nor its lanes; register the Project with the daemon before asking for a worktree",
+    );
+  }
+  return checkout;
+}
+
+/**
+ * Create the human's interactive worktree, forked from the FRESH trunk.
+ *
+ * Fetch first, always. The base is a remote ref by construction, and the whole
+ * failure this method removes is the bare `git worktree add <dir> <branch>`
+ * resolving the local ref instead — invisible until the push comes back
+ * non-fast-forward.
+ */
+export function bindAcpWorktreeAdd(deps: AcpWorktreeDeps) {
+  const git = deps.git ?? runGit;
+  return async (context: RedskillsAcpMethodContext<WorktreeAddParams>): Promise<WorktreeAddAnswer> => {
+    const checkout = requireRegisteredCheckout(deps);
+    const remote = checkout.trunk?.remote ?? "origin";
+    const branchOfBase = context.params.base ?? checkout.trunk?.branch;
+    if (branchOfBase == null || branchOfBase === "") {
+      throw worktreeRefusal(
+        WORKTREE_REFUSAL_REASONS.trunkUnknown,
+        "this Project's registration states no trunk branch, so worktree_add has nothing to fork " +
+          "from; name a base, or re-register with explicit git coordinates",
+      );
+    }
+    const directory = interactiveWorktreeDirectory(context.params.slug);
+    const branch = context.params.branch ?? `afk/${context.params.slug}`;
+    const base = `${remote}/${branchOfBase}`;
+
+    await git(checkout.checkout_root, ["fetch", remote, branchOfBase]);
+    await git(checkout.checkout_root, ["worktree", "add", directory, "-b", branch, base]);
+
+    return {
+      version: 1,
+      kind: "interactive",
+      path: directory,
+      branch,
+      base,
+      lane: REDSKILLED_INTERACTIVE_WORKTREE_LANE,
+      project_label: checkout.project_label,
+    };
+  };
+}
+
+/**
+ * The ONE inventory: the registered checkout's own worktrees, and the Workers'.
+ *
+ * The two halves come from different authorities and neither can see the other.
+ * Git knows what hangs off the client checkout; only the daemon knows the
+ * Worker worktrees, because a Worker's workspace is a clone of its own in
+ * temporary storage and is registered in THAT clone, not in the human's.
+ */
+export function bindAcpWorktreeList(deps: AcpWorktreeDeps) {
+  const git = deps.git ?? runGit;
+  return async (): Promise<WorktreeListAnswer> => {
+    const checkout = requireRegisteredCheckout(deps);
+    const porcelain = await git(checkout.checkout_root, ["worktree", "list", "--porcelain"]);
+    const checkoutWorktrees = parseWorktreePorcelain(porcelain)
+      .map((fact) => classify(checkout.checkout_root, fact));
+    const workerWorktrees: WorktreeEntry[] = deps.workerWorktrees().map((worker) => ({
+      kind: "worker" as const,
+      path: worker.path,
+      branch: null,
+      worker_id: worker.worker_id,
+    }));
+    return {
+      version: 1,
+      project_label: checkout.project_label,
+      worktrees: [...checkoutWorktrees, ...workerWorktrees],
+    };
+  };
+}
+
+/** One `git worktree list --porcelain` record, as git states it. */
+interface WorktreeFact {
+  readonly path: string;
+  readonly branch: string | null;
+}
+
+/**
+ * Read git's own inventory rather than sweeping the lane directories.
+ *
+ * A sweep is blind by construction to a worktree created anywhere else, and a
+ * host CLI's `--worktree` flag creates exactly that. Git already keeps the
+ * list, and it answers for hosts that do not exist yet.
+ */
+export function parseWorktreePorcelain(output: string): readonly WorktreeFact[] {
+  const facts: WorktreeFact[] = [];
+  let path: string | undefined;
+  let branch: string | null = null;
+  const flush = () => {
+    if (path != null) facts.push({ path, branch });
+    path = undefined;
+    branch = null;
+  };
+  for (const line of output.split("\n")) {
+    const trimmed = line.trimEnd();
+    if (trimmed.startsWith("worktree ")) {
+      flush();
+      path = trimmed.slice("worktree ".length);
+    } else if (trimmed.startsWith("branch ")) {
+      branch = trimmed.slice("branch ".length).replace(/^refs\/heads\//, "");
+    }
+  }
+  flush();
+  return facts;
+}
+
+/** Judge one worktree against the lanes this repo registers. */
+function classify(checkoutRoot: string, fact: WorktreeFact): WorktreeEntry {
+  const relative = relativeTo(checkoutRoot, fact.path);
+  const kind = relative === null ? "unregistered" : kindOf(relative);
+  const lane = relative === null ? undefined : laneOf(relative);
+  return {
+    kind,
+    path: fact.path,
+    branch: fact.branch,
+    ...(lane === undefined ? {} : { lane }),
+  };
+}
+
+function kindOf(relative: string): WorktreeKind {
+  if (relative === "") return "checkout";
+  const parts = relative.split("/");
+  if (parts[0] !== ".red" || parts[1] !== "tmp" || parts[2] === undefined) return "unregistered";
+  if (parts[2] === "worktrees") return parts[3] === undefined ? "unregistered" : "interactive";
+  // A Worker's own worktree, when one happens to hang off this checkout rather
+  // than off the daemon's workspace clone.
+  const workerLane = (WORKER_WORKTREE_LANES as readonly string[]).includes(parts[2]);
+  return workerLane && parts.at(-1) === "worktree" ? "worker" : "unregistered";
+}
+
+function laneOf(relative: string): string | undefined {
+  const parts = relative.split("/");
+  if (parts[0] !== ".red" || parts[1] !== "tmp") return undefined;
+  if (parts[2] === "worktrees") return parts[3];
+  return (WORKER_WORKTREE_LANES as readonly string[]).includes(parts[2] ?? "") ? parts[2] : undefined;
+}
+
+/** The path under `root`, `""` for the root itself, or `null` when outside it. */
+function relativeTo(root: string, path: string): string | null {
+  const [r, p] = [normalise(root), normalise(path)];
+  if (p === r) return "";
+  return p.startsWith(`${r}/`) ? p.slice(r.length + 1) : null;
+}
+
+function normalise(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function runGit(cwd: string, args: readonly string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("git", [...args], { cwd, encoding: "utf8", timeout: GIT_TIMEOUT_MS, windowsHide: true }, (
+      error,
+      stdout,
+      stderr,
+    ) => {
+      if (error != null) {
+        reject(new Error(stderr.trim() || error.message));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+/**
+ * The worktree domain: create an interactive worktree, and read the inventory.
+ *
+ * `worktree_list` takes STRICT empty params rather than the permissive
+ * `acpNoParams` the older methods carry: the method is new, so no caller has
+ * ever been allowed to name a checkout or a Project here, and letting one
+ * through silently would read to its author as a field that worked.
+ */
+export function worktreeMethodDomain(deps: AcpWorktreeDeps): RedskillsAcpMethodDomain {
+  return {
+    domain: "worktree",
+    bindings: [
+      redskillsAcpMethod(REDSKILLS_ACP_METHODS.worktreeAdd, worktreeAddParams, bindAcpWorktreeAdd(deps)),
+      redskillsAcpMethod(
+        REDSKILLS_ACP_METHODS.worktreeList,
+        emptyRedskillsParams("worktree_list names no checkout, Project or lane; the connection's registration decides"),
+        bindAcpWorktreeList(deps),
+      ),
+    ],
+    capability: {
+      worktree: {
+        version: WORKTREE_SCHEMA.version,
+        methods: [REDSKILLS_ACP_METHODS.worktreeAdd, REDSKILLS_ACP_METHODS.worktreeList],
+        lane: REDSKILLED_INTERACTIVE_WORKTREE_LANE,
+      },
+    },
+  };
+}

--- a/apps/redskilled/tests/acp-worktree.test.ts
+++ b/apps/redskilled/tests/acp-worktree.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REDSKILLS_ACP_METHODS,
+  WORKTREE_REFUSAL_REASONS,
+  worktreeAddParams,
+} from "@reddb-io/protocol-acp";
+
+import {
+  bindAcpWorktreeAdd,
+  bindAcpWorktreeList,
+  interactiveWorktreeDirectory,
+  parseWorktreePorcelain,
+  worktreeMethodDomain,
+  REDSKILLED_INTERACTIVE_WORKTREE_LANE,
+  type AcpWorktreeDeps,
+  type RedskilledRegisteredCheckout,
+  type RedskilledWorkerWorktree,
+} from "../src/acp-worktree.js";
+
+const CHECKOUT = "/home/dev/red-skills";
+
+/** A registered checkout with the git coordinates a registration carries. */
+function registered(overrides: Partial<RedskilledRegisteredCheckout> = {}): RedskilledRegisteredCheckout {
+  return {
+    project_label: "reddb-io/red-skills",
+    checkout_root: CHECKOUT,
+    trunk: { remote: "origin", branch: "main" },
+    ...overrides,
+  };
+}
+
+/** A git that records its argv instead of touching a repository. */
+function stubGit(answers: Readonly<Record<string, string>> = {}) {
+  const calls: { cwd: string; args: readonly string[] }[] = [];
+  return {
+    calls,
+    run: async (cwd: string, args: readonly string[]): Promise<string> => {
+      calls.push({ cwd, args });
+      return answers[args[0] ?? ""] ?? "";
+    },
+  };
+}
+
+function deps(
+  checkout: RedskilledRegisteredCheckout | undefined,
+  git: AcpWorktreeDeps["git"],
+  workers: readonly RedskilledWorkerWorktree[] = [],
+): AcpWorktreeDeps {
+  return {
+    registeredCheckout: () => checkout,
+    workerWorktrees: () => workers,
+    ...(git === undefined ? {} : { git }),
+  };
+}
+
+describe("_redskills/worktree_add", () => {
+  it("creates the worktree in the manual lane, forked from the freshly fetched trunk", async () => {
+    const git = stubGit();
+    const add = bindAcpWorktreeAdd(deps(registered(), git.run));
+
+    const answer = await add({ params: { slug: "4021-worktree-add" }, client: undefined });
+
+    expect(answer).toEqual({
+      version: 1,
+      kind: "interactive",
+      path: ".red/tmp/worktrees/manual/4021-worktree-add",
+      branch: "afk/4021-worktree-add",
+      base: "origin/main",
+      lane: REDSKILLED_INTERACTIVE_WORKTREE_LANE,
+      project_label: "reddb-io/red-skills",
+    });
+    // Fetch FIRST: the base is a remote ref by construction, and a remote ref
+    // this checkout has never seen is the other way the bare form fails.
+    expect(git.calls.map((call) => call.args)).toEqual([
+      ["fetch", "origin", "main"],
+      ["worktree", "add", ".red/tmp/worktrees/manual/4021-worktree-add", "-b", "afk/4021-worktree-add", "origin/main"],
+    ]);
+    expect(git.calls.every((call) => call.cwd === CHECKOUT)).toBe(true);
+  });
+
+  it("honours a caller's branch and base, and still forks off the REMOTE ref", async () => {
+    const git = stubGit();
+    const add = bindAcpWorktreeAdd(deps(registered({ trunk: { remote: "upstream", branch: "develop" } }), git.run));
+
+    const answer = await add({
+      params: { slug: "release-toolchain", branch: "chore/release-toolchain", base: "next" },
+      client: undefined,
+    });
+
+    expect(answer.branch).toBe("chore/release-toolchain");
+    expect(answer.base).toBe("upstream/next");
+    expect(git.calls[0]!.args).toEqual(["fetch", "upstream", "next"]);
+    expect(git.calls[1]!.args).toContain("upstream/next");
+  });
+
+  it("refuses an unregistered checkout by name, and touches no git", async () => {
+    const git = stubGit();
+    const add = bindAcpWorktreeAdd(deps(undefined, git.run));
+
+    await expect(add({ params: { slug: "anything" }, client: undefined })).rejects.toMatchObject({
+      data: { reason: WORKTREE_REFUSAL_REASONS.checkoutNotRegistered },
+    });
+    expect(git.calls).toEqual([]);
+  });
+
+  it("refuses a registration that states no trunk when the caller names no base", async () => {
+    const git = stubGit();
+    const add = bindAcpWorktreeAdd(deps(registered({ trunk: undefined }), git.run));
+
+    await expect(add({ params: { slug: "anything" }, client: undefined })).rejects.toMatchObject({
+      data: { reason: WORKTREE_REFUSAL_REASONS.trunkUnknown },
+    });
+    expect(git.calls).toEqual([]);
+  });
+});
+
+describe("worktree_add params", () => {
+  it("refuses a slug that would not survive as a directory name", () => {
+    expect(() => worktreeAddParams({ slug: "../../etc" })).toThrow();
+    expect(() => worktreeAddParams({ slug: "" })).toThrow();
+    expect(() => worktreeAddParams({ slug: "a slug with spaces" })).toThrow();
+  });
+
+  it("refuses a branch git would read as an option rather than as a ref", () => {
+    expect(() => worktreeAddParams({ slug: "ok", branch: "--upload-pack=touch" })).toThrow();
+    expect(() => worktreeAddParams({ slug: "ok", base: "main..evil" })).toThrow();
+    expect(() => worktreeAddParams({ slug: "ok", base: "refs/heads/main~1" })).toThrow();
+  });
+
+  it("refuses a caller that names a checkout, a lane or a Project", () => {
+    expect(() => worktreeAddParams({ slug: "ok", lane: "landing" })).toThrow();
+    expect(() => worktreeAddParams({ slug: "ok", checkout: "/somewhere/else" })).toThrow();
+  });
+
+  it("accepts a slug alone, lowercased and trimmed", () => {
+    expect(worktreeAddParams({ slug: "  4021-Worktree_Add  " })).toEqual({ slug: "4021-worktree_add" });
+  });
+});
+
+describe("_redskills/worktree_list", () => {
+  it("is the ONE inventory: the checkout's worktrees and the daemon's Workers", async () => {
+    const git = stubGit({
+      worktree: [
+        `worktree ${CHECKOUT}`,
+        "HEAD 1111111111111111111111111111111111111111",
+        "branch refs/heads/main",
+        "",
+        `worktree ${CHECKOUT}/.red/tmp/worktrees/manual/release-toolchain`,
+        "HEAD 2222222222222222222222222222222222222222",
+        "branch refs/heads/afk/release-toolchain",
+        "",
+        `worktree ${CHECKOUT}/.muse/worktrees/red-skills-9f2`,
+        "HEAD 3333333333333333333333333333333333333333",
+        "detached",
+        "",
+      ].join("\n"),
+    });
+    const list = bindAcpWorktreeList(deps(registered(), git.run, [
+      { worker_id: "host:W4021", path: "/tmp/redskilled/workers/hIWOV/4021/worktree" },
+    ]));
+
+    const answer = await list();
+
+    expect(git.calls).toEqual([{ cwd: CHECKOUT, args: ["worktree", "list", "--porcelain"] }]);
+    expect(answer).toEqual({
+      version: 1,
+      project_label: "reddb-io/red-skills",
+      worktrees: [
+        { kind: "checkout", path: CHECKOUT, branch: "main" },
+        {
+          kind: "interactive",
+          path: `${CHECKOUT}/.red/tmp/worktrees/manual/release-toolchain`,
+          branch: "afk/release-toolchain",
+          lane: "manual",
+        },
+        { kind: "unregistered", path: `${CHECKOUT}/.muse/worktrees/red-skills-9f2`, branch: null },
+        { kind: "worker", path: "/tmp/redskilled/workers/hIWOV/4021/worktree", branch: null, worker_id: "host:W4021" },
+      ],
+    });
+  });
+
+  it("shows a worktree created by worktree_add with its kind", async () => {
+    const created = interactiveWorktreeDirectory("4021-worktree-add");
+    const git = stubGit({ worktree: `worktree ${CHECKOUT}/${created}\nbranch refs/heads/afk/4021-worktree-add\n` });
+
+    const answer = await bindAcpWorktreeList(deps(registered(), git.run))();
+
+    expect(answer.worktrees).toEqual([
+      {
+        kind: "interactive",
+        path: `${CHECKOUT}/${created}`,
+        branch: "afk/4021-worktree-add",
+        lane: REDSKILLED_INTERACTIVE_WORKTREE_LANE,
+      },
+    ]);
+  });
+
+  it("refuses an unregistered checkout by name", async () => {
+    const git = stubGit();
+
+    await expect(bindAcpWorktreeList(deps(undefined, git.run))()).rejects.toMatchObject({
+      data: { reason: WORKTREE_REFUSAL_REASONS.checkoutNotRegistered },
+    });
+    expect(git.calls).toEqual([]);
+  });
+});
+
+describe("the worktree porcelain reader", () => {
+  it("reads git's own inventory, detached heads included", () => {
+    expect(parseWorktreePorcelain("worktree /a\nHEAD abc\ndetached\n\nworktree /b\nbranch refs/heads/x\n")).toEqual([
+      { path: "/a", branch: null },
+      { path: "/b", branch: "x" },
+    ]);
+  });
+
+  it("answers an empty inventory rather than inventing one", () => {
+    expect(parseWorktreePorcelain("")).toEqual([]);
+  });
+});
+
+describe("the worktree method domain", () => {
+  it("binds both methods and advertises them with the lane they land in", () => {
+    const domain = worktreeMethodDomain(deps(registered(), stubGit().run));
+
+    expect(domain.domain).toBe("worktree");
+    expect(domain.bindings.map((binding) => binding.method)).toEqual([
+      REDSKILLS_ACP_METHODS.worktreeAdd,
+      REDSKILLS_ACP_METHODS.worktreeList,
+    ]);
+    expect(domain.capability).toMatchObject({
+      worktree: { lane: REDSKILLED_INTERACTIVE_WORKTREE_LANE },
+    });
+  });
+
+  it("lets worktree_list name nothing at all", () => {
+    const [, list] = worktreeMethodDomain(deps(registered(), stubGit().run)).bindings;
+
+    expect(list!.params({})).toEqual({});
+    expect(() => list!.params({ checkout: "/somewhere/else" })).toThrow();
+  });
+});

--- a/packages/protocol-acp/README.md
+++ b/packages/protocol-acp/README.md
@@ -45,6 +45,7 @@ it encodes what an authority permits.
 | `transport.ts` | Binding, connecting, streaming and tearing down the local ACP endpoint on both platforms. |
 | `methods.ts` | The `_redskills/*` registry and the params shape shared by the methods that take none. |
 | `go-dispatch.ts` | The `go_dispatch` params, answer, published schema and params validator. |
+| `worktree.ts` | The `worktree_add` / `worktree_list` params, answers, published schemas, params validator and refusal vocabulary. |
 
 ## Ownership guard
 

--- a/packages/protocol-acp/index.ts
+++ b/packages/protocol-acp/index.ts
@@ -8,3 +8,4 @@ export * from "./compat.js";
 export * from "./go-dispatch.js";
 export * from "./methods.js";
 export * from "./transport.js";
+export * from "./worktree.js";

--- a/packages/protocol-acp/methods.ts
+++ b/packages/protocol-acp/methods.ts
@@ -34,6 +34,8 @@ export const REDSKILLS_ACP_METHODS = {
   githubCustodyHandoff: "_redskills/github_custody_handoff",
   workerBudgetGrace: "_redskills/worker_budget_grace",
   goDispatch: "_redskills/go_dispatch",
+  worktreeAdd: "_redskills/worktree_add",
+  worktreeList: "_redskills/worktree_list",
 } as const;
 
 /** Any name the registry declares. */

--- a/packages/protocol-acp/package.json
+++ b/packages/protocol-acp/package.json
@@ -10,7 +10,8 @@
     "./compat.js": "./compat.ts",
     "./go-dispatch.js": "./go-dispatch.ts",
     "./methods.js": "./methods.ts",
-    "./transport.js": "./transport.ts"
+    "./transport.js": "./transport.ts",
+    "./worktree.js": "./worktree.ts"
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/packages/protocol-acp/worktree.ts
+++ b/packages/protocol-acp/worktree.ts
@@ -1,0 +1,281 @@
+// worktree — the wire shape of `_redskills/worktree_add` and
+// `_redskills/worktree_list` (ADR 0150 §4).
+//
+// The interactive Working mode used to be the one mode nothing coordinated: a
+// human typed `git worktree add` into whichever checkout they were standing in,
+// and the resulting worktree existed in no inventory the daemon could answer
+// from. Worker worktrees, meanwhile, live in OS temporary storage (ADR 0149)
+// and are known only to the daemon. Two half-inventories is the shape a
+// worktree is forgotten in — so `worktree_list` becomes the ONE inventory, and
+// `worktree_add` is how an interactive worktree enters it.
+//
+// What lives here is the WIRE and only the wire: what a caller may name, what
+// it reads back, the published schemas both ends validate against, and the
+// refusal vocabulary a client can branch on. WHICH lane an interactive worktree
+// lands in, WHICH trunk it forks from, and WHAT counts as registered are daemon
+// verdicts and stay with the daemon, per ADR 0148's body-versus-control cut.
+import { RequestError } from "@agentclientprotocol/sdk";
+
+import { REDSKILLS_ACP_METHODS } from "./methods.js";
+
+/**
+ * Everything a `worktree_add` caller may name.
+ *
+ * No checkout, no lane, no project: the daemon works in the checkout the
+ * caller's connection registered, and a params shape that let a caller name a
+ * different one would be the client-composed launch ADR 0144 §5 forbids,
+ * wearing a wire. `base` names a BRANCH, never a ref — the remote is the
+ * Project's registered trunk remote, so a caller cannot redirect the fork at a
+ * local ref that trails it.
+ */
+export interface WorktreeAddParams {
+  /** What the human is about to work on; becomes the directory name. */
+  readonly slug: string;
+  /** Branch to create. Defaults to the daemon's convention for the slug. */
+  readonly branch?: string;
+  /** Trunk branch to fork from. Defaults to the Project's registered trunk. */
+  readonly base?: string;
+}
+
+/** How a worktree in the inventory came to exist. */
+export type WorktreeKind =
+  /** The registered client checkout itself — the anchor every other entry hangs off. */
+  | "checkout"
+  /** A human's worktree in a registered lane of that checkout. */
+  | "interactive"
+  /** A Worker's worktree, coordinated by the daemon in its own storage. */
+  | "worker"
+  /** A worktree of this checkout in no lane anybody registered. */
+  | "unregistered";
+
+/** One worktree, however it was born. */
+export interface WorktreeEntry {
+  readonly kind: WorktreeKind;
+  /** Absolute path, as the authority that knows this worktree reports it. */
+  readonly path: string;
+  /** Checked-out branch; `null` for a detached head or a path git detached from. */
+  readonly branch: string | null;
+  /** The registered lane, present only for a worktree that lies in one. */
+  readonly lane?: string;
+  /** The Worker that owns this worktree, present only for `worker`. */
+  readonly worker_id?: string;
+}
+
+/** What one accepted `worktree_add` created. */
+export interface WorktreeAddAnswer {
+  readonly version: 1;
+  /** Always `interactive`: the method exists to create a human's worktree. */
+  readonly kind: "interactive";
+  readonly path: string;
+  readonly branch: string;
+  /** The remote ref the worktree was forked from, after a fresh fetch. */
+  readonly base: string;
+  readonly lane: string;
+  readonly project_label: string;
+}
+
+/** The one inventory: every worktree of this Project either authority knows. */
+export interface WorktreeListAnswer {
+  readonly version: 1;
+  readonly project_label: string;
+  readonly worktrees: readonly WorktreeEntry[];
+}
+
+/**
+ * Why the daemon refused, as a name rather than as a sentence.
+ *
+ * A refusal a client can only regex out of a message is a refusal no client
+ * branches on, so each reason is a value: `checkout-not-registered` is the
+ * caller's own repair (register the Project first), `trunk-unknown` is a
+ * registration too old to state its git coordinates, and `slug-unusable` /
+ * `ref-unusable` are the caller's own strings refused before they reach git's
+ * argv.
+ */
+export const WORKTREE_REFUSAL_REASONS = {
+  checkoutNotRegistered: "checkout-not-registered",
+  trunkUnknown: "trunk-unknown",
+  slugUnusable: "slug-unusable",
+  refUnusable: "ref-unusable",
+} as const;
+
+export type WorktreeRefusalReason =
+  (typeof WORKTREE_REFUSAL_REASONS)[keyof typeof WORKTREE_REFUSAL_REASONS];
+
+/**
+ * The daemon's verdict: the request was well formed and is still refused.
+ *
+ * `reason` travels in the error DATA, where a client reads it without parsing
+ * prose; `detail` travels as the message, where a human reads it. Neither is
+ * derived from the other, because a reason narrowed to fit a sentence stops
+ * being a value and a sentence widened to carry a reason stops being readable.
+ */
+export function worktreeRefusal(reason: WorktreeRefusalReason, detail: string): RequestError {
+  return RequestError.invalidRequest({ reason, detail }, detail);
+}
+
+/**
+ * The caller's own string was refused, in the same readable shape.
+ *
+ * Separate from {@link worktreeRefusal} because the two are different verdicts
+ * and JSON-RPC already distinguishes them: an unusable slug is the caller's
+ * params to fix, while an unregistered checkout is the daemon's authority
+ * speaking about a well-formed request. The `{ reason, detail }` data shape is
+ * shared so a client reads one field either way.
+ */
+export function worktreeParamsRefusal(reason: WorktreeRefusalReason, detail: string): RequestError {
+  return RequestError.invalidParams({ reason, detail }, detail);
+}
+
+/** Longest slug the wire accepts; it becomes a directory name on every platform. */
+export const WORKTREE_SLUG_MAX_LENGTH = 64;
+
+/** Longest branch or base name the wire accepts. */
+export const WORKTREE_REF_MAX_LENGTH = 200;
+
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+
+/**
+ * A branch or base name git can be handed as argv without ambiguity.
+ *
+ * The refused set is git's own (`refname` rules) plus the one shell-free
+ * hazard argv still carries: a leading `-`, which git reads as an OPTION. A
+ * caller that names `--upload-pack=…` is not naming a branch.
+ */
+function refIsUsable(value: string): boolean {
+  if (value === "" || value.length > WORKTREE_REF_MAX_LENGTH) return false;
+  if (value.startsWith("-") || value.startsWith("/") || value.endsWith("/")) return false;
+  if (value.endsWith(".") || value.endsWith(".lock")) return false;
+  if (value.includes("..") || value.includes("//") || value.includes("@{")) return false;
+  if (/[\s~^:?*[\\]/.test(value)) return false;
+  return ![...value].some((character) => {
+    const code = character.codePointAt(0) ?? 0;
+    return code < 0x20 || code === 0x7f;
+  });
+}
+
+/** The published `worktree_add` params schema; the daemon and every client read this one. */
+export const WORKTREE_ADD_PARAMS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["slug"],
+  properties: {
+    slug: {
+      type: "string",
+      minLength: 1,
+      maxLength: WORKTREE_SLUG_MAX_LENGTH,
+      pattern: SLUG_PATTERN.source,
+      description: "What the human is about to work on; becomes the worktree directory name.",
+    },
+    branch: {
+      type: "string",
+      minLength: 1,
+      maxLength: WORKTREE_REF_MAX_LENGTH,
+      description: "Branch to create; defaults to the daemon's convention for the slug.",
+    },
+    base: {
+      type: "string",
+      minLength: 1,
+      maxLength: WORKTREE_REF_MAX_LENGTH,
+      description: "Trunk BRANCH to fork from; the remote is the Project's registered trunk remote.",
+    },
+  },
+} as const;
+
+/** The published `worktree_add` answer schema. */
+export const WORKTREE_ADD_ANSWER_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["version", "kind", "path", "branch", "base", "lane", "project_label"],
+  properties: {
+    version: { const: 1 },
+    kind: { const: "interactive" },
+    path: { type: "string", minLength: 1 },
+    branch: { type: "string", minLength: 1 },
+    base: { type: "string", minLength: 1 },
+    lane: { type: "string", minLength: 1 },
+    project_label: { type: "string", minLength: 1 },
+  },
+} as const;
+
+/** The published `worktree_list` answer schema. */
+export const WORKTREE_LIST_ANSWER_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["version", "project_label", "worktrees"],
+  properties: {
+    version: { const: 1 },
+    project_label: { type: "string", minLength: 1 },
+    worktrees: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["kind", "path", "branch"],
+        properties: {
+          kind: { enum: ["checkout", "interactive", "worker", "unregistered"] },
+          path: { type: "string", minLength: 1 },
+          branch: { type: ["string", "null"] },
+          lane: { type: "string", minLength: 1 },
+          worker_id: { type: "string", minLength: 1 },
+        },
+      },
+    },
+  },
+} as const;
+
+/** The whole published contract of the two worktree methods, in one value. */
+export const WORKTREE_SCHEMA = {
+  version: 1,
+  methods: {
+    add: REDSKILLS_ACP_METHODS.worktreeAdd,
+    list: REDSKILLS_ACP_METHODS.worktreeList,
+  },
+  add: { params: WORKTREE_ADD_PARAMS_SCHEMA, answer: WORKTREE_ADD_ANSWER_SCHEMA },
+  list: { answer: WORKTREE_LIST_ANSWER_SCHEMA },
+} as const;
+
+/**
+ * Validate `worktree_add` params against the published schema.
+ *
+ * `additionalProperties: false` is enforced rather than described, for the same
+ * reason `go_dispatch` enforces it: a caller that smuggles a `checkout`, a
+ * `lane` or a `project` past this validator is naming a daemon verdict, and a
+ * silently ignored field reads to its author as a field that worked.
+ */
+export function worktreeAddParams(value: unknown): WorktreeAddParams {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw RequestError.invalidParams({}, "worktree_add requires an object naming a slug");
+  }
+  const unknownFields = Object.keys(value).filter((key) => !["slug", "branch", "base"].includes(key));
+  if (unknownFields.length > 0) {
+    throw RequestError.invalidParams(
+      { unknown_fields: unknownFields },
+      "worktree_add accepts no caller-named checkout, lane, Project or remote",
+    );
+  }
+  const named = value as { readonly slug?: unknown; readonly branch?: unknown; readonly base?: unknown };
+  const slug = typeof named.slug === "string" ? named.slug.trim().toLowerCase() : "";
+  if (slug === "" || slug.length > WORKTREE_SLUG_MAX_LENGTH || !SLUG_PATTERN.test(slug)) {
+    throw worktreeParamsRefusal(
+      WORKTREE_REFUSAL_REASONS.slugUnusable,
+      `worktree_add needs a slug of lowercase letters, digits, dot, dash or underscore, ` +
+        `at most ${WORKTREE_SLUG_MAX_LENGTH} characters`,
+    );
+  }
+  return {
+    slug,
+    ...optionalRef("branch", named.branch),
+    ...optionalRef("base", named.base),
+  };
+}
+
+function optionalRef(field: "branch" | "base", value: unknown): Record<string, string> {
+  if (value === undefined) return {};
+  if (typeof value !== "string" || !refIsUsable(value)) {
+    throw worktreeParamsRefusal(
+      WORKTREE_REFUSAL_REASONS.refUnusable,
+      `worktree_add refuses ${field} ${JSON.stringify(value)}: it is not a name git reads as a branch`,
+    );
+  }
+  return { [field]: value };
+}


### PR DESCRIPTION
Resuming preserved Worker commits for #4021.

Closes #4021

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789701467&installation_model_id=20659&pr_number=4050&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4050&signature=5b67449be2303e4966b2e54aa3e2bfc2466cc4ccc97e6cda1ba0096d604010aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->