### PR TITLE
chore(packaging): restage the Pi copy of the dev MCP launcher

### DIFF
--- a/.changeset/restage-pi-dev-hooks.md
+++ b/.changeset/restage-pi-dev-hooks.md
@@ -1,0 +1,10 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Restage the Pi copy of the dev plugin's MCP launcher
+
+The source launcher gained argument forwarding (`"$@"`) and the staged Pi mirror
+was not rebuilt with it, so `build-pi-packages --check` failed on `main` and every
+open PR inherited the red typecheck job. Generated artifact only — no behaviour
+change beyond the mirror matching its source.

--- a/packaging/pi/dev/hooks/redskilled-mcp.sh
+++ b/packaging/pi/dev/hooks/redskilled-mcp.sh
@@ -32,7 +32,7 @@ if [ -n "$plugin_json" ]; then
 fi
 
 if [ -n "$ver" ]; then
-  npx -y -p "@reddb-io/red-skills@$ver" red-skills-redskilled-mcp
+  npx -y -p "@reddb-io/red-skills@$ver" red-skills-redskilled-mcp "$@"
   status=$?
   if [ "$status" -eq 0 ]; then
     exit 0
@@ -46,7 +46,7 @@ repo="$PWD"
 if [ -f "$repo/pnpm-workspace.yaml" ] && \
    [ -f "$repo/apps/dev/package.json" ] && \
    [ -f "$repo/dist/redskilled-mcp.bundle.min.mjs" ]; then
-  exec node "$repo/dist/redskilled-mcp.bundle.min.mjs"
+  exec node "$repo/dist/redskilled-mcp.bundle.min.mjs" "$@"
 fi
 
 printf 'redskilled: could not locate the redskilled-mcp bundle\n' >&2


### PR DESCRIPTION
**`main` is red on typecheck** — the job runs `build-pi-packages --check`, and the staged Pi mirror of `plugins/dev/hooks/redskilled-mcp.sh` is one edit behind its source: the launcher gained `"$@"` argument forwarding and the mirror was never rebuilt.

Generated artifact only, regenerated with `pnpm pi:packages:build`. Verified: `node scripts/build-pi-packages.mjs --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789735730&installation_model_id=20659&pr_number=4074&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4074&signature=1bd086ae6bda76bb7215b9206ad8c98e449c427b0eaa92e7d5d96e5a61205200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->