### PR TITLE
fix: #4016 Worker terminal policy: git push and gh are refused; the Worker asks its parent to publish after the turn

### DIFF
--- a/apps/redskilled/src/acp-body-control-cut.ts
+++ b/apps/redskilled/src/acp-body-control-cut.ts
@@ -40,8 +40,12 @@ export interface WorkerBodyModule {
    *
    * A ratchet, not history: this exact name reappearing in the daemon tree is
    * the most likely shape of the move being undone.
+   *
+   * Absent when the module was BORN in the package. A body module written after
+   * the cut has no daemon name to forbid, and inventing one would put a fictional
+   * path in a ratchet whose whole value is that every path in it is real.
    */
-  readonly formerDaemonModule: string;
+  readonly formerDaemonModule?: string;
   /** Symbols this module DEFINES. The daemon may re-export them, never define them. */
   readonly defines: readonly string[];
   /** What it does once the process is already running. */
@@ -78,6 +82,21 @@ export const WORKER_BODY_MODULES: readonly WorkerBodyModule[] = [
     formerDaemonModule: "acp-worker-budget-grace.ts",
     defines: ["createAcpWorkerBudgetGraceRuntime"],
     runs: "cancels, checkpoints, asks the gateway to publish, writes the Envelope, dies",
+  },
+  {
+    module: "terminal-policy.ts",
+    defines: ["evaluateWorkerTerminalRequest"],
+    runs: "decides one child-agent terminal request: `git push`, `gh` and every credentialed remote are refused with the authority that owns them",
+  },
+  {
+    module: "terminal-host.ts",
+    defines: ["createWorkerTerminalHost"],
+    runs: "runs what the policy allowed, in the Worktree, with the Worker's credential-free environment",
+  },
+  {
+    module: "publish-request.ts",
+    defines: ["createWorkerPublisher"],
+    runs: "reads the branch and commit the turn produced and asks the ACP parent to publish them, once",
   },
 ];
 

--- a/apps/redskilled/src/acp-method-registry.ts
+++ b/apps/redskilled/src/acp-method-registry.ts
@@ -172,7 +172,12 @@ export const REDSKILLS_ACP_METHOD_DOMAINS: readonly RedskillsAcpMethodDomainDecl
     methods: ["worktreeAdd", "worktreeList"],
     served: true,
   },
-  { domain: "telemetry", module: "acp-telemetry.ts", methods: ["metrics"], served: true },
+  {
+    domain: "telemetry",
+    module: "apps/redskilled/src/acp-telemetry.ts",
+    methods: ["metrics"],
+    served: true,
+  },
   {
     domain: "worker",
     module: "packages/worker/src/acp/budget-grace.ts",

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -22,6 +22,7 @@ import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process"
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { encodeToonlLines } from "@reddb-io/toon";
+import { credentialFreeEnv } from "@reddb-io/shared/credential-free-env.js";
 import { pathWithEngineNode } from "@reddb-io/shared/engine-node.js";
 import type { RedskilledAdmissionVerdict } from "./admission.js";
 import type { RedskilledWorkerView } from "./host-state.js";
@@ -324,8 +325,13 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
   assertLaunchableSpec(spec);
 
   const env = options.env ?? process.env;
-  const ambientWorkerEnv = credentialFreeWorkerEnv(env);
-  const declaredWorkerEnv = credentialFreeWorkerEnv(spec.env ?? {});
+  // Disposable Workers use the ACP gateway, never ambient GitHub or Git
+  // authentication: the daemon strips both secret values and credential-agent
+  // doors from its own environment and from caller-declared overrides before
+  // placement sees them. `@reddb-io/shared` owns the list, because the Worker
+  // strips the same names again when it births the process that runs the model.
+  const ambientWorkerEnv = credentialFreeEnv(env);
+  const declaredWorkerEnv = credentialFreeEnv(spec.env ?? {});
   const clock = options.clock ?? (() => new Date().toISOString());
   const workerId = (spec.worker_id ?? options.workerId)?.trim()
     || mintHostWorkerId(options.liveWorkerIds ?? []);
@@ -483,34 +489,6 @@ export function launchWorker(options: LaunchWorkerOptions): LaunchedWorker {
     child,
     ...(placed?.job != null ? { job: placed.job } : {}),
   };
-}
-
-/**
- * Disposable Workers use the ACP gateway, never ambient GitHub or Git
- * authentication. Strip both secret values and credential-agent doors from the
- * daemon environment and from caller-declared overrides before placement sees
- * them.
- */
-function credentialFreeWorkerEnv(env: NodeJS.ProcessEnv): Record<string, string> {
-  const kept: Record<string, string> = {};
-  for (const [name, value] of Object.entries(env)) {
-    if (value == null || isGithubCredentialEnvironmentName(name)) continue;
-    kept[name] = value;
-  }
-  return kept;
-}
-
-function isGithubCredentialEnvironmentName(name: string): boolean {
-  const normalized = name.toUpperCase();
-  if (["SSH_AUTH_SOCK", "GIT_ASKPASS", "SSH_ASKPASS", "GIT_SSH", "GIT_SSH_COMMAND"].includes(normalized)) {
-    return true;
-  }
-  if (normalized === "REDSKILLED_HOST_TOKEN") return true;
-  if (/^(?:GH|GITHUB)(?:_[A-Z0-9]+)*_(?:TOKEN|SECRET|KEY|APP_ID|INSTALLATION)$/.test(normalized)) return true;
-  if (/^RED_GITHUB_(?:APP_ID|APP_INSTALLATION|APP_KEY)$/.test(normalized)) return true;
-  // A daemon-side authenticated git invocation may use these transiently. No
-  // inherited git config is allowed to become a Worker's authentication path.
-  return /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/.test(normalized);
 }
 
 /** Read Linux `/proc/<pid>/stat` field 22, omitting it on every unavailable host. */

