### PR TITLE
fix: #4017 Worker workspaces under the OS temporary directory, RED_MODE exported, workspace deleted on death

### DIFF
--- a/apps/dev/src/core/working-mode-guard.ts
+++ b/apps/dev/src/core/working-mode-guard.ts
@@ -34,12 +34,12 @@
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, sep } from "node:path";
+import { WORKING_MODES, type WorkingMode } from "@reddb-io/shared/working-mode.js";
 
-/** The four Working modes ADR 0150 §1 declares, in the ADR's own order. */
-export const WORKING_MODES = ["interactive", "spec-driven", "ad-hoc", "ADR-editing"] as const;
-
-/** One of the four ways work enters RedSkills. */
-export type WorkingMode = (typeof WORKING_MODES)[number];
+// The closed set lives in `@reddb-io/shared` because the daemon reads it too:
+// it exports the mode a Worker runs in as `RED_MODE`, and a marker that did not
+// spell a mode exactly the way a header declares it would never match.
+export { WORKING_MODES, type WorkingMode };
 
 /** The frontmatter key that carries the declaration. */
 export const WORKING_MODE_KEY = "working-mode";

--- a/apps/dev/tests/tmp-janitor-daemon-reclaim.test.ts
+++ b/apps/dev/tests/tmp-janitor-daemon-reclaim.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  classifyWorkerArtifact,
   planWorkerReclaim,
   type WorkerArtifact,
   type WorkerProcessVerdict,
@@ -20,6 +21,7 @@ import {
   runTmpJanitor,
 } from "../src/runtime/tmp-janitor.js";
 import type { DaemonWorkerSetReader } from "../src/runtime/liveness-anchor.js";
+import { workerWorkspaceRoot, workerWorktreePath } from "@reddb-io/redskilled/worker-workspace";
 
 const NOW = 1_800_000_000;
 const NOW_ISO = new Date(NOW * 1000).toISOString();
@@ -266,6 +268,30 @@ describe("the reclaim planner stays total", () => {
       "pointer-retained",
       "unclassified",
     ]);
