### PR TITLE
fix: #4048 The birth breaker counts a clean NO MORE TASKS exit as a loss

### DIFF
--- a/apps/dev/src/core/file-size-guard.ts
+++ b/apps/dev/src/core/file-size-guard.ts
@@ -74,7 +74,7 @@ export const FILE_SIZE_BASELINE: readonly FileSizeBaselineEntry[] = [
   // into modules that each take a sixty-field context object would satisfy this
   // number and leave the code worse. The entry states the debt with a ceiling;
   // paying it means decomposing the function, not moving its lines.
-  { path: "apps/redskilled/src/daemon/lifecycle.ts", lines: 2489 },
+  { path: "apps/redskilled/src/daemon/lifecycle.ts", lines: 2475 },
   { path: "apps/redskilled/src/cli.ts", lines: 1036 },
   { path: "apps/redskilled/src/client.ts", lines: 1003 },
   { path: "apps/redskilled/src/statusline-payload.ts", lines: 864 },

--- a/apps/redskilled/src/daemon/birth-outcome.ts
+++ b/apps/redskilled/src/daemon/birth-outcome.ts
@@ -1,0 +1,85 @@
+// birth-outcome — what a dead Worker REPORTED, and how that folds into its
+// project's birth breaker.
+//
+// The breaker asks one question: can a Worker boot HERE. A Worker that booted,
+// read the queue, found nothing eligible and said so answered it with a yes —
+// and until #4048 the daemon counted that answer as a loss, because the only
+// thing it read about a death was how long the Worker lived. On 2026-08-19 a
+// drained queue emptied three Workers within seconds of birth, the latch armed,
+// and every birth that would have consumed the queue once it was repaired was
+// refused until an operator cleared the latch by hand.
+//
+// So a death now carries an OUTCOME CLASS beside its lifetime. The vocabulary is
+// three words of the Worker protocol's own `<promise>` sentinel — never a
+// repository's account of its work (ADR 0130 rule 3): this module learns THAT a
+// Worker finished, never what it finished.
+import {
+  describeBirthOutcome,
+  EMPTY_BIRTH_HEALTH,
+  foldWorkerDeath,
+  REDSKILLED_SHORT_LIFE_MS,
+  type RedskilledBirthHealth,
+  type RedskilledWorkerBirthOutcome,
+} from "../demand-loop.js";
+
+/**
+ * What one dead Worker reported, from evidence the daemon already holds. PURE.
+ *
+ * The bounded tail read that recovers a `session-error:` boot refusal also
+ * carries the terminal sentinel, so this costs no second read and no new wire
+ * field.
+ *
+ * **A non-zero exit or a signal is unreported whatever the log says.** A Worker
+ * that printed its sentinel and then crashed on the way out did not end cleanly,
+ * and a breaker that took the sentence over the exit status would be reading the
+ * claim instead of the outcome.
+ */
+export function workerTerminalOutcome(input: {
+  readonly exitCode: number | null;
+  readonly signal: string | null;
+  readonly tail: string | null;
+}): RedskilledWorkerBirthOutcome {
+  if (input.exitCode !== 0 || input.signal != null) return "unreported";
+  const sentinel = input.tail?.match(/<promise>\s*(DONE|BLOCKED|NO MORE TASKS)\s*<\/promise>/i)?.[1];
+  if (sentinel == null) return "unreported";
+  return sentinel.toUpperCase() === "NO MORE TASKS" ? "no-eligible-work" : "work-reported";
+}
+
+export interface FoldProjectBirthHealthInput {
+  /** The daemon's live per-project record, updated in place. */
+  readonly health: Record<string, RedskilledBirthHealth>;
+  readonly projectLabel: string;
+  readonly lifetimeMs: number;
+  readonly outcome: RedskilledWorkerBirthOutcome;
+  readonly nowMs: number;
+  /** Said once, when the breaker opens; a loop that logs per cycle fills a disk. */
+  readonly announce: (line: string) => void;
+}
+
+/**
+ * Fold one death into its project's birth health.
+ *
+ * An unreadable lifetime is treated as long, never as short: the breaker exists
+ * to stop a loop it can prove, and halting a project on a clock it could not
+ * parse would be the same silent overreach in the other direction.
+ *
+ * The outcome class travels with the lifetime because a fast death and a fast
+ * FINISH look identical on a clock, and only one of them is a project to stop
+ * asking.
+ */
+export function foldProjectBirthHealth(input: FoldProjectBirthHealthInput): void {
+  const { health, projectLabel, lifetimeMs, outcome } = input;
+  if (!Number.isFinite(lifetimeMs) || lifetimeMs < 0) {
+    health[projectLabel] = EMPTY_BIRTH_HEALTH;
+    return;
+  }
+  const before = health[projectLabel] ?? EMPTY_BIRTH_HEALTH;
+  const after = foldWorkerDeath(before, lifetimeMs, input.nowMs, outcome);
+  health[projectLabel] = after;
+  if (after.haltUntilMs == null || before.haltUntilMs != null) return;
+  input.announce(
+    `redskilled: project ${JSON.stringify(projectLabel)} lost ${after.shortLifeStreak} Workers in a row inside ` +
+      `${REDSKILLED_SHORT_LIFE_MS}ms of birth (${describeBirthOutcome(outcome)}); not asking for another until ` +
+      `${new Date(after.haltUntilMs).toISOString()}\n`,
+  );
+}

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -34,15 +34,15 @@ import {
   describeBirthLatches,
   emptyDemandTick,
   planHostDemand,
-  foldWorkerDeath,
-  EMPTY_BIRTH_HEALTH,
   resetBirthHealth,
   REDSKILLED_SHORT_LIFE_MS,
   type RedskilledBirthHealth,
+  type RedskilledWorkerBirthOutcome,
   REDSKILLED_DEMAND_BACKOFF_MS,
   type RedskilledDemandGrant,
   type RedskilledDemandTick,
 } from "../demand-loop.js";
+import { foldProjectBirthHealth, workerTerminalOutcome } from "./birth-outcome.js";
 import { buildRedskilledStopReport, type RedskilledDaemonStopped, type RedskilledStopReason } from "../daemon-stop.js";
 import {
   buildHostState,
@@ -1275,38 +1275,18 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       return;
     }
     const death = await resolveUnitDeath(worker, unitExitFacts, { detail: ended, facts: { exitCode: code, signal } });
-    const refusal = worker.log_path == null
-      ? null
-      : bootRefusalFromLog(await readLogTail(worker.log_path).catch(() => null));
+    // One bounded tail read answers both questions a death asks of a log: whether
+    // boot refused, and whether the Worker reached a terminal outcome before it
+    // ended. A Worker that published a line on its heartbeat already told us the
+    // second without any read at all.
+    const tail = worker.log_path == null ? null : await readLogTail(worker.log_path).catch(() => null);
+    const refusal = bootRefusalFromLog(tail);
+    const reported = tail ?? logLines.get(worker.worker_id)?.line ?? null;
     forgetWorker(worker.worker_id);
-    record("worker-death", worker, refusal == null ? death.detail : `session-error: ${refusal}`, { ...death.facts, refusal });
+    record("worker-death", worker, refusal == null ? death.detail : `session-error: ${refusal}`, {
+      ...death.facts, refusal, birthOutcome: workerTerminalOutcome({ exitCode: code, signal, tail: reported }),
+    });
     armIdleTimer();
-  }
-
-  /**
-   * Fold one death into its project's birth health.
-   *
-   * An unreadable lifetime is treated as long, never as short: the breaker
-   * exists to stop a loop it can prove, and halting a project on a clock it
-   * could not parse would be the same silent overreach in the other direction.
-   */
-  function foldBirthHealth(projectLabel: string, lifetimeMs: number): void {
-    if (!Number.isFinite(lifetimeMs) || lifetimeMs < 0) {
-      birthHealth[projectLabel] = EMPTY_BIRTH_HEALTH;
-      return;
-    }
-    const before = birthHealth[projectLabel] ?? EMPTY_BIRTH_HEALTH;
-    const after = foldWorkerDeath(before, lifetimeMs, Date.parse(clock()));
-    birthHealth[projectLabel] = after;
-    if (after.haltUntilMs != null && before.haltUntilMs == null) {
-      // Said once, when the breaker opens rather than on every death after it:
-      // a loop that logs per cycle is the second thing filling a disk.
-      process.stderr.write(
-        `redskilled: project ${JSON.stringify(projectLabel)} lost ${after.shortLifeStreak} Workers in a row ` +
-          `inside ${REDSKILLED_SHORT_LIFE_MS}ms of birth; not asking for another until ` +
-          `${new Date(after.haltUntilMs).toISOString()}\n`,
-      );
-    }
   }
 
   /** Clear one project's birth breaker after project-scoped reach permits it. */