--- a/apps/redskilled/tests/acp-body-control-cut.test.ts
+++ b/apps/redskilled/tests/acp-body-control-cut.test.ts
@@ -66,6 +66,7 @@ describe("what runs inside the Worker lives in the package (#4015)", () => {
     const strays: string[] = [];
 
     for (const body of WORKER_BODY_MODULES) {
+      if (body.formerDaemonModule == null) continue;
       for (const [path, source] of daemon) {
         if (path.endsWith(`${body.formerDaemonModule}`)) {
           strays.push(`${body.formerDaemonModule} is back under the daemon; it is body (${body.runs})`);

--- a/packages/shared/credential-free-env.test.ts
+++ b/packages/shared/credential-free-env.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { credentialFreeEnv, isCredentialEnvironmentName } from "./credential-free-env.js";
+
+describe("the environment a disposable process may inherit", () => {
+  it("refuses every GitHub and Git credential name", () => {
+    for (const name of [
+      "GITHUB_TOKEN",
+      "GH_TOKEN",
+      "GH_ENTERPRISE_TOKEN",
+      "GITHUB_APP_KEY",
+      "RED_GITHUB_APP_ID",
+      "RED_GITHUB_APP_INSTALLATION",
+      "RED_GITHUB_APP_KEY",
+      "REDSKILLED_HOST_TOKEN",
+      "GIT_CONFIG_COUNT",
+      "GIT_CONFIG_KEY_0",
+      "GIT_CONFIG_VALUE_0",
+    ]) {
+      expect(isCredentialEnvironmentName(name), name).toBe(true);
+    }
+  });
+
+  // A door authenticates without carrying a secret, so a value-only sweep
+  // leaves a working push behind.
+  it("refuses the doors as well as the values", () => {
+    for (const name of ["SSH_AUTH_SOCK", "GIT_ASKPASS", "SSH_ASKPASS", "GIT_SSH", "GIT_SSH_COMMAND"]) {
+      expect(isCredentialEnvironmentName(name), name).toBe(true);
+    }
+  });
+
+  it("keeps everything a Worker actually needs", () => {
+    for (const name of ["PATH", "HOME", "RED_MODE", "NODE_OPTIONS", "GITHUB_REPOSITORY"]) {
+      expect(isCredentialEnvironmentName(name), name).toBe(false);
+    }
+  });
+
+  it("strips the credentials and the unset names from a whole environment", () => {
+    expect(credentialFreeEnv({
+      PATH: "/usr/bin",
+      GITHUB_TOKEN: "secret",
+      SSH_AUTH_SOCK: "/run/agent.sock",
+      RED_MODE: "spec-driven",
+      UNSET: undefined,
+    })).toEqual({ PATH: "/usr/bin", RED_MODE: "spec-driven" });
+  });
+});

--- a/packages/shared/credential-free-env.ts
+++ b/packages/shared/credential-free-env.ts
@@ -1,0 +1,43 @@
+// credential-free-env — the one list of environment names a disposable process
+// may never inherit (ADR 0144 §3, ADR 0148).
+//
+// Two processes have to strip the same names: the daemon strips them when it
+// births a Worker, and the Worker strips them again when it births the child
+// coding Agent that runs the model. Two hand-kept lists is one list that goes
+// stale — a name added where the Worker is born and forgotten where the model
+// is born re-opens the seam at the only hop that actually runs untrusted output.
+//
+// What this list is NOT is containment. It is the belt: the braces are that no
+// credential exists in the daemon's Worker environment at all, and that the
+// Worker's terminal policy refuses the commands that would want one.
+
+/**
+ * True when the name carries GitHub or Git authentication, in value or in door.
+ *
+ * Both halves matter. A token is a value a child can read; `SSH_AUTH_SOCK` and
+ * the askpass hooks carry no secret and still authenticate, which is why a
+ * value-only sweep leaves a working push behind.
+ */
+export function isCredentialEnvironmentName(name: string): boolean {
+  const normalized = name.toUpperCase();
+  if (["SSH_AUTH_SOCK", "GIT_ASKPASS", "SSH_ASKPASS", "GIT_SSH", "GIT_SSH_COMMAND"].includes(normalized)) {
+    return true;
+  }
+  if (normalized === "REDSKILLED_HOST_TOKEN") return true;
+  if (/^(?:GH|GITHUB)(?:_[A-Z0-9]+)*_(?:TOKEN|SECRET|KEY|APP_ID|INSTALLATION)$/.test(normalized)) return true;
+  if (/^RED_GITHUB_(?:APP_ID|APP_INSTALLATION|APP_KEY)$/.test(normalized)) return true;
+  // A daemon-side authenticated git invocation may use these transiently. No
+  // inherited git config is allowed to become a disposable process's
+  // authentication path.
+  return /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/.test(normalized);
+}
+
+/** The same environment minus every credential name, and minus every unset value. */
+export function credentialFreeEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const kept: Record<string, string> = {};
+  for (const [name, value] of Object.entries(env)) {
+    if (value == null || isCredentialEnvironmentName(name)) continue;
+    kept[name] = value;
+  }
+  return kept;
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,7 @@
     "./bundle-fetch.js": "./bundle-fetch.ts",
     "./canonical-invocation.js": "./canonical-invocation.ts",
     "./channel.js": "./channel.ts",
+    "./credential-free-env.js": "./credential-free-env.ts",
     "./death-attribution.js": "./death-attribution.ts",
     "./death-presence.js": "./death-presence.ts",
     "./death-record.js": "./death-record.ts",

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -44,6 +44,34 @@ they stay — and `CONTROL_PLANE_DESPITE_THE_NAME` says so out loud, because a
 reader counting them against ADR 0148's seven-module list should not have to
 guess.
 
+## The inner agent only edits and commits (ADR 0148, ADR 0144 §3)
+
+The child coding Agent mounts no MCP and holds no credential, so every command
+it wants to run arrives as a `terminal/create` request on the ACP wire.
+`acp/terminal-policy.ts` judges it and `acp/terminal-host.ts` runs what survives,
+in the Worktree, with the Worker's already credential-free environment.
+
+Three families are refused, each named for the authority that owns it rather
+than for the binary: `publication-is-parent-owned` (`git push`),
+`forge-cli-is-parent-owned` (`gh`, `glab`, `hub`) and
+`credentialed-remote-is-parent-owned` (`git fetch`/`pull`/`clone`/`remote`/
+`credential`, `ssh`, `scp`, `sftp`). The refusal carries the reason, the command
+and the route as a typed `_meta.redskills.terminalPolicy` payload, because an
+agent that learns the contract stops inventing workarounds and an agent that
+only sees a missing credential does not. `git add`, `git commit`, `git status`
+and `pnpm test` are the work, and stay allowed — including through a shell,
+where the policy opens `bash -lc` scripts but respects their quoting, so a commit
+message mentioning `git push` is still a commit.
+
+**The policy is the teacher; the credential-free environment is the guard.** A
+sufficiently creative pipeline still reaches `git push` and still finds nothing
+to push with.
+
+Refusing publication only teaches a contract if something keeps its promise, so
+when a prompt turn ends `acp/publish-request.ts` reads the branch and commit the
+turn produced and asks the ACP parent to publish them — exactly once per turn,
+never twice for the same commit, and never after a cancelled turn.
+
 The source is vendored from [`mattpocock/sandcastle`](https://github.com/mattpocock/sandcastle)
 under the MIT License; `.upstream` records the reviewed SHA and `NOTICE` carries
 the attribution (ADR 0101). The sandcastle documentation below is kept verbatim

--- a/packages/worker/src/acp/child-agent.ts
+++ b/packages/worker/src/acp/child-agent.ts
@@ -18,8 +18,11 @@ import {
   REDSKILLS_WIRE_MAJOR,
   type AcpEndpoint,
 } from "@reddb-io/protocol-acp";
+import { credentialFreeEnv } from "@reddb-io/shared/credential-free-env.js";
 import type { SpinPattern } from "../engine/spin-evaluator.js";
 import { createChildAcpSpinEpisode, type ChildAcpSpinEpisode } from "./child-spin.js";
+import { createWorkerTerminalHost, type WorkerTerminalHost } from "./terminal-host.js";
+import type { WorkerTerminalDenial } from "./terminal-policy.js";
 
 export interface ChildAgentSessionOptions {
   readonly endpoint: AcpEndpoint;
@@ -48,12 +51,20 @@ const DELEGATION_SCOPE = {
 /** One Workflow Worker may retain one child Agent, but never replace it more than once per turn. */
 export class WorkflowChildAgent {
   readonly #options: ChildAgentSessionOptions;
+  readonly #terminals: WorkerTerminalHost;
   #active: ActiveChildAgent | undefined;
   #spinEpisode: ChildAcpSpinEpisode | undefined;
   #spinUpdates: Promise<void> = Promise.resolve();
 
   constructor(options: ChildAgentSessionOptions) {
     this.#options = options;
+    // One host per child Agent, not per child PROCESS: a replacement inherits
+    // the terminals its predecessor opened rather than orphaning them.
+    this.#terminals = createWorkerTerminalHost({
+      cwd: options.cwd,
+      env: credentialFreeEnv(process.env),
+      onDenial: (denial) => void this.#terminalDenial(denial),
+    });
   }
 
   async prompt(params: PromptRequest): Promise<PromptResponse> {
@@ -120,14 +131,18 @@ export class WorkflowChildAgent {
   }
 
   close(): void {
+    this.#terminals.closeAll();
     if (this.#active != null) this.#cleanup(this.#active);
   }
 
   async #admit(event: "child-admission" | "child-replacement"): Promise<ActiveChildAgent> {
     const endpoint = this.#options.endpoint;
+    // The process that runs the model receives no credential (ADR 0144 §3).
+    // The daemon already stripped them from the Worker's own environment; this
+    // strips them again rather than trusting a hop it cannot see.
     const child = spawn(endpoint.command, endpoint.args, {
       cwd: this.#options.cwd,
-      env: process.env,
+      env: credentialFreeEnv(process.env),
       stdio: ["pipe", "pipe", "ignore"],
     });
     if (child.stdin == null || child.stdout == null) throw new Error("child ACP Agent did not expose stdio");
@@ -148,7 +163,14 @@ export class WorkflowChildAgent {
       .onRequest(methods.client.session.requestPermission, ({ params }) => this.#options.parent.request(
         methods.client.session.requestPermission,
         { ...params, sessionId: this.#options.publicSessionId },
-      ) as Promise<RequestPermissionResponse>);
+      ) as Promise<RequestPermissionResponse>)
+      // The Worker answers `terminal/*` itself: the policy refuses publication
+      // and every credentialed remote, and what survives runs in the Worktree.
+      .onRequest(methods.client.terminal.create, ({ params }) => this.#terminals.create(params))
+      .onRequest(methods.client.terminal.output, ({ params }) => this.#terminals.output(params))
+      .onRequest(methods.client.terminal.waitForExit, ({ params }) => this.#terminals.waitForExit(params))
+      .onRequest(methods.client.terminal.kill, ({ params }) => this.#terminals.kill(params))
+      .onRequest(methods.client.terminal.release, ({ params }) => this.#terminals.release(params));
     const connection = app.connect(ndJsonStream(
       Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
       Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
@@ -156,7 +178,7 @@ export class WorkflowChildAgent {
     try {
       const initialized = await connection.agent.request(methods.agent.initialize, {
         protocolVersion: ACP_PROTOCOL_VERSION,
-        clientCapabilities: {},
+        clientCapabilities: { terminal: true },
         clientInfo: { name: "RedSkills Workflow Worker", version: "1" },
         _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR } },
       });
@@ -205,6 +227,26 @@ export class WorkflowChildAgent {
     if (this.#active === active) this.#active = undefined;
     active.connection.close();
     if (active.child.exitCode == null && active.child.signalCode == null) active.child.kill();
+  }
+
+  /** Tell the parent what the policy refused, so the Worker log holds the lesson. */
+  #terminalDenial(denial: WorkerTerminalDenial): Promise<void> {
+    return this.#options.parent.notify(methods.client.session.update, {
+      sessionId: this.#options.publicSessionId,
+      update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "" } },
+      _meta: {
+        redskills: {
+          lifecycle: { event: "child-terminal-denied", agent: this.#options.endpoint.agent },
+          terminalPolicy: {
+            decision: "deny",
+            reason: denial.reason,
+            command: denial.command,
+            what: denial.what,
+            remedy: denial.remedy,
+          },
+        },
+      },
+    });
   }
 
   #lifecycle(event: string, pattern?: SpinPattern): Promise<void> {

--- a/packages/worker/src/acp/fixtures/terminal-policy-child.mjs
+++ b/packages/worker/src/acp/fixtures/terminal-policy-child.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// A stub child coding Agent that only asks for terminals.
+//
+// It exists to be REFUSED: the Worker's terminal policy is a decision made on
+// the far side of a real ACP connection, and a stub that calls the policy
+// function directly would prove the function and not the seam. Each `run` line
+// in the prompt becomes one `terminal/create`, and the outcome — allowed with
+// its output, or refused with the reason it was given — comes back in `_meta`.
+import { agent, methods, ndJsonStream } from "@agentclientprotocol/sdk";
+import { Readable, Writable } from "node:stream";
+
+const ARGUMENT_SEPARATOR = " :: ";
+
+const app = agent({ name: "terminal policy child fixture" })
+  .onRequest(methods.agent.initialize, () => ({
+    protocolVersion: 1,
+    agentCapabilities: { promptCapabilities: {} },
+    agentInfo: { name: "terminal policy child fixture", version: "1" },
+  }))
+  .onRequest(methods.agent.session.new, () => ({ sessionId: "terminal-policy-child" }))
+  .onRequest(methods.agent.session.prompt, async ({ params, client: parent }) => {
+    const text = params.prompt
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n");
+    const terminals = [];
+    for (const line of text.split("\n")) {
+      if (!line.startsWith("run ")) continue;
+      const [command, ...args] = line.slice(4).split(ARGUMENT_SEPARATOR);
+      terminals.push(await attempt(parent, params.sessionId, command, args));
+    }
+    return { stopReason: "end_turn", _meta: { stub: { terminals } } };
+  });
+
+async function attempt(parent, sessionId, command, args) {
+  try {
+    const created = await parent.request(methods.client.terminal.create, { sessionId, command, args });
+    const exit = await parent.request(methods.client.terminal.waitForExit, {
+      sessionId,
+      terminalId: created.terminalId,
+    });
+    const output = await parent.request(methods.client.terminal.output, {
+      sessionId,
+      terminalId: created.terminalId,
+    });
+    await parent.request(methods.client.terminal.release, { sessionId, terminalId: created.terminalId });
+    return {
+      command,
+      allowed: true,
+      exitCode: exit.exitCode ?? null,
+      output: output.output,
+    };
+  } catch (error) {
+    return {
+      command,
+      allowed: false,
+      message: error?.message ?? String(error),
+      data: error?.data ?? null,
+    };
+  }
+}
+
+app.connect(ndJsonStream(
+  Writable.toWeb(process.stdout),
+  Readable.toWeb(process.stdin),
+));

--- a/packages/worker/src/acp/index.ts
+++ b/packages/worker/src/acp/index.ts
@@ -8,6 +8,32 @@ export { runAcpWorkerCommand } from "./command.js";
 export { runNativeAcpWorker } from "./native-worker.js";
 export { WorkflowChildAgent, type ChildAgentSessionOptions } from "./child-agent.js";
 export {
+  createWorkerTerminalHost,
+  DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT,
+  type WorkerTerminalHost,
+  type WorkerTerminalHostOptions,
+} from "./terminal-host.js";
+export {
+  evaluateWorkerTerminalRequest,
+  shellSegments,
+  workerTerminalDenialMessage,
+  workerTerminalDenialMeta,
+  WORKER_DENIED_TERMINAL_PROGRAMS,
+  type WorkerTerminalDecision,
+  type WorkerTerminalDenial,
+  type WorkerTerminalDenialReason,
+  type WorkerTerminalRequest,
+} from "./terminal-policy.js";
+export {
+  createWorkerPublisher,
+  readWorktreePublication,
+  WORKER_PUBLISH_METHOD,
+  type WorkerPublication,
+  type WorkerPublishOutcome,
+  type WorkerPublisher,
+  type WorkerPublisherOptions,
+} from "./publish-request.js";
+export {
   createChildAcpSpinEpisode,
   type ChildAcpSpinEpisode,
   type ChildSpinObservation,

--- a/packages/worker/src/acp/native-worker.ts
+++ b/packages/worker/src/acp/native-worker.ts
@@ -11,6 +11,7 @@ import { randomUUID } from "node:crypto";
 import {
   agent,
   methods,
+  type AgentContext,
   type NewSessionRequest,
   type PromptRequest,
   type PromptResponse,
@@ -29,6 +30,7 @@ import {
   type AcpSessionRecoveryCheckpoint,
 } from "@reddb-io/protocol-acp";
 import { WorkflowChildAgent } from "./child-agent.js";
+import { createWorkerPublisher, type WorkerPublisher } from "./publish-request.js";
 
 /** The daemon-admitted native Workflow Worker. */
 export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpEndpoint): Promise<number> {
@@ -36,8 +38,181 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
   const sessions = new Map<string, {
     readonly request: NewSessionRequest;
     child?: WorkflowChildAgent;
+    publisher?: WorkerPublisher;
   }>();
   const recoveries = new Map<string, AcpSessionRecoveryCheckpoint>();
+  /**
+   * Ask the parent to publish what this turn committed, at most once per turn.
+   *
+   * A cancelled turn publishes nothing: cancellation is the one outcome where
+   * the commit in the Worktree may be mid-thought, and publishing it would put
+   * an abandoned state on the Project remote under the branch's name.
+   */
+  async function publishAfterTurn(
+    sessionId: string,
+    parent: AgentContext,
+    response: PromptResponse,
+  ): Promise<void> {
+    if (response.stopReason === "cancelled") return;
+    const held = sessions.get(sessionId);
+    if (held == null) return;
+    held.publisher ??= createWorkerPublisher({
+      cwd: held.request.cwd,
+      idempotencyScope: `worker-turn:${sessionId}`,
+      request: (method, write) => parent.request(method, write),
+    });
+    const outcome = await held.publisher.publishTurn();
+    if (outcome == null) return;
+    await parent.notify(methods.client.session.update, {
+      sessionId,
+      update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "" } },
+      _meta: {
+        redskills: {
+          lifecycle: { event: `publication-${outcome.status}` },
+          publication: {
+            branch: outcome.publication.branch,
+            commit: outcome.publication.commit,
+            ...(outcome.status === "refused" ? { detail: outcome.detail } : {}),
+          },
+        },
+      },
+    });
+  }
+
+  async function runPromptTurn(
+    params: PromptRequest,
+    parent: AgentContext,
+  ): Promise<PromptResponse> {
+    const held = sessions.get(params.sessionId);
+    if (held == null) throw new Error("unknown native Worker ACP session");
+    const controller = new AbortController();
+    controllers.set(params.sessionId, controller);
+    try {
+      const recovery = recoveries.get(params.sessionId);
+      if (recovery != null) {
+        recoveries.delete(params.sessionId);
+        await notifySessionRecovery(parent, params.sessionId, recovery);
+      }
+      const prompt = promptText(params);
+      if (prompt.includes("delegate child")) {
+        held.child ??= new WorkflowChildAgent({
+          endpoint: childEndpoint,
+          cwd: held.request.cwd,
+          mcpServers: held.request.mcpServers,
+          ...(held.request.additionalDirectories == null
+            ? {}
+            : { additionalDirectories: held.request.additionalDirectories }),
+          publicSessionId: params.sessionId,
+          parent,
+        });
+        return await held.child.prompt(params);
+      }
+      await parent.notify(methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "plan",
+          entries: [{ content: "Execute the prompt inside the admitted native Worker", priority: "high", status: "in_progress" }],
+        },
+      });
+      await parent.notify(methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "native Worker is executing the prompt\n" },
+        },
+        _meta: { redskills: { lifecycle: { event: "tool-activity" } } },
+      });
+      let permissionResolution: string | undefined;
+      if (prompt.includes("permission")) {
+        // The delay gives the public launch-edge transport time to disappear;
+        // policy resolution remains daemon-owned after it does.
+        await abortableDelay(75, controller.signal);
+        const title = prompt.includes("denial")
+          ? "denied operation"
+          : prompt.includes("uncovered")
+            ? "uncovered operation"
+            : "governed write";
+        const permission = await parent.request(methods.client.session.requestPermission, {
+          sessionId: params.sessionId,
+          toolCall: {
+            toolCallId: randomUUID(),
+            title,
+            kind: "edit",
+            status: "pending",
+          },
+          options: [
+            { optionId: "once", name: "Allow once", kind: "allow_once" },
+            { optionId: "always", name: "Always allow", kind: "allow_always" },
+            { optionId: "reject", name: "Reject", kind: "reject_once" },
+          ],
+        });
+        permissionResolution = (permission._meta as {
+          redskills?: { permissionResolution?: string };
+        } | undefined)?.redskills?.permissionResolution;
+        if (permission.outcome.outcome === "cancelled" || permissionResolution === "hitl-required") {
+          return {
+            stopReason: "cancelled",
+            _meta: { redskills: { permissionResolution, workflowOutcome: "permission-hitl" } },
+          } satisfies PromptResponse;
+        }
+        const chosen = permission.outcome.optionId;
+        if (chosen === "reject") {
+          return {
+            stopReason: "end_turn",
+            _meta: { redskills: { permissionResolution } },
+          } satisfies PromptResponse;
+        }
+      }
+      if (prompt.includes("wait for cancellation")) {
+        await waitForAbort(controller.signal);
+      } else {
+        await abortableDelay(35, controller.signal);
+      }
+      if (controller.signal.aborted) {
+        await parent.notify(methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "native Worker cancelled the prompt\n" },
+          },
+        });
+        return { stopReason: "cancelled" } satisfies PromptResponse;
+      }
+
+      await parent.notify(methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "plan",
+          entries: [{ content: "Execute the prompt inside the admitted native Worker", priority: "high", status: "completed" }],
+        },
+      });
+      await parent.notify(methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: `native Worker completed: ${prompt}\n` },
+        },
+      });
+      const workflowOutcome = prompt.includes("complete workflow")
+        ? "completion"
+        : prompt.includes("budget verdict")
+          ? "budget-verdict"
+          : prompt.includes("replace worker")
+            ? "replacement"
+            : prompt.includes("explicit control")
+              ? "explicit-control"
+              : undefined;
+      return {
+        stopReason: "end_turn",
+        ...(workflowOutcome == null && permissionResolution == null
+          ? {}
+          : { _meta: { redskills: { workflowOutcome, permissionResolution } } }),
+      } satisfies PromptResponse;
+    } finally {
+      controllers.delete(params.sessionId);
+    }
+  }
+
   const app = agent({ name: "RedSkills native Worker" })
     .onRequest(methods.agent.initialize, ({ params }) => {
       requireCompatibleWireMajor(params._meta, true);
@@ -66,134 +241,12 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
       };
     })
     .onRequest(methods.agent.session.prompt, async ({ params, client: parent }) => {
-      const held = sessions.get(params.sessionId);
-      if (held == null) throw new Error("unknown native Worker ACP session");
-      const controller = new AbortController();
-      controllers.set(params.sessionId, controller);
-      try {
-        const recovery = recoveries.get(params.sessionId);
-        if (recovery != null) {
-          recoveries.delete(params.sessionId);
-          await notifySessionRecovery(parent, params.sessionId, recovery);
-        }
-        const prompt = promptText(params);
-        if (prompt.includes("delegate child")) {
-          held.child ??= new WorkflowChildAgent({
-            endpoint: childEndpoint,
-            cwd: held.request.cwd,
-            mcpServers: held.request.mcpServers,
-            ...(held.request.additionalDirectories == null
-              ? {}
-              : { additionalDirectories: held.request.additionalDirectories }),
-            publicSessionId: params.sessionId,
-            parent,
-          });
-          return await held.child.prompt(params);
-        }
-        await parent.notify(methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "plan",
-            entries: [{ content: "Execute the prompt inside the admitted native Worker", priority: "high", status: "in_progress" }],
-          },
-        });
-        await parent.notify(methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: "native Worker is executing the prompt\n" },
-          },
-          _meta: { redskills: { lifecycle: { event: "tool-activity" } } },
-        });
-        let permissionResolution: string | undefined;
-        if (prompt.includes("permission")) {
-          // The delay gives the public launch-edge transport time to disappear;
-          // policy resolution remains daemon-owned after it does.
-          await abortableDelay(75, controller.signal);
-          const title = prompt.includes("denial")
-            ? "denied operation"
-            : prompt.includes("uncovered")
-              ? "uncovered operation"
-              : "governed write";
-          const permission = await parent.request(methods.client.session.requestPermission, {
-            sessionId: params.sessionId,
-            toolCall: {
-              toolCallId: randomUUID(),
-              title,
-              kind: "edit",
-              status: "pending",
-            },
-            options: [
-              { optionId: "once", name: "Allow once", kind: "allow_once" },
-              { optionId: "always", name: "Always allow", kind: "allow_always" },
-              { optionId: "reject", name: "Reject", kind: "reject_once" },
-            ],
-          });
-          permissionResolution = (permission._meta as {
-            redskills?: { permissionResolution?: string };
-          } | undefined)?.redskills?.permissionResolution;
-          if (permission.outcome.outcome === "cancelled" || permissionResolution === "hitl-required") {
-            return {
-              stopReason: "cancelled",
-              _meta: { redskills: { permissionResolution, workflowOutcome: "permission-hitl" } },
-            } satisfies PromptResponse;
-          }
-          const chosen = permission.outcome.optionId;
-          if (chosen === "reject") {
-            return {
-              stopReason: "end_turn",
-              _meta: { redskills: { permissionResolution } },
-            } satisfies PromptResponse;
-          }
-        }
-        if (prompt.includes("wait for cancellation")) {
-          await waitForAbort(controller.signal);
-        } else {
-          await abortableDelay(35, controller.signal);
-        }
-        if (controller.signal.aborted) {
-          await parent.notify(methods.client.session.update, {
-            sessionId: params.sessionId,
-            update: {
-              sessionUpdate: "agent_message_chunk",
-              content: { type: "text", text: "native Worker cancelled the prompt\n" },
-            },
-          });
-          return { stopReason: "cancelled" } satisfies PromptResponse;
-        }
-
-        await parent.notify(methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "plan",
-            entries: [{ content: "Execute the prompt inside the admitted native Worker", priority: "high", status: "completed" }],
-          },
-        });
-        await parent.notify(methods.client.session.update, {
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: `native Worker completed: ${prompt}\n` },
-          },
-        });
-        const workflowOutcome = prompt.includes("complete workflow")
-          ? "completion"
-          : prompt.includes("budget verdict")
-            ? "budget-verdict"
-            : prompt.includes("replace worker")
-              ? "replacement"
-              : prompt.includes("explicit control")
-                ? "explicit-control"
-                : undefined;
-        return {
-          stopReason: "end_turn",
-          ...(workflowOutcome == null && permissionResolution == null
-            ? {}
-            : { _meta: { redskills: { workflowOutcome, permissionResolution } } }),
-        } satisfies PromptResponse;
-      } finally {
-        controllers.delete(params.sessionId);
-      }
+      const response = await runPromptTurn(params, parent);
+      // The turn is over, so the publication request is the LAST thing the
+      // Worker does with it: the inner agent was refused `git push` on the way
+      // in, and this is the promise that refusal made (ADR 0148).
+      await publishAfterTurn(params.sessionId, parent, response);
+      return response;
     })
     .onNotification(methods.agent.session.cancel, async ({ params }) => {
       controllers.get(params.sessionId)?.abort();

--- a/packages/worker/src/acp/publish-request.test.ts
+++ b/packages/worker/src/acp/publish-request.test.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RedskilledGithubWriteRequest } from "@reddb-io/protocol-acp";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createWorkerPublisher,
+  readWorktreePublication,
+  WORKER_PUBLISH_METHOD,
+} from "./publish-request.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+function recordingParent() {
+  const requests: { readonly method: string; readonly params: RedskilledGithubWriteRequest }[] = [];
+  return {
+    requests,
+    request: async (method: string, params: RedskilledGithubWriteRequest) => {
+      requests.push({ method, params });
+      return { published: true };
+    },
+  };
+}
+
+describe("the Worker's post-turn publication request", () => {
+  it("asks the parent exactly once, naming the branch and the commit", async () => {
+    const parent = recordingParent();
+    const publisher = createWorkerPublisher({
+      cwd: "/worktree",
+      idempotencyScope: "worker-turn:s",
+      request: parent.request,
+      readPublication: async () => ({ branch: "afk/4016-terminal-policy", commit: "c0ffee" }),
+    });
+
+    const outcome = await publisher.publishTurn();
+
+    expect(outcome).toEqual({
+      status: "requested",
+      publication: { branch: "afk/4016-terminal-policy", commit: "c0ffee" },
+      receipt: { published: true },
+    });
+    expect(parent.requests).toEqual([{
+      method: WORKER_PUBLISH_METHOD,
+      params: {
+        idempotency_key: "worker-turn:s:c0ffee",
+        write: { kind: "repository-push", ref: "afk/4016-terminal-policy", sha: "c0ffee" },
+      },
+    }]);
+  });
+
+  // A Worker spans several prompt turns. Re-asking for the commit the parent
+  // already holds is not a retry — it is one publication asked for twice.
+  it("stays silent on a turn that committed nothing new, and speaks again when it did", async () => {
+    const parent = recordingParent();
+    let commit = "c0ffee";
+    const publisher = createWorkerPublisher({
+      cwd: "/worktree",
+      idempotencyScope: "worker-turn:s",
+      request: parent.request,
+      readPublication: async () => ({ branch: "afk/4016", commit }),
+    });
+
+    await publisher.publishTurn();
+    expect(await publisher.publishTurn()).toBeNull();
+    commit = "decade";
+    await publisher.publishTurn();
+
+    expect(parent.requests.map(({ params }) => params.write)).toEqual([
+      { kind: "repository-push", ref: "afk/4016", sha: "c0ffee" },
+      { kind: "repository-push", ref: "afk/4016", sha: "decade" },
+    ]);
+  });
+
+  it("returns a parent's refusal instead of costing the Worker its turn", async () => {
+    const publisher = createWorkerPublisher({
+      cwd: "/worktree",
+      idempotencyScope: "worker-turn:s",
+      request: async () => {
+        throw new Error("no GitHub gateway is bound to this Project");
+      },
+      readPublication: async () => ({ branch: "afk/4016", commit: "c0ffee" }),
+    });
+
+    expect(await publisher.publishTurn()).toEqual({
+      status: "refused",
+      publication: { branch: "afk/4016", commit: "c0ffee" },
+      detail: "no GitHub gateway is bound to this Project",
+    });
+  });
+
+  it("asks for nothing when the Worktree holds no publishable commit", async () => {
+    const parent = recordingParent();
+    const publisher = createWorkerPublisher({
+      cwd: "/worktree",
+      idempotencyScope: "worker-turn:s",
+      request: parent.request,
+      readPublication: async () => null,
+    });
+
+    expect(await publisher.publishTurn()).toBeNull();
+    expect(parent.requests).toEqual([]);
+  });
+});
+
+describe("reading the Worktree's publication", () => {
+  it("names the branch the inner agent committed on and the commit it left", async () => {
+    const root = await mkdtemp(join(tmpdir(), "worker-publish-"));
+    roots.push(root);
+    const git = (...args: string[]) => execFileSync("git", args, { cwd: root, stdio: "pipe" });
+    git("init", "--initial-branch", "afk/4016-terminal-policy");
+    git("config", "user.email", "worker@example.invalid");
+    git("config", "user.name", "Worker");
+    await writeFile(join(root, "edited.txt"), "the inner agent only edits and commits\n");
+    git("add", "--", "edited.txt");
+    git("commit", "-m", "Refs #4016");
+
+    const publication = await readWorktreePublication(root);
+
+    expect(publication?.branch).toBe("afk/4016-terminal-policy");
+    expect(publication?.commit).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("publishes nothing from a directory that is not a Worktree", async () => {
+    const root = await mkdtemp(join(tmpdir(), "worker-publish-bare-"));
+    roots.push(root);
+
+    expect(await readWorktreePublication(root)).toBeNull();
+  });
+});

--- a/packages/worker/src/acp/publish-request.ts
+++ b/packages/worker/src/acp/publish-request.ts
@@ -1,0 +1,95 @@
+/**
+ * After the turn, the Worker asks its ACP parent to publish.
+ *
+ * The other half of the terminal policy. Refusing `git push` only teaches a
+ * contract if something else keeps the promise, so when a prompt turn ends the
+ * Worker reads what the inner agent committed and hands the parent the branch
+ * and the commit. redskilled's Project-bound gateway performs the write; no
+ * credential crosses this seam in either direction (ADR 0148, ADR 0144 §3).
+ *
+ * EXACTLY ONE request per turn, and none at all when there is nothing new to
+ * publish. A Worker may span several prompt turns, and a second request naming
+ * the commit the parent already has is not a retry — it is the same publication
+ * asked for twice, which the gateway would have to deduplicate on the Worker's
+ * behalf.
+ */
+import { execFile } from "node:child_process";
+import { REDSKILLS_ACP_METHODS, type RedskilledGithubWriteRequest } from "@reddb-io/protocol-acp";
+
+/** The ACP method the Worker's publication request travels on. */
+export const WORKER_PUBLISH_METHOD = REDSKILLS_ACP_METHODS.githubWrite;
+
+/** What the inner agent left behind in the Worktree, ready to publish. */
+export interface WorkerPublication {
+  readonly branch: string;
+  readonly commit: string;
+}
+
+export interface WorkerPublisherOptions {
+  /** The Worktree the inner agent committed in. */
+  readonly cwd: string;
+  /** Sends the request to the ACP parent; the parent owns the credential. */
+  readonly request: (method: string, params: RedskilledGithubWriteRequest) => Promise<unknown>;
+  /** Stable per-Worker prefix, so a re-asked publication is the same write. */
+  readonly idempotencyScope: string;
+  /** Test seam over `git rev-parse`. Production reads the real Worktree. */
+  readonly readPublication?: (cwd: string) => Promise<WorkerPublication | null>;
+}
+
+export interface WorkerPublisher {
+  /**
+   * Publish what this turn produced.
+   *
+   * Resolves to the publication that was asked for, or `null` when the turn
+   * committed nothing new. Never rejects: a parent that cannot publish must not
+   * also cost the Worker the turn's answer, so the failure is returned.
+   */
+  publishTurn(): Promise<WorkerPublishOutcome | null>;
+}
+
+export type WorkerPublishOutcome =
+  | { readonly status: "requested"; readonly publication: WorkerPublication; readonly receipt: unknown }
+  | { readonly status: "refused"; readonly publication: WorkerPublication; readonly detail: string };
+
+export function createWorkerPublisher(options: WorkerPublisherOptions): WorkerPublisher {
+  const readPublication = options.readPublication ?? readWorktreePublication;
+  let published: string | undefined;
+  return {
+    async publishTurn() {
+      const publication = await readPublication(options.cwd).catch(() => null);
+      if (publication == null || publication.commit === published) return null;
+      published = publication.commit;
+      const write: RedskilledGithubWriteRequest = {
+        idempotency_key: `${options.idempotencyScope}:${publication.commit}`,
+        write: { kind: "repository-push", ref: publication.branch, sha: publication.commit },
+      };
+      try {
+        return { status: "requested", publication, receipt: await options.request(WORKER_PUBLISH_METHOD, write) };
+      } catch (error) {
+        return { status: "refused", publication, detail: error instanceof Error ? error.message : String(error) };
+      }
+    },
+  };
+}
+
+/**
+ * The Worktree's current branch and commit, or `null` when there is neither.
+ *
+ * A detached HEAD is `null` on purpose: publication needs a ref name, and
+ * guessing one for a Worker that never checked a branch out would push work
+ * somewhere nobody asked for it.
+ */
+export async function readWorktreePublication(cwd: string): Promise<WorkerPublication | null> {
+  const branch = await git(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  if (branch == null || branch === "HEAD") return null;
+  const commit = await git(cwd, ["rev-parse", "HEAD"]);
+  return commit == null ? null : { branch, commit };
+}
+
+function git(cwd: string, args: readonly string[]): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile("git", [...args], { cwd }, (error, stdout) => {
+      resolve(error != null ? null : stdout.trim() || null);
+    });
+  });
+}

