### PR TITLE
fix: #4018 Evidence lane ~/.red/tmp/workers/<id>: log, session artifact and verdict kept on death, pruned by TTL

### DIFF
--- a/apps/redskilled/README.md
+++ b/apps/redskilled/README.md
@@ -466,6 +466,7 @@ plugins:
       memory_ceiling: 8G
       validation_ceiling: 2
       idle_ms: 300000
+      evidence_ttl_ms: 2592000000
 ```
 
 Resolution is `serve` flag > environment > home config > derived default.
@@ -475,7 +476,12 @@ counterparts are `REDSKILLED_WORKER_CEILING` and `REDSKILLED_MEMORY_CEILING`.
 full-suite semaphore. When absent, its capacity is the tightest of half the
 available CPU count, the resolved memory ceiling in 2 GiB shares, and the
 Worker ceiling; every dimension retains a minimum capacity of one.
-`REDSKILLED_IDLE_MS` follows the same precedence for idle time. `host-state`
+`REDSKILLED_IDLE_MS` follows the same precedence for idle time.
+`evidence_ttl_ms` (or `REDSKILLED_EVIDENCE_TTL_MS`) is how long a dead Worker's
+evidence lane under `~/.red/tmp/workers/<id>/` survives — its log, the runner's
+session artifact and the daemon's verdict — and defaults to thirty days. `0`
+keeps nothing; a live Worker's lane is never pruned at any TTL. The daemon's own
+log stays in `~/.red/redskilled/`, which this TTL never touches. `host-state`
 reports the resolved `ceiling` and the `memory_source` / `worker_source` that won,
 so a restart or an auto-spawn from another project remains directly auditable.
 

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -114,6 +114,10 @@ export interface StartRedskillsAcpControlPlaneOptions {
   readonly githubGateway?: RedskilledGithubGatewayRegistration;
   /** Explicit endpoint authority; ordinary public/project ACP stays false. */
   readonly hostAdministration?: boolean;
+  /** Where a dead Worker's evidence is kept; this operator's lane by default. */
+  readonly evidenceRoot?: string;
+  /** How long an expired evidence lane survives (ADR 0149 §2). Host policy. */
+  readonly evidenceTtlMs?: number;
   /** Daemon clock used to date status projections. */
   readonly clock?: () => string;
 }

--- a/apps/redskilled/src/acp-worker-admission.ts
+++ b/apps/redskilled/src/acp-worker-admission.ts
@@ -9,6 +9,7 @@
 import { randomBytes } from "node:crypto";
 import { constants, accessSync } from "node:fs";
 import type { Socket } from "node:net";
+import { homedir } from "node:os";
 import { delimiter, isAbsolute, join } from "node:path";
 import {
   client,
@@ -41,6 +42,11 @@ import { resolveAcpWorkerEndpoint, type RedskilledPaths } from "./paths.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 import { mintHostWorkerId, type LaunchedWorker, type RedskilledWorkerSpec } from "./worker-launch.js";
 import {
+  DEFAULT_WORKER_EVIDENCE_TTL_MS,
+  workerEvidenceRoot,
+  type WorkerEvidencePlan,
+} from "./worker-evidence.js";
+import {
   materializeWorkerWorkspace,
   releaseWorkerWorkspace,
   workerWorkspaceRoot,
@@ -67,6 +73,16 @@ interface NativeWorkerAdmissionOptions {
   readonly hostState?: () => { readonly workers: readonly { readonly worker_id: string }[] };
   /** The host root Worker workspaces hang off. Defaults to the OS temporary root. */
   readonly workspaceRoot?: string;
+  /**
+   * The lane a dead Worker's log, session artifact and verdict are copied into.
+   *
+   * Defaults to this operator's `~/.red/tmp/workers` (ADR 0149 §2). Named here
+   * rather than at cleanup because a handle being dropped is the last moment
+   * anything knows this Worker existed.
+   */
+  readonly evidenceRoot?: string;
+  /** How long an expired lane survives. Host policy; thirty days by default. */
+  readonly evidenceTtlMs?: number;
 }
 
 export async function admitNativeAcpWorker(
@@ -116,6 +132,7 @@ export async function admitNativeAcpWorker(
   rendezvous.server.close();
 
   let downstreamSessionId = "";
+  let sessionArtifact: WorkerEvidencePlan["sessionArtifact"];
   const downstreamApp = client({ name: "redskilled" })
     .onNotification(methods.client.session.update, async ({ params }) => {
       const downstreamRedskills = (params._meta as {
@@ -182,6 +199,7 @@ export async function admitNativeAcpWorker(
     await sessionJournal.worker(publicSessionId, launched.worker.worker_id, downstreamSessionId, replacement);
     const evidence = providerSessionEvidenceFromMeta(downstreamSession._meta);
     if (evidence != null) {
+      sessionArtifact = evidence;
       await sessionJournal.evidence(publicSessionId, launched.worker.worker_id, evidence);
     }
   } catch (error) {
@@ -195,6 +213,12 @@ export async function admitNativeAcpWorker(
   return {
     workerId: launched.worker.worker_id,
     workspace,
+    evidence: {
+      root: options.evidenceRoot ?? workerEvidenceRoot(homedir()),
+      ttlMs: options.evidenceTtlMs ?? DEFAULT_WORKER_EVIDENCE_TTL_MS,
+      ...(launched.worker.log_path == null ? {} : { logPath: launched.worker.log_path }),
+      ...(sessionArtifact == null ? {} : { sessionArtifact }),
+    },
     downstreamSessionId,
     connection,
     socket: workerSocket,

--- a/apps/redskilled/src/acp-worker-lifecycle.ts
+++ b/apps/redskilled/src/acp-worker-lifecycle.ts
@@ -9,6 +9,11 @@ import {
 import type { AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
 import { removeAcpEndpoint } from "@reddb-io/protocol-acp";
 import { redskilledMetrics } from "./telemetry-metrics.js";
+import {
+  pruneWorkerEvidence,
+  retainWorkerEvidence,
+  type WorkerEvidencePlan,
+} from "./worker-evidence.js";
 import { releaseWorkerWorkspace, type MaterializedWorkerWorkspace } from "./worker-workspace.js";
 
 export interface ActiveWorkflowWorker {
@@ -27,6 +32,14 @@ export interface ActiveWorkflowWorker {
    * dropped without it is bytes nobody will ever attribute again (ADR 0149 §1).
    */
   readonly workspace?: MaterializedWorkerWorkspace;
+  /**
+   * Where this Worker's cheap, irreplaceable bytes go when it dies.
+   *
+   * Held here for the same reason the workspace is, and it is the SAME fact
+   * seen from the other side: the workspace is what death may take, the
+   * evidence is what death must keep (ADR 0149 §2).
+   */
+  readonly evidence?: WorkerEvidencePlan;
   readonly dispatch?: AcpTargetedDispatchIntent;
   idleTimer?: NodeJS.Timeout;
   cancelled: boolean;
@@ -52,7 +65,7 @@ export async function reapWorkflowWorker(
   reason: string,
 ): Promise<void> {
   await notifyWorkerLifecycle(worker, "reaping", reason).catch(() => undefined);
-  cleanupWorkflowWorker(sessionId, worker, active);
+  cleanupWorkflowWorker(sessionId, worker, active, reason);
 }
 
 export async function notifyWorkerLifecycle(
@@ -94,6 +107,7 @@ export function cleanupWorkflowWorker(
   sessionId: string,
   worker: ActiveWorkflowWorker,
   active: Map<string, ActiveWorkflowWorker>,
+  outcome = "cleanup",
 ): void {
   if (worker.cleaned) return;
   worker.cleaned = true;
@@ -102,10 +116,51 @@ export function cleanupWorkflowWorker(
   worker.connection.close();
   worker.socket.destroy();
   void removeAcpEndpoint(worker.endpoint);
-  // The workspace goes with the Worker. It is expensive and regenerable, and
-  // deleting it costs no conscience precisely because nothing a human returns to
-  // was ever written there (ADR 0149 §1).
-  if (worker.workspace != null) void releaseWorkerWorkspace(worker.workspace).catch(() => undefined);
+  // The live set is snapshotted HERE, synchronously, while it is still true.
+  // Reading it inside the prune's continuation would judge a later host: a
+  // Worker admitted in the meantime would be absent from a set captured before
+  // it existed, and the prune would be free to take its lane.
+  const stillLive = [...active.values()].map((held) => held.workerId);
+  // Evidence is retained BEFORE the workspace goes, because a Worker's log may
+  // be inside the directory about to be deleted.
+  const retained = worker.evidence == null
+    ? Promise.resolve()
+    : retainWorkerEvidence(evidenceFor(worker, worker.evidence, outcome)).then(() => undefined);
+  void retained
+    .catch(() => undefined)
+    .then(async () => {
+      // The workspace goes with the Worker. It is expensive and regenerable, and
+      // deleting it costs no conscience precisely because everything a human
+      // returns to has already been copied out (ADR 0149 §1/§2).
+      if (worker.workspace != null) await releaseWorkerWorkspace(worker.workspace).catch(() => undefined);
+      if (worker.evidence == null) return;
+      await pruneWorkerEvidence({
+        root: worker.evidence.root,
+        ttlMs: worker.evidence.ttlMs,
+        live: stillLive,
+      }).catch(() => undefined);
+    })
+    .catch(() => undefined);
+}
+
+/** What this death asks the evidence lane to keep. PURE. */
+function evidenceFor(
+  worker: ActiveWorkflowWorker,
+  plan: WorkerEvidencePlan,
+  outcome: string,
+): Parameters<typeof retainWorkerEvidence>[0] {
+  return {
+    root: plan.root,
+    ...(plan.logPath == null ? {} : { logPath: plan.logPath }),
+    verdict: {
+      workerId: worker.workerId,
+      outcome,
+      diedAt: new Date().toISOString(),
+      publicSessionId: worker.publicSessionId,
+      ...(worker.workspace == null ? {} : { workspacePath: worker.workspace.workspacePath }),
+      ...(plan.sessionArtifact == null ? {} : { sessionArtifact: plan.sessionArtifact }),
+    },
+  };
 }
 
 export function workerTransportIsClosed(worker: ActiveWorkflowWorker): boolean {

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -29,6 +29,7 @@ import { startRedskilledHostOtlpExport } from "./telemetry-otlp.js";
 import {
   readRedskilledHostConfig,
   readRedskilledHostGithubApp,
+  redskilledDaemonPolicy,
   resolveRedskilledHostEventSinks,
   resolveRedskilledHostSettings,
 } from "./host-config.js";
@@ -533,8 +534,7 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       daemon = await startRedskilledDaemon({
         paths,
         ...(hostEventSinks == null ? {} : { hostEventSinks }),
-        idleMs: hostSettings.idleMs,
-        ceiling: hostSettings.ceiling,
+        ...redskilledDaemonPolicy(hostSettings),
         // The artifact states what it IS. Absent, the daemon reports the version
         // baked into this build rather than a placeholder, because "what version is
         // answering" is the first fact a skew investigation needs.

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -2412,6 +2412,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       startWorker,
       hostState,
       ...(options.githubGateway == null ? {} : { githubGateway: options.githubGateway }),
+      ...(options.evidenceTtlMs == null ? {} : { evidenceTtlMs: options.evidenceTtlMs }),
     });
   } catch (error) {
     await stop({ reason: "requested", note: "ACP control plane failed to bind" }).catch(() => undefined);

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -120,6 +120,14 @@ export interface RedskilledDaemonOptions {
   /** Registrations proved to remain behind another live daemon beyond this socket. */
   readonly orphanedRegistrations?: readonly RedskilledOrphanedRegistration[];
   readonly idleMs?: number;
+  /**
+   * How long a dead Worker's evidence lane survives (ADR 0149 §2).
+   *
+   * Host policy, resolved once at boot and carried to admission, because every
+   * Worker on this machine must age out on the same clock — a per-repository
+   * answer is the shape the host-scoped daemon exists to refuse.
+   */
+  readonly evidenceTtlMs?: number;
   /** The host-wide ceiling admission is decided against; the host's own by default. */
   readonly ceiling?: RedskilledHostCeiling;
   readonly owner?: RedskilledLeaseOwner;

--- a/apps/redskilled/src/host-config.ts
+++ b/apps/redskilled/src/host-config.ts
@@ -26,6 +26,7 @@ import {
 } from "./event-lane.js";
 import type { RedskilledLaunchTemplate } from "./launch-template.js";
 import type { RedskilledHostEventSinks } from "./host-event-sink.js";
+import { DEFAULT_WORKER_EVIDENCE_TTL_MS } from "./worker-evidence.js";
 import type { RedskilledTelemetryConfig } from "./telemetry-otlp.js";
 import type {
   RedskilledGithubCredentialProfileDeclaration,
@@ -33,6 +34,7 @@ import type {
 } from "./github-credential-profiles.js";
 
 export const REDSKILLED_IDLE_MS_ENV = "REDSKILLED_IDLE_MS";
+export const REDSKILLED_EVIDENCE_TTL_MS_ENV = "REDSKILLED_EVIDENCE_TTL_MS";
 export const REDSKILLED_HOST_CONFIG_PATH = ".red/config.yaml";
 
 export interface RedskilledHostConfig {
@@ -40,6 +42,8 @@ export interface RedskilledHostConfig {
   readonly memoryCeiling?: string;
   readonly validationCeiling?: string;
   readonly idleMs?: string;
+  /** How long a dead Worker's evidence lane survives (ADR 0149 §2). */
+  readonly evidenceTtlMs?: string;
   /** Operator-scoped programs fired for public Worker lifecycle changes. */
   readonly hooks?: Partial<Record<RedskilledPublicHostEventKind, RedskilledLaunchTemplate>>;
   /** Public Worker lifecycle changes also surfaced through the native desktop sink. */
@@ -63,12 +67,16 @@ export interface RedskilledHostSettingFlags {
   readonly memoryCeiling?: string;
   readonly validationCeiling?: string;
   readonly idleMs?: number;
+  readonly evidenceTtlMs?: number;
 }
 
 export interface RedskilledHostSettings {
   readonly ceiling: RedskilledHostCeiling;
   readonly idleMs: number;
   readonly idleMsSource: RedskilledHostSettingSource;
+  /** How long a dead Worker's evidence lane survives, and who said so. */
+  readonly evidenceTtlMs: number;
+  readonly evidenceTtlMsSource: RedskilledHostSettingSource;
 }
 
 /** Attach persistent operator policy to one daemon invocation. */
@@ -135,6 +143,7 @@ export async function readRedskilledHostConfig(
       ...scalarAt(redskilled, "memory_ceiling", "memoryCeiling"),
       ...scalarAt(redskilled, "validation_ceiling", "validationCeiling"),
       ...scalarAt(redskilled, "idle_ms", "idleMs"),
+      ...scalarAt(redskilled, "evidence_ttl_ms", "evidenceTtlMs"),
       ...hooksAt(redskilled),
       ...notificationsAt(redskilled),
       ...githubProfilesAt(redskilled),
@@ -248,6 +257,21 @@ function optionalScalar(value: unknown, profile: string, field: string): string 
   return String(value).trim();
 }
 
+/**
+ * The resolved host policy one daemon boot is started with. PURE.
+ *
+ * One namer for "which resolved setting becomes a daemon option", so the next
+ * host-wide value reaches the daemon by being RESOLVED rather than by every
+ * caller remembering to forward it by hand.
+ */
+export function redskilledDaemonPolicy(settings: RedskilledHostSettings): {
+  readonly idleMs: number;
+  readonly ceiling: RedskilledHostCeiling;
+  readonly evidenceTtlMs: number;
+} {
+  return { idleMs: settings.idleMs, ceiling: settings.ceiling, evidenceTtlMs: settings.evidenceTtlMs };
+}
+
 /** Resolve every daemon-owned setting under one explicit precedence table. */
 export function resolveRedskilledHostSettings(input: {
   readonly flags?: RedskilledHostSettingFlags;
@@ -263,19 +287,52 @@ export function resolveRedskilledHostSettings(input: {
     config,
     ...(input.availableParallelism == null ? {} : { availableParallelism: input.availableParallelism }),
   });
+  const evidence = resolveEvidenceTtl(input.flags, env, config);
   const idle = select(input.flags?.idleMs == null ? undefined : String(input.flags.idleMs), env[REDSKILLED_IDLE_MS_ENV], config.idleMs);
   if (idle == null) {
-    return { ceiling, idleMs: DEFAULT_REDSKILLED_IDLE_MS, idleMsSource: "derived-default" };
+    return { ceiling, idleMs: DEFAULT_REDSKILLED_IDLE_MS, idleMsSource: "derived-default", ...evidence };
   }
   const parsed = Number(idle.value);
   if (Number.isSafeInteger(parsed) && parsed > 0) {
-    return { ceiling, idleMs: parsed, idleMsSource: idle.source };
+    return { ceiling, idleMs: parsed, idleMsSource: idle.source, ...evidence };
   }
   warn(
     `redskilled: ${describeSource(idle.source)} idle_ms=${JSON.stringify(idle.value)} is not a positive integer; ` +
       `using the default ${DEFAULT_REDSKILLED_IDLE_MS}ms instead.`,
   );
-  return { ceiling, idleMs: DEFAULT_REDSKILLED_IDLE_MS, idleMsSource: "derived-default" };
+  return { ceiling, idleMs: DEFAULT_REDSKILLED_IDLE_MS, idleMsSource: "derived-default", ...evidence };
+}
+
+/**
+ * How long dead Workers' evidence survives, under the same precedence as idle.
+ *
+ * **Zero is a legal answer, so the bound is `>= 0` and not `> 0`.** An operator
+ * who sets `evidence_ttl_ms: 0` is saying "keep nothing", and rejecting it as a
+ * typo would silently retain thirty days of somebody's transcripts on a machine
+ * where that was the whole objection.
+ */
+function resolveEvidenceTtl(
+  flags: RedskilledHostSettingFlags | undefined,
+  env: NodeJS.ProcessEnv,
+  config: RedskilledHostConfig,
+): Pick<RedskilledHostSettings, "evidenceTtlMs" | "evidenceTtlMsSource"> {
+  const declared = select(
+    flags?.evidenceTtlMs == null ? undefined : String(flags.evidenceTtlMs),
+    env[REDSKILLED_EVIDENCE_TTL_MS_ENV],
+    config.evidenceTtlMs,
+  );
+  if (declared == null) {
+    return { evidenceTtlMs: DEFAULT_WORKER_EVIDENCE_TTL_MS, evidenceTtlMsSource: "derived-default" };
+  }
+  const parsed = Number(declared.value);
+  if (Number.isSafeInteger(parsed) && parsed >= 0) {
+    return { evidenceTtlMs: parsed, evidenceTtlMsSource: declared.source };
+  }
+  warn(
+    `redskilled: ${describeSource(declared.source)} evidence_ttl_ms=${JSON.stringify(declared.value)} is not a ` +
+      `non-negative integer; using the default ${DEFAULT_WORKER_EVIDENCE_TTL_MS}ms instead.`,
+  );
+  return { evidenceTtlMs: DEFAULT_WORKER_EVIDENCE_TTL_MS, evidenceTtlMsSource: "derived-default" };
 }
 
 function select(

--- a/apps/redskilled/src/worker-evidence.ts
+++ b/apps/redskilled/src/worker-evidence.ts
@@ -1,0 +1,292 @@
+/**
+ * worker-evidence — the cheap, irreplaceable bytes a dead Worker leaves behind.
+ *
+ * ADR 0149 §2 splits what a Worker produces by COST, not by tidiness. The
+ * workspace is expensive and regenerable, so it lives in OS temporary storage
+ * and the daemon deletes it the moment the Worker dies (`worker-workspace.ts`).
+ * What this module keeps is the other half: the Worker's log, the runner's
+ * session artifact and the verdict — a few kilobytes that no rerun reproduces,
+ * because they describe a run that already happened. They go to
+ * `~/.red/tmp/workers/<id>/`, which is what a human reads after a reboot has
+ * taken the workspace with it.
+ *
+ * **The lane is not the daemon's home, and that separation is the point.**
+ * `~/.red/redskilled/` holds what must survive indefinitely — the daemon's own
+ * log, its registrations, its credentials, its incidents. Evidence is
+ * irreplaceable but not eternal: a Worker that died five weeks ago explains
+ * nothing anybody is still asking about, so the lane carries a TTL and the
+ * durable home does not. Putting evidence under the durable home would have
+ * meant either pruning the daemon's own records or never pruning evidence.
+ *
+ * **Pruning is a prefix scan, and that is why the id is a timestamp.** A Worker
+ * id is fixed-width base62 of its birth instant (ADR 0149 §3), so the cutoff is
+ * an id too: encode `now - ttl`, and every lexicographically smaller directory
+ * name is expired. No stat, no mtime — and mtime is exactly the anchor inversion
+ * the Worker reclaim rule forbids, because touching a file would resurrect a
+ * lane the operator meant to lose.
+ *
+ * **A live Worker's lane is never pruned, whatever its age says.** The daemon
+ * owns birth and death by construction, so the live set it hands in is the
+ * authority; an id absent from it is only then judged by age. A directory whose
+ * name is not a Worker id at all is RETAINED and reported, never guessed at.
+ */
+import { copyFile, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { extname, join } from "node:path";
+import { encode as encodeToon } from "@reddb-io/toon";
+import { encodeHostWorkerId, isHostWorkerId } from "./worker-launch.js";
+
+/** The segments below the operator's home. `~/.red/tmp/workers` (ADR 0149 §2). */
+export const WORKER_EVIDENCE_SEGMENTS = [".red", "tmp", "workers"] as const;
+
+/** Owner-only: a Worker's log quotes somebody's private repository back at them. */
+export const WORKER_EVIDENCE_MODE = 0o700;
+
+/** The Worker's own narrative lane, copied under the name it already has. */
+export const WORKER_EVIDENCE_LOG_FILE = "worker.log.toonl";
+
+/** The daemon's account of how this Worker ended. Always written, even when nothing else is. */
+export const WORKER_EVIDENCE_VERDICT_FILE = "verdict.toon";
+
+/** The runner's own session artifact, under a stable name plus its native extension. */
+export const WORKER_EVIDENCE_SESSION_STEM = "session-artifact";
+
+/** ADR 0149 §2's default: thirty days. Host-tunable, never per repository. */
+export const DEFAULT_WORKER_EVIDENCE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Raised when a lane cannot be named. Fail closed: never guess a path to delete. */
+export class WorkerEvidenceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkerEvidenceError";
+  }
+}
+
+/** The evidence lane for one operator. PURE. */
+export function workerEvidenceRoot(homeDir: string): string {
+  return join(homeDir, ...WORKER_EVIDENCE_SEGMENTS);
+}
+
+/** One Worker's lane inside it. PURE, and refuses an id that would escape. */
+export function workerEvidenceDir(root: string, workerId: string): string {
+  const segment = workerId.trim();
+  if (segment === "" || segment === "." || segment === ".." || /[/\\]/.test(segment)) {
+    throw new WorkerEvidenceError(
+      `invalid Worker id ${JSON.stringify(workerId)}: it would escape the host's evidence lane.`,
+    );
+  }
+  return join(root, segment);
+}
+
+/** What the runner said about its own session artifact, verbatim. */
+export interface WorkerEvidenceSessionArtifact {
+  readonly provider: string;
+  readonly availability: "available" | "absent" | "inaccessible";
+  /** The runner's own path or handle; copied only when it names a readable file. */
+  readonly reference?: string;
+}
+
+/** The daemon's account of one Worker's death, written whatever else is missing. */
+export interface WorkerEvidenceVerdict {
+  readonly workerId: string;
+  /** Why the Worker ended, in the daemon's own words — `idle-policy`, `completion`, … */
+  readonly outcome: string;
+  readonly diedAt: string;
+  /** The workspace that went with it, so the verdict says what is no longer there. */
+  readonly workspacePath?: string;
+  readonly publicSessionId?: string;
+  readonly sessionArtifact?: WorkerEvidenceSessionArtifact;
+}
+
+export interface RetainWorkerEvidenceInput {
+  readonly root: string;
+  readonly verdict: WorkerEvidenceVerdict;
+  /** The Worker's narrative log, wherever the daemon told it to write one. */
+  readonly logPath?: string;
+}
+
+/** Whether one artifact reached the lane, and why it did not when it did not. */
+export type WorkerEvidenceCapture = "copied" | "absent" | "unreadable";
+
+export interface RetainedWorkerEvidence {
+  readonly evidenceDir: string;
+  readonly verdictPath: string;
+  readonly log: WorkerEvidenceCapture;
+  readonly sessionArtifact: WorkerEvidenceCapture;
+}
+
+/**
+ * Copy a dead Worker's evidence into its lane, and say what arrived.
+ *
+ * **The verdict is written last and unconditionally.** A lane holding only a
+ * verdict is a complete answer — "this Worker died this way and left nothing
+ * else" — while a lane holding only bytes is a puzzle. Writing it after the
+ * copies also means the verdict can report what the copies actually did, so a
+ * human reading the lane never has to infer a missing file's meaning.
+ *
+ * Nothing here throws for a source that is not there: a Worker that died before
+ * it logged a line is the ordinary early-death case, not an error, and losing
+ * the verdict too would delete the only record of it.
+ */
+export async function retainWorkerEvidence(
+  input: RetainWorkerEvidenceInput,
+): Promise<RetainedWorkerEvidence> {
+  const evidenceDir = workerEvidenceDir(input.root, input.verdict.workerId);
+  await mkdir(evidenceDir, { recursive: true, mode: WORKER_EVIDENCE_MODE });
+
+  const log = await capture(input.logPath, join(evidenceDir, WORKER_EVIDENCE_LOG_FILE));
+  const artifact = input.verdict.sessionArtifact;
+  const sessionArtifact = artifact == null || artifact.availability !== "available"
+    ? "absent"
+    : await capture(
+      artifact.reference,
+      join(evidenceDir, `${WORKER_EVIDENCE_SESSION_STEM}${extname(artifact.reference ?? "")}`),
+    );
+
+  const verdictPath = join(evidenceDir, WORKER_EVIDENCE_VERDICT_FILE);
+  await writeFile(verdictPath, `${encodeToon({
+    version: 1,
+    worker_id: input.verdict.workerId,
+    outcome: input.verdict.outcome,
+    died_at: input.verdict.diedAt,
+    ...(input.verdict.publicSessionId == null ? {} : { public_session_id: input.verdict.publicSessionId }),
+    ...(input.verdict.workspacePath == null ? {} : { released_workspace_path: input.verdict.workspacePath }),
+    log,
+    session_artifact: sessionArtifact,
+    ...(artifact == null ? {} : {
+      session_artifact_report: {
+        provider: artifact.provider,
+        availability: artifact.availability,
+        ...(artifact.reference == null ? {} : { reference: artifact.reference }),
+      },
+    }),
+  })}\n`, { mode: 0o600 });
+
+  return { evidenceDir, verdictPath, log, sessionArtifact };
+}
+
+/** What the prune decided about one directory in the lane. */
+export type WorkerEvidenceDisposition = "pruned" | "live" | "retained" | "unrecognized" | "failed";
+
+export interface WorkerEvidencePruneEntry {
+  readonly workerId: string;
+  readonly dir: string;
+  readonly disposition: WorkerEvidenceDisposition;
+  /** Why, in operator words — a sweep that cannot explain itself is a sweep nobody trusts. */
+  readonly reason: string;
+}
+
+export interface WorkerEvidencePruneReport {
+  readonly root: string;
+  readonly ttlMs: number;
+  /** The prefix-scan boundary: every smaller id was born before the cutoff. */
+  readonly cutoffWorkerId: string;
+  readonly scanned: number;
+  readonly pruned: number;
+  readonly entries: readonly WorkerEvidencePruneEntry[];
+}
+
+export interface PruneWorkerEvidenceOptions {
+  readonly root: string;
+  readonly ttlMs?: number;
+  readonly now?: () => number;
+  /** The Workers the daemon currently holds. Their lanes go untouched at any age. */
+  readonly live?: Iterable<string>;
+}
+
+/**
+ * Remove the lanes whose Worker died longer ago than the TTL allows.
+ *
+ * Never throws on an entry it cannot remove: a lane behind a bad permission is
+ * reported `failed` and the sweep continues, because one unreadable directory
+ * must not leave every other expired one on disk.
+ */
+export async function pruneWorkerEvidence(
+  options: PruneWorkerEvidenceOptions,
+): Promise<WorkerEvidencePruneReport> {
+  const ttlMs = Number.isFinite(options.ttlMs) && options.ttlMs! >= 0
+    ? options.ttlMs!
+    : DEFAULT_WORKER_EVIDENCE_TTL_MS;
+  const live = new Set(options.live ?? []);
+  const cutoffMs = Math.max(0, (options.now ?? Date.now)() - ttlMs);
+  const cutoffWorkerId = encodeHostWorkerId(cutoffMs);
+
+  let names: string[];
+  try {
+    names = (await readdir(options.root, { withFileTypes: true }))
+      .filter((child) => child.isDirectory())
+      .map((child) => child.name)
+      .sort();
+  } catch {
+    // A lane that was never written is a host that has lost no Worker, not a fault.
+    return { root: options.root, ttlMs, cutoffWorkerId, scanned: 0, pruned: 0, entries: [] };
+  }
+
+  const entries: WorkerEvidencePruneEntry[] = [];
+  for (const name of names) {
+    const dir = join(options.root, name);
+    if (live.has(name)) {
+      entries.push({ workerId: name, dir, disposition: "live", reason: "the daemon still holds this Worker" });
+      continue;
+    }
+    if (!isHostWorkerId(name)) {
+      entries.push({
+        workerId: name,
+        dir,
+        disposition: "unrecognized",
+        reason: "the directory name is not a host Worker id, so its age is unknown",
+      });
+      continue;
+    }
+    if (name >= cutoffWorkerId) {
+      entries.push({ workerId: name, dir, disposition: "retained", reason: `born at or after ${cutoffWorkerId}` });
+      continue;
+    }
+    try {
+      await rm(dir, { recursive: true, force: true });
+      entries.push({ workerId: name, dir, disposition: "pruned", reason: `born before ${cutoffWorkerId}` });
+    } catch (error) {
+      entries.push({
+        workerId: name,
+        dir,
+        disposition: "failed",
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return {
+    root: options.root,
+    ttlMs,
+    cutoffWorkerId,
+    scanned: entries.length,
+    pruned: entries.filter((entry) => entry.disposition === "pruned").length,
+    entries,
+  };
+}
+
+/** Copy one source into the lane, reporting rather than throwing. */
+async function capture(source: string | undefined, target: string): Promise<WorkerEvidenceCapture> {
+  if (source == null || source.trim() === "") return "absent";
+  try {
+    await copyFile(source, target);
+    return "copied";
+  } catch {
+    return "unreadable";
+  }
+}
+
+/**
+ * Everything a live Worker must already hold to leave evidence when it dies.
+ *
+ * Carried on the Worker handle rather than looked up at death, for the same
+ * reason its workspace is: at cleanup the process is already gone, the runner
+ * has already reported its artifact, and the only thing that ever knew where
+ * those bytes were is the handle about to be dropped.
+ */
+export interface WorkerEvidencePlan {
+  readonly root: string;
+  readonly ttlMs: number;
+  /** The Worker's narrative log; absent when the client asked for none. */
+  readonly logPath?: string;
+  readonly sessionArtifact?: WorkerEvidenceSessionArtifact;
+}

--- a/apps/redskilled/src/worker-launch.ts
+++ b/apps/redskilled/src/worker-launch.ts
@@ -197,6 +197,19 @@ export function encodeHostWorkerId(epochMs: number): string {
 }
 
 /**
+ * Whether `value` is a well-formed host Worker id. PURE.
+ *
+ * Asked by anything that reads a DIRECTORY NAME back as an id — the evidence
+ * lane's prune, above all. A name that is not one of these ids carries no birth
+ * instant, so judging its age would be a guess; the caller retains it and says
+ * so instead (ADR 0149 §3).
+ */
+export function isHostWorkerId(value: string): boolean {
+  return value.length === HOST_WORKER_ID_WIDTH &&
+    [...value].every((character) => HOST_WORKER_ID_ALPHABET.includes(character));
+}
+
+/**
  * Mint the host's Worker handle: the birth epoch in milliseconds, base62.
  *
  * **A collision walks the birth instant forward by 1 ms rather than redrawing.**

--- a/apps/redskilled/tests/host-config.test.ts
+++ b/apps/redskilled/tests/host-config.test.ts
@@ -14,9 +14,11 @@ import {
   RedskilledGithubProfileConfigError,
   readRedskilledHostConfig,
   resolveRedskilledHostEventSinks,
+  REDSKILLED_EVIDENCE_TTL_MS_ENV,
   resolveRedskilledHostSettings,
 } from "../src/host-config.js";
 import { provisionRedskilledHome } from "../src/provision.js";
+import { DEFAULT_WORKER_EVIDENCE_TTL_MS } from "../src/worker-evidence.js";
 
 const roots: string[] = [];
 const TOTAL = 16_000_000_000;
@@ -250,6 +252,31 @@ describe("host setting precedence", () => {
       config: { idleMs: "60000" },
       totalMemoryBytes: TOTAL,
     })).toMatchObject({ idleMs: 60_000, idleMsSource: "home-config" });
+  });
+
+  it("resolves the evidence TTL with the same precedence, and lets an operator ask for zero", () => {
+    expect(resolveRedskilledHostSettings({
+      flags: { evidenceTtlMs: 1_000 },
+      env: { [REDSKILLED_EVIDENCE_TTL_MS_ENV]: "2000" },
+      config: { evidenceTtlMs: "3000" },
+      totalMemoryBytes: TOTAL,
+    })).toMatchObject({ evidenceTtlMs: 1_000, evidenceTtlMsSource: "flag" });
+    expect(resolveRedskilledHostSettings({
+      env: { [REDSKILLED_EVIDENCE_TTL_MS_ENV]: "2000" },
+      config: { evidenceTtlMs: "3000" },
+      totalMemoryBytes: TOTAL,
+    })).toMatchObject({ evidenceTtlMs: 2_000, evidenceTtlMsSource: "environment" });
+    expect(resolveRedskilledHostSettings({
+      env: {},
+      config: { evidenceTtlMs: "3000" },
+      totalMemoryBytes: TOTAL,
+    })).toMatchObject({ evidenceTtlMs: 3_000, evidenceTtlMsSource: "home-config" });
+    // ADR 0149 §2's default, for a host that has never said otherwise.
+    expect(resolveRedskilledHostSettings({ env: {}, totalMemoryBytes: TOTAL }))
+      .toMatchObject({ evidenceTtlMs: DEFAULT_WORKER_EVIDENCE_TTL_MS, evidenceTtlMsSource: "derived-default" });
+    // "Keep nothing" is a declaration, not a typo: zero survives the bound.
+    expect(resolveRedskilledHostSettings({ env: {}, config: { evidenceTtlMs: "0" }, totalMemoryBytes: TOTAL }))
+      .toMatchObject({ evidenceTtlMs: 0, evidenceTtlMsSource: "home-config" });
   });
 
   it("derives validation slots from the tightest CPU, memory, and Worker ceiling", () => {

--- a/apps/redskilled/tests/test-host-isolation.test.ts
+++ b/apps/redskilled/tests/test-host-isolation.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { resolveRedskilledPaths } from "../src/paths.js";
+import { workerEvidenceRoot } from "../src/worker-evidence.js";
 import { assertIsolatedHostIdentity } from "./support/test-host-isolation.js";
 
 const SETUP_FILE = "./tests/support/test-host-isolation.ts";
@@ -24,6 +25,9 @@ describe("the redskilled test host", () => {
     expect(paths.machineClaimPath.startsWith(root)).toBe(true);
     expect(paths.eventLanePath.startsWith(root)).toBe(true);
     expect(paths.registrationIntentPath.startsWith(root)).toBe(true);
+    // The evidence lane is ambient too: admission defaults it from `homedir()`,
+    // so a Worker dying inside a test must not write into the operator's own.
+    expect(workerEvidenceRoot(homedir()).startsWith(root)).toBe(true);
   });
 
   it("refuses a test that restores host identity before making a mutation", () => {

--- a/apps/redskilled/tests/worker-evidence.test.ts
+++ b/apps/redskilled/tests/worker-evidence.test.ts
@@ -1,0 +1,269 @@
+// What a dead Worker leaves behind, and what a TTL is allowed to take (issue
+// #4018, ADR 0149 §2/§4).
+//
+// The workspace is expensive and regenerable and goes with the Worker (#4017).
+// These three files are the other half: cheap, irreplaceable, and the only
+// thing a human has left after a reboot cleared OS temporary storage. So the
+// assertions are made against a REAL Worker death — the daemon admits one, it
+// writes a log, it dies, and the lane is inspected — and against a prune that
+// is handed a live Worker and a dead one at once.
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Socket } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { decode } from "@reddb-io/toon";
+import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
+import { cleanupWorkflowWorker, type ActiveWorkflowWorker } from "../src/acp-worker-lifecycle.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+import { materializeWorkerWorkspace, workerWorkspaceRoot } from "../src/worker-workspace.js";
+import { encodeHostWorkerId, mintHostWorkerId } from "../src/worker-launch.js";
+import {
+  DEFAULT_WORKER_EVIDENCE_TTL_MS,
+  pruneWorkerEvidence,
+  retainWorkerEvidence,
+  WORKER_EVIDENCE_LOG_FILE,
+  WORKER_EVIDENCE_VERDICT_FILE,
+  workerEvidenceDir,
+  workerEvidenceRoot,
+  WorkerEvidenceError,
+} from "../src/worker-evidence.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+/** A lane for a Worker that already died, at a stated birth instant. */
+async function deadLane(root: string, bornAtMs: number, outcome = "idle-policy"): Promise<string> {
+  const workerId = encodeHostWorkerId(bornAtMs);
+  await retainWorkerEvidence({
+    root,
+    verdict: { workerId, outcome, diedAt: new Date(bornAtMs).toISOString() },
+  });
+  return workerId;
+}
+
+describe("where a Worker's evidence lives", () => {
+  it("is the operator's ~/.red/tmp/workers, never the daemon's durable home", () => {
+    expect(workerEvidenceRoot("/home/ada")).toBe("/home/ada/.red/tmp/workers");
+    expect(workerEvidenceDir(workerEvidenceRoot("/home/ada"), "0aBcDeF"))
+      .toBe("/home/ada/.red/tmp/workers/0aBcDeF");
+  });
+
+  it("leaves the daemon's own log where ADR 0130 Amendment 2 put it", () => {
+    // The evidence lane is a NEW place; it moves nothing. `~/.red/redskilled/`
+    // stays the durable home for the daemon's own log and registrations.
+    const paths = resolveRedskilledPaths({ homeDir: "/home/ada", runtimeDir: "/run/user/1000" });
+    expect(paths.eventLanePath).toBe("/home/ada/.red/redskilled/redskilled.log.toonl");
+    expect(redskilledHomeDir("/home/ada")).toBe("/home/ada/.red/redskilled");
+    expect(paths.eventLanePath.startsWith(workerEvidenceRoot("/home/ada"))).toBe(false);
+  });
+
+  it("refuses an id that would escape the lane rather than resolving it", () => {
+    const root = workerEvidenceRoot("/home/ada");
+    expect(() => workerEvidenceDir(root, "../elsewhere")).toThrow(WorkerEvidenceError);
+    expect(() => workerEvidenceDir(root, "  ")).toThrow(WorkerEvidenceError);
+  });
+});
+
+describe("what a dead Worker leaves in its lane", () => {
+  it("holds the log, the runner's session artifact and the verdict", async () => {
+    const home = await scratch("redskilled-evidence-home-");
+    const runner = await scratch("redskilled-runner-session-");
+    const root = workerEvidenceRoot(home);
+    const workerId = encodeHostWorkerId(1_760_000_000_000);
+
+    const logPath = join(await scratch("redskilled-worker-log-"), "worker.log.toonl");
+    await writeFile(logPath, "event: birth\nevent: death\n");
+    const artifactPath = join(runner, "01H-session.jsonl");
+    await writeFile(artifactPath, '{"role":"assistant"}\n');
+
+    const retained = await retainWorkerEvidence({
+      root,
+      logPath,
+      verdict: {
+        workerId,
+        outcome: "completion",
+        diedAt: "2026-08-19T05:00:00.000Z",
+        workspacePath: "/tmp/red-skills-1000/workers/xxxxxxx",
+        publicSessionId: "session-4018",
+        sessionArtifact: { provider: "claude", availability: "available", reference: artifactPath },
+      },
+    });
+
+    expect(retained.evidenceDir).toBe(join(root, workerId));
+    expect(retained.log).toBe("copied");
+    expect(retained.sessionArtifact).toBe("copied");
+    expect(await readFile(join(retained.evidenceDir, WORKER_EVIDENCE_LOG_FILE), "utf8"))
+      .toBe("event: birth\nevent: death\n");
+    expect(await readFile(join(retained.evidenceDir, "session-artifact.jsonl"), "utf8"))
+      .toBe('{"role":"assistant"}\n');
+
+    const verdict = decode(await readFile(retained.verdictPath, "utf8")) as Record<string, unknown>;
+    expect(verdict).toMatchObject({
+      worker_id: workerId,
+      outcome: "completion",
+      died_at: "2026-08-19T05:00:00.000Z",
+      released_workspace_path: "/tmp/red-skills-1000/workers/xxxxxxx",
+      log: "copied",
+      session_artifact: "copied",
+    });
+  });
+
+  it("still writes the verdict for a Worker that died before it logged anything", async () => {
+    const home = await scratch("redskilled-evidence-home-");
+    const root = workerEvidenceRoot(home);
+    const workerId = encodeHostWorkerId(1_760_000_000_001);
+
+    const retained = await retainWorkerEvidence({
+      root,
+      logPath: join(home, "never-written.toonl"),
+      verdict: {
+        workerId,
+        outcome: "session-error",
+        diedAt: "2026-08-19T05:00:01.000Z",
+        sessionArtifact: { provider: "redskills-native", availability: "absent" },
+      },
+    });
+
+    expect(retained.log).toBe("unreadable");
+    expect(retained.sessionArtifact).toBe("absent");
+    expect(await readdir(retained.evidenceDir)).toEqual([WORKER_EVIDENCE_VERDICT_FILE]);
+    const verdict = decode(await readFile(retained.verdictPath, "utf8")) as Record<string, unknown>;
+    expect(verdict).toMatchObject({ outcome: "session-error", log: "unreadable", session_artifact: "absent" });
+  });
+});
+
+describe("pruning the evidence lane by its host TTL", () => {
+  it("removes a dead lane at TTL 0, keeps the same lane under the default TTL", async () => {
+    const home = await scratch("redskilled-evidence-home-");
+    const root = workerEvidenceRoot(home);
+    const bornAtMs = 1_760_000_000_000;
+    const workerId = await deadLane(root, bornAtMs);
+
+    const kept = await pruneWorkerEvidence({ root, now: () => bornAtMs + 1_000, live: [] });
+    expect(kept.ttlMs).toBe(DEFAULT_WORKER_EVIDENCE_TTL_MS);
+    expect(kept.pruned).toBe(0);
+    expect(kept.entries).toEqual([expect.objectContaining({ workerId, disposition: "retained" })]);
+    expect(existsSync(join(root, workerId))).toBe(true);
+
+    const swept = await pruneWorkerEvidence({ root, ttlMs: 0, now: () => bornAtMs + 1_000, live: [] });
+    expect(swept.pruned).toBe(1);
+    expect(swept.entries).toEqual([expect.objectContaining({ workerId, disposition: "pruned" })]);
+    expect(existsSync(join(root, workerId))).toBe(false);
+  });
+
+  it("never removes a live Worker's lane, however old the name says it is", async () => {
+    const home = await scratch("redskilled-evidence-home-");
+    const root = workerEvidenceRoot(home);
+    const ancient = 1_000_000_000_000;
+    const live = await deadLane(root, ancient, "still-running");
+    const dead = await deadLane(root, ancient + 1);
+
+    const report = await pruneWorkerEvidence({ root, ttlMs: 0, now: () => ancient + 10_000, live: [live] });
+    expect(report.entries).toEqual([
+      expect.objectContaining({ workerId: live, disposition: "live" }),
+      expect.objectContaining({ workerId: dead, disposition: "pruned" }),
+    ]);
+    expect(existsSync(join(root, live))).toBe(true);
+    expect(existsSync(join(root, dead))).toBe(false);
+  });
+
+  it("retains a directory whose name carries no birth instant, and says so", async () => {
+    const home = await scratch("redskilled-evidence-home-");
+    const root = workerEvidenceRoot(home);
+    await mkdir(join(root, "h1a2b"), { recursive: true });
+    await writeFile(join(root, "h1a2b", "worker.log.toonl"), "from an older id scheme\n");
+
+    const report = await pruneWorkerEvidence({ root, ttlMs: 0, now: () => 1_760_000_000_000 });
+    expect(report.entries).toEqual([expect.objectContaining({ workerId: "h1a2b", disposition: "unrecognized" })]);
+    expect(existsSync(join(root, "h1a2b"))).toBe(true);
+  });
+
+  it("reports an empty sweep for a host that has never lost a Worker", async () => {
+    const home = await scratch("redskilled-evidence-home-");
+    const report = await pruneWorkerEvidence({ root: workerEvidenceRoot(home), ttlMs: 0 });
+    expect(report).toMatchObject({ scanned: 0, pruned: 0, entries: [] });
+  });
+});
+
+describe("a Worker's death, from the daemon's cleanup path", () => {
+  it("keeps the evidence and lets the workspace go, then prunes what has expired", async () => {
+    const home = await scratch("redskilled-evidence-home-");
+    const tmpRoot = await scratch("redskilled-tmp-root-");
+    const root = workerEvidenceRoot(home);
+    const workspaceRoot = workerWorkspaceRoot({ tmpDir: tmpRoot, uid: 4018 });
+
+    // One Worker that died long ago, so this death's prune has something to take.
+    const ancient = await deadLane(root, 1_000_000_000_000);
+
+    // Minted at the real instant, so this Worker's own lane is younger than the
+    // TTL its death sweeps with — a lane the sweep it triggered would eat is a
+    // retention policy that keeps nothing.
+    const workerId = mintHostWorkerId([]);
+    const workspace = await materializeWorkerWorkspace({
+      root: workspaceRoot,
+      workerId,
+      projectWorkspacePath: await scratch("redskilled-not-a-repo-"),
+    });
+    // The Worker's log lives INSIDE the workspace about to be deleted: the case
+    // that decides whether retention happens before or after the release.
+    const logPath = join(workspace.workspacePath, "worker.log.toonl");
+    await writeFile(logPath, "event: birth\n");
+    const artifactPath = join(await scratch("redskilled-runner-session-"), "session.jsonl");
+    await writeFile(artifactPath, '{"role":"user"}\n');
+
+    const active = new Map<string, ActiveWorkflowWorker>();
+    const worker = {
+      workerId,
+      workspace,
+      evidence: {
+        root,
+        ttlMs: DEFAULT_WORKER_EVIDENCE_TTL_MS,
+        logPath,
+        sessionArtifact: { provider: "claude", availability: "available", reference: artifactPath },
+      },
+      downstreamSessionId: "downstream-session",
+      connection: { close: () => undefined },
+      socket: new Socket(),
+      endpoint: join(tmpRoot, "unused-test-endpoint.sock"),
+      publicSessionId: "public-session-4018",
+      notify: async () => undefined,
+      cancelled: false,
+      cleaned: false,
+    } as unknown as ActiveWorkflowWorker;
+    active.set("public-session-4018", worker);
+
+    cleanupWorkflowWorker("public-session-4018", worker, active, "idle-policy");
+
+    const evidenceDir = join(root, workerId);
+    await vi.waitFor(() => {
+      expect(existsSync(join(evidenceDir, WORKER_EVIDENCE_VERDICT_FILE))).toBe(true);
+      expect(existsSync(workspace.workspacePath)).toBe(false);
+      expect(existsSync(join(root, ancient))).toBe(false);
+    });
+
+    expect(await readFile(join(evidenceDir, WORKER_EVIDENCE_LOG_FILE), "utf8")).toBe("event: birth\n");
+    expect(await readFile(join(evidenceDir, "session-artifact.jsonl"), "utf8")).toBe('{"role":"user"}\n');
+    const verdict = decode(await readFile(join(evidenceDir, WORKER_EVIDENCE_VERDICT_FILE), "utf8")) as
+      Record<string, unknown>;
+    expect(verdict).toMatchObject({
+      worker_id: workerId,
+      outcome: "idle-policy",
+      public_session_id: "public-session-4018",
+      released_workspace_path: workspace.workspacePath,
+      log: "copied",
+      session_artifact: "copied",
+    });
+    expect(existsSync(evidenceDir)).toBe(true);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #4018. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #4018

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789712633&installation_model_id=20659&pr_number=4057&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4057&signature=b29f08d443cc4aa2942a6a7b9a82c4b159eff2c5c9d565971a71d85c3b8e1e72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->