@@ -1644,6 +1624,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     detail: string | null,
     facts: Omit<RecordWorkerEventInput, "kind" | "worker" | "ts" | "detail"> & {
       readonly refusal?: string | null;
+      /** What this Worker reported before ending; absent when the caller saw nothing. */
+      readonly birthOutcome?: RedskilledWorkerBirthOutcome;
     } = {},
   ): void {
     // A stopped daemon is no longer authoritative; its successor re-derives state.
@@ -1669,9 +1651,15 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       );
       // Every death reaches here, which is why the breaker folds here rather
       // than at the five call sites that end a Worker. What it reads is a
-      // lifetime, never a cause: the daemon is not owed a reason (rule 3), and
-      // a Worker dead in seconds is spent whatever the reason was.
-      foldBirthHealth(worker.project_label, Date.parse(ts) - Date.parse(worker.started_at));
+      // lifetime and an outcome class — never a cause (rule 3): a Worker dead in
+      // seconds is spent whatever the reason was UNLESS it reported that it was
+      // finished, which is the one thing a spent birth never does.
+      foldProjectBirthHealth({
+        health: birthHealth, projectLabel: worker.project_label, nowMs: Date.parse(ts),
+        lifetimeMs: Date.parse(ts) - Date.parse(worker.started_at),
+        outcome: facts.birthOutcome ?? "unreported",
+        announce: (line) => process.stderr.write(line),
+      });
     }
     void eventLane
       .recordWorker(input)

