### PR TITLE
fix(scripts): the navigator MCP manifest entry is optional after #4010

### DIFF
--- a/.changeset/navigator-manifest-optional.md
+++ b/.changeset/navigator-manifest-optional.md
@@ -1,0 +1,13 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The navigator MCP manifest entry is optional, and its absence is the shipped state
+
+ADR 0147 §4 switched `navigator` off at the declaration while its code stays, and
+#4010 landed that removal — but `validate-install-metadata.sh` still required the
+entry, so every PR after it failed `validate-marketplace` with "navigator MCP
+manifest must use the on-demand launcher". The launcher assertion survives
+inverted rather than deleted: the launcher must still exist and be executable,
+and a manifest that names the server must still reach it through that launcher.
+Only the requirement that the entry be PRESENT is gone.

--- a/scripts/validate-install-metadata.sh
+++ b/scripts/validate-install-metadata.sh
@@ -102,8 +102,14 @@ validate_plugin() {
     if [[ "$plugin" == "dev" ]]; then
       [[ -x "$dir/hooks/code-nav-mcp.sh" ]] \
         || fail "$plugin: navigator MCP launcher must exist and be executable"
-      jq -e '.mcpServers["navigator"].args[]? | contains("code-nav-mcp.sh")' "$dir/${codex_mcp_path#./}" >/dev/null \
-        || fail "$plugin: navigator MCP manifest must use the on-demand launcher"
+      # ADR 0147 §4 switched `navigator` off at the DECLARATION while its code
+      # stays, so the entry is optional and its absence is the shipped state.
+      # Present-but-wrong is still a failure: a manifest that names the server
+      # must reach it through the on-demand launcher, never a bare command.
+      if jq -e '.mcpServers | has("navigator")' "$dir/${codex_mcp_path#./}" >/dev/null; then
+        jq -e '.mcpServers["navigator"].args[]? | contains("code-nav-mcp.sh")' "$dir/${codex_mcp_path#./}" >/dev/null \
+          || fail "$plugin: navigator MCP manifest must use the on-demand launcher"
+      fi
       [[ -x "$dir/hooks/redskilled-mcp.sh" ]] \
         || fail "$plugin: redskilled MCP launcher must exist and be executable"
       jq -e '.mcpServers["redskilled"].args[]? | contains("redskilled-mcp.sh")' "$dir/${codex_mcp_path#./}" >/dev/null \


### PR DESCRIPTION
`validate-install-metadata.sh` still required the `navigator` entry that #4010 removed under ADR 0147 §4, so `validate-marketplace` failed on every PR opened after that merge — currently blocking #4045 (version PR) and #4051.

The assertion is inverted rather than deleted: the launcher must still exist and be executable, and a manifest that *does* name navigator must still reach it through the on-demand launcher. Only the requirement that the entry be present is gone.

Verified locally: `bash scripts/validate-install-metadata.sh` → `install metadata ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789729251&installation_model_id=20659&pr_number=4059&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4059&signature=f5921ae7c68d0a3e24e8baac32a0a8b7250d79f314dbfdcd3e2ae004de1b7b47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->