+  });
+
+  it("still calls the daemon's OS-temporary workspace a workspace after ADR 0149 moved it", () => {
+    // The lane moved out of the client checkout and into `os.tmpdir()`; the
+    // COST did not change, and the cost is what the rule reads. A relocated
+    // workspace that stopped classifying as one is a lane nothing ever reclaims.
+    const worktree = workerWorktreePath(workerWorkspaceRoot({ tmpDir: "/tmp", uid: 1000 }), "0aBcDeF");
+    expect(worktree).toBe("/tmp/red-skills-1000/workers/0aBcDeF/worktree");
+    expect(classifyWorkerArtifact("worktree")).toBe("workspace");
+
+    const plan = planWorkerReclaim(
+      [{ worker_id: "0aBcDeF", kind: "worktree", path: worktree }],
+      { liveness: dead, nowIso: NOW_ISO },
+    );
+
+    expect(plan.reclaim).toEqual([
+      expect.objectContaining({
+        class: "workspace",
+        reclaim: true,
+        verdict: "workspace-reclaimable",
+        artifact: expect.objectContaining({ path: worktree }),
+      }),
+    ]);
+    expect(plan.totals).toEqual({ considered: 1, reclaim: 1, retain: 0, dropped: 0 });
   });
 
   it("reports a path no Worker accounts for instead of touching it", () => {

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -34,6 +34,7 @@
     "./supervision": "./src/supervision.ts",
     "./worker-display": "./src/worker-display.ts",
     "./worker-launch": "./src/worker-launch.ts",
+    "./worker-workspace": "./src/worker-workspace.ts",
     "./statusline-command": "./src/statusline-command.ts"
   },
   "description": "redskilled — the host-scoped RedSkills control plane: one singleton per machine owns Project control state and Worker lifecycle.",

--- a/apps/redskilled/src/acp-connection-methods.ts
+++ b/apps/redskilled/src/acp-connection-methods.ts
@@ -195,6 +195,7 @@ function goAdmission(deps: ConnectionMethodDeps, dialect: GoDialect) {
   return createGoWorkerAdmission({
     paths: deps.paths,
     startWorker: deps.startWorker,
+    hostState: deps.hostState,
     sessionJournal: deps.sessionJournal,
     sessions: deps.sessions,
     active: deps.active,

--- a/apps/redskilled/src/acp-go-admission.ts
+++ b/apps/redskilled/src/acp-go-admission.ts
@@ -30,6 +30,12 @@ import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
 export interface GoWorkerAdmissionDeps {
   readonly paths: RedskilledPaths;
   readonly startWorker: (spec: RedskilledWorkerSpec) => LaunchedWorker;
+  /**
+   * The Workers this host already holds. An ad-hoc dispatch mints its id from
+   * the same live set every other birth does, because two Workers born inside
+   * one millisecond would otherwise be handed one workspace directory.
+   */
+  readonly hostState: () => { readonly workers: readonly { readonly worker_id: string }[] };
   readonly sessionJournal: AcpSessionJournal;
   /** This connection's public sessions; a dispatch mints one of its own. */
   readonly sessions: Map<string, PublicSession>;
@@ -66,7 +72,7 @@ export function createGoWorkerAdmission(deps: GoWorkerAdmissionDeps) {
     let worker: ActiveWorkflowWorker;
     try {
       worker = await admitNativeAcpWorker(
-        { paths: deps.paths, startWorker: deps.startWorker },
+        { paths: deps.paths, startWorker: deps.startWorker, hostState: deps.hostState },
         deps.sessionJournal,
         session,
         sessionId,

--- a/apps/redskilled/src/acp-worker-admission.ts
+++ b/apps/redskilled/src/acp-worker-admission.ts
@@ -36,9 +36,16 @@ import {
   type AcpSessionJournal,
 } from "./acp-session-journal.js";
 import type { AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
+import { workerModeEnv } from "@reddb-io/shared/working-mode.js";
 import { resolveAcpWorkerEndpoint, type RedskilledPaths } from "./paths.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
-import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
+import { mintHostWorkerId, type LaunchedWorker, type RedskilledWorkerSpec } from "./worker-launch.js";
+import {
+  materializeWorkerWorkspace,
+  releaseWorkerWorkspace,
+  workerWorkspaceRoot,
+  type MaterializedWorkerWorkspace,
+} from "./worker-workspace.js";
 import type { ActiveWorkflowWorker } from "./acp-worker-lifecycle.js";
 
 interface NativeWorkerSession {
@@ -49,6 +56,17 @@ interface NativeWorkerSession {
 interface NativeWorkerAdmissionOptions {
   readonly paths: RedskilledPaths;
   readonly startWorker: (spec: RedskilledWorkerSpec) => LaunchedWorker;
+  /**
+   * The Workers this host already holds, so the minted id does not collide.
+   *
+   * The id is minted HERE rather than inside the launch, because the workspace
+   * is named after it and has to exist before the process that stands in it
+   * (ADR 0149 §3). Absent, the mint sees an empty live set — legal, since the id
+   * is the birth instant and a collision walks it forward.
+   */
+  readonly hostState?: () => { readonly workers: readonly { readonly worker_id: string }[] };
+  /** The host root Worker workspaces hang off. Defaults to the OS temporary root. */
+  readonly workspaceRoot?: string;
 }
 
 export async function admitNativeAcpWorker(
@@ -63,23 +81,37 @@ export async function admitNativeAcpWorker(
 ): Promise<ActiveWorkflowWorker> {
   const endpointId = randomBytes(6).toString("hex");
   const endpoint = resolveAcpWorkerEndpoint(options.paths, endpointId);
+  // The workspace is named after the id and has to exist before the process
+  // that stands in it, so the mint happens here rather than inside the launch.
+  const workerId = mintHostWorkerId((options.hostState?.().workers ?? []).map((worker) => worker.worker_id));
+  const workspace = await materializeWorkerWorkspace({
+    root: options.workspaceRoot ?? workerWorkspaceRoot(),
+    workerId,
+    projectWorkspacePath: session.project.workspacePath,
+  });
   const rendezvous = await bindWorkerRendezvous(endpoint);
-  let launched: LaunchedWorker;
-  try {
-    launched = options.startWorker(nativeWorkerSpec(session.project, endpoint, options.paths.runtimeDir));
-  } catch (error) {
+  // Every failure from here on releases the workspace: a Worker that never
+  // reached its rendezvous still cost a clone, and nothing else knows it exists.
+  const abandon = async (error: unknown): Promise<never> => {
     rendezvous.server.close();
     await removeAcpEndpoint(endpoint);
+    await releaseWorkerWorkspace(workspace).catch(() => undefined);
     throw error;
+  };
+  let launched: LaunchedWorker;
+  try {
+    launched = options.startWorker(
+      nativeWorkerSpec(session.project, workspace, endpoint, options.paths.runtimeDir, dispatch?.workerKind),
+    );
+  } catch (error) {
+    return await abandon(error);
   }
 
   let workerSocket: Socket;
   try {
     workerSocket = await withTimeout(rendezvous.connected, 10_000, "native ACP Worker rendezvous");
   } catch (error) {
-    rendezvous.server.close();
-    await removeAcpEndpoint(endpoint);
-    throw error;
+    return await abandon(error);
   }
   rendezvous.server.close();
 
@@ -139,7 +171,7 @@ export async function admitNativeAcpWorker(
         },
       };
     const downstreamSession = await connection.agent.request(methods.agent.session.new, {
-      cwd: session.project.workspacePath,
+      cwd: workspace.worktreePath,
       mcpServers: session.request.mcpServers as McpServer[],
       ...(session.request.additionalDirectories == null
         ? {}
@@ -156,11 +188,13 @@ export async function admitNativeAcpWorker(
     connection.close();
     workerSocket.destroy();
     await removeAcpEndpoint(endpoint);
+    await releaseWorkerWorkspace(workspace).catch(() => undefined);
     throw error;
   }
 
   return {
     workerId: launched.worker.worker_id,
+    workspace,
     downstreamSessionId,
     connection,
     socket: workerSocket,
@@ -175,17 +209,26 @@ export async function admitNativeAcpWorker(
 
 function nativeWorkerSpec(
   project: AcpProjectWorkspace,
+  workspace: MaterializedWorkerWorkspace,
   endpoint: string,
   runtimeDir: string,
+  workerKind: "afk" | "go" | "scout" | undefined,
 ): RedskilledWorkerSpec {
   const entry = process.argv[1];
   if (entry == null || entry === "") throw new Error("redskilled cannot resolve its Worker entry");
   const childAgent = pinChildAgentExecutable(defaultChildAgentEndpoint());
   return {
+    worker_id: workspace.workerId,
     // The host's authority key must survive a repository rename. The current
     // GitHub full name remains display metadata on the public session.
     project_label: project.projectId,
-    workspace_path: project.workspacePath,
+    // The Worker stands in ITS OWN worktree in temporary storage (ADR 0149 §1);
+    // the Project workspace is what that worktree was forked from, never a cwd
+    // two Workers could share.
+    workspace_path: workspace.worktreePath,
+    // ADR 0150 §2: the run declares its Working mode, so a skill written for a
+    // human's checkout refuses inside a Worker instead of running there.
+    env: workerModeEnv(workerKind),
     command: process.execPath,
     args: [
       ...process.execArgv,

--- a/apps/redskilled/src/acp-worker-lifecycle.ts
+++ b/apps/redskilled/src/acp-worker-lifecycle.ts
@@ -9,6 +9,7 @@ import {
 import type { AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
 import { removeAcpEndpoint } from "@reddb-io/protocol-acp";
 import { redskilledMetrics } from "./telemetry-metrics.js";
+import { releaseWorkerWorkspace, type MaterializedWorkerWorkspace } from "./worker-workspace.js";
 
 export interface ActiveWorkflowWorker {
   readonly workerId: string;
@@ -18,6 +19,14 @@ export interface ActiveWorkflowWorker {
   readonly endpoint: string;
   readonly publicSessionId: string;
   readonly notify: AgentConnection["client"]["notify"];
+  /**
+   * The OS-temporary workspace this Worker stands in, released when it dies.
+   *
+   * Held on the handle rather than looked up at cleanup time: the daemon is the
+   * only thing that knows this directory exists, so a Worker whose handle is
+   * dropped without it is bytes nobody will ever attribute again (ADR 0149 §1).
+   */
+  readonly workspace?: MaterializedWorkerWorkspace;
   readonly dispatch?: AcpTargetedDispatchIntent;
   idleTimer?: NodeJS.Timeout;
   cancelled: boolean;
@@ -93,6 +102,10 @@ export function cleanupWorkflowWorker(
   worker.connection.close();
   worker.socket.destroy();
   void removeAcpEndpoint(worker.endpoint);
+  // The workspace goes with the Worker. It is expensive and regenerable, and
+  // deleting it costs no conscience precisely because nothing a human returns to
+  // was ever written there (ADR 0149 §1).
+  if (worker.workspace != null) void releaseWorkerWorkspace(worker.workspace).catch(() => undefined);
 }
 
 export function workerTransportIsClosed(worker: ActiveWorkflowWorker): boolean {

--- a/apps/redskilled/src/worker-workspace.ts
+++ b/apps/redskilled/src/worker-workspace.ts
@@ -1,0 +1,213 @@
+/**
+ * worker-workspace — where a Worker's bytes live, and who deletes them.
+ *
+ * ADR 0149 §1: **a Worker's workspace is created by the daemon under the OS
+ * temporary directory**, `os.tmpdir()/red-skills-<uid>/workers/<id>/`, forked
+ * from the daemon-owned Project workspace. Nothing a Worker writes lands in the
+ * human's checkout, and the daemon deletes the whole directory when the Worker
+ * dies.
+ *
+ * The move is not tidiness. Workers materialised under the client checkout's
+ * `.red/tmp/workers/` beside human worktrees, and on one developer machine that
+ * lane reached 3.1 GB across 1593 directories. The janitor that swept it needed
+ * three guards against deleting the wrong thing (#2679, #3650) — all three
+ * because it shared a directory with live work it did not own. **A cleaner that
+ * owns everything it can see needs no guards at all**, which is why the location
+ * is the fix rather than a fourth guard.
+ *
+ * Two properties the layout is chosen for:
+ *
+ *   - **The uid segment is the boundary, and `0700` is the enforcement.** The OS
+ *     temporary directory is shared by every user of the machine, so a workspace
+ *     holding a checkout of somebody's private repository cannot be world-
+ *     readable, and two operators on one host cannot land in one directory.
+ *   - **The Worker id is the whole name.** It is fixed-width base62 of the birth
+ *     instant (ADR 0149 §3), so a listing sorts as a timeline and pruning births
+ *     older than a cutoff is a prefix scan rather than a stat of every entry.
+ *
+ * The daemon may find the OS has reclaimed the directory under it — that is the
+ * accepted cost of the location, and precisely why the evidence a human reads
+ * after a reboot lives somewhere else (ADR 0149 §2).
+ */
+import { execFile } from "node:child_process";
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir, userInfo } from "node:os";
+import { join } from "node:path";
+
+const GIT_TIMEOUT_MS = 120_000;
+
+/** The one directory name the daemon claims inside the OS temporary directory. */
+export const WORKER_TMP_ROOT_PREFIX = "red-skills";
+
+/** The lane's leaf: the parent of every Worker directory. */
+const WORKERS_SEGMENT = "workers";
+
+/** A Worker's git worktree is the conventional direct child (ADR 0105's shape, relocated). */
+const WORKTREE_SEGMENT = "worktree";
+
+/** Raised when a workspace cannot be named or released. Fail closed: no guess. */
+export class WorkerWorkspaceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkerWorkspaceError";
+  }
+}
+
+export interface WorkerWorkspaceRootOptions {
+  /** The OS temporary directory. Defaults to {@link tmpdir}, which answers on Windows too. */
+  readonly tmpDir?: string;
+  /** The owning user. Defaults to this process's uid, or its username where there is none. */
+  readonly uid?: string | number;
+}
+
+/**
+ * The root every Worker workspace on this host hangs off.
+ *
+ * PURE apart from its two defaults, so the layout is testable without writing to
+ * the real temporary directory — and so a test never has to guess which uid the
+ * process it is running under resolved to.
+ */
+export function workerWorkspaceRoot(options: WorkerWorkspaceRootOptions = {}): string {
+  const uid = options.uid ?? process.getuid?.() ?? userInfo().username;
+  const segment = String(uid).trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  if (segment === "") throw new WorkerWorkspaceError("redskilled cannot name a Worker workspace root without a user");
+  return join(options.tmpDir ?? tmpdir(), `${WORKER_TMP_ROOT_PREFIX}-${segment}`, WORKERS_SEGMENT);
+}
+
+/** One Worker's whole directory: everything released when that Worker dies. */
+export function workerWorkspaceDir(root: string, workerId: string): string {
+  return join(root, workspaceSegment(workerId));
+}
+
+/** The git worktree the Worker actually runs in. */
+export function workerWorktreePath(root: string, workerId: string): string {
+  return join(workerWorkspaceDir(root, workerId), WORKTREE_SEGMENT);
+}
+
+/** A Worker workspace that exists on disk, and the facts needed to release it. */
+export interface MaterializedWorkerWorkspace {
+  readonly workerId: string;
+  /** The host root this workspace hangs off — the containment a release checks. */
+  readonly root: string;
+  /** `<root>/<workerId>`: the directory deleted at death. */
+  readonly workspacePath: string;
+  /** `<workspacePath>/worktree`: the Worker's working directory. */
+  readonly worktreePath: string;
+  /**
+   * The commit the fork landed on, absent when the Project workspace holds none.
+   *
+   * A Project workspace with no commit is legal — a generic ACP client may bind
+   * a directory that is not a repository at all — and reporting `undefined`
+   * beats reporting a sha nothing points at.
+   */
+  readonly baseCommit?: string;
+}
+
+export interface MaterializeWorkerWorkspaceInput {
+  readonly root: string;
+  readonly workerId: string;
+  /** The daemon-owned Project workspace this Worker forks from (ADR 0144 §5). */
+  readonly projectWorkspacePath: string;
+  /**
+   * Run git in a directory, rejecting when `required`. Injected so the layout is
+   * testable without a clone.
+   */
+  readonly git?: (cwd: string, args: readonly string[], required?: boolean) => Promise<string | undefined>;
+}
+
+/**
+ * Create one Worker's workspace, forked from the Project workspace's base commit.
+ *
+ * The fork is a CLONE rather than a `git worktree add`, and that is deliberate:
+ * a worktree is registered in the repository it hangs off, so a Worker's would
+ * appear in the Project workspace's inventory and its removal would leave a
+ * stale registration behind — the failure that made the old janitor prune after
+ * every sweep (#2866). A clone is registered in itself and takes the whole
+ * directory with it when it goes.
+ */
+export async function materializeWorkerWorkspace(
+  input: MaterializeWorkerWorkspaceInput,
+): Promise<MaterializedWorkerWorkspace> {
+  const git = input.git ?? runGit;
+  const workspacePath = workerWorkspaceDir(input.root, input.workerId);
+  const worktreePath = join(workspacePath, WORKTREE_SEGMENT);
+  // `0700` on the way down: the OS temporary directory is shared by every user
+  // of the machine, and a Worker's worktree is a checkout of somebody's code.
+  await mkdir(workspacePath, { recursive: true, mode: 0o700 });
+
+  const isRepository = await git(input.projectWorkspacePath, ["rev-parse", "--is-inside-work-tree"]) === "true";
+  if (!isRepository) {
+    await mkdir(worktreePath, { recursive: true, mode: 0o700 });
+    return { workerId: input.workerId, root: input.root, workspacePath, worktreePath };
+  }
+
+  await git(input.projectWorkspacePath, [
+    "clone",
+    "--no-hardlinks",
+    "--quiet",
+    "--",
+    input.projectWorkspacePath,
+    worktreePath,
+  ], true);
+  const baseCommit = await git(worktreePath, ["rev-parse", "HEAD"]);
+  return {
+    workerId: input.workerId,
+    root: input.root,
+    workspacePath,
+    worktreePath,
+    ...(baseCommit == null ? {} : { baseCommit }),
+  };
+}
+
+/**
+ * Delete a dead Worker's workspace, and refuse to delete anything else.
+ *
+ * The containment check is not defensive habit: this is the one call in the
+ * daemon that removes a directory tree recursively, and the failure it is
+ * modelled on deleted a live worktree because a path was assembled from the
+ * wrong two halves. A workspace carries the root it was born under, so the
+ * check compares two facts rather than re-deriving one.
+ *
+ * Idempotent by construction — a workspace the OS already reclaimed is the
+ * expected case in temporary storage, not an error.
+ */
+export async function releaseWorkerWorkspace(workspace: MaterializedWorkerWorkspace): Promise<void> {
+  const expected = workerWorkspaceDir(workspace.root, workspace.workerId);
+  if (workspace.workspacePath !== expected) {
+    throw new WorkerWorkspaceError(
+      `redskilled refuses to release ${JSON.stringify(workspace.workspacePath)}: Worker ` +
+        `${workspace.workerId} owns ${JSON.stringify(expected)} under its host root`,
+    );
+  }
+  await rm(workspace.workspacePath, { recursive: true, force: true });
+}
+
+/** A single path segment: never empty, never a separator, never a traversal. */
+function workspaceSegment(workerId: string): string {
+  const segment = workerId.trim();
+  if (segment === "" || segment === "." || segment === ".." || /[/\\]/.test(segment)) {
+    throw new WorkerWorkspaceError(
+      `invalid Worker id ${JSON.stringify(workerId)}: it would escape the host's workspace root.`,
+    );
+  }
+  return segment;
+}
+
+async function runGit(cwd: string, args: readonly string[], required = false): Promise<string | undefined> {
+  return await new Promise<string | undefined>((resolve, reject) => {
+    execFile("git", [...args], {
+      cwd,
+      encoding: "utf8",
+      timeout: GIT_TIMEOUT_MS,
+      windowsHide: true,
+    }, (error, stdout) => {
+      if (error != null) {
+        if (required) reject(error);
+        else resolve(undefined);
+        return;
+      }
+      const value = stdout.trim();
+      resolve(value === "" ? undefined : value);
+    });
+  });
+}

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -22,6 +22,7 @@ import { readRedskilledEvents } from "../src/event-lane.js";
 import { createRedskilledMajorHandover } from "../src/major-handover.js";
 import { resolveRedskilledPaths } from "../src/paths.js";
 import { requestWorkflowTurn, type ActiveWorkflowWorker } from "../src/acp-worker-lifecycle.js";
+import { workerWorkspaceRoot } from "../src/worker-workspace.js";
 
 const require_ = createRequire(import.meta.url);
 const tsxLoader = require_.resolve("tsx");
@@ -573,7 +574,12 @@ describe("the public RedSkills ACP v1 control plane", () => {
 
     const firstBirth = await waitForEvent(paths.eventLanePath, "worker-birth");
     expect(firstBirth.project_label).toBe(project.projectId);
-    expect(firstBirth.workspace_path).toBe(project.workspacePath);
+    // ADR 0149 §1: the Worker stands in its OWN workspace in OS temporary
+    // storage, forked from the Project workspace rather than sharing it.
+    expect(firstBirth.workspace_path).not.toBe(project.workspacePath);
+    expect(firstBirth.workspace_path).toBe(
+      join(workerWorkspaceRoot(), firstBirth.worker_id, "worktree"),
+    );
     expect(firstBirth.pid).toBeGreaterThan(0);
     const liveBetweenTurns = await connection.agent.request<{ workers: Array<{ worker_id: string }> }>(
       "_redskills/host_state",
@@ -826,7 +832,9 @@ describe("the public RedSkills ACP v1 control plane", () => {
     });
     const projectBirth = await waitForEvent(paths.eventLanePath, "worker-birth");
     expect(projectBirth.project_label).toBe(firstProject.projectId);
-    expect(projectBirth.workspace_path).toBe(firstProject.workspacePath);
+    expect(projectBirth.workspace_path).toBe(
+      join(workerWorkspaceRoot(), projectBirth.worker_id, "worktree"),
+    );
     const liveScoped = await first.agent.request<{ workers: Array<{ project_label: string }> }>(
       "_redskills/host_state",
       {},

--- a/apps/redskilled/tests/worker-workspace.test.ts
+++ b/apps/redskilled/tests/worker-workspace.test.ts
@@ -1,0 +1,180 @@
+// A Worker's bytes live in OS temporary storage, never in the human's checkout
+// (issue #4017, ADR 0149 §1, ADR 0150 §2).
+//
+// The three facts this pins are the three the old layout got wrong. A Worker
+// materialised inside the client checkout's `.red/tmp`, so a human's directory
+// grew to 3.1 GB and a janitor had to guess which entries were its own; nothing
+// told the process which Working mode it was running in; and a dead Worker's
+// workspace outlived it because deleting it meant trusting a path assembled
+// from two halves. So the assertions are made against a REAL process: the
+// Worker is born, it reports where it stands and what mode it was told it is
+// in, it dies, and the checkout is inspected before and after.
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { evaluateWorkerAdmission, UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { launchWorker, mintHostWorkerId } from "../src/worker-launch.js";
+import {
+  materializeWorkerWorkspace,
+  releaseWorkerWorkspace,
+  workerWorkspaceDir,
+  workerWorkspaceRoot,
+  workerWorktreePath,
+  WorkerWorkspaceError,
+} from "../src/worker-workspace.js";
+import { workerModeEnv } from "@reddb-io/shared/working-mode.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+/** A client checkout with an empty `.red/tmp`: the lane nothing may write into. */
+async function clientCheckout(): Promise<string> {
+  const checkout = await scratch("redskilled-client-checkout-");
+  const git = (...args: string[]) => execFileSync("git", args, { cwd: checkout, stdio: "pipe" });
+  git("init", "--initial-branch", "main");
+  git("config", "user.email", "daemon@example.invalid");
+  git("config", "user.name", "redskilled");
+  await mkdir(join(checkout, ".red", "tmp"), { recursive: true });
+  await writeFile(join(checkout, "tracked.txt"), "committed in the Project workspace\n");
+  git("add", "--", "tracked.txt");
+  git("commit", "-m", "Refs #4017");
+  return checkout;
+}
+
+describe("the host root a Worker workspace hangs off", () => {
+  it("is the OS temporary directory, segmented by the owning user", () => {
+    expect(workerWorkspaceRoot({ tmpDir: "/var/tmp", uid: 1000 })).toBe("/var/tmp/red-skills-1000/workers");
+    expect(workerWorkspaceRoot({ tmpDir: "/var/tmp", uid: "Ada Lovelace" })).toBe(
+      "/var/tmp/red-skills-ada-lovelace/workers",
+    );
+  });
+
+  it("names a Worker by its id alone, with the worktree as the direct child", () => {
+    const root = workerWorkspaceRoot({ tmpDir: "/var/tmp", uid: 1000 });
+    expect(workerWorkspaceDir(root, "0aBcDeF")).toBe("/var/tmp/red-skills-1000/workers/0aBcDeF");
+    expect(workerWorktreePath(root, "0aBcDeF")).toBe("/var/tmp/red-skills-1000/workers/0aBcDeF/worktree");
+  });
+
+  it("refuses an id that would escape the root rather than resolving it", () => {
+    const root = workerWorkspaceRoot({ tmpDir: "/var/tmp", uid: 1000 });
+    expect(() => workerWorkspaceDir(root, "../elsewhere")).toThrow(WorkerWorkspaceError);
+    expect(() => workerWorkspaceDir(root, "  ")).toThrow(WorkerWorkspaceError);
+  });
+});
+
+describe("a real-process Worker born under the OS temp root", () => {
+  it("stands in its own worktree with RED_MODE set, and leaves the checkout untouched", async () => {
+    const checkout = await clientCheckout();
+    const tmpDir = await scratch("redskilled-tmp-root-");
+    const root = workerWorkspaceRoot({ tmpDir, uid: 4017 });
+    const workerId = mintHostWorkerId([]);
+
+    const workspace = await materializeWorkerWorkspace({
+      root,
+      workerId,
+      projectWorkspacePath: checkout,
+    });
+    expect(workspace.worktreePath).toBe(join(root, workerId, "worktree"));
+    expect(workspace.baseCommit).toMatch(/^[0-9a-f]{40}$/);
+    // The fork carries the Project workspace's committed state, and only that.
+    expect(existsSync(join(workspace.worktreePath, "tracked.txt"))).toBe(true);
+
+    const report = join(workspace.workspacePath, "report.toonl");
+    const launched = launchWorker({
+      spec: {
+        worker_id: workerId,
+        project_label: "github:4017",
+        workspace_path: workspace.worktreePath,
+        command: process.execPath,
+        args: [
+          "-e",
+          "require('node:fs').writeFileSync(process.argv[1], `${process.cwd()}\\n${process.env.RED_MODE}\\n`)",
+          report,
+        ],
+        env: workerModeEnv("afk"),
+      },
+      admission: evaluateWorkerAdmission({ ceiling: UNBOUNDED_HOST_CEILING, workers: [] }),
+    });
+    expect(launched.worker.worker_id).toBe(workerId);
+    await new Promise<void>((resolve) => launched.child.once("exit", () => resolve()));
+
+    const [cwd, mode] = (await readFile(report, "utf8")).trim().split("\n");
+    expect(cwd).toBe(workspace.worktreePath);
+    expect(mode).toBe("spec-driven");
+    // ADR 0149 §4: nothing a Worker does reaches the human's lane.
+    expect(readdirSync(join(checkout, ".red", "tmp"))).toEqual([]);
+
+    await releaseWorkerWorkspace(workspace);
+    expect(existsSync(workspace.workspacePath)).toBe(false);
+    expect(readdirSync(join(checkout, ".red", "tmp"))).toEqual([]);
+  });
+
+  it("carries the ad-hoc marker for a /go dispatch", async () => {
+    const checkout = await clientCheckout();
+    const tmpDir = await scratch("redskilled-tmp-root-");
+    const root = workerWorkspaceRoot({ tmpDir, uid: 4017 });
+    const workspace = await materializeWorkerWorkspace({
+      root,
+      workerId: mintHostWorkerId([]),
+      projectWorkspacePath: checkout,
+    });
+
+    const report = join(workspace.workspacePath, "mode.txt");
+    const launched = launchWorker({
+      spec: {
+        worker_id: workspace.workerId,
+        project_label: "github:4017",
+        workspace_path: workspace.worktreePath,
+        command: process.execPath,
+        args: ["-e", "require('node:fs').writeFileSync(process.argv[1], process.env.RED_MODE ?? '')", report],
+        env: workerModeEnv("go"),
+      },
+      admission: evaluateWorkerAdmission({ ceiling: UNBOUNDED_HOST_CEILING, workers: [] }),
+    });
+    await new Promise<void>((resolve) => launched.child.once("exit", () => resolve()));
+
+    expect(await readFile(report, "utf8")).toBe("ad-hoc");
+  });
+});
+
+describe("releasing a dead Worker's workspace", () => {
+  it("is idempotent, because temporary storage may have reclaimed it first", async () => {
+    const tmpDir = await scratch("redskilled-tmp-root-");
+    const root = workerWorkspaceRoot({ tmpDir, uid: 4017 });
+    const workspace = await materializeWorkerWorkspace({
+      root,
+      workerId: "0aBcDeF",
+      projectWorkspacePath: await scratch("redskilled-not-a-repo-"),
+    });
+    expect(existsSync(workspace.worktreePath)).toBe(true);
+
+    await releaseWorkerWorkspace(workspace);
+    await releaseWorkerWorkspace(workspace);
+    expect(existsSync(workspace.workspacePath)).toBe(false);
+  });
+
+  it("refuses a path the Worker does not own under its host root", async () => {
+    const tmpDir = await scratch("redskilled-tmp-root-");
+    const root = workerWorkspaceRoot({ tmpDir, uid: 4017 });
+    const elsewhere = await scratch("redskilled-someone-elses-");
+    await expect(releaseWorkerWorkspace({
+      workerId: "0aBcDeF",
+      root,
+      workspacePath: elsewhere,
+      worktreePath: join(elsewhere, "worktree"),
+    })).rejects.toThrow(WorkerWorkspaceError);
+    expect(existsSync(elsewhere)).toBe(true);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -43,7 +43,8 @@
     "./self-update.js": "./self-update.ts",
     "./toon-migration.js": "./toon-migration.ts",
     "./worker-scope.js": "./worker-scope.ts",
-    "./worker-workspace.js": "./worker-workspace.ts"
+    "./worker-workspace.js": "./worker-workspace.ts",
+    "./working-mode.js": "./working-mode.ts"
   },
   "dependencies": {
     "@reddb-io/toon": "catalog:",

--- a/packages/shared/working-mode.test.ts
+++ b/packages/shared/working-mode.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  RED_MODE_ENV,
+  WORKER_WORKING_MODES,
+  WORKING_MODES,
+  declaredWorkingMode,
+  workerModeEnv,
+  workingModeOfWorkerKind,
+} from "./working-mode.js";
+
+describe("the four Working modes", () => {
+  it("stays the closed set ADR 0150 §1 declares, in the ADR's order", () => {
+    expect([...WORKING_MODES]).toEqual(["interactive", "spec-driven", "ad-hoc", "ADR-editing"]);
+  });
+
+  it("names only the two a Worker can be in", () => {
+    expect([...WORKER_WORKING_MODES]).toEqual(["spec-driven", "ad-hoc"]);
+  });
+});
+
+describe("the mode a dispatch kind runs in", () => {
+  it("calls the one ad-hoc entrance ad-hoc and every queue-driven one spec-driven", () => {
+    expect(workingModeOfWorkerKind("go")).toBe("ad-hoc");
+    expect(workingModeOfWorkerKind("afk")).toBe("spec-driven");
+    expect(workingModeOfWorkerKind("scout")).toBe("spec-driven");
+  });
+
+  it("reads an untargeted birth as the drain's, because /go always names its Ticket", () => {
+    expect(workingModeOfWorkerKind()).toBe("spec-driven");
+  });
+});
+
+describe("the marker the daemon exports", () => {
+  it("is one name carrying the mode, for both kinds of run", () => {
+    expect(workerModeEnv("afk")).toEqual({ [RED_MODE_ENV]: "spec-driven" });
+    expect(workerModeEnv("go")).toEqual({ [RED_MODE_ENV]: "ad-hoc" });
+  });
+
+  it("reads back the mode a Worker was born in", () => {
+    expect(declaredWorkingMode({ RED_MODE: "ad-hoc" })).toBe("ad-hoc");
+    expect(declaredWorkingMode({ RED_MODE: " spec-driven " })).toBe("spec-driven");
+  });
+
+  it("says nothing rather than guessing when the marker is absent or unknown", () => {
+    expect(declaredWorkingMode({})).toBeUndefined();
+    expect(declaredWorkingMode({ RED_MODE: "" })).toBeUndefined();
+    expect(declaredWorkingMode({ RED_MODE: "autonomous" })).toBeUndefined();
+  });
+});

--- a/packages/shared/working-mode.ts
+++ b/packages/shared/working-mode.ts
@@ -1,0 +1,66 @@
+// working-mode — the four ways work enters RedSkills, and the marker a Worker
+// exports so a skill can tell which one it is running inside (ADR 0150 §1–§2).
+//
+// The vocabulary was already written down once, as a guard over shipped skill
+// headers (`apps/dev/src/core/working-mode-guard.ts`). It lives HERE now because
+// a second reader needs it: the daemon, which exports the marker. Two hand-kept
+// copies of a four-value closed set is the shape a fifth value gets added to one
+// of them, and the marker a Worker exports must be the SAME string a skill
+// header declares — otherwise a skill comparing the two never matches and the
+// refusal ADR 0150 §2 asks for silently never fires.
+//
+// **Only two of the four modes are a Worker's.** Interactive and ADR-editing
+// work happens in a human's checkout, where nobody exports anything; spec-driven
+// and ad-hoc work is coordinated by `redskilled`, whose Workers run in OS
+// temporary storage (ADR 0149) with no human attached. So the marker's absence
+// is meaningful too — it says "not inside a Worker" — and this module never
+// invents a value for a process that has none.
+
+/** The four Working modes ADR 0150 §1 declares, in the ADR's own order. */
+export const WORKING_MODES = ["interactive", "spec-driven", "ad-hoc", "ADR-editing"] as const;
+
+/** One of the four ways work enters RedSkills. */
+export type WorkingMode = (typeof WORKING_MODES)[number];
+
+/** The environment name a Worker exports its Working mode under. */
+export const RED_MODE_ENV = "RED_MODE";
+
+/**
+ * The two modes a Worker can be in. A Worker exists because the daemon admitted
+ * one, and the daemon is only ever asked for spec-driven or ad-hoc work.
+ */
+export const WORKER_WORKING_MODES: readonly WorkingMode[] = ["spec-driven", "ad-hoc"];
+
+/** The governed kinds of dispatch a Worker is born for (`AcpWorkerKind`). */
+export type WorkerDispatchKind = "afk" | "go" | "scout";
+
+/**
+ * The Working mode a dispatch kind runs in.
+ *
+ * `go` is the one ad-hoc entrance (ADR 0081): one demand, one Ticket, straight
+ * to the daemon. `afk` drains the spec-driven queue and `scout` investigates an
+ * issue that queue produced, so both are spec-driven. **An absent kind is
+ * spec-driven too**, because a Worker with no targeted dispatch was admitted by
+ * the drain — never by `/go`, which cannot dispatch without naming its Ticket.
+ */
+export function workingModeOfWorkerKind(kind?: WorkerDispatchKind): WorkingMode {
+  return kind === "go" ? "ad-hoc" : "spec-driven";
+}
+
+/**
+ * The environment a Worker's mode contributes, as the daemon merges it into the
+ * launch spec. One name, one value, no ambient read: the caller states the kind.
+ */
+export function workerModeEnv(kind?: WorkerDispatchKind): Readonly<Record<string, string>> {
+  return { [RED_MODE_ENV]: workingModeOfWorkerKind(kind) };
+}
+
+/**
+ * The mode this process is running in, or `undefined` when it is not inside a
+ * Worker at all. An unrecognised value is `undefined` rather than a guess: a
+ * skill gating on the marker must not be steered by a string nobody declared.
+ */
+export function declaredWorkingMode(env: NodeJS.ProcessEnv): WorkingMode | undefined {
+  const declared = env[RED_MODE_ENV]?.trim();
+  return WORKING_MODES.find((mode) => mode === declared);
+}


### PR DESCRIPTION
Automated AFK landing for #4017. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #4017

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789710873&installation_model_id=20659&pr_number=4056&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4056&signature=a26332cf446cf94f8c4f646fec3c27e74435fc479b9a85f497182602be7aece8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->