--- a/apps/redskilled/src/demand-loop.ts
+++ b/apps/redskilled/src/demand-loop.ts
@@ -42,11 +42,23 @@
  * back a healthy neighbour, and a host-wide backoff would make it do exactly
  * that.
  *
+ * **A clean "nothing to do" is not a loss.** The breaker asks whether a Worker
+ * can boot HERE, and one that booted, read the queue, found it empty and said so
+ * answered that question with a yes. Counting it as a loss inverted the meaning:
+ * on 2026-08-19 a drained queue emptied three Workers within seconds of birth,
+ * the latch armed, and when the queue was repaired nothing was born to consume
+ * it until an operator cleared the latch by hand. The streak therefore folds an
+ * OUTCOME CLASS beside the lifetime — see
+ * {@link RedskilledWorkerBirthOutcome} — and only a death that reached no
+ * terminal outcome counts.
+ *
  * **Rule 3 survives.** A selector and an argv are carried and handed back; not
  * one branch here turns on what either of them says. The planner reads a depth,
  * a target, a count of live Workers and a streak of short-lived deaths — four
- * integers — and nothing else. It never learns WHY a Worker died; a lifetime in
- * milliseconds is not a reason, and the daemon is not owed one.
+ * integers — and nothing else. The outcome class is a closed vocabulary of three
+ * words the Worker protocol already speaks, never a repository's reason: this
+ * module learns THAT a Worker reached a terminal outcome, never what the work
+ * was, and the daemon is owed no more than that.
  *
  * PURE.
  */
