### PR TITLE
feat(brain): rs_brain names the adapter, and the store is the user's at ~/.red/brain

### DIFF
--- a/.changeset/rs-brain-host-scoped.md
+++ b/.changeset/rs-brain-host-scoped.md
@@ -1,0 +1,15 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Brain is the user's: `rs_brain` names the adapter and the store defaults to `~/.red/brain`
+
+ADR 0152 makes brain host-scoped — a second repository is not a second brain — so
+the default root is now `~/.red/brain` and every checkout reaches the same store.
+The explicit overrides keep precedence in the order they always had:
+`RED_BRAIN_ROOT`, then `plugins.brain.rootDir` in `.red/config.yaml`. A checkout
+that ALREADY holds a store keeps using it, because silently pointing an existing
+brain at an empty one loses a user's notes.
+
+The plugin's MCP server is renamed `brain` → `rs_brain` per ADR 0147 §2, matching
+`rs_dev`.

--- a/apps/brain/src/config.ts
+++ b/apps/brain/src/config.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 
 export const DEFAULT_CONNECTION_STRING = "file://./.red/brain/brain.rdb";
@@ -32,18 +33,36 @@ export async function findBrainRoot(
   const configRoot = await findConfiguredBrainRoot(startDir);
   if (configRoot) return configRoot;
 
+  // **Brain is the USER's, not a project's** (ADR 0152). A second repository is
+  // not a second brain, so the default root is host-scoped and every checkout
+  // reaches the same store. An explicit `RED_BRAIN_ROOT` or a
+  // `plugins.brain.rootDir` in config still wins above — both are read before
+  // this line — and a checkout that ALREADY holds a store keeps it, because
+  // silently pointing an existing brain at an empty one loses a user's notes.
+  const existing = findExistingProjectBrainRoot(startDir);
+  if (existing) return existing;
+  return hostBrainRoot(options.env ?? process.env);
+}
+
+/** `~/.red/brain`'s owning directory, honouring HOME on every platform. */
+export function hostBrainRoot(env: Record<string, string | undefined> = process.env): string {
+  const home = env["HOME"] ?? env["USERPROFILE"] ?? homedir();
+  return join(home, ".red");
+}
+
+/** A checkout that already carries a brain store, walking up from `startDir`. */
+function findExistingProjectBrainRoot(startDir: string): string | null {
   let current = resolve(startDir);
-  let fallbackRedRoot: string | null = null;
   while (true) {
     const redDir = join(current, ".red");
-    if (existsSync(redDir)) {
-      fallbackRedRoot ??= current;
-      if (existsSync(join(redDir, "brain")) || existsSync(join(redDir, BRAIN_ROOT_MARKER))) {
-        return current;
-      }
+    if (
+      existsSync(redDir) &&
+      (existsSync(join(redDir, "brain")) || existsSync(join(redDir, BRAIN_ROOT_MARKER)))
+    ) {
+      return current;
     }
     const parent = dirname(current);
-    if (parent === current) return fallbackRedRoot ?? resolve(startDir);
+    if (parent === current) return null;
     current = parent;
   }
 }

--- a/apps/brain/tests/config.test.ts
+++ b/apps/brain/tests/config.test.ts
@@ -57,9 +57,18 @@ afterEach(async () => {
 });
 
 describe("Brain config", () => {
-  it("uses the initial directory when no .red ancestor exists", async () => {
+  // ADR 0152: brain is the USER's, so a directory that carries no store of its
+  // own resolves to the host root rather than minting a per-checkout brain.
+  it("uses the host root when no directory on the path carries a brain", async () => {
     const root = await tempRootWithoutRedAncestor();
-    await expect(findBrainRoot(root)).resolves.toBe(root);
+    const env = { HOME: root };
+    await expect(findBrainRoot(root, { env })).resolves.toBe(join(root, ".red"));
+  });
+
+  it("keeps a checkout that already carries a brain store", async () => {
+    const root = await tempRootWithoutRedAncestor();
+    await mkdir(join(root, ".red", "brain"), { recursive: true });
+    await expect(findBrainRoot(root, { env: { HOME: "/nonexistent-home" } })).resolves.toBe(root);
   });
 
   it("uses an ancestor umbrella brain instead of a child repo .red directory", async () => {
@@ -117,14 +126,16 @@ describe("Brain config", () => {
     await expect(findBrainRoot(tetisRepo)).resolves.toBe(tetis);
   });
 
-  it("falls back to the nearest .red ancestor when no brain root exists", async () => {
+  // A bare `.red` is not a brain (ADR 0152): the walk-up honours a checkout that
+  // HOLDS a store, and anything else is the user's host brain.
+  it("prefers the host root over a .red ancestor that carries no brain", async () => {
     const root = await tempRoot();
     const repo = join(root, "service");
     const start = join(repo, "src");
     await mkdir(join(repo, ".red"), { recursive: true });
     await mkdir(start, { recursive: true });
 
-    await expect(findBrainRoot(start)).resolves.toBe(repo);
+    await expect(findBrainRoot(start, { env: { HOME: root } })).resolves.toBe(join(root, ".red"));
   });
 
   it("lets an environment root override walk-up brain resolution", async () => {

--- a/apps/dev/tests/plugin-structural-smoke.test.ts
+++ b/apps/dev/tests/plugin-structural-smoke.test.ts
@@ -76,8 +76,10 @@ describe("memory and brain declare no default red-ui", () => {
     expect(declaredServers("memory")).toEqual(["red-memory"]);
   });
 
+  // #4026: the brain adapter is `rs_brain` (ADR 0147 §2), still the one server
+  // the plugin declares.
   it("leaves brain with its own local data server only", () => {
-    expect(declaredServers("brain")).toEqual(["brain"]);
+    expect(declaredServers("brain")).toEqual(["rs_brain"]);
   });
 
   it("keeps the viewer out of both declarations, opt-in or not", () => {

--- a/apps/opencode-host/tests/mcp-passthrough.test.ts
+++ b/apps/opencode-host/tests/mcp-passthrough.test.ts
@@ -248,8 +248,9 @@ describe("planPluginMcp against the real source tree", () => {
     expect(redMemory.entry.command[2]).toBe("mcp");
   });
 
-  it("plans the brain plugin's brain MCP, with no default red-ui", () => {
-    expect(planPluginMcp(REAL_PLUGINS, "brain").map((p) => p.name)).toEqual(["brain"]);
+  // ADR 0147 §2 / #4026: the brain adapter ships as `rs_brain`.
+  it("plans the brain plugin's rs_brain MCP, with no default red-ui", () => {
+    expect(planPluginMcp(REAL_PLUGINS, "brain").map((p) => p.name)).toEqual(["rs_brain"]);
   });
 
   it("returns an empty list when the plugin has no .mcp.json", () => {

--- a/packaging/pi/brain/.mcp.json
+++ b/packaging/pi/brain/.mcp.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
-    "brain": {
+    "rs_brain": {
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/brain\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/brain\" \"$HOME/.codex/plugins/cache/red-skills/brain\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'brain: could not locate brain plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/brain\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/brain\" \"$HOME/.codex/plugins/cache/red-skills/brain\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'rs_brain: could not locate brain plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
       ]
     }
   }

--- a/plugins/brain/.mcp.json
+++ b/plugins/brain/.mcp.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
-    "brain": {
+    "rs_brain": {
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/brain\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/brain\" \"$HOME/.codex/plugins/cache/red-skills/brain\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'brain: could not locate brain plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/brain\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/brain\" \"$HOME/.codex/plugins/cache/red-skills/brain\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'rs_brain: could not locate brain plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
       ]
     }
   }


### PR DESCRIPTION
Refs #4026 (ADR 0152, ADR 0147 §2).

**A second repository is not a second brain.** The default root moves from *walk up until something looks like a brain* to the host-scoped `~/.red/brain`, so every checkout on a machine reaches one store. Precedence above it is unchanged: `RED_BRAIN_ROOT`, then `plugins.brain.rootDir`.

One case is deliberately preserved — a checkout that **already** carries a store keeps resolving to it, because silently repointing an existing brain at an empty one loses a user's notes. What changed is that a *bare* `.red` is no longer mistaken for a brain.

The MCP server is renamed `brain` → `rs_brain`, with the generated Codex/Gemini/Pi manifests regenerated and the passthrough + structural-smoke assertions repointed rather than dropped.

### Not in this slice

The Ticket's *"daemon holds the store handle, two sessions share it"* half needs a brain ACP surface that does not exist yet — the adapter cannot forward to a method the daemon does not serve. Stated on the Ticket so the remaining half is visible rather than assumed done.

### Verification

- `pnpm -C apps/brain exec vitest run` — 127/127, including two new cases: a directory with no store resolves to the host root, and a checkout that holds one keeps it
- `pnpm -C apps/opencode-host exec vitest run` — 142/142
- `pnpm -C apps/dev test:invariants` — 270/270
- `pnpm typecheck` — 17/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789733614&installation_model_id=20659&pr_number=4067&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4067&signature=ad1afc66556291ae3db1da9b5c6e21355633204c327ae75abca15d0f3ea363e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->