--- a/packages/worker/src/acp/terminal-host.test.ts
+++ b/packages/worker/src/acp/terminal-host.test.ts
@@ -1,0 +1,146 @@
+import type { ChildProcess, spawn as nodeSpawn } from "node:child_process";
+import { RequestError } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+
+import { createWorkerTerminalHost } from "./terminal-host.js";
+import type { WorkerTerminalDenial } from "./terminal-policy.js";
+
+interface RecordedSpawn {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string | undefined;
+  readonly env: NodeJS.ProcessEnv;
+}
+
+function recordingHost(env: NodeJS.ProcessEnv = { PATH: "/usr/bin" }) {
+  const spawns: RecordedSpawn[] = [];
+  const denials: WorkerTerminalDenial[] = [];
+  const spawn = ((command: string, args: readonly string[], options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+  }) => {
+    spawns.push({ command, args, cwd: options.cwd, env: options.env ?? {} });
+    return {
+      stdout: null,
+      stderr: null,
+      once: () => undefined,
+      kill: () => true,
+    } as unknown as ChildProcess;
+  }) as unknown as typeof nodeSpawn;
+  const host = createWorkerTerminalHost({
+    cwd: "/worktree",
+    env,
+    spawn,
+    onDenial: (denial) => denials.push(denial),
+  });
+  return { host, spawns, denials };
+}
+
+describe("the Worker's terminal host", () => {
+  it("runs an ordinary command in the Worktree", () => {
+    const { host, spawns, denials } = recordingHost();
+
+    const created = host.create({ sessionId: "s", command: "pnpm", args: ["test"] });
+
+    expect(created.terminalId).toBeTruthy();
+    expect(spawns).toEqual([
+      { command: "pnpm", args: ["test"], cwd: "/worktree", env: { PATH: "/usr/bin" } },
+    ]);
+    expect(denials).toEqual([]);
+  });
+
+  it("refuses git push and gh, and starts no process for either", () => {
+    const { host, spawns, denials } = recordingHost();
+
+    for (const request of [
+      { sessionId: "s", command: "git", args: ["push", "origin", "HEAD"] },
+      { sessionId: "s", command: "gh", args: ["pr", "create", "--fill"] },
+    ]) {
+      expect(() => host.create(request)).toThrow(RequestError);
+    }
+
+    expect(spawns).toEqual([]);
+    expect(denials.map((denial) => denial.reason))
+      .toEqual(["publication-is-parent-owned", "forge-cli-is-parent-owned"]);
+  });
+
+  it("hands the refusal back as a typed payload rather than as prose", () => {
+    const { host } = recordingHost();
+
+    let thrown: unknown;
+    try {
+      host.create({ sessionId: "s", command: "git", args: ["push"] });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(RequestError);
+    expect((thrown as RequestError).data).toMatchObject({
+      redskills: { terminalPolicy: { decision: "deny", reason: "publication-is-parent-owned" } },
+    });
+    expect((thrown as RequestError).message).toContain("publication-is-parent-owned");
+  });
+
+  // The braces behind the policy's belt: even a request that names a credential
+  // outright cannot put one into a process the Worker starts.
+  it("drops a credential name the request declares for itself", () => {
+    const { host, spawns } = recordingHost({ PATH: "/usr/bin" });
+
+    host.create({
+      sessionId: "s",
+      command: "pnpm",
+      args: ["test"],
+      env: [
+        { name: "GITHUB_TOKEN", value: "smuggled" },
+        { name: "RED_MODE", value: "spec-driven" },
+      ],
+    });
+
+    expect(spawns[0]!.env).toEqual({ PATH: "/usr/bin", RED_MODE: "spec-driven" });
+  });
+
+  it("refuses to answer for a terminal it never minted", () => {
+    const { host } = recordingHost();
+
+    expect(() => host.output({ sessionId: "s", terminalId: "invented" })).toThrow(RequestError);
+  });
+});
+
+describe("the Worker's terminal host, running real commands", () => {
+  it("returns the output and the exit status of a command it allowed", async () => {
+    const host = createWorkerTerminalHost({ cwd: process.cwd(), env: process.env });
+
+    const created = host.create({
+      sessionId: "s",
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('worktree-ok'); process.exit(3)"],
+    });
+    const exit = await host.waitForExit({ sessionId: "s", terminalId: created.terminalId });
+
+    expect(exit.exitCode).toBe(3);
+    expect(host.output({ sessionId: "s", terminalId: created.terminalId })).toMatchObject({
+      output: "worktree-ok",
+      truncated: false,
+      exitStatus: { exitCode: 3 },
+    });
+    host.release({ sessionId: "s", terminalId: created.terminalId });
+  });
+
+  it("keeps the tail when the output passes the caller's byte limit", async () => {
+    const host = createWorkerTerminalHost({ cwd: process.cwd(), env: process.env });
+
+    const created = host.create({
+      sessionId: "s",
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('a'.repeat(64) + 'TAIL')"],
+      outputByteLimit: 8,
+    });
+    await host.waitForExit({ sessionId: "s", terminalId: created.terminalId });
+
+    const output = host.output({ sessionId: "s", terminalId: created.terminalId });
+    expect(output.truncated).toBe(true);
+    expect(output.output.endsWith("TAIL")).toBe(true);
+    expect(output.output.length).toBeLessThanOrEqual(8);
+    host.release({ sessionId: "s", terminalId: created.terminalId });
+  });
+});

--- a/packages/worker/src/acp/terminal-host.ts
+++ b/packages/worker/src/acp/terminal-host.ts
@@ -1,0 +1,195 @@
+/**
+ * The Worker's answer to the child Agent's `terminal/*` methods.
+ *
+ * The inner coding Agent mounts no MCP and holds no credential; every command
+ * it wants to run comes back up the ACP wire as a request, and THIS is what
+ * decides and then executes it (ADR 0148). Two things happen here and nowhere
+ * else: `terminal-policy.ts` judges the command, and an allowed one runs as a
+ * child of the Worker, in the Worker's Worktree, with the Worker's already
+ * credential-free environment.
+ *
+ * Execution stays in the Worker rather than being forwarded to the ACP parent
+ * because the parent is control: it decides whether a Worker exists, not what
+ * runs inside one.
+ */
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
+import {
+  RequestError,
+  type CreateTerminalRequest,
+  type CreateTerminalResponse,
+  type KillTerminalRequest,
+  type KillTerminalResponse,
+  type ReleaseTerminalRequest,
+  type ReleaseTerminalResponse,
+  type TerminalOutputRequest,
+  type TerminalOutputResponse,
+  type WaitForTerminalExitRequest,
+  type WaitForTerminalExitResponse,
+} from "@agentclientprotocol/sdk";
+import { isCredentialEnvironmentName } from "@reddb-io/shared/credential-free-env.js";
+import {
+  evaluateWorkerTerminalRequest,
+  workerTerminalDenialMessage,
+  workerTerminalDenialMeta,
+  type WorkerTerminalDenial,
+} from "./terminal-policy.js";
+
+/** Retained output per terminal when the caller states no limit of its own. */
+export const DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT = 1_048_576;
+
+export interface WorkerTerminalHostOptions {
+  /** The Worktree. A request naming no `cwd` runs here, never in the Worker's own. */
+  readonly cwd: string;
+  /** The environment allowed children inherit. Already stripped of credentials. */
+  readonly env: NodeJS.ProcessEnv;
+  /** Test seam. Production passes nothing and gets `node:child_process`. */
+  readonly spawn?: typeof nodeSpawn;
+  /** Called with every refusal, so the Worker's log records what it taught. */
+  readonly onDenial?: (denial: WorkerTerminalDenial) => void;
+}
+
+export interface WorkerTerminalHost {
+  create(params: CreateTerminalRequest): CreateTerminalResponse;
+  output(params: TerminalOutputRequest): TerminalOutputResponse;
+  waitForExit(params: WaitForTerminalExitRequest): Promise<WaitForTerminalExitResponse>;
+  kill(params: KillTerminalRequest): KillTerminalResponse;
+  release(params: ReleaseTerminalRequest): ReleaseTerminalResponse;
+  /** Kill and forget every terminal this host still holds. */
+  closeAll(): void;
+}
+
+interface HeldTerminal {
+  readonly child: ChildProcess;
+  readonly limit: number;
+  chunks: Buffer[];
+  bytes: number;
+  truncated: boolean;
+  exit: { readonly exitCode: number | null; readonly signal: string | null } | undefined;
+  readonly exited: Promise<void>;
+}
+
+export function createWorkerTerminalHost(options: WorkerTerminalHostOptions): WorkerTerminalHost {
+  const spawn = options.spawn ?? nodeSpawn;
+  const terminals = new Map<string, HeldTerminal>();
+  let minted = 0;
+
+  const held = (terminalId: string): HeldTerminal => {
+    const terminal = terminals.get(terminalId);
+    if (terminal == null) throw RequestError.resourceNotFound(terminalId);
+    return terminal;
+  };
+
+  return {
+    create(params) {
+      const decision = evaluateWorkerTerminalRequest(params);
+      if (decision.decision === "deny") {
+        options.onDenial?.(decision);
+        throw RequestError.authRequired(
+          workerTerminalDenialMeta(decision),
+          workerTerminalDenialMessage(decision),
+        );
+      }
+      minted += 1;
+      const terminalId = `worker-terminal-${minted}`;
+      const child = spawn(params.command, [...(params.args ?? [])], {
+        cwd: params.cwd ?? options.cwd,
+        env: { ...options.env, ...declaredEnv(params) },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const terminal: HeldTerminal = {
+        child,
+        limit: params.outputByteLimit ?? DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT,
+        chunks: [],
+        bytes: 0,
+        truncated: false,
+        exit: undefined,
+        exited: new Promise<void>((resolve) => {
+          child.once("error", () => {
+            terminal.exit = { exitCode: null, signal: null };
+            resolve();
+          });
+          child.once("close", (code, signal) => {
+            terminal.exit = { exitCode: code, signal: signal ?? null };
+            resolve();
+          });
+        }),
+      };
+      for (const stream of [child.stdout, child.stderr]) {
+        stream?.on("data", (chunk: Buffer) => retain(terminal, chunk));
+      }
+      terminals.set(terminalId, terminal);
+      return { terminalId };
+    },
+
+    output(params) {
+      const terminal = held(params.terminalId);
+      return {
+        output: Buffer.concat(terminal.chunks).toString("utf8"),
+        truncated: terminal.truncated,
+        ...(terminal.exit == null ? {} : { exitStatus: terminal.exit }),
+      };
+    },
+
+    async waitForExit(params) {
+      const terminal = held(params.terminalId);
+      await terminal.exited;
+      return terminal.exit ?? { exitCode: null, signal: null };
+    },
+
+    kill(params) {
+      held(params.terminalId).child.kill();
+      return {};
+    },
+
+    release(params) {
+      const terminal = held(params.terminalId);
+      terminals.delete(params.terminalId);
+      if (terminal.exit == null) terminal.child.kill();
+      return {};
+    },
+
+    closeAll() {
+      for (const terminal of terminals.values()) {
+        if (terminal.exit == null) terminal.child.kill();
+      }
+      terminals.clear();
+    },
+  };
+}
+
+/**
+ * Keep the tail of the output within the caller's byte limit.
+ *
+ * Trimming happens from the FRONT, per ACP: a command's last words are the ones
+ * that say how it ended. The trim then advances to the next UTF-8 lead byte, so
+ * a multi-byte character cut in half never reaches the agent as a replacement
+ * character it will try to interpret.
+ */
+function retain(terminal: HeldTerminal, chunk: Buffer): void {
+  terminal.chunks.push(chunk);
+  terminal.bytes += chunk.byteLength;
+  if (terminal.bytes <= terminal.limit) return;
+  terminal.truncated = true;
+  let joined = Buffer.concat(terminal.chunks);
+  let start = joined.byteLength - terminal.limit;
+  while (start < joined.byteLength && (joined[start]! & 0xc0) === 0x80) start += 1;
+  joined = joined.subarray(start);
+  terminal.chunks = [joined];
+  terminal.bytes = joined.byteLength;
+}
+
+/**
+ * The variables the request itself declares, minus every credential name.
+ *
+ * The inner agent has no credential to inject, so the filter buys nothing
+ * today; it exists so that the ONE place a child-named environment enters a
+ * Worker-spawned process is the same place that already refuses those names.
+ */
+function declaredEnv(params: CreateTerminalRequest): Record<string, string> {
+  const declared: Record<string, string> = {};
+  for (const variable of params.env ?? []) {
+    if (isCredentialEnvironmentName(variable.name)) continue;
+    declared[variable.name] = variable.value;
+  }
+  return declared;
+}

--- a/packages/worker/src/acp/terminal-policy.test.ts
+++ b/packages/worker/src/acp/terminal-policy.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateWorkerTerminalRequest,
+  shellSegments,
+  workerTerminalDenialMessage,
+  workerTerminalDenialMeta,
+  type WorkerTerminalDenial,
+} from "./terminal-policy.js";
+
+function deny(command: string, ...args: string[]): WorkerTerminalDenial {
+  const decision = evaluateWorkerTerminalRequest({ command, args });
+  if (decision.decision !== "deny") throw new Error(`expected \`${command}\` to be refused`);
+  return decision;
+}
+
+function allows(command: string, ...args: string[]): boolean {
+  return evaluateWorkerTerminalRequest({ command, args }).decision === "allow";
+}
+
+describe("the Worker's terminal policy", () => {
+  it("refuses publication and names the authority that owns it", () => {
+    expect(deny("git", "push", "origin", "HEAD").reason).toBe("publication-is-parent-owned");
+    expect(deny("git", "push").remedy).toContain("publish the branch and commit");
+  });
+
+  it("refuses every forge CLI", () => {
+    expect(deny("gh", "pr", "create", "--fill").reason).toBe("forge-cli-is-parent-owned");
+    expect(deny("gh", "api", "repos/reddb-io/red-skills").reason).toBe("forge-cli-is-parent-owned");
+    expect(deny("glab", "mr", "create").reason).toBe("forge-cli-is-parent-owned");
+  });
+
+  it("refuses the other authenticated remote reaches", () => {
+    expect(deny("git", "fetch", "origin").reason).toBe("credentialed-remote-is-parent-owned");
+    expect(deny("git", "credential", "fill").reason).toBe("credentialed-remote-is-parent-owned");
+    expect(deny("ssh", "git@github.com").reason).toBe("credentialed-remote-is-parent-owned");
+  });
+
+  // The inner agent's whole job is edits and commits, so a policy that refused
+  // `git` would refuse the work rather than the authority.
+  it("allows the ordinary work of a turn", () => {
+    expect(allows("pnpm", "test")).toBe(true);
+    expect(allows("pnpm", "-C", "apps/dev", "test:invariants")).toBe(true);
+    expect(allows("git", "add", "--", "src/index.ts")).toBe(true);
+    expect(allows("git", "commit", "-m", "Refs #4016")).toBe(true);
+    expect(allows("git", "status", "--short")).toBe(true);
+    expect(allows("git", "log", "--oneline", "origin/main..HEAD")).toBe(true);
+  });
+
+  it("reads the same command through a shell, an absolute path and an env prefix", () => {
+    expect(deny("bash", "-lc", "git push origin HEAD").reason).toBe("publication-is-parent-owned");
+    expect(deny("sh", "-c", "pnpm build && gh release create").reason).toBe("forge-cli-is-parent-owned");
+    expect(deny("/usr/bin/git", "push").reason).toBe("publication-is-parent-owned");
+    expect(deny("env", "GIT_TERMINAL_PROMPT=0", "git", "push").reason).toBe("publication-is-parent-owned");
+    expect(deny("git", "-C", "/worktree", "push").reason).toBe("publication-is-parent-owned");
+    expect(deny("bash", "-lc", "echo start; gh pr view 1").reason).toBe("forge-cli-is-parent-owned");
+    expect(deny("bash", "-lc", "echo $(gh pr view 1)").reason).toBe("forge-cli-is-parent-owned");
+  });
+
+  // A refusal nobody predicted is a rule the agent stops believing, so a commit
+  // message that merely MENTIONS a refused command stays ordinary work.
+  it("does not refuse a quoted mention of a refused command", () => {
+    expect(allows("git", "commit", "-m", "prepare for git push")).toBe(true);
+    expect(allows("bash", "-lc", 'git commit -m "ready to gh pr create && push"')).toBe(true);
+    expect(allows("bash", "-lc", "echo 'git push is the parent\\'s'")).toBe(true);
+  });
+
+  it("splits a shell script on its operators and not inside its quotes", () => {
+    expect(shellSegments('git commit -m "a && b"; pnpm test'))
+      .toEqual(["git commit -m a && b", " pnpm test"]);
+  });
+
+  it("carries the reason, the command and the route in the payload the agent reads", () => {
+    const denial = deny("gh", "pr", "create");
+
+    expect(workerTerminalDenialMeta(denial)).toEqual({
+      redskills: {
+        terminalPolicy: {
+          decision: "deny",
+          reason: "forge-cli-is-parent-owned",
+          command: "gh pr create",
+          what: "a GitHub CLI call",
+          remedy: denial.remedy,
+        },
+      },
+    });
+    expect(workerTerminalDenialMessage(denial)).toContain("forge-cli-is-parent-owned");
+    expect(workerTerminalDenialMessage(denial)).toContain("gh pr create");
+  });
+});

--- a/packages/worker/src/acp/terminal-policy.ts
+++ b/packages/worker/src/acp/terminal-policy.ts
@@ -1,0 +1,299 @@
+/**
+ * The Worker's terminal policy: the inner agent only edits and commits.
+ *
+ * ADR 0148 states the contract and ADR 0144 §3 says why: no credential ever
+ * reaches the process that runs the model, so every operation that would need
+ * one — publishing a branch, anything `gh`, any authenticated remote — is the
+ * ACP parent's. The inner agent learns that by being REFUSED WITH A REASON it
+ * can read, rather than by watching `git push` fail on a missing credential and
+ * spending its turn inventing workarounds.
+ *
+ * **This is a teacher, not a sandbox.** Containment is that the Worker's
+ * environment holds no credential at all (`credentialFreeEnv`); a sufficiently
+ * creative `xargs` still reaches `git push` and still finds nothing to push
+ * with. So the table below is small, explicit and named after the AUTHORITY
+ * each entry belongs to, because a rule the agent can predict is a rule it
+ * stops testing.
+ */
+
+/** Which authority owns the refused operation. The agent reads this verbatim. */
+export type WorkerTerminalDenialReason =
+  /** Publishing a branch: the Worker asks its parent after the turn. */
+  | "publication-is-parent-owned"
+  /** Any forge CLI: redskilled is the Project's only GitHub gateway. */
+  | "forge-cli-is-parent-owned"
+  /** Any other authenticated remote reach: the Worker holds no credential. */
+  | "credentialed-remote-is-parent-owned";
+
+export interface WorkerTerminalDenial {
+  readonly decision: "deny";
+  readonly reason: WorkerTerminalDenialReason;
+  /** The simple command that tripped the policy, re-joined for the agent to see. */
+  readonly command: string;
+  /** What the refused command would have done, in one noun phrase. */
+  readonly what: string;
+  /** What to do instead, named concretely enough to act on. */
+  readonly remedy: string;
+}
+
+export interface WorkerTerminalAllowance {
+  readonly decision: "allow";
+}
+
+export type WorkerTerminalDecision = WorkerTerminalAllowance | WorkerTerminalDenial;
+
+export interface WorkerTerminalRequest {
+  readonly command: string;
+  readonly args?: readonly string[];
+}
+
+/** One refused program, or one refused subcommand family of a program. */
+interface DeniedProgram {
+  /** Program basename, lowercased, without a Windows executable suffix. */
+  readonly program: string;
+  /** Absent means the whole program is refused; present narrows it to these. */
+  readonly subcommands?: readonly string[];
+  readonly reason: WorkerTerminalDenialReason;
+  readonly what: string;
+}
+
+/**
+ * What the Worker refuses, as data.
+ *
+ * `git` is split by subcommand because refusing the program would refuse the
+ * inner agent's actual job — `git add`, `git commit`, `git diff`, `git log` are
+ * the whole point. Every entry below is a subcommand that talks to a remote.
+ */
+export const WORKER_DENIED_TERMINAL_PROGRAMS: readonly DeniedProgram[] = [
+  {
+    program: "git",
+    subcommands: ["push"],
+    reason: "publication-is-parent-owned",
+    what: "publishing commits to the Project remote",
+  },
+  {
+    program: "git",
+    subcommands: [
+      "fetch",
+      "pull",
+      "clone",
+      "remote",
+      "ls-remote",
+      "submodule",
+      "send-email",
+      "request-pull",
+      "credential",
+      "credential-cache",
+      "credential-store",
+    ],
+    reason: "credentialed-remote-is-parent-owned",
+    what: "an authenticated git operation against a remote",
+  },
+  { program: "gh", reason: "forge-cli-is-parent-owned", what: "a GitHub CLI call" },
+  { program: "glab", reason: "forge-cli-is-parent-owned", what: "a GitLab CLI call" },
+  { program: "hub", reason: "forge-cli-is-parent-owned", what: "a GitHub CLI call" },
+  { program: "ssh", reason: "credentialed-remote-is-parent-owned", what: "an authenticated SSH session" },
+  { program: "scp", reason: "credentialed-remote-is-parent-owned", what: "an authenticated remote copy" },
+  { program: "sftp", reason: "credentialed-remote-is-parent-owned", what: "an authenticated remote transfer" },
+];
+
+const REMEDIES: Readonly<Record<WorkerTerminalDenialReason, string>> = {
+  "publication-is-parent-owned":
+    "Commit locally and finish the turn; the Worker asks its ACP parent to publish the branch and commit afterwards.",
+  "forge-cli-is-parent-owned":
+    "Ask the ACP parent instead: redskilled is the Project's only GitHub gateway and this process holds no token.",
+  "credentialed-remote-is-parent-owned":
+    "Ask the ACP parent instead: this process holds no credential, so the operation can only succeed there.",
+};
+
+/** Shells whose `-c` script is a command line, not an argument. */
+const SHELL_PROGRAMS: readonly string[] = ["sh", "bash", "zsh", "dash", "ksh", "fish", "pwsh", "powershell"];
+
+/** Programs that run another program: the real head is further along the argv. */
+const WRAPPER_PROGRAMS: readonly string[] = ["env", "sudo", "nohup", "command", "exec", "nice", "stdbuf"];
+
+/**
+ * Decide one `terminal/create` request.
+ *
+ * Shell invocations are opened, because `bash -lc "git push"` is the same
+ * operation with one more layer, and an agent that discovers the layer works
+ * has learned the opposite of the contract. Quoting is respected while doing it:
+ * refusing `git commit -m "ready for gh pr create"` would teach a rule nobody
+ * meant and is exactly the false refusal that makes an agent distrust the whole
+ * policy.
+ */
+export function evaluateWorkerTerminalRequest(request: WorkerTerminalRequest): WorkerTerminalDecision {
+  for (const simple of simpleCommands([request.command, ...(request.args ?? [])])) {
+    const denial = refuse(simple);
+    if (denial != null) return denial;
+  }
+  return { decision: "allow" };
+}
+
+/** The typed payload a refusal carries back over ACP, under `_meta.redskills`. */
+export function workerTerminalDenialMeta(denial: WorkerTerminalDenial): Record<string, unknown> {
+  return {
+    redskills: {
+      terminalPolicy: {
+        decision: "deny",
+        reason: denial.reason,
+        command: denial.command,
+        what: denial.what,
+        remedy: denial.remedy,
+      },
+    },
+  };
+}
+
+/** One line stating the refusal, its reason and its route, for the agent to read. */
+export function workerTerminalDenialMessage(denial: WorkerTerminalDenial): string {
+  return `${denial.reason}: the Worker refuses \`${denial.command}\` — ${denial.what} is the ACP parent's. ${denial.remedy}`;
+}
+
+function refuse(tokens: readonly string[]): WorkerTerminalDenial | null {
+  const head = headOf(tokens);
+  if (head == null) return null;
+  const program = programName(tokens[head.index] ?? "");
+  const subcommand = subcommandOf(program, tokens.slice(head.index + 1));
+  for (const denied of WORKER_DENIED_TERMINAL_PROGRAMS) {
+    if (denied.program !== program) continue;
+    if (denied.subcommands != null && (subcommand == null || !denied.subcommands.includes(subcommand))) {
+      continue;
+    }
+    return {
+      decision: "deny",
+      reason: denied.reason,
+      command: tokens.slice(head.index).join(" "),
+      what: denied.what,
+      remedy: REMEDIES[denied.reason],
+    };
+  }
+  return null;
+}
+
+/**
+ * Where the real program starts, past wrappers and `NAME=value` prefixes.
+ *
+ * `env GIT_TERMINAL_PROMPT=0 git push` names three tokens before the operation
+ * this policy is about, and reading the first one would call it `env`.
+ */
+function headOf(tokens: readonly string[]): { readonly index: number } | null {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index] ?? "";
+    if (token === "") continue;
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) continue;
+    if (token.startsWith("-")) continue;
+    if (WRAPPER_PROGRAMS.includes(programName(token))) continue;
+    return { index };
+  }
+  return null;
+}
+
+/** The first token past the program's own options — `git -C dir push` is a push. */
+function subcommandOf(program: string, rest: readonly string[]): string | null {
+  if (program !== "git") return rest.find((token) => !token.startsWith("-")) ?? null;
+  // `git`'s pre-command options are the reason this is not `rest[0]`: `-C`, `-c`
+  // and `--git-dir` each swallow or carry a value that is not the subcommand.
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index] ?? "";
+    if (token === "-C" || token === "-c" || token === "--namespace" || token === "--exec-path") {
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) continue;
+    return token;
+  }
+  return null;
+}
+
+function programName(token: string): string {
+  const base = token.split(/[/\\]/).pop() ?? token;
+  return base.replace(/\.(?:exe|cmd|bat|com)$/i, "").toLowerCase();
+}
+
+/**
+ * Every simple command the request would run, argv first and shell scripts too.
+ *
+ * A non-shell invocation is one simple command: its own argv. A shell `-c`
+ * script is however many its operators separate.
+ */
+function simpleCommands(argv: readonly string[]): readonly (readonly string[])[] {
+  const simple: (readonly string[])[] = [argv];
+  const program = programName(argv[0] ?? "");
+  if (!SHELL_PROGRAMS.includes(program)) return simple;
+  for (const script of shellScripts(argv.slice(1))) {
+    for (const segment of shellSegments(script)) simple.push(tokenize(segment));
+  }
+  return simple;
+}
+
+/** The argument of each `-c`-shaped flag; a shell may take more than one. */
+function shellScripts(rest: readonly string[]): readonly string[] {
+  const scripts: string[] = [];
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index] ?? "";
+    const next = rest[index + 1];
+    if (token === "--command" || /^-[a-z]*c$/i.test(token) || /^\/[cC]$/.test(token)) {
+      if (next != null) {
+        scripts.push(next);
+        index += 1;
+      }
+    }
+  }
+  return scripts;
+}
+
+/**
+ * Split a shell script into its simple commands, respecting quotes.
+ *
+ * Quote awareness is the whole value: splitting naively turns a commit message
+ * mentioning `&&` into a second command, and the resulting refusal is one no
+ * rule in this module explains.
+ */
+export function shellSegments(script: string): readonly string[] {
+  const segments: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  for (let index = 0; index < script.length; index += 1) {
+    const char = script[index]!;
+    if (quote != null) {
+      if (char === "\\" && quote === '"') {
+        current += char + (script[index + 1] ?? "");
+        index += 1;
+        continue;
+      }
+      if (char === quote) quote = null;
+      else current += char;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === "\\") {
+      current += script[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+    // `$(` and a backtick open a command substitution: what follows is another
+    // command line, so the boundary is the same boundary as `;`.
+    if (char === "$" && script[index + 1] === "(") {
+      segments.push(current);
+      current = "";
+      index += 1;
+      continue;
+    }
+    if (";|&\n()`".includes(char)) {
+      segments.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  segments.push(current);
+  return segments.filter((segment) => segment.trim() !== "");
+}
+
+function tokenize(segment: string): readonly string[] {
+  return segment.trim().split(/\s+/).filter((token) => token !== "");
+}

--- a/packages/worker/src/acp/worker-terminal-and-publish.test.ts
+++ b/packages/worker/src/acp/worker-terminal-and-publish.test.ts
@@ -1,0 +1,188 @@
+// The two halves of the contract, proved across a real ACP connection: the
+// inner agent is REFUSED `git push` and `gh` with a reason it can read, and the
+// Worker keeps the promise that refusal made by asking its parent to publish
+// after the turn (issue #4016, ADR 0148, ADR 0144 §3).
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { Server, Socket } from "node:net";
+import {
+  client,
+  methods,
+  type AgentConnection,
+} from "@agentclientprotocol/sdk";
+import {
+  ACP_PROTOCOL_VERSION,
+  REDSKILLS_ACP_METHODS,
+  REDSKILLS_WIRE_MAJOR,
+  bindWorkerRendezvous,
+  closeServer,
+  removeAcpEndpoint,
+  socketStream,
+  type RedskilledGithubWriteRequest,
+} from "@reddb-io/protocol-acp";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { WorkflowChildAgent } from "./child-agent.js";
+import { runNativeAcpWorker } from "./native-worker.js";
+
+const childFixture = resolve(__dirname, "fixtures", "terminal-policy-child.mjs");
+const roots: string[] = [];
+const servers: Server[] = [];
+const sockets: Socket[] = [];
+
+afterEach(async () => {
+  for (const socket of sockets.splice(0)) socket.destroy();
+  for (const server of servers.splice(0)) await closeServer(server);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+interface StubTerminalOutcome {
+  readonly command: string;
+  readonly allowed: boolean;
+  readonly exitCode?: number | null;
+  readonly output?: string;
+  readonly message?: string;
+  readonly data?: unknown;
+}
+
+/** A Worktree with one commit, which is what the inner agent is allowed to leave. */
+async function committedWorktree(prefix: string, branch: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  const git = (...args: string[]) => execFileSync("git", args, { cwd: root, stdio: "pipe" });
+  git("init", "--initial-branch", branch);
+  git("config", "user.email", "worker@example.invalid");
+  git("config", "user.name", "Worker");
+  await writeFile(join(root, "edited.txt"), "only edits and commits\n");
+  git("add", "--", "edited.txt");
+  git("commit", "-m", "Refs #4016");
+  return root;
+}
+
+describe("a child Agent asking the Worker for terminals", () => {
+  it("is refused git push and gh with the typed reason, and allowed ordinary work", async () => {
+    const cwd = await committedWorktree("worker-terminal-policy-", "afk/4016");
+    const notices: unknown[] = [];
+    const parent = {
+      notify: async (_method: string, params: unknown) => void notices.push(params),
+      request: async () => ({}),
+    } as unknown as AgentConnection["client"];
+    const child = new WorkflowChildAgent({
+      endpoint: { agent: "redcode", transport: "stdio", command: process.execPath, args: [childFixture] },
+      cwd,
+      mcpServers: [],
+      publicSessionId: "public-session",
+      parent,
+    });
+
+    try {
+      const response = await child.prompt({
+        sessionId: "public-session",
+        prompt: [{
+          type: "text",
+          text: [
+            "run git :: push :: origin :: HEAD",
+            "run gh :: pr :: create :: --fill",
+            `run ${process.execPath} :: -e :: process.stdout.write('terminal-ok')`,
+          ].join("\n"),
+        }],
+      });
+
+      const terminals = (response._meta as {
+        stub?: { terminals?: readonly StubTerminalOutcome[] };
+      } | undefined)?.stub?.terminals ?? [];
+      expect(terminals).toHaveLength(3);
+
+      const [push, forge, ordinary] = terminals;
+      expect(push?.allowed).toBe(false);
+      expect(push?.message).toContain("publication-is-parent-owned");
+      expect(forge?.allowed).toBe(false);
+      expect(forge?.message).toContain("forge-cli-is-parent-owned");
+      expect(ordinary?.allowed).toBe(true);
+      expect(ordinary?.exitCode).toBe(0);
+      expect(ordinary?.output).toBe("terminal-ok");
+    } finally {
+      child.close();
+    }
+
+    // The refusal is not only the child's problem: the parent is told what the
+    // policy taught, so a Worker log holds the lesson after the process is gone.
+    const denials = notices.filter((notice) => (notice as {
+      _meta?: { redskills?: { terminalPolicy?: unknown } };
+    })._meta?.redskills?.terminalPolicy != null);
+    expect(denials).toHaveLength(2);
+  }, 30_000);
+});
+
+describe("a Worker finishing a prompt turn", () => {
+  it("asks its parent to publish exactly once, naming the branch and the commit", async () => {
+    const root = await mkdtemp(join(tmpdir(), "worker-publish-turn-"));
+    roots.push(root);
+    const socketPath = join(root, "worker.sock");
+    const cwd = await committedWorktree("worker-publish-worktree-", "afk/4016-publish");
+    const published: RedskilledGithubWriteRequest[] = [];
+
+    const rendezvous = await bindWorkerRendezvous(socketPath);
+    servers.push(rendezvous.server);
+    const worker = runNativeAcpWorker(socketPath, {
+      agent: "redcode",
+      transport: "stdio",
+      command: process.execPath,
+      args: [childFixture],
+    });
+    const socket = await rendezvous.connected;
+    sockets.push(socket);
+    // Not awaited: `close(cb)` only calls back once every accepted connection
+    // has ended, and the one just accepted is the Worker's for the whole test.
+    rendezvous.server.close();
+
+    const parent = client({ name: "stub parent" })
+      .onNotification(methods.client.session.update, () => undefined)
+      .onRequest(
+        REDSKILLS_ACP_METHODS.githubWrite,
+        (value: unknown) => value as RedskilledGithubWriteRequest,
+        ({ params }) => {
+          published.push(params);
+          return { receipt: "stub" };
+        },
+      );
+    const connection = parent.connect(socketStream(socket));
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: ACP_PROTOCOL_VERSION,
+        clientCapabilities: {},
+        clientInfo: { name: "stub parent", version: "1" },
+        _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR } },
+      });
+      const session = await connection.agent.request(methods.agent.session.new, { cwd, mcpServers: [] });
+      const response = await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "complete workflow" }],
+      });
+
+      expect(response.stopReason).toBe("end_turn");
+      expect(published).toHaveLength(1);
+      expect(published[0]!.write).toEqual({
+        kind: "repository-push",
+        ref: "afk/4016-publish",
+        sha: expect.stringMatching(/^[0-9a-f]{40}$/),
+      });
+      expect(published[0]!.idempotency_key).toContain(session.sessionId);
+
+      // A second turn that committed nothing new is not a second publication.
+      await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "complete workflow again" }],
+      });
+      expect(published).toHaveLength(1);
+    } finally {
+      connection.close();
+      socket.destroy();
+      await worker;
+      await removeAcpEndpoint(socketPath);
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
Automated AFK landing for #4016. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #4016

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789708635&installation_model_id=20659&pr_number=4055&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4055&signature=9a15a9f71cd09ce6cb14b807a24d7b8f9ab141d44ceaa82d4d2e8a3cc9d126c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->