@@ -166,6 +178,19 @@ export interface PlanHostDemandInput {
 }
 
 /**
+ * How a refusal says which loss armed the latch. PURE.
+ *
+ * An unstated class is reported as unstated rather than assumed to be the
+ * crashloop: a caller that passed only a halt instant told us when, not why, and
+ * a sentence that guessed would be the confusion this whole change removes.
+ */
+function lossPhrase(outcome: RedskilledWorkerBirthOutcome | null | undefined): string {
+  return outcome == null
+    ? "outcome class unstated by the caller"
+    : `outcome class ${JSON.stringify(outcome)}: ${describeBirthOutcome(outcome)}`;
+}
+
+/**
  * Decide what every registered project may ask for this tick. PURE.
  *
  * **Births are spread one apiece before a second**, so the project that happens
@@ -214,8 +239,8 @@ export function planHostDemand(input: PlanHostDemandInput): RedskilledDemandPlan
         detail:
           `project ${JSON.stringify(project.project_label)} lost ` +
           `${REDSKILLED_SHORT_LIFE_STREAK} Workers in a row inside ` +
-          `${REDSKILLED_SHORT_LIFE_MS}ms of birth, so it is not asked for another before ` +
-          `${new Date(haltUntilMs).toISOString()} — a Worker that cannot survive boot will not ` +
+          `${REDSKILLED_SHORT_LIFE_MS}ms of birth (each ${lossPhrase(health?.lossOutcome)}), so it is not asked ` +
+          `for another before ${new Date(haltUntilMs).toISOString()} — a Worker that cannot survive boot will not ` +
           `survive the next one either, and every birth spends host quota shared with every project`,
       });
       continue;
@@ -356,6 +381,35 @@ export function isRedskilledDemandTick(value: unknown): value is RedskilledDeman
 }
 
 /**
+ * What one dead Worker managed to REPORT before it ended. PURE vocabulary.
+ *
+ * Three words, and every one of them is the Worker protocol's own — a
+ * `<promise>` sentinel — rather than a repository's account of its work. The
+ * distinction the breaker needs is exactly this coarse: a Worker that reached
+ * any terminal outcome proved boot works here, and a Worker that reached none is
+ * the shape the breaker exists to stop.
+ */
+export type RedskilledWorkerBirthOutcome =
+  /** Exited cleanly having reported the queue held nothing eligible for it. */
+  | "no-eligible-work"
+  /** Exited cleanly having reported a terminal verdict on work it took. */
+  | "work-reported"
+  /** Ended without reaching any terminal outcome — the loss the breaker counts. */
+  | "unreported";
+
+/** How an operator reading one line should hear an outcome class. PURE. */
+export function describeBirthOutcome(outcome: RedskilledWorkerBirthOutcome): string {
+  switch (outcome) {
+    case "no-eligible-work":
+      return "exited cleanly reporting no eligible work";
+    case "work-reported":
+      return "exited cleanly reporting a terminal outcome on its work";
+    default:
+      return "died before reporting any terminal outcome";
+  }
+}
+
+/**
  * One project's record of Workers that died before they could work.
  *
  * The streak, not a rate: a project that loses one Worker an hour is not
@@ -372,6 +426,14 @@ export interface RedskilledBirthHealth {
   readonly openedAtMs: number | null;
   /** The sole half-open Worker; while present no second birth is admitted. */
   readonly probeWorkerId: string | null;
+  /**
+   * The outcome class of the deaths in the current streak; `null` with no streak.
+   *
+   * Carried so the refusal an operator reads names WHICH loss armed the latch —
+   * a crashloop and a drained queue produced the same sentence before, and only
+   * one of them is a project to distrust.
+   */
+  readonly lossOutcome: RedskilledWorkerBirthOutcome | null;
 }
 
 /** A project with no history — never halted, no streak. */
@@ -380,6 +442,7 @@ export const EMPTY_BIRTH_HEALTH: RedskilledBirthHealth = {
   haltUntilMs: null,
   openedAtMs: null,
   probeWorkerId: null,
+  lossOutcome: null,
 };
 
 /** The structured cure carried beside every visible birth latch. */
