### PR TITLE
fix: #4019 The daemon publishes and lands on Worker request: _redskills/publish and _redskills/land

### DIFF
--- a/apps/redskilled/src/acp-method-registry.ts
+++ b/apps/redskilled/src/acp-method-registry.ts
@@ -36,6 +36,7 @@ export type RedskillsAcpMethodDomainName =
   | "go"
   | "worktree"
   | "telemetry"
+  | "publication"
   | "worker";
 
 /** One domain's contribution: its bindings and what `initialize` advertises. */
@@ -114,9 +115,11 @@ export function redskillsAcpMethodTable(
  *
  * Declared here rather than discovered, so `apps/redskilled/tests/acp-control-plane-layout.test.ts`
  * can pin ONE module per domain and refuse a method with no home. `served`
- * states whether the public control plane binds the domain: `worker_budget_grace`
- * travels daemon → Worker and is answered by the Worker, so it has an owner and
- * no control-plane binding.
+ * states whether the PUBLIC control plane binds the domain, which two domains
+ * deliberately are not: `worker_budget_grace` travels daemon → Worker and is
+ * answered by the Worker, and `publication` travels Worker → daemon on the
+ * Worker's own connection, because that connection is the only honest proof of
+ * which Worker is asking (#4019).
  */
 export interface RedskillsAcpMethodDomainDeclaration {
   readonly domain: RedskillsAcpMethodDomainName;
@@ -177,6 +180,12 @@ export const REDSKILLS_ACP_METHOD_DOMAINS: readonly RedskillsAcpMethodDomainDecl
     module: "apps/redskilled/src/acp-telemetry.ts",
     methods: ["metrics"],
     served: true,
+  },
+  {
+    domain: "publication",
+    module: "apps/redskilled/src/acp-publication.ts",
+    methods: ["publish", "land"],
+    served: false,
   },
   {
     domain: "worker",

--- a/apps/redskilled/src/acp-publication.ts
+++ b/apps/redskilled/src/acp-publication.ts
@@ -1,0 +1,370 @@
+// acp-publication — the daemon publishes and lands on Worker request (#4019).
+//
+// ADR 0144 §3: no GitHub credential reaches the process that runs the model.
+// The Worker's terminal policy refuses `git push` and `gh` (#4016), and this
+// module is the promise that refusal made. A Worker names the branch and the
+// commit its turn produced; the daemon — holding the Project's credential
+// profile, its canonical workspace and its remote — performs the write.
+//
+// The methods are bound on the WORKER-facing connection, not on the public
+// control plane, which is why the `publication` domain is declared unserved.
+// Who is asking is therefore answered by the socket rather than by the params:
+// a `worker_id` a caller could spell would let any peer publish as any Worker,
+// and that is the one authority this module exists to hold.
+//
+// **The objects have to be delivered before they can be pushed.** A Worker's
+// Worktree is a CLONE of the Project workspace (ADR 0149 §1,
+// `materializeWorkerWorkspace`), not a linked worktree, so the commit it names
+// does not exist in the repository the push runs from. Publication fetches the
+// branch into a `refs/redskilled/publications/` ref first and refuses when the
+// named commit still is not there — a push that skipped that step would fail
+// deep inside git on a sha the remote has never heard of.
+//
+// **Landing arms custody; it never awaits a merge.** The land method opens the
+// pull request and hands "this pull request ends merged" to the Queue Custodian,
+// which outlives the Worker. A landing that waited would hold a Worker — and
+// its workspace, its budget and its host slot — open for the length of review.
+import { execFile } from "node:child_process";
+import { RequestError } from "@agentclientprotocol/sdk";
+import {
+  REDSKILLS_ACP_METHODS,
+  type RedskilledLandAnswer,
+  type RedskilledLandRequest,
+  type RedskilledPublishAnswer,
+  type RedskilledPublishRequest,
+} from "@reddb-io/protocol-acp";
+import {
+  redskillsAcpMethod,
+  type RedskillsAcpMethodDomain,
+} from "./acp-method-registry.js";
+import { RedskilledGithubCredentialProfileError } from "./github-credential-profiles.js";
+import {
+  RedskilledGithubAuthorityError,
+  type RedskilledGithubCredentialSelection,
+  type RedskilledGithubGatewayRegistration,
+  type RedskilledGithubManagedProjectReader,
+  type RedskilledGithubProjectReader,
+} from "./github-gateway.js";
+import type { AcpProjectWorkspace } from "./project-workspace.js";
+
+/** How long a local object delivery may take before publication gives up. */
+const DELIVERY_TIMEOUT_MS = 120_000;
+
+/** A full object name, which is what `git rev-parse HEAD` in a Worktree gives. */
+const OBJECT_NAME = /^[0-9a-f]{40}$/;
+
+/**
+ * One ordinary branch name, spelled the same way the write outbox spells it.
+ *
+ * Restated rather than imported because the two checks answer different
+ * questions at different depths: the outbox refuses a malformed write, and this
+ * refuses a malformed REQUEST before a Worker's objects are moved for it. The
+ * pattern is deliberately identical so a branch cannot pass one and fail the
+ * other, which would be a publication that fetched and then refused.
+ */
+const ORDINARY_BRANCH = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+
+/**
+ * One Worker the daemon still holds, seen from the publication seam.
+ *
+ * `worktreePath` is the daemon's own record of where it materialised this
+ * Worker, never something the Worker told it — which is what makes "publish
+ * what I committed" safe to answer at all.
+ */
+export interface RedskilledPublicationWorker {
+  readonly workerId: string;
+  readonly worktreePath: string;
+  readonly project: AcpProjectWorkspace;
+}
+
+/** One local object transfer, from a Worker's clone into the Project workspace. */
+export interface RedskilledPublicationDelivery {
+  readonly workerId: string;
+  readonly worktreePath: string;
+  readonly workspacePath: string;
+  readonly branch: string;
+  readonly commit: string;
+}
+
+export interface AcpPublicationDeps {
+  readonly gateway: RedskilledGithubGatewayRegistration | undefined;
+  /**
+   * The Worker on the other end, while the daemon still holds it.
+   *
+   * `undefined` is the refusal: a Worker already reaped has no workspace to
+   * read, no budget to charge and nobody left to answer for what it publishes.
+   */
+  readonly held: () => RedskilledPublicationWorker | undefined;
+  /** Test seam over the local fetch. Production moves real objects. */
+  readonly deliver?: (delivery: RedskilledPublicationDelivery) => Promise<void>;
+}
+
+/** Push what a Worker's turn committed, under the Project's credential profile. */
+export function bindAcpWorkerPublish(deps: AcpPublicationDeps) {
+  const deliver = deps.deliver ?? deliverWorkerCommit;
+  return async (
+    { params }: { readonly params: RedskilledPublishRequest },
+  ): Promise<RedskilledPublishAnswer> => {
+    const worker = requireHeldWorker(deps.held());
+    const reader = await projectReader(deps.gateway, worker.project);
+    await deliver({
+      workerId: worker.workerId,
+      worktreePath: worker.worktreePath,
+      workspacePath: worker.project.workspacePath,
+      branch: params.branch,
+      commit: params.commit,
+    });
+    const published = await reader.write({
+      idempotency_key: params.idempotency_key,
+      // Fully qualified on the way out: the Worker names the branch it is on,
+      // and only a `refs/heads/` ref says which namespace that is on a remote.
+      write: { kind: "repository-push", ref: `refs/heads/${params.branch}`, sha: params.commit },
+    });
+    return {
+      version: 1,
+      worker_id: worker.workerId,
+      branch: params.branch,
+      commit: params.commit,
+      published_at: published.published_at,
+    };
+  };
+}
+
+/** Open the pull request for a published branch and hand its merge to custody. */
+export function bindAcpWorkerLand(deps: AcpPublicationDeps) {
+  return async (
+    { params }: { readonly params: RedskilledLandRequest },
+  ): Promise<RedskilledLandAnswer> => {
+    const worker = requireHeldWorker(deps.held());
+    const reader = await projectReader(deps.gateway, worker.project);
+    const opened = await reader.write({
+      idempotency_key: params.idempotency_key,
+      write: {
+        kind: "pull-request",
+        head: params.branch,
+        base: params.base,
+        title: params.title,
+        body: params.body,
+      },
+    });
+    const pullRequest = pullRequestNumber(opened.value);
+    // The handoff RECORDS the obligation and returns. Whether the pull request
+    // ends merged is the Queue Custodian's question, asked on its own tick.
+    const custody = await custodian(reader).handoffMergeCustody({
+      pull_request: pullRequest,
+      owner_ticket: params.owner_ticket,
+      branch: params.branch,
+      base: params.base,
+    });
+    return {
+      version: 1,
+      worker_id: worker.workerId,
+      pull_request: pullRequest,
+      branch: params.branch,
+      base: params.base,
+      custody_state: custody.state,
+      handed_off_at: custody.handed_off_at,
+    };
+  };
+}
+
+/** Reject caller-controlled Project, credential, remote and Worker authority. */
+export function publishParams(value: unknown): RedskilledPublishRequest {
+  const params = exactly(value, ["idempotency_key", "branch", "commit"], "a Worker publication");
+  const commit = params.commit;
+  if (typeof commit !== "string" || !OBJECT_NAME.test(commit)) {
+    throw new RedskilledGithubAuthorityError("a Worker publication names one full commit object name");
+  }
+  return {
+    idempotency_key: text(params.idempotency_key, "idempotency key"),
+    branch: branchName(params.branch),
+    commit,
+  };
+}
+
+/** Reject caller-controlled Project, credential, remote and Worker authority. */
+export function landParams(value: unknown): RedskilledLandRequest {
+  const params = exactly(
+    value,
+    ["idempotency_key", "branch", "base", "title", "body", "owner_ticket"],
+    "a Worker landing",
+  );
+  const ticket = params.owner_ticket;
+  if (typeof ticket !== "number" || !Number.isSafeInteger(ticket) || ticket <= 0) {
+    throw new RedskilledGithubAuthorityError("a Worker landing names the Ticket that inherits the merge");
+  }
+  return {
+    idempotency_key: text(params.idempotency_key, "idempotency key"),
+    branch: branchName(params.branch),
+    base: branchName(params.base),
+    title: text(params.title, "title"),
+    body: text(params.body, "body"),
+    owner_ticket: ticket,
+  };
+}
+
+/**
+ * The `publication` domain: the two methods a Worker asks its parent for.
+ *
+ * It advertises no capability and is bound on the Worker connection rather than
+ * on the public control plane, so `REDSKILLS_ACP_METHOD_DOMAINS` declares it
+ * unserved. A client that could call these would be publishing as a Worker the
+ * daemon holds, and the connection is the only honest proof of which one.
+ */
+export function publicationMethodDomain(deps: AcpPublicationDeps): RedskillsAcpMethodDomain {
+  return {
+    domain: "publication",
+    bindings: [
+      redskillsAcpMethod(REDSKILLS_ACP_METHODS.publish, publishParams, bindAcpWorkerPublish(deps)),
+      redskillsAcpMethod(REDSKILLS_ACP_METHODS.land, landParams, bindAcpWorkerLand(deps)),
+    ],
+  };
+}
+
+function requireHeldWorker(
+  worker: RedskilledPublicationWorker | undefined,
+): RedskilledPublicationWorker {
+  if (worker != null) return worker;
+  throw RequestError.invalidRequest(
+    { version: 1, kind: "worker-not-held" },
+    "redskilled does not hold the Worker this publication came from",
+  );
+}
+
+async function projectReader(
+  gateway: RedskilledGithubGatewayRegistration | undefined,
+  project: AcpProjectWorkspace,
+): Promise<RedskilledGithubProjectReader> {
+  let selection: RedskilledGithubCredentialSelection | null | undefined;
+  try {
+    selection = await gateway?.credentialForProject({
+      projectId: project.projectId,
+      projectLabel: project.projectLabel,
+      workspacePath: project.workspacePath,
+    });
+  } catch (error) {
+    if (error instanceof RedskilledGithubCredentialProfileError) {
+      throw RequestError.authRequired(error.refusal, error.message);
+    }
+    throw error;
+  }
+  if (gateway == null || selection == null) {
+    throw RequestError.authRequired(
+      {
+        version: 1,
+        kind: "github-credential-profile",
+        reason: "missing-credentials",
+        credential_profile: "personal",
+      },
+      "this Project has no resolvable daemon-owned GitHub credential profile",
+    );
+  }
+  return gateway.gateway.forProject({
+    projectId: project.projectId,
+    projectLabel: project.projectLabel,
+    workspacePath: project.workspacePath,
+    credentialProfile: selection.profile,
+  }, selection.credential);
+}
+
+function custodian(reader: RedskilledGithubProjectReader): RedskilledGithubManagedProjectReader {
+  const managed = reader as RedskilledGithubManagedProjectReader;
+  if (typeof managed.handoffMergeCustody !== "function") {
+    throw new RedskilledGithubAuthorityError("this GitHub gateway has no durable merge custodian");
+  }
+  return managed;
+}
+
+function pullRequestNumber(value: unknown): number {
+  const number = (value as { readonly number?: unknown } | null)?.number;
+  if (typeof number !== "number" || !Number.isSafeInteger(number) || number <= 0) {
+    throw new RedskilledGithubAuthorityError(
+      "the opened pull request answered with no number to take custody of",
+    );
+  }
+  return number;
+}
+
+/**
+ * Move the Worker's branch into the Project workspace, then prove the commit landed.
+ *
+ * The fetch names the BRANCH rather than the commit because a bare object name
+ * is only fetchable from a repository configured to serve one, and a Worker's
+ * clone is not. The `cat-file` afterwards is what turns "the fetch reported
+ * success" into "the object the caller named is here".
+ */
+async function deliverWorkerCommit(delivery: RedskilledPublicationDelivery): Promise<void> {
+  const destination = `refs/redskilled/publications/${delivery.workerId}/${delivery.branch}`;
+  await git(delivery.workspacePath, [
+    "fetch",
+    "--no-tags",
+    "--quiet",
+    "--",
+    delivery.worktreePath,
+    `+refs/heads/${delivery.branch}:${destination}`,
+  ]);
+  await git(delivery.workspacePath, ["cat-file", "-e", `${delivery.commit}^{commit}`]);
+}
+
+function git(cwd: string, args: readonly string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile("git", [...args], {
+      cwd,
+      encoding: "utf8",
+      timeout: DELIVERY_TIMEOUT_MS,
+      windowsHide: true,
+    }, (error, _stdout, stderr) => {
+      if (error == null) {
+        resolve();
+        return;
+      }
+      reject(new RedskilledGithubAuthorityError(
+        `redskilled could not deliver the Worker's publication: ${String(stderr).trim() || error.message}`,
+      ));
+    });
+  });
+}
+
+function exactly(
+  value: unknown,
+  keys: readonly string[],
+  subject: string,
+): Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new RedskilledGithubAuthorityError(`${subject} needs one request object`);
+  }
+  const params = value as Record<string, unknown>;
+  if (Object.keys(params).length !== keys.length || keys.some((key) => !(key in params))) {
+    throw new RedskilledGithubAuthorityError(
+      `${subject} cannot name a Project, credential profile, remote, Worker, or host operation`,
+    );
+  }
+  return params;
+}
+
+function text(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new RedskilledGithubAuthorityError(`a Worker publication needs a ${field}`);
+  }
+  return value;
+}
+
+/**
+ * A branch name safe to interpolate into a refspec and hand to `git`.
+ *
+ * The Worker read this from its own `rev-parse --abbrev-ref HEAD`, so the check
+ * is less distrust of the name than of the SOCKET: a leading `-` would be read
+ * by git as an option rather than as a ref, which is how a refspec turns into
+ * an argument nobody meant to pass.
+ */
+function branchName(value: unknown): string {
+  const branch = text(value, "branch");
+  const refused = !ORDINARY_BRANCH.test(branch) || branch.includes("..") || branch.includes("//") ||
+    branch.endsWith(".") || branch.endsWith("/") || branch.includes("@{");
+  if (refused) {
+    throw new RedskilledGithubAuthorityError(
+      `${JSON.stringify(branch)} is not a branch redskilled can publish`,
+    );
+  }
+  return branch;
+}

