### PR TITLE
fix(packaging): resolve the dev bundle from the plugin package that owns it

### DIFF
--- a/.changeset/dev-shim-resolves-plugin-package.md
+++ b/.changeset/dev-shim-resolves-plugin-package.md
@@ -1,0 +1,16 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The `red-skills-dev` shim finds the bundle in the plugin package that now owns it
+
+ADR 0146 moved every per-plugin runtime bundle into
+`@reddb-io/red-skills-<plugin>` and left the bin surface in the core package, so
+the shim looked for `dist/dev.bundle.min.mjs` beside itself and found nothing:
+3.20.0 and 3.21.0 both publish a `dist/` without it. Every Worker the daemon
+birthed died on `red-skills-dev: packaged bundle missing` before it could claim a
+Ticket, which is a fully stopped drain on any host running a current release.
+
+The lookup is ordered — this package's own `dist/` first so an older install
+keeps working, then `@reddb-io/red-skills-dev` — and the failure message names
+both locations and the command that installs the missing one.

--- a/apps/dev/tests/dev-shim-bundle-resolution.test.ts
+++ b/apps/dev/tests/dev-shim-bundle-resolution.test.ts
@@ -1,0 +1,61 @@
+// The core package ships the `red-skills-dev` bin; ADR 0146 moved the bundle it
+// execs into `@reddb-io/red-skills-dev`. A shim that looks only beside itself
+// therefore finds nothing on a current install — 3.20.0 and 3.21.0 both publish
+// a `dist/` without `dev.bundle.min.mjs`, and every Worker died on
+// `packaged bundle missing` before it could claim a Ticket.
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SHIM = join(import.meta.dirname, "..", "..", "..", "packaging", "npm", "bin", "red-skills-dev.mjs");
+
+/** A node_modules tree with the core package, and optionally the plugin one. */
+function install(options: { readonly local?: boolean; readonly plugin?: boolean }): string {
+  const root = mkdtempSync(join(tmpdir(), "red-shim-"));
+  const core = join(root, "node_modules", "@reddb-io", "red-skills");
+  mkdirSync(join(core, "bin"), { recursive: true });
+  writeFileSync(join(core, "package.json"), JSON.stringify({ name: "@reddb-io/red-skills", version: "0.0.0" }));
+  writeFileSync(join(core, "bin", "red-skills-dev.mjs"), execFileSync("cat", [SHIM]));
+  if (options.local === true) {
+    mkdirSync(join(core, "dist"), { recursive: true });
+    writeFileSync(join(core, "dist", "dev.bundle.min.mjs"), 'process.stdout.write("from-core\\n");');
+  }
+  if (options.plugin === true) {
+    const plugin = join(root, "node_modules", "@reddb-io", "red-skills-dev");
+    mkdirSync(join(plugin, "dist"), { recursive: true });
+    writeFileSync(
+      join(plugin, "package.json"),
+      JSON.stringify({ name: "@reddb-io/red-skills-dev", version: "0.0.0", exports: { "./dist/*": "./dist/*" } }),
+    );
+    writeFileSync(join(plugin, "dist", "dev.bundle.min.mjs"), 'process.stdout.write("from-plugin\\n");');
+  }
+  return join(core, "bin", "red-skills-dev.mjs");
+}
+
+const run = (shim: string): { readonly out: string; readonly code: number } => {
+  try {
+    return { out: execFileSync(process.execPath, [shim], { encoding: "utf8" }), code: 0 };
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    return { out: failure.stderr ?? "", code: failure.status ?? 1 };
+  }
+};
+
+describe("the red-skills-dev shim finds the bundle wherever the package split left it", () => {
+  it("execs the plugin package's bundle when the core package carries none", () => {
+    expect(run(install({ plugin: true })).out).toContain("from-plugin");
+  });
+
+  it("still execs a bundle beside itself, so an older install keeps working", () => {
+    expect(run(install({ local: true })).out).toContain("from-core");
+  });
+
+  it("names both locations and the install command when neither has it", () => {
+    const { out, code } = run(install({}));
+    expect(code).toBe(1);
+    expect(out).toContain("@reddb-io/red-skills-dev/dist/dev.bundle.min.mjs");
+    expect(out).toContain("npm i -g @reddb-io/red-skills-dev");
+  });
+});