@@ -409,6 +472,16 @@ export interface RedskilledBirthLatch {
  * that did is a complete answer — carrying forward failures from before a
  * working boot would halt a project that has already recovered.
  *
+ * **A reported terminal outcome clears the streak exactly as a long life does,
+ * however short the Worker lived.** A Worker that boots, reads the queue, finds
+ * nothing eligible and says so is not a Worker that failed to boot — it is the
+ * proof the chain works, delivered in seconds. Counting it armed the breaker on
+ * a drained queue and then refused every birth that would have consumed the
+ * queue once it was refilled. Only `unreported` — an end with no terminal
+ * outcome behind it — is a loss, which leaves the guard's original job whole: a
+ * probe that refuses, a workspace that will not materialise and a runner that is
+ * not installed all end that way.
+ *
  * The halt is armed on the death that completes the streak and re-armed by
  * every short death after it, so a project probed after the window and still
  * broken goes quiet again immediately instead of leaking one birth per window
@@ -418,18 +491,21 @@ export function foldWorkerDeath(
   health: RedskilledBirthHealth,
   lifetimeMs: number,
   nowMs: number,
+  outcome: RedskilledWorkerBirthOutcome = "unreported",
 ): RedskilledBirthHealth {
+  if (outcome !== "unreported") return EMPTY_BIRTH_HEALTH;
   if (lifetimeMs >= REDSKILLED_SHORT_LIFE_MS) return EMPTY_BIRTH_HEALTH;
   const shortLifeStreak = health.shortLifeStreak + 1;
   const wasLatched = health.haltUntilMs != null || health.probeWorkerId != null;
   if (!wasLatched && shortLifeStreak < REDSKILLED_SHORT_LIFE_STREAK) {
-    return { shortLifeStreak, haltUntilMs: null, openedAtMs: null, probeWorkerId: null };
+    return { shortLifeStreak, haltUntilMs: null, openedAtMs: null, probeWorkerId: null, lossOutcome: outcome };
   }
   return {
     shortLifeStreak,
     haltUntilMs: nowMs + REDSKILLED_BIRTH_HALT_MS,
     openedAtMs: nowMs,
     probeWorkerId: null,
+    lossOutcome: outcome,
   };
 }
 
@@ -460,7 +536,7 @@ export function describeBirthLatch(
     opened_at: new Date(health.openedAtMs).toISOString(),
     reason:
       `${health.shortLifeStreak} Workers from this project died before surviving ` +
-      `${REDSKILLED_SHORT_LIFE_MS}ms`,
+      `${REDSKILLED_SHORT_LIFE_MS}ms (${lossPhrase(health.lossOutcome)})`,
     closes: halfOpen
       ? health.probeWorkerId == null
         ? "the next demand tick admits one probe Worker; surviving the short-life window closes the latch"

--- a/apps/redskilled/tests/birth-breaker.test.ts
+++ b/apps/redskilled/tests/birth-breaker.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "vitest";
 import {
   birthHaltMap,
+  describeBirthLatch,
   EMPTY_BIRTH_HEALTH,
   foldWorkerDeath,
   planHostDemand,
@@ -15,6 +16,7 @@ import {
   REDSKILLED_SHORT_LIFE_STREAK,
   type RedskilledDemandProject,
 } from "../src/demand-loop.js";
+import { workerTerminalOutcome } from "../src/daemon/birth-outcome.js";
 
 const NOW_MS = Date.parse("2026-08-02T23:00:00.000Z");
 
@@ -65,6 +67,99 @@ describe("foldWorkerDeath", () => {
 
   it("treats a lifetime exactly at the threshold as long enough", () => {
     expect(foldWorkerDeath(EMPTY_BIRTH_HEALTH, REDSKILLED_SHORT_LIFE_MS, NOW_MS)).toEqual(EMPTY_BIRTH_HEALTH);
+  });
+});
+
+// The 2026-08-19 incident: the queue emptied while four Tickets were
+// quarantined, so the Workers already running found nothing to do, said so and
+// exited 0 seconds after birth. The breaker read three clean exits as three
+// losses and then refused every birth that would have consumed the queue once
+// it was repaired.
+describe("a Worker that reported no eligible work", () => {
+  it("does not increment the streak", () => {
+    const health = foldWorkerDeath(EMPTY_BIRTH_HEALTH, 4_000, NOW_MS, "no-eligible-work");
+    expect(health.shortLifeStreak).toBe(0);
+    expect(health.haltUntilMs).toBeNull();
+  });
+
+  it("leaves the breaker closed after three in a row", () => {
+    let health = EMPTY_BIRTH_HEALTH;
+    for (let i = 0; i < REDSKILLED_SHORT_LIFE_STREAK; i += 1) {
+      health = foldWorkerDeath(health, 4_000, NOW_MS, "no-eligible-work");
+    }
+    expect(health).toEqual(EMPTY_BIRTH_HEALTH);
+    expect(birthHaltMap({ drained: health }, NOW_MS)).toEqual({});
+  });
+
+  it("clears a streak the losses before it built", () => {
+    // Proof the chain works, delivered in seconds. Carrying forward failures
+    // from before it would halt a project that has already recovered — the same
+    // reason a long life clears the streak outright.
+    const nearly = streak(REDSKILLED_SHORT_LIFE_STREAK - 1, 13_000);
+    expect(foldWorkerDeath(nearly, 4_000, NOW_MS, "no-eligible-work")).toEqual(EMPTY_BIRTH_HEALTH);
+  });
+
+  it("closes a latched breaker when the half-open probe reports it", () => {
+    const halted = streak(REDSKILLED_SHORT_LIFE_STREAK, 13_000);
+    const probed = { ...halted, probeWorkerId: "w9" };
+    expect(foldWorkerDeath(probed, 4_000, NOW_MS + 1, "no-eligible-work")).toEqual(EMPTY_BIRTH_HEALTH);
+  });
+
+  it("still halts a project whose Workers die unreported — the original job", () => {
+    const health = streak(REDSKILLED_SHORT_LIFE_STREAK, 13_000);
+    expect(health.haltUntilMs).toBe(NOW_MS + REDSKILLED_BIRTH_HALT_MS);
+    expect(health.lossOutcome).toBe("unreported");
+  });
+});
+
+describe("workerTerminalOutcome", () => {
+  it("reads the Worker protocol's own sentinel out of a clean exit", () => {
+    expect(workerTerminalOutcome({ exitCode: 0, signal: null, tail: "<promise>NO MORE TASKS</promise>" }))
+      .toBe("no-eligible-work");
+    expect(workerTerminalOutcome({ exitCode: 0, signal: null, tail: "x <promise>DONE</promise>" }))
+      .toBe("work-reported");
+  });
+
+  it("is unreported when nothing terminal was said", () => {
+    expect(workerTerminalOutcome({ exitCode: 0, signal: null, tail: "booting" })).toBe("unreported");
+    expect(workerTerminalOutcome({ exitCode: 0, signal: null, tail: null })).toBe("unreported");
+  });
+
+  it("takes the exit status over the claim", () => {
+    // A Worker that printed its sentinel and then crashed on the way out did
+    // not end cleanly, whatever the last line says.
+    expect(workerTerminalOutcome({ exitCode: 1, signal: null, tail: "<promise>NO MORE TASKS</promise>" }))
+      .toBe("unreported");
+    expect(workerTerminalOutcome({ exitCode: 0, signal: "SIGKILL", tail: "<promise>DONE</promise>" }))
+      .toBe("unreported");
+  });
+});
+
+describe("the refusal an operator reads", () => {
+  it("names the outcome class that armed the latch", () => {
+    const health = streak(REDSKILLED_SHORT_LIFE_STREAK, 13_000);
+    const plan = planHostDemand({
+      projects: [project("looping")],
+      queue: { looping: 5 },
+      live: { looping: 0 },
+      nowMs: NOW_MS,
+      birthHealth: { looping: health },
+    });
+    const detail = plan.intents[0]?.detail ?? "";
+    expect(detail).toContain("unreported");
+    expect(detail).toContain("died before reporting any terminal outcome");
+    expect(describeBirthLatch("looping", health, NOW_MS)?.reason).toContain("unreported");
+  });
+
+  it("says the class is unstated when the caller passed only a halt instant", () => {
+    const plan = planHostDemand({
+      projects: [project("looping")],
+      queue: { looping: 5 },
+      live: { looping: 0 },
+      nowMs: NOW_MS,
+      birthHaltUntilMs: { looping: NOW_MS + REDSKILLED_BIRTH_HALT_MS },
+    });
+    expect(plan.intents[0]?.detail).toContain("unstated");
   });
 });
 

--- a/apps/redskilled/tests/birth-outcome.test.ts
+++ b/apps/redskilled/tests/birth-outcome.test.ts
@@ -1,0 +1,184 @@
+// A clean "NO MORE TASKS" exit is not a loss (issue #4048). On 2026-08-19 the
+// queue emptied while four Tickets were quarantined; the Workers already running
+// found nothing to do, printed the sentinel and exited 0 seconds after birth.
+// The daemon read three fast exits as three losses, refused every further demand
+// for the project, and the latch had to be cleared by hand — so when the queue
+// was repaired, nothing was born to consume it.
+//
+// The breaker's original job is intact and tested here beside it: a Worker that
+// ends without reaching any terminal outcome still counts, and three of those
+// still open the latch.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { REDSKILLED_SHORT_LIFE_STREAK } from "../src/demand-loop.js";
+import { readRedskilledEvents } from "../src/event-lane.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+import type { LaunchedWorker, LaunchWorkerOptions } from "../src/worker-launch.js";
+
+const START_MS = Date.parse("2026-08-19T06:29:23.000Z");
+const PROJECT = "reddb-io/red-skills";
+const NO_MORE_TASKS = "<promise>NO MORE TASKS</promise>";
+
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+/** A launch that hands back the daemon's own exit callback, so a test can end a Worker the way the OS does. */
+function exitableLaunch(exits: Map<string, LaunchWorkerOptions["onExit"]>) {
+  let born = 0;
+  return (options: LaunchWorkerOptions): LaunchedWorker => {
+    if (!options.admission.admitted) throw new Error(options.admission.reason);
+    born += 1;
+    const workerId = `w${born}`;
+    exits.set(workerId, options.onExit);
+    return {
+      worker: {
+        worker_id: workerId,
+        project_label: options.spec.project_label,
+        workspace_path: options.spec.workspace_path,
+        log_path: join(options.spec.workspace_path, "worker.log.toonl"),
+        pid: 4_000 + born,
+        started_at: options.clock!(),
+        isolated: false,
+        warnings: [],
+      },
+      admission: options.admission,
+      warnings: [],
+      plan: {
+        backend: "none",
+        command: options.spec.command,
+        args: [...(options.spec.args ?? [])],
+        isolated: false,
+        warnings: [],
+      } as unknown as LaunchedWorker["plan"],
+      child: { pid: 4_000 + born, once: () => undefined, unref: () => undefined } as unknown as LaunchedWorker["child"],
+    };
+  };
+}
+
+interface Harness {
+  readonly daemon: RedskilledDaemon;
+  readonly eventLanePath: string;
+  /** Birth one Worker, live `lifetimeMs`, then end it with this exit status. */
+  kill(lifetimeMs: number, code: number | null): Promise<void>;
+  advance(ms: number): void;
+}
+
+/** One daemon holding one registered project, with the Worker's last line posed. */
+async function harness(tail: string | null): Promise<Harness> {
+  let nowMs = START_MS;
+  const exits = new Map<string, LaunchWorkerOptions["onExit"]>();
+  const session = await scratch("redskilled-birth-outcome-");
+  const workspace = await scratch("redskilled-birth-outcome-workspace-");
+  const paths = resolveRedskilledPaths({
+    env: { REDSKILLED_SESSION: `test:${session}`, REDSKILLED_MACHINE_DIR: session },
+    runtimeDir: session,
+  });
+  const daemon = await startRedskilledDaemon({
+    paths,
+    ceiling: UNBOUNDED_HOST_CEILING,
+    clock: () => new Date(nowMs).toISOString(),
+    sampleMs: 0,
+    demandMs: 0,
+    liveness: () => true,
+    launch: exitableLaunch(exits),
+    // The bounded tail read the daemon already performs on a death; posing it is
+    // how a test says what the Worker's last line was without writing a log.
+    readLogTail: async () => tail,
+    queueDiscovery: { intervalMs: 0, transport: async () => answer(1) },
+  });
+  running.push(daemon);
+  daemon.registerProject({
+    project_label: PROJECT,
+    selector: `repo:${PROJECT} label:ready-for-agent`,
+    argv: ["red-skills-dev", "run", "--once"],
+    workspace_path: workspace,
+    target: 6,
+  });
+  return {
+    daemon,
+    eventLanePath: paths.eventLanePath,
+    advance: (ms) => { nowMs += ms; },
+    async kill(lifetimeMs, code) {
+      await daemon.pollQueueDiscovery();
+      const tick = await daemon.driveDemand();
+      expect(tick.granted).toHaveLength(1);
+      const workerId = tick.granted[0]!.worker_id;
+      nowMs += lifetimeMs;
+      exits.get(workerId)?.(workerId, code, null);
+      await daemon.flushEvents();
+      nowMs += 2_000;
+    },
+  };
+}
+
+describe("the daemon's birth breaker and a Worker's terminal outcome", () => {
+  it("keeps asking after three clean NO MORE TASKS exits", async () => {
+    const { daemon, kill } = await harness(NO_MORE_TASKS);
+    for (let death = 0; death < REDSKILLED_SHORT_LIFE_STREAK; death += 1) await kill(4_000, 0);
+
+    // Nothing latched, and the very next tick still births: the empty queue that
+    // repaired itself is met by a Worker, not by a hand-cleared breaker.
+    expect(daemon.hostState().birth_latches ?? []).toEqual([]);
+    await daemon.pollQueueDiscovery();
+    const after = await daemon.driveDemand();
+    expect(after.granted).toHaveLength(1);
+    expect(after.projects[0]?.outcome).toBe("asking");
+  });
+
+  it("still halts a project whose Workers end without reporting anything", async () => {
+    const { daemon, kill, eventLanePath } = await harness("still booting");
+    for (let death = 0; death < REDSKILLED_SHORT_LIFE_STREAK; death += 1) await kill(13_000, 1);
+
+    expect(daemon.hostState().birth_latches?.[0]).toMatchObject({
+      name: "project-birth-breaker",
+      project_label: PROJECT,
+      state: "open",
+    });
+    await daemon.pollQueueDiscovery();
+    const held = await daemon.driveDemand();
+    expect(held.granted).toEqual([]);
+    expect(held.projects[0]?.outcome).toBe("birth-halted");
+
+    // The refusal on the lane names which outcome class armed the latch, so an
+    // operator reading it can tell a crashloop from a drained queue.
+    await daemon.flushEvents();
+    const refusals = (await readRedskilledEvents(eventLanePath)).filter(
+      (event) => event.event === "demand-refusal",
+    );
+    expect(refusals.at(-1)).toMatchObject({
+      project_label: PROJECT,
+      detail: expect.stringContaining("unreported"),
+    });
+  });
+
+  it("counts a Worker that printed the sentinel and then crashed anyway", async () => {
+    // The sentence is a claim; the exit status is the outcome.
+    const { daemon, kill } = await harness(NO_MORE_TASKS);
+    for (let death = 0; death < REDSKILLED_SHORT_LIFE_STREAK; death += 1) await kill(13_000, 9);
+    expect(daemon.hostState().birth_latches?.[0]).toMatchObject({ state: "open" });
+  });
+});
+
+function answer(depth: number): unknown {
+  return {
+    data: {
+      rateLimit: { remaining: 4_900, resetAt: null },
+      q0: { issueCount: depth },
+    },
+  };
+}


### PR DESCRIPTION
Automated AFK landing for #4048. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #4048

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789714124&installation_model_id=20659&pr_number=4058&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4058&signature=c4a89cae49b1a1c0f183e6195dcff81ccb46dc0e1816082ddf0f797d6c1102f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->