--- a/apps/redskilled/src/acp-worker-admission.ts
+++ b/apps/redskilled/src/acp-worker-admission.ts
@@ -22,6 +22,7 @@ import {
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
 import { ACP_AGENT_CATALOG, type AcpEndpoint } from "./acp-agent-catalog.js";
+import { publicationMethodDomain } from "./acp-publication.js";
 import {
   ACP_PROTOCOL_VERSION,
   REDSKILLS_WIRE_MAJOR,
@@ -37,6 +38,7 @@ import {
   type AcpSessionJournal,
 } from "./acp-session-journal.js";
 import type { AcpTargetedDispatchIntent } from "./acp-dispatch-intent.js";
+import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
 import { workerModeEnv } from "@reddb-io/shared/working-mode.js";
 import { resolveAcpWorkerEndpoint, type RedskilledPaths } from "./paths.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
@@ -83,6 +85,14 @@ interface NativeWorkerAdmissionOptions {
   readonly evidenceRoot?: string;
   /** How long an expired lane survives. Host policy; thirty days by default. */
   readonly evidenceTtlMs?: number;
+  /**
+   * The Project-bound GitHub gateway this Worker publishes and lands THROUGH.
+   *
+   * Absent is legal and means the Worker's publication requests are refused
+   * with the gateway's own authorization answer — which is the truth when a
+   * daemon has no forge, and better than a Worker discovering it by pushing.
+   */
+  readonly githubGateway?: RedskilledGithubGatewayRegistration;
 }
 
 export async function admitNativeAcpWorker(
@@ -133,6 +143,18 @@ export async function admitNativeAcpWorker(
 
   let downstreamSessionId = "";
   let sessionArtifact: WorkerEvidencePlan["sessionArtifact"];
+  // Filled in once the handle exists, and read on every publication request.
+  // Until then — and after `cleanupWorkflowWorker` marks the handle spent —
+  // there is no Worker for the daemon to publish AS, and the domain refuses.
+  const holding: { worker?: ActiveWorkflowWorker } = {};
+  const publication = publicationMethodDomain({
+    ...(options.githubGateway == null ? { gateway: undefined } : { gateway: options.githubGateway }),
+    held: () => {
+      const worker = holding.worker;
+      if (worker == null || worker.cleaned) return undefined;
+      return { workerId: worker.workerId, worktreePath: workspace.worktreePath, project: session.project };
+    },
+  });
   const downstreamApp = client({ name: "redskilled" })
     .onNotification(methods.client.session.update, async ({ params }) => {
       const downstreamRedskills = (params._meta as {
@@ -165,6 +187,14 @@ export async function admitNativeAcpWorker(
       ...params,
       sessionId: publicSessionId,
     }));
+  // Bound HERE rather than on the public control plane: the socket is what says
+  // which Worker is asking, and no client of the daemon may publish as one.
+  for (const binding of publication.bindings) {
+    // The Worker connection hands a handler no peer of its own: the daemon IS
+    // the peer here, so the context the domain expects is completed with none.
+    downstreamApp.onRequest(binding.method, binding.params, ({ params }) =>
+      binding.handle({ params, client: undefined }));
+  }
   const connection = downstreamApp.connect(socketStream(workerSocket));
   try {
     const initialized = await connection.agent.request(methods.agent.initialize, {
@@ -210,7 +240,7 @@ export async function admitNativeAcpWorker(
     throw error;
   }
 
-  return {
+  const admitted: ActiveWorkflowWorker = {
     workerId: launched.worker.worker_id,
     workspace,
     evidence: {
@@ -229,6 +259,8 @@ export async function admitNativeAcpWorker(
     cancelled: false,
     cleaned: false,
   };
+  holding.worker = admitted;
+  return admitted;
 }
 
 function nativeWorkerSpec(

--- a/apps/redskilled/tests/acp-publication.test.ts
+++ b/apps/redskilled/tests/acp-publication.test.ts
@@ -1,0 +1,239 @@
+// The daemon publishes and lands on Worker request (#4019, ADR 0144 §3, ADR 0148).
+//
+// Three properties, one per acceptance criterion: a publish request puts the
+// branch on the remote without the request ever carrying a credential; a land
+// request opens the pull request and hands the merge to custody WITHOUT waiting
+// for it; and a request from a Worker the daemon does not hold is refused
+// before any of that happens.
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  bindAcpWorkerLand,
+  bindAcpWorkerPublish,
+  landParams,
+  publicationMethodDomain,
+  publishParams,
+  type RedskilledPublicationWorker,
+} from "../src/acp-publication.js";
+import {
+  createRedskilledGithubGateway,
+  createRedskilledGithubWriteUpstream,
+  type CreateRedskilledGithubGatewayOptions,
+  type RedskilledGithubGatewayRegistration,
+} from "../src/github-gateway.js";
+import type { AcpProjectWorkspace } from "../src/project-workspace.js";
+
+const roots: string[] = [];
+const gateways: { close?(): void }[] = [];
+
+afterEach(async () => {
+  // The custodian ticks on a timer and writes its record; closing before the
+  // fixture goes keeps teardown from racing a write into a directory being removed.
+  for (const gateway of gateways.splice(0)) gateway.close?.();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function fixtureRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+const git = (cwd: string, ...args: string[]): string =>
+  execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+
+/**
+ * A stub remote, the daemon's Project workspace, and one Worker that committed.
+ *
+ * The Worker's Worktree is a CLONE of the Project workspace, exactly as
+ * `materializeWorkerWorkspace` makes it — which is the whole reason publication
+ * has to deliver the objects before it can push them.
+ */
+async function hostFixture(branch: string): Promise<{
+  readonly root: string;
+  readonly remote: string;
+  readonly project: AcpProjectWorkspace;
+  readonly worker: RedskilledPublicationWorker;
+  readonly commit: string;
+}> {
+  const root = await fixtureRoot("redskilled-publication-");
+  const remote = join(root, "remote.git");
+  execFileSync("git", ["init", "--bare", "--initial-branch", "main", remote], { stdio: "ignore" });
+
+  const seed = join(root, "seed");
+  execFileSync("git", ["clone", "--quiet", "--", remote, seed], { stdio: "ignore" });
+  git(seed, "config", "user.email", "daemon@example.invalid");
+  git(seed, "config", "user.name", "redskilled");
+  await writeFile(join(seed, "README.md"), "seed\n");
+  git(seed, "add", "--", "README.md");
+  git(seed, "commit", "-m", "seed");
+  git(seed, "push", "--quiet", "origin", "main");
+
+  const workspacePath = join(root, "workspace");
+  execFileSync("git", ["clone", "--quiet", "--", remote, workspacePath], { stdio: "ignore" });
+
+  const worktreePath = join(root, "worker", "worktree");
+  execFileSync("git", ["clone", "--no-hardlinks", "--quiet", "--", workspacePath, worktreePath], {
+    stdio: "ignore",
+  });
+  git(worktreePath, "config", "user.email", "worker@example.invalid");
+  git(worktreePath, "config", "user.name", "Worker");
+  git(worktreePath, "checkout", "--quiet", "-b", branch);
+  await writeFile(join(worktreePath, "edited.txt"), "the inner agent only edits and commits\n");
+  git(worktreePath, "add", "--", "edited.txt");
+  git(worktreePath, "commit", "-m", "Refs #4019");
+  const commit = git(worktreePath, "rev-parse", "HEAD");
+
+  const project: AcpProjectWorkspace = {
+    projectId: "R_publication",
+    projectLabel: "acme/widgets",
+    checkoutRoot: seed,
+    workspacePath,
+  };
+  return {
+    root,
+    remote,
+    project,
+    commit,
+    worker: { workerId: "0000000Worker", worktreePath, project },
+  };
+}
+
+function registration(
+  root: string,
+  overrides: Partial<CreateRedskilledGithubGatewayOptions> = {},
+): RedskilledGithubGatewayRegistration {
+  const gateway = createRedskilledGithubGateway({
+    upstream: async () => ({ value: {}, budget: null }),
+    outboxPath: join(root, "github-outbox.toon"),
+    writeUpstream: createRedskilledGithubWriteUpstream(),
+    ...overrides,
+  });
+  gateways.push(gateway);
+  return {
+    gateway,
+    credentialForProject: () => ({ profile: "engineering", credential: { secret: "fixture-secret" } }),
+  };
+}
+
+describe("`_redskills/publish` — the daemon pushes the Worker's branch", () => {
+  it("puts the commit on the remote from a Worktree the request never names", async () => {
+    const host = await hostFixture("afk/4019-publication");
+    const publish = bindAcpWorkerPublish({
+      gateway: registration(host.root),
+      held: () => host.worker,
+    });
+
+    const request = publishParams({
+      idempotency_key: "worker-turn:s:1",
+      branch: "afk/4019-publication",
+      commit: host.commit,
+    });
+    const answer = await publish({ params: request });
+
+    expect(git(host.remote, "rev-parse", "refs/heads/afk/4019-publication")).toBe(host.commit);
+    expect(answer.worker_id).toBe("0000000Worker");
+    expect(answer.commit).toBe(host.commit);
+    // The credential is the daemon's. Neither half of the exchange carries it.
+    expect(JSON.stringify(request)).not.toContain("fixture-secret");
+    expect(JSON.stringify(answer)).not.toContain("fixture-secret");
+  }, 30_000);
+
+  it("refuses a request from a Worker this daemon does not hold", async () => {
+    const host = await hostFixture("afk/4019-unheld");
+    const publish = bindAcpWorkerPublish({
+      gateway: registration(host.root),
+      held: () => undefined,
+    });
+
+    await expect(publish({
+      params: publishParams({
+        idempotency_key: "worker-turn:s:1",
+        branch: "afk/4019-unheld",
+        commit: host.commit,
+      }),
+    })).rejects.toThrow(/no longer holds|does not hold/i);
+    expect(() => git(host.remote, "rev-parse", "refs/heads/afk/4019-unheld")).toThrow();
+  }, 30_000);
+
+  it("refuses params that name a Project, a remote or another Worker", () => {
+    expect(() => publishParams({
+      idempotency_key: "k",
+      branch: "afk/4019",
+      commit: "0".repeat(40),
+      worker_id: "somebody-else",
+    })).toThrow();
+    expect(() => publishParams({ idempotency_key: "k", branch: "afk/4019", commit: "not-a-sha" })).toThrow();
+    expect(() => publishParams({ idempotency_key: "k", branch: "--upload-pack=evil", commit: "0".repeat(40) }))
+      .toThrow();
+  });
+});
+
+describe("`_redskills/land` — the daemon opens the PR and hands the merge on", () => {
+  it("records custody and returns while the merge is still pending", async () => {
+    const host = await hostFixture("afk/4019-landing");
+    let armed = 0;
+    const gateway = registration(host.root, {
+      custodyPath: join(host.root, "github-custody.toon"),
+      // Long enough that a landing which awaited the merge would time this out.
+      custodyTickMs: 3_600_000,
+      writeUpstream: async ({ write }) => write.kind === "pull-request" ? { number: 73 } : {},
+      custodyUpstream: {
+        observe: async () => ({ forge_state: "open-clean", native_intent: false }),
+        arm: async () => {
+          armed += 1;
+          return { forge_state: "open-pending", native_intent: true };
+        },
+      },
+    });
+    const land = bindAcpWorkerLand({ gateway, held: () => host.worker });
+
+    const answer = await land({
+      params: landParams({
+        idempotency_key: "worker-land:s:1",
+        branch: "afk/4019-landing",
+        base: "main",
+        title: "The daemon publishes and lands",
+        body: "Refs #4019",
+        owner_ticket: 4019,
+      }),
+    });
+
+    expect(answer.pull_request).toBe(73);
+    expect(answer.worker_id).toBe("0000000Worker");
+    // Custody is ACCEPTED, not finished: the Queue Custodian outlives the Worker.
+    expect(answer.custody_state).toBe("active");
+    expect(armed).toBe(0);
+  }, 30_000);
+
+  it("refuses a land request from a Worker this daemon does not hold", async () => {
+    const host = await hostFixture("afk/4019-unheld-landing");
+    const land = bindAcpWorkerLand({ gateway: registration(host.root), held: () => undefined });
+
+    await expect(land({
+      params: landParams({
+        idempotency_key: "worker-land:s:1",
+        branch: "afk/4019-unheld-landing",
+        base: "main",
+        title: "unheld",
+        body: "Refs #4019",
+        owner_ticket: 4019,
+      }),
+    })).rejects.toThrow(/no longer holds|does not hold/i);
+  }, 30_000);
+});
+
+describe("the publication domain", () => {
+  it("declares both methods and advertises nothing on the public control plane", () => {
+    const domain = publicationMethodDomain({ gateway: undefined, held: () => undefined });
+
+    expect(domain.domain).toBe("publication");
+    expect(domain.bindings.map((binding) => binding.method))
+      .toEqual(["_redskills/publish", "_redskills/land"]);
+    expect(domain.capability).toBeUndefined();
+  });
+});

--- a/apps/redskilled/tests/acp-worker-budget-grace.test.ts
+++ b/apps/redskilled/tests/acp-worker-budget-grace.test.ts
@@ -17,7 +17,7 @@ describe("ACP Worker Budget grace", () => {
       cancelChildAgent: async () => { order.push("cancel"); },
       checkpointLocalWork: async () => {
         order.push("checkpoint");
-        return { ref: "refs/heads/worker-3842", sha: "a".repeat(40) };
+        return { branch: "worker-3842", commit: "a".repeat(40) };
       },
       requestPublication,
       writeEnvelope: async (value) => { order.push("envelope"); envelope = value; },
@@ -35,11 +35,8 @@ describe("ACP Worker Budget grace", () => {
     expect(order).toEqual(["cancel", "checkpoint", "publication", "envelope", "exit"]);
     expect(requestPublication).toHaveBeenCalledWith({
       idempotency_key: "worker-budget-grace:wGRACE",
-      write: {
-        kind: "repository-push",
-        ref: "refs/heads/worker-3842",
-        sha: "a".repeat(40),
-      },
+      branch: "worker-3842",
+      commit: "a".repeat(40),
     });
     expect(requestPublication.mock.calls[0]![0]).not.toHaveProperty("credential");
     expect(requestPublication.mock.calls[0]![0]).not.toHaveProperty("token");

--- a/packages/protocol-acp/index.ts
+++ b/packages/protocol-acp/index.ts
@@ -9,6 +9,7 @@ export * from "./endpoint.js";
 export * from "./github-write.js";
 export * from "./go-dispatch.js";
 export * from "./methods.js";
+export * from "./publication.js";
 export * from "./session-recovery.js";
 export * from "./transport.js";
 export * from "./worktree.js";

--- a/packages/protocol-acp/methods.ts
+++ b/packages/protocol-acp/methods.ts
@@ -32,6 +32,8 @@ export const REDSKILLS_ACP_METHODS = {
   githubWrite: "_redskills/github_write",
   githubUpdate: "_redskills/github_update",
   githubCustodyHandoff: "_redskills/github_custody_handoff",
+  publish: "_redskills/publish",
+  land: "_redskills/land",
   workerBudgetGrace: "_redskills/worker_budget_grace",
   goDispatch: "_redskills/go_dispatch",
   worktreeAdd: "_redskills/worktree_add",

--- a/packages/protocol-acp/publication.ts
+++ b/packages/protocol-acp/publication.ts
@@ -1,0 +1,68 @@
+// publication — the `_redskills/publish` and `_redskills/land` params (ADR 0144 §3, ADR 0148).
+//
+// The Worker's terminal policy refuses `git push` and `gh` (#4016). These two
+// methods are the promise that refusal made: the Worker names the branch and
+// the commit its turn produced, and the daemon — which holds the Project's
+// credential profile, its canonical workspace and its remote — performs the
+// write. Only the REQUEST is wire; the credential, the remote and the Worktree
+// the objects come from are daemon authority and stay behind the socket.
+//
+// Two things a request may NOT name, and the reason each is absent:
+//
+//   - **Which Worker is asking.** The connection already answers that. A
+//     `worker_id` in the params would let any peer publish as any Worker, which
+//     is precisely the authority the daemon is holding on their behalf.
+//   - **Which Project, remote or credential profile.** Naming one would make a
+//     Worker the chooser of where its work lands, and there would be nothing
+//     left for the gateway to enforce.
+
+/** Push one commit the Worker's turn produced onto its branch. */
+export interface RedskilledPublishRequest {
+  /** Stable caller-minted identity. Reusing it returns the durable receipt. */
+  readonly idempotency_key: string;
+  /** The branch the inner agent committed on, without its `refs/heads/` prefix. */
+  readonly branch: string;
+  /** The commit that branch points at, as a full 40-character object name. */
+  readonly commit: string;
+}
+
+export interface RedskilledPublishAnswer {
+  readonly version: 1;
+  /** The Worker the daemon published FOR, resolved from the connection. */
+  readonly worker_id: string;
+  readonly branch: string;
+  readonly commit: string;
+  readonly published_at: string;
+}
+
+/**
+ * Open the pull request for a published branch and hand its merge to custody.
+ *
+ * `owner_ticket` is the Ticket that inherits the merge when the Worker is gone,
+ * which is why landing can return before the merge happens (ADR 0144 §3).
+ */
+export interface RedskilledLandRequest {
+  readonly idempotency_key: string;
+  readonly branch: string;
+  readonly base: string;
+  readonly title: string;
+  readonly body: string;
+  readonly owner_ticket: number;
+}
+
+export interface RedskilledLandAnswer {
+  readonly version: 1;
+  readonly worker_id: string;
+  readonly pull_request: number;
+  readonly branch: string;
+  readonly base: string;
+  /**
+   * The custody the daemon accepted, NEVER the merge's outcome.
+   *
+   * `active` is the ordinary answer to a successful landing: the Queue
+   * Custodian now owns "this pull request ends merged", and the Worker that
+   * asked is free to die.
+   */
+  readonly custody_state: "active" | "terminal";
+  readonly handed_off_at: string;
+}

--- a/packages/worker/src/acp/budget-grace.ts
+++ b/packages/worker/src/acp/budget-grace.ts
@@ -1,6 +1,6 @@
 import {
   REDSKILLS_ACP_METHODS,
-  type RedskilledGithubWriteRequest,
+  type RedskilledPublishRequest,
 } from "@reddb-io/protocol-acp";
 
 /** ACP control delivered to a Worker after the daemon records its budget verdict. */
@@ -14,9 +14,17 @@ export interface WorkerBudgetGraceControl {
   readonly deadline_at: string;
 }
 
+/**
+ * The recoverable work a dying Worker committed, in the publication's own words.
+ *
+ * A branch rather than a `refs/heads/` ref, and a commit rather than a sha,
+ * because this goes out on `_redskills/publish` (#4019): a checkpoint that
+ * spelled its ref differently from an ordinary post-turn publication would be
+ * two vocabularies for one act, and the daemon would have to guess which.
+ */
 export interface WorkerBudgetGraceCheckpoint {
-  readonly ref: string;
-  readonly sha: string;
+  readonly branch: string;
+  readonly commit: string;
 }
 
 export interface WorkerBudgetExtensionBlocker {
@@ -45,7 +53,7 @@ export interface AcpWorkerBudgetGraceDeps {
   /** Commit recoverable local work and return the ref/commit to publish. */
   checkpointLocalWork(control: WorkerBudgetGraceControl): Promise<WorkerBudgetGraceCheckpoint | null>;
   /** Ask redskilled's Project-bound GitHub gateway to publish; no credential crosses this seam. */
-  requestPublication(request: RedskilledGithubWriteRequest): Promise<unknown>;
+  requestPublication(request: RedskilledPublishRequest): Promise<unknown>;
   writeEnvelope(envelope: WorkerBudgetGraceEnvelope): Promise<void>;
   /** End the Worker. Deadline expiry may independently kill it at any point. */
   terminate(): Promise<void> | void;
@@ -108,7 +116,8 @@ async function runBudgetGrace(
     try {
       publicationReceipt = await deps.requestPublication({
         idempotency_key: `worker-budget-grace:${control.worker_id}`,
-        write: { kind: "repository-push", ref: checkpoint.ref, sha: checkpoint.sha },
+        branch: checkpoint.branch,
+        commit: checkpoint.commit,
       });
     } catch (error) {
       failures.push(`publication: ${reason(error)}`);

--- a/packages/worker/src/acp/publish-request.test.ts
+++ b/packages/worker/src/acp/publish-request.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { RedskilledGithubWriteRequest } from "@reddb-io/protocol-acp";
+import type { RedskilledPublishRequest } from "@reddb-io/protocol-acp";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -18,10 +18,10 @@ afterEach(async () => {
 });
 
 function recordingParent() {
-  const requests: { readonly method: string; readonly params: RedskilledGithubWriteRequest }[] = [];
+  const requests: { readonly method: string; readonly params: RedskilledPublishRequest }[] = [];
   return {
     requests,
-    request: async (method: string, params: RedskilledGithubWriteRequest) => {
+    request: async (method: string, params: RedskilledPublishRequest) => {
       requests.push({ method, params });
       return { published: true };
     },
@@ -49,7 +49,8 @@ describe("the Worker's post-turn publication request", () => {
       method: WORKER_PUBLISH_METHOD,
       params: {
         idempotency_key: "worker-turn:s:c0ffee",
-        write: { kind: "repository-push", ref: "afk/4016-terminal-policy", sha: "c0ffee" },
+        branch: "afk/4016-terminal-policy",
+        commit: "c0ffee",
       },
     }]);
   });
@@ -71,9 +72,9 @@ describe("the Worker's post-turn publication request", () => {
     commit = "decade";
     await publisher.publishTurn();
 
-    expect(parent.requests.map(({ params }) => params.write)).toEqual([
-      { kind: "repository-push", ref: "afk/4016", sha: "c0ffee" },
-      { kind: "repository-push", ref: "afk/4016", sha: "decade" },
+    expect(parent.requests.map(({ params }) => ({ branch: params.branch, commit: params.commit }))).toEqual([
+      { branch: "afk/4016", commit: "c0ffee" },
+      { branch: "afk/4016", commit: "decade" },
     ]);
   });
 

--- a/packages/worker/src/acp/publish-request.ts
+++ b/packages/worker/src/acp/publish-request.ts
@@ -14,10 +14,10 @@
  * behalf.
  */
 import { execFile } from "node:child_process";
-import { REDSKILLS_ACP_METHODS, type RedskilledGithubWriteRequest } from "@reddb-io/protocol-acp";
+import { REDSKILLS_ACP_METHODS, type RedskilledPublishRequest } from "@reddb-io/protocol-acp";
 
 /** The ACP method the Worker's publication request travels on. */
-export const WORKER_PUBLISH_METHOD = REDSKILLS_ACP_METHODS.githubWrite;
+export const WORKER_PUBLISH_METHOD = REDSKILLS_ACP_METHODS.publish;
 
 /** What the inner agent left behind in the Worktree, ready to publish. */
 export interface WorkerPublication {
@@ -29,7 +29,7 @@ export interface WorkerPublisherOptions {
   /** The Worktree the inner agent committed in. */
   readonly cwd: string;
   /** Sends the request to the ACP parent; the parent owns the credential. */
-  readonly request: (method: string, params: RedskilledGithubWriteRequest) => Promise<unknown>;
+  readonly request: (method: string, params: RedskilledPublishRequest) => Promise<unknown>;
   /** Stable per-Worker prefix, so a re-asked publication is the same write. */
   readonly idempotencyScope: string;
   /** Test seam over `git rev-parse`. Production reads the real Worktree. */
@@ -59,12 +59,13 @@ export function createWorkerPublisher(options: WorkerPublisherOptions): WorkerPu
       const publication = await readPublication(options.cwd).catch(() => null);
       if (publication == null || publication.commit === published) return null;
       published = publication.commit;
-      const write: RedskilledGithubWriteRequest = {
+      const request: RedskilledPublishRequest = {
         idempotency_key: `${options.idempotencyScope}:${publication.commit}`,
-        write: { kind: "repository-push", ref: publication.branch, sha: publication.commit },
+        branch: publication.branch,
+        commit: publication.commit,
       };
       try {
-        return { status: "requested", publication, receipt: await options.request(WORKER_PUBLISH_METHOD, write) };
+        return { status: "requested", publication, receipt: await options.request(WORKER_PUBLISH_METHOD, request) };
       } catch (error) {
         return { status: "refused", publication, detail: error instanceof Error ? error.message : String(error) };
       }

--- a/packages/worker/src/acp/worker-terminal-and-publish.test.ts
+++ b/packages/worker/src/acp/worker-terminal-and-publish.test.ts
@@ -20,7 +20,7 @@ import {
   closeServer,
   removeAcpEndpoint,
   socketStream,
-  type RedskilledGithubWriteRequest,
+  type RedskilledPublishRequest,
 } from "@reddb-io/protocol-acp";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -122,7 +122,7 @@ describe("a Worker finishing a prompt turn", () => {
     roots.push(root);
     const socketPath = join(root, "worker.sock");
     const cwd = await committedWorktree("worker-publish-worktree-", "afk/4016-publish");
-    const published: RedskilledGithubWriteRequest[] = [];
+    const published: RedskilledPublishRequest[] = [];
 
     const rendezvous = await bindWorkerRendezvous(socketPath);
     servers.push(rendezvous.server);
@@ -141,8 +141,8 @@ describe("a Worker finishing a prompt turn", () => {
     const parent = client({ name: "stub parent" })
       .onNotification(methods.client.session.update, () => undefined)
       .onRequest(
-        REDSKILLS_ACP_METHODS.githubWrite,
-        (value: unknown) => value as RedskilledGithubWriteRequest,
+        REDSKILLS_ACP_METHODS.publish,
+        (value: unknown) => value as RedskilledPublishRequest,
         ({ params }) => {
           published.push(params);
           return { receipt: "stub" };
@@ -165,11 +165,8 @@ describe("a Worker finishing a prompt turn", () => {
 
       expect(response.stopReason).toBe("end_turn");
       expect(published).toHaveLength(1);
-      expect(published[0]!.write).toEqual({
-        kind: "repository-push",
-        ref: "afk/4016-publish",
-        sha: expect.stringMatching(/^[0-9a-f]{40}$/),
-      });
+      expect(published[0]!.branch).toBe("afk/4016-publish");
+      expect(published[0]!.commit).toMatch(/^[0-9a-f]{40}$/);
       expect(published[0]!.idempotency_key).toContain(session.sessionId);
 
       // A second turn that committed nothing new is not a second publication.


### PR DESCRIPTION
Automated AFK landing for #4019. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #4019

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789731841&installation_model_id=20659&pr_number=4065&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4065&signature=e48fe29b58ab9f165529ab6513ccf04fa811a9727eef72efe5686f81bd0bfe5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->