### PR TITLE
fix: #4015 Worker-side ACP modules move from the daemon into packages/worker; the body-vs-control cut is written down

### DIFF
--- a/apps/redskilled/src/acp-agent-catalog.ts
+++ b/apps/redskilled/src/acp-agent-catalog.ts
@@ -11,9 +11,13 @@ import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
+import { ACP_AGENT_IDS, type AcpAgentId, type AcpEndpoint } from "@reddb-io/protocol-acp";
 
-export const ACP_AGENT_IDS = ["redcode", "claude-code", "codex", "pi", "opencode"] as const;
-export type AcpAgentId = typeof ACP_AGENT_IDS[number];
+// The Agent identities and the resolved endpoint are shared wire (ADR 0148):
+// the Worker body reads an endpoint it never resolves, so it must not have to
+// import this catalog to do it. Re-exported here so daemon-side callers keep
+// asking the authority that owns discovery.
+export { ACP_AGENT_IDS, type AcpAgentId, type AcpEndpoint };
 
 export const ACP_AGENT_REQUIRED_CAPABILITIES = [
   "session/new",
@@ -90,13 +94,6 @@ export const ACP_AGENT_CATALOG: readonly AcpAgentDescriptor[] = [
 ] as const;
 
 /** Credential-free launch projection handed to a Worker. */
-export interface AcpEndpoint {
-  readonly agent: AcpAgentId;
-  readonly transport: "stdio";
-  readonly command: string;
-  readonly args: readonly string[];
-}
-
 export interface AcpAgentProbeResult {
   readonly protocolVersion: number;
   readonly capabilities: readonly string[];

--- a/apps/redskilled/src/acp-body-control-cut.ts
+++ b/apps/redskilled/src/acp-body-control-cut.ts
@@ -1,0 +1,197 @@
+// acp-body-control-cut — ADR 0148's one rule, declared so both sides are checkable.
+//
+//   WHAT RUNS INSIDE THE WORKER IS THE BODY, and lives in `@reddb-io/worker`.
+//   WHETHER, WHEN AND WHERE A WORKER EXISTS IS THE CONTROL PLANE, and stays
+//   behind `redskilled`.
+//
+// The rule reads as obvious and drifts anyway, because the two halves meet in
+// the middle of single files. `acp-native-worker.ts` held both: the function
+// that DECIDED a Worker should exist and the function the resulting process
+// RAN, one after the other, importing each other's neighbours. Nothing in a
+// type checker can tell those apart — both compile, both pass their tests, and
+// the seam is invisible until someone reaches across it.
+//
+// So the cut is DATA, checked in both directions by
+// `apps/redskilled/tests/acp-body-control-cut.test.ts`:
+//
+//   1. A body module the daemon still holds FAILS — by its old name coming
+//      back under `apps/redskilled/src/`, or by any daemon module DEFINING a
+//      symbol the body owns. Re-exporting one is fine and deliberate: the
+//      daemon's `acp-worker` entry is still the daemon's entry, it just loads
+//      the body from the package.
+//   2. A control-plane surface the package reaches for FAILS. Admission,
+//      budget authority, placement, the session journal and the GitHub gateway
+//      are the five the Worker most plausibly wants and may never have,
+//      because each is an answer about OTHER Workers or about credentials the
+//      Worker is not trusted with.
+//   3. An UNDECLARED module under `packages/worker/src/acp/` FAILS, so the
+//      inventory cannot quietly stop being one.
+//
+// Names are pinned by IDENTIFIER, never by the word. A Worker running out of
+// budget checkpoints itself in `budget-grace.ts`, and that is body: the daemon
+// decided the verdict, set the deadline and performs the kill.
+
+/** One module that runs inside the Worker process. */
+export interface WorkerBodyModule {
+  /** Path under `packages/worker/src/acp/`. */
+  readonly module: string;
+  /**
+   * The name it carried under `apps/redskilled/src/` before ADR 0148.
+   *
+   * A ratchet, not history: this exact name reappearing in the daemon tree is
+   * the most likely shape of the move being undone.
+   */
+  readonly formerDaemonModule: string;
+  /** Symbols this module DEFINES. The daemon may re-export them, never define them. */
+  readonly defines: readonly string[];
+  /** What it does once the process is already running. */
+  readonly runs: string;
+}
+
+export const WORKER_BODY_MODULES: readonly WorkerBodyModule[] = [
+  {
+    module: "command.ts",
+    formerDaemonModule: "acp-worker-command.ts",
+    defines: ["runAcpWorkerCommand"],
+    runs: "parses the daemon-chosen argv the `acp-worker` re-exec was handed",
+  },
+  {
+    module: "native-worker.ts",
+    formerDaemonModule: "acp-native-worker.ts",
+    defines: ["runNativeAcpWorker"],
+    runs: "serves the Worker's own ACP agent surface for the length of the process",
+  },
+  {
+    module: "child-agent.ts",
+    formerDaemonModule: "acp-child-agent.ts",
+    defines: ["WorkflowChildAgent"],
+    runs: "spawns, prompts, steers and reaps the one governed child coding Agent",
+  },
+  {
+    module: "child-spin.ts",
+    formerDaemonModule: "acp-child-spin.ts",
+    defines: ["createChildAcpSpinEpisode"],
+    runs: "judges Spin over the child's own updates, inside the turn that produced them",
+  },
+  {
+    module: "budget-grace.ts",
+    formerDaemonModule: "acp-worker-budget-grace.ts",
+    defines: ["createAcpWorkerBudgetGraceRuntime"],
+    runs: "cancels, checkpoints, asks the gateway to publish, writes the Envelope, dies",
+  },
+];
+
+/**
+ * A module the "Worker" in its name would move, and the cut keeps.
+ *
+ * ADR 0148 enumerates seven Worker-side `acp-*` modules and then states the
+ * rule that decides them: whatever decides WHETHER, WHEN AND WHERE a Worker
+ * exists stays in the daemon. Two of the seven are named for the Worker and
+ * are, by that rule, control: they run in the DAEMON process, holding the
+ * daemon's map of live Workers, admitting one when a turn needs it, replacing
+ * a dead one and reaping an idle one. Moving them would have put admission and
+ * reaping inside the package this cut exists to keep them out of — and issue
+ * #4015 refuses exactly that in its second acceptance criterion.
+ *
+ * Declared rather than silently skipped, because a reader who counts five
+ * moved modules against the ADR's seven deserves the answer here, at the point
+ * they would go looking for it.
+ */
+export interface ControlPlaneDespiteTheName {
+  /** Path under `apps/redskilled/src/`. */
+  readonly module: string;
+  /** Symbols proving it is the daemon's side of the socket, not the Worker's. */
+  readonly defines: readonly string[];
+  /** Why the name misleads. */
+  readonly why: string;
+}
+
+export const CONTROL_PLANE_DESPITE_THE_NAME: readonly ControlPlaneDespiteTheName[] = [
+  {
+    module: "acp-worker-lifecycle.ts",
+    defines: ["scheduleIdleCleanup", "reapWorkflowWorker", "cleanupWorkflowWorker"],
+    why: "it is the daemon's handle on a live Worker — its socket, its idle timer and its reaping",
+  },
+  {
+    module: "acp-workflow-turn.ts",
+    defines: ["runAcpWorkflowTurn"],
+    why: "it admits, replaces and reaps across one public turn; a Worker cannot decide its own succession",
+  },
+];
+
+/** A control-plane authority the Worker body may never hold. */
+export interface ControlPlaneSurface {
+  readonly surface: "admission" | "budget" | "placement" | "journal" | "gateway";
+  /** Repo-relative modules that own it. Each must exist under the daemon. */
+  readonly modules: readonly string[];
+  /** Symbols no module in `packages/worker` may define. */
+  readonly defines: readonly string[];
+  /** Why a Worker cannot be trusted with it. */
+  readonly why: string;
+}
+
+export const CONTROL_PLANE_SURFACES: readonly ControlPlaneSurface[] = [
+  {
+    surface: "admission",
+    modules: [
+      "apps/redskilled/src/acp-worker-admission.ts",
+      "apps/redskilled/src/acp-go-admission.ts",
+    ],
+    defines: ["admitNativeAcpWorker", "createGoWorkerAdmission"],
+    why: "a Worker that could admit a Worker is a Worker that outlives its own reaping",
+  },
+  {
+    surface: "budget",
+    modules: [
+      "apps/redskilled/src/acp-budget.ts",
+      "apps/redskilled/src/budget-accounting.ts",
+      "apps/redskilled/src/daemon/budget-grace.ts",
+    ],
+    defines: [
+      "budgetMethodDomain",
+      "buildBudgetAccounting",
+      "createBudgetGraceRuntime",
+      "signalWorkerForBudgetGrace",
+    ],
+    why: "the verdict, the deadline and the kill answer for the host, not for the process being killed",
+  },
+  {
+    surface: "placement",
+    modules: ["apps/redskilled/src/worker-placement.ts"],
+    defines: ["planWorkerPlacement", "selectWorkerPlacementDriver"],
+    why: "where a Worker runs is a host resource decision the Worker is downstream of",
+  },
+  {
+    surface: "journal",
+    modules: ["apps/redskilled/src/acp-session-journal.ts"],
+    defines: ["createAcpSessionJournal", "acpSessionJournalPath"],
+    why: "durable public session evidence must survive the Worker that produced it",
+  },
+  {
+    surface: "gateway",
+    modules: ["apps/redskilled/src/github-gateway.ts", "apps/redskilled/src/github-write.ts"],
+    defines: ["createRedskilledGithubGateway", "createRedskilledGithubUpstream"],
+    why: "no GitHub credential crosses the seam; a Worker asks, the daemon writes",
+  },
+];
+
+/** Strip comments before matching — prose describing the cut is not the cut. */
+export function stripSourceComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+/**
+ * True when `source` DEFINES `name`, as opposed to re-exporting it.
+ *
+ * The distinction is the whole point: `acp-control-plane.ts` re-exports
+ * `runNativeAcpWorker` so the daemon's entry keeps its shape, and that is the
+ * move working rather than the move failing.
+ */
+export function definesSymbol(source: string, name: string): boolean {
+  const declaration = new RegExp(
+    String.raw`(?:^|[\n;{])\s*(?:export\s+)?(?:declare\s+)?(?:default\s+)?(?:async\s+)?(?:function|class|const|let|var)\s+${name}\b`,
+  );
+  return declaration.test(stripSourceComments(source));
+}

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -90,8 +90,8 @@ import {
   workflowOutcome,
   type ActiveWorkflowWorker,
 } from "./acp-worker-lifecycle.js";
-import { admitNativeAcpWorker } from "./acp-native-worker.js";
-export { runNativeAcpWorker } from "./acp-native-worker.js";
+import { admitNativeAcpWorker } from "./acp-worker-admission.js";
+export { runNativeAcpWorker } from "@reddb-io/worker/acp";
 import { runAcpWorkflowTurn } from "./acp-workflow-turn.js";
 
 export { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "@reddb-io/protocol-acp";

--- a/apps/redskilled/src/acp-go-admission.ts
+++ b/apps/redskilled/src/acp-go-admission.ts
@@ -20,7 +20,7 @@ import type { PublicSession } from "./acp-control-plane.js";
 import { createAcpSessionJournal as createAcpDispatchJournal } from "./acp-dispatch-intent.js";
 import type { AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
 import type { GoWorkerAdmission } from "./acp-go-dispatch.js";
-import { admitNativeAcpWorker } from "./acp-native-worker.js";
+import { admitNativeAcpWorker } from "./acp-worker-admission.js";
 import type { ActiveWorkflowWorker } from "./acp-worker-lifecycle.js";
 import type { AcpSessionJournal } from "./acp-session-journal.js";
 import type { RedskilledPaths } from "./paths.js";

--- a/apps/redskilled/src/acp-method-registry.ts
+++ b/apps/redskilled/src/acp-method-registry.ts
@@ -120,7 +120,14 @@ export function redskillsAcpMethodTable(
  */
 export interface RedskillsAcpMethodDomainDeclaration {
   readonly domain: RedskillsAcpMethodDomainName;
-  /** Repo-relative module, under `apps/redskilled/src/`, that owns the domain. */
+  /**
+   * Repo-relative path of the module that owns the domain.
+   *
+   * Repo-relative rather than daemon-relative because a domain may be answered
+   * from the OTHER side of ADR 0148's body-versus-control cut: `worker` is
+   * served by the Worker body in `packages/worker`, and a path that could only
+   * spell `apps/redskilled/src/` would have had to hide that.
+   */
   readonly module: string;
   /** Keys of `REDSKILLS_ACP_METHODS` this domain owns. */
   readonly methods: readonly (keyof typeof REDSKILLS_ACP_METHODS)[];
@@ -129,31 +136,46 @@ export interface RedskillsAcpMethodDomainDeclaration {
 }
 
 export const REDSKILLS_ACP_METHOD_DOMAINS: readonly RedskillsAcpMethodDomainDeclaration[] = [
-  { domain: "host", module: "acp-host-methods.ts", methods: ["hostState"], served: true },
+  {
+    domain: "host",
+    module: "apps/redskilled/src/acp-host-methods.ts",
+    methods: ["hostState"],
+    served: true,
+  },
   {
     domain: "project",
-    module: "project-control.ts",
+    module: "apps/redskilled/src/project-control.ts",
     methods: ["projectDrain", "projectStop", "projectStatus"],
     served: true,
   },
   {
     domain: "github",
-    module: "acp-github.ts",
+    module: "apps/redskilled/src/acp-github.ts",
     methods: ["githubRead", "githubWrite", "githubUpdate", "githubCustodyHandoff"],
     served: true,
   },
-  { domain: "budget", module: "acp-budget.ts", methods: ["projectBudget", "hostBudgets"], served: true },
-  { domain: "go", module: "acp-go-dispatch.ts", methods: ["goDispatch"], served: true },
+  {
+    domain: "budget",
+    module: "apps/redskilled/src/acp-budget.ts",
+    methods: ["projectBudget", "hostBudgets"],
+    served: true,
+  },
+  {
+    domain: "go",
+    module: "apps/redskilled/src/acp-go-dispatch.ts",
+    methods: ["goDispatch"],
+    served: true,
+  },
   {
     domain: "worktree",
-    module: "acp-worktree.ts",
+    module: "apps/redskilled/src/acp-worktree.ts",
     methods: ["worktreeAdd", "worktreeList"],
     served: true,
   },
   { domain: "telemetry", module: "acp-telemetry.ts", methods: ["metrics"], served: true },
   {
     domain: "worker",
-    module: "acp-worker-budget-grace.ts",
+    module: "packages/worker/src/acp/budget-grace.ts",
     methods: ["workerBudgetGrace"],
     served: false,
   },

--- a/apps/redskilled/src/acp-session-journal.ts
+++ b/apps/redskilled/src/acp-session-journal.ts
@@ -9,43 +9,33 @@
 import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import {
-  methods,
-  type AgentConnection,
-  type NewSessionRequest,
-  type PromptRequest,
-  type PromptResponse,
-  type RequestPermissionRequest,
-  type SessionNotification,
+import type {
+  PromptRequest,
+  PromptResponse,
+  RequestPermissionRequest,
+  SessionNotification,
 } from "@agentclientprotocol/sdk";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import {
+  notifySessionRecovery,
+  replacementRecoveryMeta,
+  sessionRecoveryFromMeta,
+  type AcpSessionJournalEntry,
+  type AcpSessionRecoveryCheckpoint,
+} from "@reddb-io/protocol-acp";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 
-export type AcpSessionJournalEntry =
-  | { readonly sequence: number; readonly kind: "prompt"; readonly prompt: PromptRequest["prompt"] }
-  | { readonly sequence: number; readonly kind: "plan"; readonly update: SessionNotification["update"] }
-  | {
-    readonly sequence: number;
-    readonly kind: "workflow-pointer";
-    readonly worker_id: string;
-    readonly worker_session_id: string;
-    readonly replacement: boolean;
-  }
-  | {
-    readonly sequence: number;
-    readonly kind: "checkpoint";
-    readonly stop_reason: PromptResponse["stopReason"];
-    readonly workflow_outcome?: string;
-  }
-  | {
-    readonly sequence: number;
-    readonly kind: "permission";
-    readonly tool_call_id: string;
-    readonly policy_key: string;
-    readonly decision: "attached-approved" | "attached-denied" | "policy-pre-authorized" | "hitl-required";
-    readonly option_id?: string;
-    readonly option_kind?: "allow_once" | "allow_always" | "reject_once" | "reject_always";
-  };
+// The entry union and the replacement checkpoint travel to a Worker inside
+// `_meta`, so they are declared on the shared wire (ADR 0148) and re-exported
+// here. The journal itself — the durable file, its snapshot and its append
+// path — is control plane and stays behind the daemon.
+export {
+  notifySessionRecovery,
+  replacementRecoveryMeta,
+  sessionRecoveryFromMeta,
+  type AcpSessionJournalEntry,
+  type AcpSessionRecoveryCheckpoint,
+};
 
 type WithoutSequence<T> = T extends unknown ? Omit<T, "sequence"> : never;
 type AcpSessionJournalEntryInput = WithoutSequence<AcpSessionJournalEntry>;
@@ -82,14 +72,6 @@ export interface AcpRetakeEvidenceProjection {
 interface AcpSessionJournalSnapshot {
   readonly version: 1;
   readonly sessions: readonly AcpSessionJournalRecord[];
-}
-
-export interface AcpSessionRecoveryCheckpoint {
-  readonly version: 1;
-  readonly source: "redskilled-public-journal";
-  readonly public_session_id: string;
-  readonly completed_turns: number;
-  readonly entries: readonly AcpSessionJournalEntry[];
 }
 
 export interface AcpSessionJournal {
@@ -243,42 +225,6 @@ export function providerSessionEvidenceFromMeta(meta: unknown): ProviderSessionE
     availability,
     ...(reference == null ? {} : { reference }),
   };
-}
-
-export function replacementRecoveryMeta(
-  meta: NewSessionRequest["_meta"],
-  recovery: AcpSessionRecoveryCheckpoint,
-): NonNullable<NewSessionRequest["_meta"]> {
-  const redskills = (meta as { redskills?: object } | undefined)?.redskills ?? {};
-  return {
-    ...(meta ?? {}),
-    redskills: { ...redskills, recovery },
-  };
-}
-
-export function sessionRecoveryFromMeta(meta: NewSessionRequest["_meta"]): AcpSessionRecoveryCheckpoint | undefined {
-  const recovery = (meta as { redskills?: { recovery?: AcpSessionRecoveryCheckpoint } } | undefined)
-    ?.redskills?.recovery;
-  return recovery?.source === "redskilled-public-journal" ? recovery : undefined;
-}
-
-export async function notifySessionRecovery(
-  parent: AgentConnection["client"],
-  downstreamSessionId: string,
-  recovery: AcpSessionRecoveryCheckpoint,
-): Promise<void> {
-  const turns = recovery.completed_turns;
-  await parent.notify(methods.client.session.update, {
-    sessionId: downstreamSessionId,
-    update: {
-      sessionUpdate: "agent_message_chunk",
-      content: {
-        type: "text",
-        text: `native Worker resumed ${turns} completed turn${turns === 1 ? "" : "s"} from the public journal\n`,
-      },
-    },
-    _meta: { redskills: { lifecycle: { event: "checkpoint-resume" } } },
-  });
 }
 
 async function readSnapshot(path: string): Promise<Map<string, AcpSessionJournalRecord>> {

--- a/apps/redskilled/src/acp-worker-admission.ts
+++ b/apps/redskilled/src/acp-worker-admission.ts
@@ -1,42 +1,39 @@
-/** Daemon admission and the native ACP Workflow Worker implementation. */
-import { randomBytes, randomUUID } from "node:crypto";
+/**
+ * Admission of a native ACP Workflow Worker: whether, when and where one exists.
+ *
+ * Everything here is a decision the Worker is not allowed to make for itself —
+ * which child Agent it may spawn, where its rendezvous socket lives, what argv
+ * re-execs it, and the journal pointers its session leaves behind. What the
+ * admitted process then DOES lives in `@reddb-io/worker/acp` (ADR 0148).
+ */
+import { randomBytes } from "node:crypto";
 import { constants, accessSync } from "node:fs";
 import type { Socket } from "node:net";
 import { delimiter, isAbsolute, join } from "node:path";
 import {
-  agent,
   client,
   methods,
   type AgentConnection,
   type McpServer,
   type NewSessionRequest,
-  type PromptRequest,
-  type PromptResponse,
   type RequestPermissionRequest,
   type RequestPermissionResponse,
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
 import { ACP_AGENT_CATALOG, type AcpEndpoint } from "./acp-agent-catalog.js";
-import { WorkflowChildAgent } from "./acp-child-agent.js";
 import {
   ACP_PROTOCOL_VERSION,
   REDSKILLS_WIRE_MAJOR,
-  abortableDelay,
   bindWorkerRendezvous,
-  connectWithDeadline,
   removeAcpEndpoint,
   requireCompatibleWireMajor,
   socketStream,
-  waitForAbort,
   withTimeout,
 } from "@reddb-io/protocol-acp";
 import {
-  notifySessionRecovery,
   providerSessionEvidenceFromMeta,
   replacementRecoveryMeta,
-  sessionRecoveryFromMeta,
   type AcpSessionJournal,
-  type AcpSessionRecoveryCheckpoint,
 } from "./acp-session-journal.js";
 import type { AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
 import { resolveAcpWorkerEndpoint, type RedskilledPaths } from "./paths.js";
@@ -236,188 +233,4 @@ function defaultChildAgentEndpoint(): AcpEndpoint {
     command: descriptor.command[0],
     args: descriptor.command.slice(1),
   };
-}
-
-/** The daemon-admitted native Workflow Worker. */
-export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpEndpoint): Promise<number> {
-  const controllers = new Map<string, AbortController>();
-  const sessions = new Map<string, {
-    readonly request: NewSessionRequest;
-    child?: WorkflowChildAgent;
-  }>();
-  const recoveries = new Map<string, AcpSessionRecoveryCheckpoint>();
-  const app = agent({ name: "RedSkills native Worker" })
-    .onRequest(methods.agent.initialize, ({ params }) => {
-      requireCompatibleWireMajor(params._meta, true);
-      return {
-        protocolVersion: ACP_PROTOCOL_VERSION,
-        agentCapabilities: { promptCapabilities: {} },
-        agentInfo: { name: "RedSkills native Worker", version: "1" },
-        _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR, worker: true } },
-      };
-    })
-    .onRequest(methods.agent.session.new, ({ params }) => {
-      const sessionId = randomUUID();
-      sessions.set(sessionId, { request: params });
-      const recovery = sessionRecoveryFromMeta(params._meta);
-      if (recovery != null) recoveries.set(sessionId, recovery);
-      return {
-        sessionId,
-        _meta: {
-          redskills: {
-            sessionEvidence: {
-              provider: "redskills-native",
-              availability: "absent",
-            },
-          },
-        },
-      };
-    })
-    .onRequest(methods.agent.session.prompt, async ({ params, client: parent }) => {
-      const held = sessions.get(params.sessionId);
-      if (held == null) throw new Error("unknown native Worker ACP session");
-      const controller = new AbortController();
-      controllers.set(params.sessionId, controller);
-      try {
-        const recovery = recoveries.get(params.sessionId);
-        if (recovery != null) {
-          recoveries.delete(params.sessionId);
-          await notifySessionRecovery(parent, params.sessionId, recovery);
-        }
-        const prompt = promptText(params);
-        if (prompt.includes("delegate child")) {
-          held.child ??= new WorkflowChildAgent({
-            endpoint: childEndpoint,
-            cwd: held.request.cwd,
-            mcpServers: held.request.mcpServers,
-            ...(held.request.additionalDirectories == null
-              ? {}
-              : { additionalDirectories: held.request.additionalDirectories }),
-            publicSessionId: params.sessionId,
-            parent,
-          });
-          return await held.child.prompt(params);
-        }
-        await parent.notify(methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "plan",
-            entries: [{ content: "Execute the prompt inside the admitted native Worker", priority: "high", status: "in_progress" }],
-          },
-        });
-        await parent.notify(methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: "native Worker is executing the prompt\n" },
-          },
-          _meta: { redskills: { lifecycle: { event: "tool-activity" } } },
-        });
-        let permissionResolution: string | undefined;
-        if (prompt.includes("permission")) {
-          // The delay gives the public launch-edge transport time to disappear;
-          // policy resolution remains daemon-owned after it does.
-          await abortableDelay(75, controller.signal);
-          const title = prompt.includes("denial")
-            ? "denied operation"
-            : prompt.includes("uncovered")
-              ? "uncovered operation"
-              : "governed write";
-          const permission = await parent.request(methods.client.session.requestPermission, {
-            sessionId: params.sessionId,
-            toolCall: {
-              toolCallId: randomUUID(),
-              title,
-              kind: "edit",
-              status: "pending",
-            },
-            options: [
-              { optionId: "once", name: "Allow once", kind: "allow_once" },
-              { optionId: "always", name: "Always allow", kind: "allow_always" },
-              { optionId: "reject", name: "Reject", kind: "reject_once" },
-            ],
-          });
-          permissionResolution = (permission._meta as {
-            redskills?: { permissionResolution?: string };
-          } | undefined)?.redskills?.permissionResolution;
-          if (permission.outcome.outcome === "cancelled" || permissionResolution === "hitl-required") {
-            return {
-              stopReason: "cancelled",
-              _meta: { redskills: { permissionResolution, workflowOutcome: "permission-hitl" } },
-            } satisfies PromptResponse;
-          }
-          const chosen = permission.outcome.optionId;
-          if (chosen === "reject") {
-            return {
-              stopReason: "end_turn",
-              _meta: { redskills: { permissionResolution } },
-            } satisfies PromptResponse;
-          }
-        }
-        if (prompt.includes("wait for cancellation")) {
-          await waitForAbort(controller.signal);
-        } else {
-          await abortableDelay(35, controller.signal);
-        }
-        if (controller.signal.aborted) {
-          await parent.notify(methods.client.session.update, {
-            sessionId: params.sessionId,
-            update: {
-              sessionUpdate: "agent_message_chunk",
-              content: { type: "text", text: "native Worker cancelled the prompt\n" },
-            },
-          });
-          return { stopReason: "cancelled" } satisfies PromptResponse;
-        }
-
-        await parent.notify(methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "plan",
-            entries: [{ content: "Execute the prompt inside the admitted native Worker", priority: "high", status: "completed" }],
-          },
-        });
-        await parent.notify(methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: `native Worker completed: ${prompt}\n` },
-          },
-        });
-        const workflowOutcome = prompt.includes("complete workflow")
-          ? "completion"
-          : prompt.includes("budget verdict")
-            ? "budget-verdict"
-            : prompt.includes("replace worker")
-              ? "replacement"
-              : prompt.includes("explicit control")
-                ? "explicit-control"
-                : undefined;
-        return {
-          stopReason: "end_turn",
-          ...(workflowOutcome == null && permissionResolution == null
-            ? {}
-            : { _meta: { redskills: { workflowOutcome, permissionResolution } } }),
-        } satisfies PromptResponse;
-      } finally {
-        controllers.delete(params.sessionId);
-      }
-    })
-    .onNotification(methods.agent.session.cancel, async ({ params }) => {
-      controllers.get(params.sessionId)?.abort();
-      await sessions.get(params.sessionId)?.child?.cancel(params._meta);
-    });
-
-  const socket = await connectWithDeadline(socketPath, 10_000);
-  const connection = app.connect(socketStream(socket));
-  await connection.closed;
-  for (const session of sessions.values()) session.child?.close();
-  return 0;
-}
-
-function promptText(params: PromptRequest): string {
-  return params.prompt
-    .filter((block): block is Extract<typeof block, { type: "text" }> => block.type === "text")
-    .map((block) => block.text)
-    .join("\n");
 }

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -78,7 +78,7 @@ import {
 import { awaitRedskilledTakeoverCommit, isRedskilledSupervised } from "./self-replace.js";
 import { stabilizeRedskilledEntry } from "./stable-bundle.js";
 import { runRedskillsAcpAdapter } from "./acp-control-plane.js";
-import { runAcpWorkerCommand } from "./acp-worker-command.js";
+import { runAcpWorkerCommand } from "@reddb-io/worker/acp";
 import { resolveRedskilledClientEndpoint } from "./client-rendezvous.js";
 
 /**

--- a/apps/redskilled/src/github-write.ts
+++ b/apps/redskilled/src/github-write.ts
@@ -8,38 +8,15 @@ import {
   githubUpstreamRefusal,
   responseValue,
 } from "./github-transport.js";
+import type {
+  RedskilledGithubWrite,
+  RedskilledGithubWriteRequest,
+} from "@reddb-io/protocol-acp";
 
-export type RedskilledGithubWrite =
-  | { readonly kind: "repository-push"; readonly ref: string; readonly sha: string }
-  | {
-      readonly kind: "pull-request";
-      readonly head: string;
-      readonly base: string;
-      readonly title: string;
-      readonly body: string;
-    }
-  | {
-      readonly kind: "issue-publication";
-      /** Absent to open a Ticket; present to publish a comment on that Ticket. */
-      readonly issue?: number;
-      readonly title?: string;
-      readonly body: string;
-      /**
-       * Labels stamped on a NEWLY opened Ticket.
-       *
-       * A lane label decides who may claim the Ticket, so stamping it in the
-       * SAME call that opens the Ticket is what keeps the window shut: a Ticket
-       * opened unlabelled and labelled a round-trip later is claimable by
-       * whoever lists the queue in between.
-       */
-      readonly labels?: readonly string[];
-    };
-
-export interface RedskilledGithubWriteRequest {
-  /** Stable caller-minted identity. Reusing it returns the durable receipt. */
-  readonly idempotency_key: string;
-  readonly write: RedskilledGithubWrite;
-}
+// The request a caller sends is wire (ADR 0148): a Worker composes one without
+// holding a credential. Everything below — custody, the durable receipt, the
+// upstream call — is the gateway that answers it, and stays here.
+export type { RedskilledGithubWrite, RedskilledGithubWriteRequest };
 
 export interface RedskilledGithubWriteUpstreamInput {
   readonly project: RedskilledGithubProjectAuthority;

--- a/apps/redskilled/tests/acp-body-control-cut.test.ts
+++ b/apps/redskilled/tests/acp-body-control-cut.test.ts
@@ -1,0 +1,174 @@
+/**
+ * The body-versus-control cut, refused in both directions (issue #4015, ADR 0148).
+ *
+ * A Worker-side module left under the daemon fails, an undeclared body module
+ * fails, and a control-plane authority reached for from the package fails.
+ * The declaration lives in `../src/acp-body-control-cut.js`; this file only
+ * pins it against the two live trees, so the inventory cannot drift into
+ * fiction in either direction.
+ */
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  CONTROL_PLANE_DESPITE_THE_NAME,
+  CONTROL_PLANE_SURFACES,
+  WORKER_BODY_MODULES,
+  definesSymbol,
+  stripSourceComments,
+} from "../src/acp-body-control-cut.js";
+
+const repoRoot = join(__dirname, "..", "..", "..");
+const daemonSource = join(repoRoot, "apps", "redskilled", "src");
+const workerSource = join(repoRoot, "packages", "worker", "src");
+const workerAcp = join(workerSource, "acp");
+
+async function typescriptFiles(root: string): Promise<string[]> {
+  const found: string[] = [];
+  for (const entry of await readdir(root, { withFileTypes: true, recursive: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".ts") || entry.name.endsWith(".test.ts")) continue;
+    found.push(join(entry.parentPath, entry.name));
+  }
+  return found;
+}
+
+async function sources(root: string): Promise<Map<string, string>> {
+  const files = await typescriptFiles(root);
+  const read = await Promise.all(files.map(async (path) => [path, await readFile(path, "utf8")] as const));
+  return new Map(read);
+}
+
+describe("what runs inside the Worker lives in the package (#4015)", () => {
+  it("finds every declared body module where the package says it is", async () => {
+    const held = await readdir(workerAcp);
+
+    for (const body of WORKER_BODY_MODULES) {
+      expect(held, `${body.module} is declared body and is not in packages/worker/src/acp`)
+        .toContain(body.module);
+      const source = await readFile(join(workerAcp, body.module), "utf8");
+      for (const name of body.defines) {
+        expect(definesSymbol(source, name), `${body.module} no longer defines ${name}`).toBe(true);
+      }
+    }
+  });
+
+  it("declares every module under the package's ACP directory", async () => {
+    const declared = new Set(["index.ts", ...WORKER_BODY_MODULES.map((body) => body.module)]);
+    const undeclared = (await readdir(workerAcp))
+      .filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts") && !declared.has(name));
+
+    expect(undeclared, `undeclared Worker body modules: ${undeclared.join(", ")}`).toEqual([]);
+  });
+
+  it("keeps no Worker-side module under the daemon's source tree", async () => {
+    const daemon = await sources(daemonSource);
+    const strays: string[] = [];
+
+    for (const body of WORKER_BODY_MODULES) {
+      for (const [path, source] of daemon) {
+        if (path.endsWith(`${body.formerDaemonModule}`)) {
+          strays.push(`${body.formerDaemonModule} is back under the daemon; it is body (${body.runs})`);
+        }
+        for (const name of body.defines) {
+          if (definesSymbol(source, name)) {
+            strays.push(`${path} defines ${name}; the daemon may re-export the body, never define it`);
+          }
+        }
+      }
+    }
+
+    expect(strays, strays.join("\n")).toEqual([]);
+  });
+
+  it("still lets the daemon RE-EXPORT the body it re-execs into", async () => {
+    const [controlPlane, cli] = await Promise.all([
+      readFile(join(daemonSource, "acp-control-plane.ts"), "utf8"),
+      readFile(join(daemonSource, "cli.ts"), "utf8"),
+    ]);
+
+    expect(controlPlane).toContain('export { runNativeAcpWorker } from "@reddb-io/worker/acp"');
+    expect(cli).toContain('import { runAcpWorkerCommand } from "@reddb-io/worker/acp"');
+  });
+});
+
+describe("whether, when and where a Worker exists stays with the daemon (#4015)", () => {
+  it("finds every control-plane surface where the daemon says it is", async () => {
+    for (const surface of CONTROL_PLANE_SURFACES) {
+      for (const module of surface.modules) {
+        expect(module.startsWith("apps/redskilled/src/"), `${surface.surface} left the daemon`).toBe(true);
+      }
+      const held = await Promise.all(
+        surface.modules.map((module) => readFile(join(repoRoot, module), "utf8")),
+      );
+      for (const name of surface.defines) {
+        expect(
+          held.some((source) => definesSymbol(source, name)),
+          `no ${surface.surface} module defines ${name}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("keeps no control-plane module in the package", async () => {
+    const body = await sources(workerSource);
+    const crossings: string[] = [];
+
+    for (const surface of CONTROL_PLANE_SURFACES) {
+      for (const [path, source] of body) {
+        for (const name of surface.defines) {
+          if (definesSymbol(source, name)) {
+            crossings.push(`${path} defines ${name} (${surface.surface}): ${surface.why}`);
+          }
+        }
+      }
+    }
+
+    expect(crossings, crossings.join("\n")).toEqual([]);
+  });
+
+  it("keeps the two modules the name would have moved", async () => {
+    for (const held of CONTROL_PLANE_DESPITE_THE_NAME) {
+      const source = await readFile(join(daemonSource, held.module), "utf8");
+      for (const name of held.defines) {
+        expect(definesSymbol(source, name), `${held.module} no longer defines ${name}`).toBe(true);
+      }
+      expect(
+        WORKER_BODY_MODULES.some((body) => body.formerDaemonModule === held.module),
+        `${held.module} is claimed as body and as control at once`,
+      ).toBe(false);
+    }
+  });
+
+  it("never lets the package import the daemon", async () => {
+    const body = await sources(workerSource);
+    const reaches: string[] = [];
+
+    for (const [path, source] of body) {
+      const code = stripSourceComments(source);
+      if (/from\s+["'][^"']*apps\/redskilled/.test(code) || /from\s+["']@reddb-io\/redskilled/.test(code)) {
+        reaches.push(`${path} imports the daemon; the body is imported BY it, never the other way`);
+      }
+    }
+
+    expect(reaches, reaches.join("\n")).toEqual([]);
+  });
+
+  it("scanned both trees — a walker that reaches nothing is green by accident", async () => {
+    expect((await typescriptFiles(daemonSource)).length).toBeGreaterThan(50);
+    expect((await typescriptFiles(workerSource)).length).toBeGreaterThan(50);
+  });
+});
+
+describe("the cut is written down where the package is read (#4015)", () => {
+  it("states the rule, both halves, in the package README", async () => {
+    const readme = await readFile(join(repoRoot, "packages", "worker", "README.md"), "utf8");
+
+    expect(readme).toContain("What runs inside the Worker is the body");
+    expect(readme).toContain("Whether, when and where a Worker exists is the control plane");
+    for (const surface of CONTROL_PLANE_SURFACES) {
+      expect(readme, `the README never names ${surface.surface} as control plane`)
+        .toContain(surface.surface);
+    }
+  });
+});

--- a/apps/redskilled/tests/acp-control-plane-layout.test.ts
+++ b/apps/redskilled/tests/acp-control-plane-layout.test.ts
@@ -1,13 +1,15 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { REDSKILLS_ACP_METHODS, REDSKILLS_ACP_METHOD_NAMES } from "@reddb-io/protocol-acp";
 
 import { REDSKILLS_ACP_METHOD_DOMAINS } from "../src/acp-method-registry.js";
 
+const repoRoot = join(__dirname, "..", "..", "..");
 const sourceRoot = join(__dirname, "..", "src");
-const wirePackage = join(__dirname, "..", "..", "..", "packages", "protocol-acp");
+const workerAcp = join(repoRoot, "packages", "worker", "src", "acp");
+const wirePackage = join(repoRoot, "packages", "protocol-acp");
 
 describe("the ACP control-plane module boundary", () => {
   it("keeps the public control plane at or below its headroom target", async () => {
@@ -34,7 +36,7 @@ describe("the ACP control-plane module boundary", () => {
     const [controlPlane, workflowTurn, childAgent] = await Promise.all([
       readFile(join(sourceRoot, "acp-control-plane.ts"), "utf8"),
       readFile(join(sourceRoot, "acp-workflow-turn.ts"), "utf8"),
-      readFile(join(sourceRoot, "acp-child-agent.ts"), "utf8"),
+      readFile(join(workerAcp, "child-agent.ts"), "utf8"),
     ]);
 
     expect(controlPlane).not.toMatch(/evaluateSpin|createChildAcpSpinEpisode|SpinPattern/);
@@ -71,7 +73,7 @@ describe("the `_redskills/*` method domains", () => {
   it("spells each domain's method keys in that domain's module and nowhere else", async () => {
     const sources = new Map<string, string>();
     for (const domain of REDSKILLS_ACP_METHOD_DOMAINS) {
-      sources.set(domain.module, await readFile(join(sourceRoot, domain.module), "utf8"));
+      sources.set(domain.module, await readFile(join(repoRoot, domain.module), "utf8"));
     }
 
     const misplaced: string[] = [];
@@ -101,7 +103,7 @@ describe("the `_redskills/*` method domains", () => {
     const composed = await readFile(join(sourceRoot, "acp-connection-methods.ts"), "utf8");
 
     for (const domain of REDSKILLS_ACP_METHOD_DOMAINS.filter((entry) => entry.served)) {
-      const specifier = `from "./${domain.module.replace(/\.ts$/, ".js")}"`;
+      const specifier = `from "./${basename(domain.module).replace(/\.ts$/, ".js")}"`;
       expect(composed, `the ${domain.domain} domain is never composed`).toContain(specifier);
     }
     expect(composed).toContain("v1: table(");

--- a/apps/redskilled/tests/acp-local-transport.test.ts
+++ b/apps/redskilled/tests/acp-local-transport.test.ts
@@ -31,7 +31,9 @@ const stdioAdapterProgram = `
   process.exitCode = await runRedskillsAcpAdapter(resolveRedskilledPaths());
 `;
 const workerProgram = `
-  import { runNativeAcpWorker } from ${JSON.stringify(pathToFileURL(resolve(__dirname, "..", "src", "acp-native-worker.ts")).href)};
+  import { runNativeAcpWorker } from ${JSON.stringify(pathToFileURL(resolve(
+    __dirname, "..", "..", "..", "packages", "worker", "src", "acp", "native-worker.ts",
+  )).href)};
   const endpoint = process.env.REDSKILLED_TEST_WORKER_ENDPOINT;
   if (endpoint == null || endpoint === "") throw new Error("missing test Worker endpoint");
   process.exitCode = await runNativeAcpWorker(endpoint, {

--- a/apps/redskilled/tests/acp-worker-budget-grace.test.ts
+++ b/apps/redskilled/tests/acp-worker-budget-grace.test.ts
@@ -3,7 +3,7 @@ import {
   REDSKILLED_WORKER_BUDGET_GRACE_METHOD,
   createAcpWorkerBudgetGraceRuntime,
   type WorkerBudgetGraceEnvelope,
-} from "../src/acp-worker-budget-grace.js";
+} from "@reddb-io/worker/acp";
 
 describe("ACP Worker Budget grace", () => {
   it("cancels, checkpoints, requests tokenless publication, writes its Envelope, and exits in order", async () => {

--- a/packages/protocol-acp/endpoint.ts
+++ b/packages/protocol-acp/endpoint.ts
@@ -1,0 +1,22 @@
+// endpoint — the child ACP Agent endpoint redskilled hands a Worker (ADR 0148).
+//
+// The endpoint is the one thing that crosses the body-versus-control cut on the
+// `acp-worker` argv. redskilled decides WHICH Agent — catalog pins, npm
+// integrity, host credentials, adapter provisioning and fallback policy all
+// stay on the daemon's side of the boundary — and the Worker receives only the
+// resolved stdio command it is authorized to spawn. Both ends therefore spell
+// the same shape, and neither of them owns it: the daemon's catalog re-exports
+// these names rather than declaring them, so a Worker never has to import the
+// catalog to read the endpoint it was handed.
+export const ACP_AGENT_IDS = ["redcode", "claude-code", "codex", "pi", "opencode"] as const;
+
+/** The only first-class child Agent identities. */
+export type AcpAgentId = (typeof ACP_AGENT_IDS)[number];
+
+/** One resolved child Agent: what to spawn, already chosen by the daemon. */
+export interface AcpEndpoint {
+  readonly agent: AcpAgentId;
+  readonly transport: "stdio";
+  readonly command: string;
+  readonly args: readonly string[];
+}

--- a/packages/protocol-acp/github-write.ts
+++ b/packages/protocol-acp/github-write.ts
@@ -1,0 +1,37 @@
+// github-write — the `_redskills/github_write` params shape (ADR 0148).
+//
+// A Worker holds no GitHub credential. When it needs to publish — a checkpoint
+// push under Budget grace, a Ticket comment, a pull request — it asks
+// redskilled's Project-bound gateway and the daemon performs the write. The
+// REQUEST is therefore wire and lives here; custody, idempotency durability,
+// rate accounting and the upstream call all stay with the gateway.
+export type RedskilledGithubWrite =
+  | { readonly kind: "repository-push"; readonly ref: string; readonly sha: string }
+  | {
+      readonly kind: "pull-request";
+      readonly head: string;
+      readonly base: string;
+      readonly title: string;
+      readonly body: string;
+    }
+  | {
+      readonly kind: "issue-publication";
+      /** Absent to open a Ticket; present to publish a comment on that Ticket. */
+      readonly issue?: number;
+      readonly title?: string;
+      readonly body: string;
+      /**
+       * Labels stamped on a NEWLY opened Ticket.
+       *
+       * A lane label decides who may claim the Ticket, so stamping it in the
+       * same authorized write that opens it is what keeps an unlabelled Ticket
+       * from existing at all.
+       */
+      readonly labels?: readonly string[];
+    };
+
+export interface RedskilledGithubWriteRequest {
+  /** Stable caller-minted identity. Reusing it returns the durable receipt. */
+  readonly idempotency_key: string;
+  readonly write: RedskilledGithubWrite;
+}

--- a/packages/protocol-acp/index.ts
+++ b/packages/protocol-acp/index.ts
@@ -5,7 +5,10 @@
 // ACP v1/v2 compat and draft-revision gating, the RedSkills wire major, the
 // local Unix-socket / Named Pipe transport, and the `_redskills/*` methods.
 export * from "./compat.js";
+export * from "./endpoint.js";
+export * from "./github-write.js";
 export * from "./go-dispatch.js";
 export * from "./methods.js";
+export * from "./session-recovery.js";
 export * from "./transport.js";
 export * from "./worktree.js";

--- a/packages/protocol-acp/package.json
+++ b/packages/protocol-acp/package.json
@@ -8,8 +8,11 @@
   "exports": {
     ".": "./index.ts",
     "./compat.js": "./compat.ts",
+    "./endpoint.js": "./endpoint.ts",
+    "./github-write.js": "./github-write.ts",
     "./go-dispatch.js": "./go-dispatch.ts",
     "./methods.js": "./methods.ts",
+    "./session-recovery.js": "./session-recovery.ts",
     "./transport.js": "./transport.ts",
     "./worktree.js": "./worktree.ts"
   },

--- a/packages/protocol-acp/session-recovery.ts
+++ b/packages/protocol-acp/session-recovery.ts
@@ -1,0 +1,92 @@
+// session-recovery — the public-journal checkpoint carried in `_meta` (ADR 0148).
+//
+// redskilled owns the durable public ACP session journal; a Worker never reads
+// or writes it. What DOES cross the seam is one checkpoint: when the daemon
+// replaces a dead Worker mid-session, it stamps the completed turns into the
+// replacement's `session/new` `_meta`, and the replacement reports the resume
+// back on its first prompt. Encoder and decoder are the two ends of one slot,
+// so they are declared together here — a checkpoint written by a shape the
+// reader does not accept is a silent loss of every completed turn.
+import {
+  methods,
+  type AgentConnection,
+  type NewSessionRequest,
+  type PromptRequest,
+  type PromptResponse,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk";
+
+/** One retained public-boundary fact. Thought chunks are never admitted. */
+export type AcpSessionJournalEntry =
+  | { readonly sequence: number; readonly kind: "prompt"; readonly prompt: PromptRequest["prompt"] }
+  | { readonly sequence: number; readonly kind: "plan"; readonly update: SessionNotification["update"] }
+  | {
+    readonly sequence: number;
+    readonly kind: "workflow-pointer";
+    readonly worker_id: string;
+    readonly worker_session_id: string;
+    readonly replacement: boolean;
+  }
+  | {
+    readonly sequence: number;
+    readonly kind: "checkpoint";
+    readonly stop_reason: PromptResponse["stopReason"];
+    readonly workflow_outcome?: string;
+  }
+  | {
+    readonly sequence: number;
+    readonly kind: "permission";
+    readonly tool_call_id: string;
+    readonly policy_key: string;
+    readonly decision: "attached-approved" | "attached-denied" | "policy-pre-authorized" | "hitl-required";
+    readonly option_id?: string;
+    readonly option_kind?: "allow_once" | "allow_always" | "reject_once" | "reject_always";
+  };
+
+/** What a replacement Worker is told about the turns it did not run. */
+export interface AcpSessionRecoveryCheckpoint {
+  readonly version: 1;
+  readonly source: "redskilled-public-journal";
+  readonly public_session_id: string;
+  readonly completed_turns: number;
+  readonly entries: readonly AcpSessionJournalEntry[];
+}
+
+/** Daemon side: stamp a checkpoint onto the replacement's `session/new`. */
+export function replacementRecoveryMeta(
+  meta: NewSessionRequest["_meta"],
+  recovery: AcpSessionRecoveryCheckpoint,
+): NonNullable<NewSessionRequest["_meta"]> {
+  const redskills = (meta as { redskills?: object } | undefined)?.redskills ?? {};
+  return {
+    ...(meta ?? {}),
+    redskills: { ...redskills, recovery },
+  };
+}
+
+/** Worker side: read the checkpoint, and only the daemon's own journal source. */
+export function sessionRecoveryFromMeta(meta: NewSessionRequest["_meta"]): AcpSessionRecoveryCheckpoint | undefined {
+  const recovery = (meta as { redskills?: { recovery?: AcpSessionRecoveryCheckpoint } } | undefined)
+    ?.redskills?.recovery;
+  return recovery?.source === "redskilled-public-journal" ? recovery : undefined;
+}
+
+/** Worker side: say out loud, on the public wire, what was resumed. */
+export async function notifySessionRecovery(
+  parent: AgentConnection["client"],
+  downstreamSessionId: string,
+  recovery: AcpSessionRecoveryCheckpoint,
+): Promise<void> {
+  const turns = recovery.completed_turns;
+  await parent.notify(methods.client.session.update, {
+    sessionId: downstreamSessionId,
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: `native Worker resumed ${turns} completed turn${turns === 1 ? "" : "s"} from the public journal\n`,
+      },
+    },
+    _meta: { redskills: { lifecycle: { event: "checkpoint-resume" } } },
+  });
+}

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -1,10 +1,48 @@
 # `@reddb-io/worker` — the Worker body
 
 **This package is what runs INSIDE one admitted Worker process, and nothing
-else.** Agent and sandbox providers, worktree materialisation, the gate runner
-and the turn loop live here; whether, when and where a Worker exists belongs to
-the `redskilled` daemon (ADR 0148). A Worker is cattle — it performs bounded
-work in an isolated worktree and carries no durable project-control authority.
+else.** Agent and sandbox providers, worktree materialisation, the gate runner,
+the turn loop and the Worker's own ACP surface (`@reddb-io/worker/acp`) live
+here. A Worker is cattle — it performs bounded work in an isolated worktree and
+carries no durable project-control authority.
+
+## The cut (ADR 0148)
+
+**What runs inside the Worker is the body**, and it lives here.
+**Whether, when and where a Worker exists is the control plane**, and it stays
+behind the `redskilled` daemon.
+
+| Question | Answer | Home |
+| --- | --- | --- |
+| Should a Worker exist at all? | admission | `redskilled` |
+| How much may it spend, and when is it killed? | budget | `redskilled` |
+| Which host, unit or container runs it? | placement | `redskilled` |
+| What survives it? | journal | `redskilled` |
+| Who holds the GitHub credential? | gateway | `redskilled` |
+| What does the running process actually do? | body | this package |
+
+The daemon re-execs its own binary as `acp-worker` and that entry loads the
+body from `@reddb-io/worker/acp`; the dependency runs one way only, and the
+package never imports the daemon. Shapes both ends must agree on — the child
+Agent endpoint, the public-journal recovery checkpoint, the governed GitHub
+write request — belong to neither and live in `@reddb-io/protocol-acp`.
+
+The rule drifts because the two halves meet in the middle of single files: one
+module once held both the function that DECIDED a Worker should exist and the
+function the resulting process RAN. So the cut is declared as data in
+`apps/redskilled/src/acp-body-control-cut.ts` and refused in both directions by
+`apps/redskilled/tests/acp-body-control-cut.test.ts`. It is pinned by
+identifier, never by word: a Worker running out of budget checkpoints itself in
+`acp/budget-grace.ts`, and that is body — the daemon decided the verdict, set
+the deadline, and performs the kill.
+
+The same reading keeps two daemon modules that are NAMED for the Worker.
+`acp-worker-lifecycle.ts` and `acp-workflow-turn.ts` run in the daemon process,
+holding its map of live Workers: they admit one when a turn needs it, replace a
+dead one and reap an idle one. That is whether and when a Worker exists, so
+they stay — and `CONTROL_PLANE_DESPITE_THE_NAME` says so out loud, because a
+reader counting them against ADR 0148's seven-module list should not have to
+guess.
 
 The source is vendored from [`mattpocock/sandcastle`](https://github.com/mattpocock/sandcastle)
 under the MIT License; `.upstream` records the reviewed SHA and `NOTICE` carries

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -7,6 +7,7 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./acp": "./src/acp/index.ts",
     "./mcp-server": "./src/mcp-server.ts",
     "./engine": "./src/engine/index.ts",
     "./engine/spin-evaluator": "./src/engine/spin-evaluator.ts",
@@ -43,11 +44,13 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@agentclientprotocol/sdk": "1.3.0",
     "@clack/prompts": "^1.1.0",
     "@effect/cli": "^0.74.0",
     "@effect/platform": "^0.95.0",
     "@effect/platform-node": "^0.105.0",
     "@reddb-io/github": "workspace:*",
+    "@reddb-io/protocol-acp": "workspace:*",
     "@reddb-io/shared": "workspace:*",
     "@reddb-io/toon": "catalog:",
     "@standard-schema/spec": "^1.0.0",

--- a/packages/worker/src/acp/budget-grace.ts
+++ b/packages/worker/src/acp/budget-grace.ts
@@ -1,5 +1,7 @@
-import type { RedskilledGithubWriteRequest } from "./github-write.js";
-import { REDSKILLS_ACP_METHODS } from "@reddb-io/protocol-acp";
+import {
+  REDSKILLS_ACP_METHODS,
+  type RedskilledGithubWriteRequest,
+} from "@reddb-io/protocol-acp";
 
 /** ACP control delivered to a Worker after the daemon records its budget verdict. */
 export const REDSKILLED_WORKER_BUDGET_GRACE_METHOD = REDSKILLS_ACP_METHODS.workerBudgetGrace;

--- a/packages/worker/src/acp/child-agent.ts
+++ b/packages/worker/src/acp/child-agent.ts
@@ -13,10 +13,13 @@ import {
   type RequestPermissionResponse,
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
-import type { AcpEndpoint } from "./acp-agent-catalog.js";
-import { ACP_PROTOCOL_VERSION, REDSKILLS_WIRE_MAJOR } from "@reddb-io/protocol-acp";
-import { createChildAcpSpinEpisode, type ChildAcpSpinEpisode } from "./acp-child-spin.js";
-import type { SpinPattern } from "@reddb-io/worker/engine/spin-evaluator";
+import {
+  ACP_PROTOCOL_VERSION,
+  REDSKILLS_WIRE_MAJOR,
+  type AcpEndpoint,
+} from "@reddb-io/protocol-acp";
+import type { SpinPattern } from "../engine/spin-evaluator.js";
+import { createChildAcpSpinEpisode, type ChildAcpSpinEpisode } from "./child-spin.js";
 
 export interface ChildAgentSessionOptions {
   readonly endpoint: AcpEndpoint;

--- a/packages/worker/src/acp/child-spin.ts
+++ b/packages/worker/src/acp/child-spin.ts
@@ -6,7 +6,7 @@ import {
   SPIN_THRESHOLDS,
   type NormalizedRunnerStreamEvent,
   type SpinPattern,
-} from "@reddb-io/worker/engine/spin-evaluator";
+} from "../engine/spin-evaluator.js";
 
 export type ChildSpinObservation =
   | { readonly kind: "detected"; readonly pattern: SpinPattern }

--- a/packages/worker/src/acp/command.ts
+++ b/packages/worker/src/acp/command.ts
@@ -1,7 +1,14 @@
-/** Internal CLI adapter for a daemon-selected Workflow Worker child endpoint. */
+/**
+ * The `acp-worker` re-exec entry: argv in, one Worker body out.
+ *
+ * The daemon re-execs its own binary with this subcommand; the binary's router
+ * hands the arguments straight here. Every value it reads was CHOSEN by the
+ * daemon — the rendezvous socket and the child Agent endpoint — so this parses
+ * and refuses, and decides nothing (ADR 0148).
+ */
 import { parseFlags } from "@reddb-io/shared/args.js";
-import { ACP_AGENT_IDS, type AcpAgentId } from "./acp-agent-catalog.js";
-import { runNativeAcpWorker } from "./acp-native-worker.js";
+import { ACP_AGENT_IDS, type AcpAgentId } from "@reddb-io/protocol-acp";
+import { runNativeAcpWorker } from "./native-worker.js";
 
 const ACP_WORKER_FLAGS = {
   socket: { kind: "value", coerce: (raw: string) => raw },

--- a/packages/worker/src/acp/index.ts
+++ b/packages/worker/src/acp/index.ts
@@ -1,0 +1,24 @@
+// @reddb-io/worker/acp — the Worker body's ACP surface (ADR 0148).
+//
+// THE CUT: what runs inside the Worker is here; whether, when and where a
+// Worker exists is redskilled's. `packages/worker/README.md` states the rule
+// and `apps/redskilled/tests/acp-body-control-cut.test.ts` refuses both
+// directions of drift.
+export { runAcpWorkerCommand } from "./command.js";
+export { runNativeAcpWorker } from "./native-worker.js";
+export { WorkflowChildAgent, type ChildAgentSessionOptions } from "./child-agent.js";
+export {
+  createChildAcpSpinEpisode,
+  type ChildAcpSpinEpisode,
+  type ChildSpinObservation,
+} from "./child-spin.js";
+export {
+  createAcpWorkerBudgetGraceRuntime,
+  REDSKILLED_WORKER_BUDGET_GRACE_METHOD,
+  type AcpWorkerBudgetGraceDeps,
+  type AcpWorkerBudgetGraceRuntime,
+  type WorkerBudgetExtensionBlocker,
+  type WorkerBudgetGraceCheckpoint,
+  type WorkerBudgetGraceControl,
+  type WorkerBudgetGraceEnvelope,
+} from "./budget-grace.js";

--- a/packages/worker/src/acp/native-worker.ts
+++ b/packages/worker/src/acp/native-worker.ts
@@ -1,0 +1,215 @@
+/**
+ * The native ACP Workflow Worker: everything that runs INSIDE the process.
+ *
+ * redskilled decides that this Worker should exist, binds its rendezvous
+ * socket, launches it and reaps it. From the moment the process is running,
+ * what it does with its turn — the child Agent it delegates to, the plan and
+ * message chunks it emits, the permission it asks its parent for, the
+ * cancellation it honours — is body, and lives here (ADR 0148).
+ */
+import { randomUUID } from "node:crypto";
+import {
+  agent,
+  methods,
+  type NewSessionRequest,
+  type PromptRequest,
+  type PromptResponse,
+} from "@agentclientprotocol/sdk";
+import {
+  ACP_PROTOCOL_VERSION,
+  REDSKILLS_WIRE_MAJOR,
+  abortableDelay,
+  connectWithDeadline,
+  notifySessionRecovery,
+  requireCompatibleWireMajor,
+  sessionRecoveryFromMeta,
+  socketStream,
+  waitForAbort,
+  type AcpEndpoint,
+  type AcpSessionRecoveryCheckpoint,
+} from "@reddb-io/protocol-acp";
+import { WorkflowChildAgent } from "./child-agent.js";
+
+/** The daemon-admitted native Workflow Worker. */
+export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpEndpoint): Promise<number> {
+  const controllers = new Map<string, AbortController>();
+  const sessions = new Map<string, {
+    readonly request: NewSessionRequest;
+    child?: WorkflowChildAgent;
+  }>();
+  const recoveries = new Map<string, AcpSessionRecoveryCheckpoint>();
+  const app = agent({ name: "RedSkills native Worker" })
+    .onRequest(methods.agent.initialize, ({ params }) => {
+      requireCompatibleWireMajor(params._meta, true);
+      return {
+        protocolVersion: ACP_PROTOCOL_VERSION,
+        agentCapabilities: { promptCapabilities: {} },
+        agentInfo: { name: "RedSkills native Worker", version: "1" },
+        _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR, worker: true } },
+      };
+    })
+    .onRequest(methods.agent.session.new, ({ params }) => {
+      const sessionId = randomUUID();
+      sessions.set(sessionId, { request: params });
+      const recovery = sessionRecoveryFromMeta(params._meta);
+      if (recovery != null) recoveries.set(sessionId, recovery);
+      return {
+        sessionId,
+        _meta: {
+          redskills: {
+            sessionEvidence: {
+              provider: "redskills-native",
+              availability: "absent",
+            },
+          },
+        },
+      };
+    })
+    .onRequest(methods.agent.session.prompt, async ({ params, client: parent }) => {
+      const held = sessions.get(params.sessionId);
+      if (held == null) throw new Error("unknown native Worker ACP session");
+      const controller = new AbortController();
+      controllers.set(params.sessionId, controller);
+      try {
+        const recovery = recoveries.get(params.sessionId);
+        if (recovery != null) {
+          recoveries.delete(params.sessionId);
+          await notifySessionRecovery(parent, params.sessionId, recovery);
+        }
+        const prompt = promptText(params);
+        if (prompt.includes("delegate child")) {
+          held.child ??= new WorkflowChildAgent({
+            endpoint: childEndpoint,
+            cwd: held.request.cwd,
+            mcpServers: held.request.mcpServers,
+            ...(held.request.additionalDirectories == null
+              ? {}
+              : { additionalDirectories: held.request.additionalDirectories }),
+            publicSessionId: params.sessionId,
+            parent,
+          });
+          return await held.child.prompt(params);
+        }
+        await parent.notify(methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "plan",
+            entries: [{ content: "Execute the prompt inside the admitted native Worker", priority: "high", status: "in_progress" }],
+          },
+        });
+        await parent.notify(methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "native Worker is executing the prompt\n" },
+          },
+          _meta: { redskills: { lifecycle: { event: "tool-activity" } } },
+        });
+        let permissionResolution: string | undefined;
+        if (prompt.includes("permission")) {
+          // The delay gives the public launch-edge transport time to disappear;
+          // policy resolution remains daemon-owned after it does.
+          await abortableDelay(75, controller.signal);
+          const title = prompt.includes("denial")
+            ? "denied operation"
+            : prompt.includes("uncovered")
+              ? "uncovered operation"
+              : "governed write";
+          const permission = await parent.request(methods.client.session.requestPermission, {
+            sessionId: params.sessionId,
+            toolCall: {
+              toolCallId: randomUUID(),
+              title,
+              kind: "edit",
+              status: "pending",
+            },
+            options: [
+              { optionId: "once", name: "Allow once", kind: "allow_once" },
+              { optionId: "always", name: "Always allow", kind: "allow_always" },
+              { optionId: "reject", name: "Reject", kind: "reject_once" },
+            ],
+          });
+          permissionResolution = (permission._meta as {
+            redskills?: { permissionResolution?: string };
+          } | undefined)?.redskills?.permissionResolution;
+          if (permission.outcome.outcome === "cancelled" || permissionResolution === "hitl-required") {
+            return {
+              stopReason: "cancelled",
+              _meta: { redskills: { permissionResolution, workflowOutcome: "permission-hitl" } },
+            } satisfies PromptResponse;
+          }
+          const chosen = permission.outcome.optionId;
+          if (chosen === "reject") {
+            return {
+              stopReason: "end_turn",
+              _meta: { redskills: { permissionResolution } },
+            } satisfies PromptResponse;
+          }
+        }
+        if (prompt.includes("wait for cancellation")) {
+          await waitForAbort(controller.signal);
+        } else {
+          await abortableDelay(35, controller.signal);
+        }
+        if (controller.signal.aborted) {
+          await parent.notify(methods.client.session.update, {
+            sessionId: params.sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "native Worker cancelled the prompt\n" },
+            },
+          });
+          return { stopReason: "cancelled" } satisfies PromptResponse;
+        }
+
+        await parent.notify(methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "plan",
+            entries: [{ content: "Execute the prompt inside the admitted native Worker", priority: "high", status: "completed" }],
+          },
+        });
+        await parent.notify(methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: `native Worker completed: ${prompt}\n` },
+          },
+        });
+        const workflowOutcome = prompt.includes("complete workflow")
+          ? "completion"
+          : prompt.includes("budget verdict")
+            ? "budget-verdict"
+            : prompt.includes("replace worker")
+              ? "replacement"
+              : prompt.includes("explicit control")
+                ? "explicit-control"
+                : undefined;
+        return {
+          stopReason: "end_turn",
+          ...(workflowOutcome == null && permissionResolution == null
+            ? {}
+            : { _meta: { redskills: { workflowOutcome, permissionResolution } } }),
+        } satisfies PromptResponse;
+      } finally {
+        controllers.delete(params.sessionId);
+      }
+    })
+    .onNotification(methods.agent.session.cancel, async ({ params }) => {
+      controllers.get(params.sessionId)?.abort();
+      await sessions.get(params.sessionId)?.child?.cancel(params._meta);
+    });
+
+  const socket = await connectWithDeadline(socketPath, 10_000);
+  const connection = app.connect(socketStream(socket));
+  await connection.closed;
+  for (const session of sessions.values()) session.child?.close();
+  return 0;
+}
+
+function promptText(params: PromptRequest): string {
+  return params.prompt
+    .filter((block): block is Extract<typeof block, { type: "text" }> => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,6 +622,9 @@ importers:
 
   packages/worker:
     dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: 1.3.0
+        version: 1.3.0(zod@4.4.3)
       '@clack/prompts':
         specifier: ^1.1.0
         version: 1.7.0
@@ -637,6 +640,9 @@ importers:
       '@reddb-io/github':
         specifier: workspace:*
         version: link:../github
+      '@reddb-io/protocol-acp':
+        specifier: workspace:*
+        version: link:../protocol-acp
       '@reddb-io/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
Automated AFK landing for #4015. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #4015

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789706312&installation_model_id=20659&pr_number=4054&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4054&signature=46093b90dea4c10972df53c28ec5bdf84036098a1fd42e563d60568d5298ce89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->