--- a/packaging/npm/bin/red-skills-dev.mjs
+++ b/packaging/npm/bin/red-skills-dev.mjs
@@ -1,22 +1,56 @@
 #!/usr/bin/env node
 /**
- * red-skills-dev — thin shim that execs the `dev` runtime bundle packaged inside
- * this npm tarball (`dist/dev.bundle.min.mjs`). ADR 0091: the bundle ships in the
- * package tarball itself (platform-independent JS, ~2MB), so there is no
- * postinstall download and no GitHub-release fetch. Every arg is forwarded
- * verbatim to the bundle, which owns its own command surface.
+ * red-skills-dev — thin shim that execs the `dev` runtime bundle.
+ *
+ * **The bundle is not in this package any more, and the shim still is.** ADR
+ * 0146 moved every per-plugin runtime bundle into `@reddb-io/red-skills-<plugin>`
+ * and left this core package carrying the bin surface, so a shim that looks only
+ * beside itself finds nothing: 3.20.0 and 3.21.0 both publish a `dist/` without
+ * `dev.bundle.min.mjs`, and every Worker the daemon birthed died on
+ * `packaged bundle missing` before it could claim a Ticket.
+ *
+ * So the lookup is ordered rather than fixed: this package's own `dist/` first,
+ * because an older install still carries the bundle there, then the plugin
+ * package that owns it now. Every arg is forwarded verbatim to the bundle, which
+ * owns its own command surface.
  */
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const bundle = join(here, "..", "dist", "dev.bundle.min.mjs");
-if (!existsSync(bundle)) {
-  process.stderr.write(`red-skills-dev: packaged bundle missing at ${bundle}\n`);
+const PLUGIN_PACKAGE = "@reddb-io/red-skills-dev";
+const BUNDLE = "dev.bundle.min.mjs";
+
+/** Where the bundle can be, newest layout last so a stale copy never wins. */
+function resolveBundle() {
+  const local = join(here, "..", "dist", BUNDLE);
+  if (existsSync(local)) return { path: local, from: "this package" };
+  // `createRequire` resolves through node's own algorithm, so the plugin package
+  // is found whether it sits beside this one in a shared `node_modules` or is
+  // nested under it — the two shapes npx and pnpm produce.
+  const require = createRequire(import.meta.url);
+  try {
+    const path = require.resolve(`${PLUGIN_PACKAGE}/dist/${BUNDLE}`);
+    if (existsSync(path)) return { path, from: PLUGIN_PACKAGE };
+  } catch {
+    /* fall through to the reported failure below */
+  }
+  return null;
+}
+
+const found = resolveBundle();
+if (!found) {
+  process.stderr.write(
+    `red-skills-dev: the dev runtime bundle is not installed.\n` +
+      `  looked in this package: ${join(here, "..", "dist", BUNDLE)}\n` +
+      `  looked in the plugin package that owns it (ADR 0146): ${PLUGIN_PACKAGE}/dist/${BUNDLE}\n` +
+      `  install it with: npm i -g ${PLUGIN_PACKAGE}\n`,
+  );
   process.exit(1);
 }
-const res = spawnSync(process.execPath, [bundle, ...process.argv.slice(2)], { stdio: "inherit" });
+const res = spawnSync(process.execPath, [found.path, ...process.argv.slice(2)], { stdio: "inherit" });
 if (res.signal) process.kill(process.pid, res.signal);
 process.exit(res.status ?? 1);


### PR DESCRIPTION
**The drain is fully stopped on any host running a current release.** Every Worker the daemon births dies with `red-skills-dev: packaged bundle missing` before it can claim a Ticket; three in a row arm the birth breaker and the project stops being asked for more.

ADR 0146 moved per-plugin runtime bundles into `@reddb-io/red-skills-<plugin>` and left the bin surface in the core package — but the shim still looked for `dist/dev.bundle.min.mjs` beside itself. Verified against the published tarballs:

| package | `dist/dev.bundle.min.mjs` |
|---|---|
| `@reddb-io/red-skills@3.20.0` | absent |
| `@reddb-io/red-skills@3.21.0` | absent |
| `@reddb-io/red-skills-dev@3.21.0` | **present** |

The lookup is now ordered: this package's own `dist/` first, so an older install keeps working, then the plugin package resolved through node's own algorithm (found whether it sits beside this package or nested under it). The failure message names both locations and the install command.

Proven end to end against the real registry: installing `@reddb-io/red-skills-dev@3.21.0` and running the patched shim prints `dev 3.21.0 70fd9071`.

New test `apps/dev/tests/dev-shim-bundle-resolution.test.ts` covers all three shapes — plugin-only, core-only, neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789731953&installation_model_id=20659&pr_number=4066&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4066&signature=4dfa6b56f21014b00f5f0e30131972aa05e31b66f7ebaa424d80d95c662982bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->