### PR TITLE
fix(opencode-host): follow the dev adapter's rename to rs_dev

### DIFF
--- a/.changeset/opencode-host-rs-dev.md
+++ b/.changeset/opencode-host-rs-dev.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The opencode-host passthrough follows the dev adapter's rename to `rs_dev`
+
+#4023 renamed the dev plugin's MCP server from `redskilled` to `rs_dev` (ADR
+0147 §2) but left `apps/opencode-host` asserting the old name, so `main` went red
+on `test-packages` and every open PR inherited the failure. The assertions are
+repointed at the new server name; the launcher script keeps its own name, because
+only the server moved.

--- a/apps/opencode-host/tests/mcp-passthrough.test.ts
+++ b/apps/opencode-host/tests/mcp-passthrough.test.ts
@@ -220,19 +220,22 @@ describe("planPluginMcp against the real source tree", () => {
   // ADR 0147 §4 left each plugin declaring the one server it owns: navigator,
   // rsp and the default red-ui are switched off at the declaration, so what the
   // passthrough plans from the shipped tree is exactly that remainder.
-  it("plans the dev plugin's redskilled MCP and nothing beside it", () => {
+  // ADR 0147 §2 renamed the dev plugin's adapter to `rs_dev` (#4023). The
+  // launcher script keeps its own name — it is the same on-demand entry the
+  // passthrough has always resolved — so only the SERVER name moved.
+  it("plans the dev plugin's rs_dev MCP and nothing beside it", () => {
     const plans = planPluginMcp(REAL_PLUGINS, "dev");
-    expect(plans.map((p) => p.name)).toEqual(["redskilled"]);
-    const redskilled = plans[0]!;
-    expect(redskilled.entry.type).toBe("local");
+    expect(plans.map((p) => p.name)).toEqual(["rs_dev"]);
+    const rsDev = plans[0]!;
+    expect(rsDev.entry.type).toBe("local");
     // The source dev checkout ships the launcher; the resolved
     // command must point at the absolute script path.
-    expect(redskilled.entry.command[1]).toMatch(/redskilled-mcp\.sh$/);
+    expect(rsDev.entry.command[1]).toMatch(/redskilled-mcp\.sh$/);
   });
 
   it("keeps the installed RedSkills launcher in the runtime fallback chain", () => {
     const raw = readMcpJson(REAL_PLUGINS, "dev")!;
-    const body = raw.mcpServers!.redskilled!.args![1]!;
+    const body = raw.mcpServers!.rs_dev!.args![1]!;
     expect(body).toContain("$HOME/.codex/.tmp/marketplaces/red-skills");
   });
 


### PR DESCRIPTION
`main` is red: #4023 renamed the dev plugin's MCP server from `redskilled` to `rs_dev` (ADR 0147 §2) and left `apps/opencode-host/tests/mcp-passthrough.test.ts` asserting the old name. `test-packages` fails on `main`, so **every open PR inherits the failure** — it is what is blocking #4051 right now.

Assertions repointed, not dropped: the plan still names exactly one dev server and still resolves it through the on-demand launcher, whose filename is unchanged because only the server moved.

Verified: `pnpm -C apps/opencode-host exec vitest run` — 142/142; the other `rs_dev` consumers (gemini generator, adapter ownership guard, mcp prompts, statusline doc) — 38/38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789731450&installation_model_id=20659&pr_number=4063&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4063&signature=bed5f14a5f4114baa523eaf6ad3cc1d1b088f29d240ab3b4996c0a1e4161903d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->