### PR TITLE
fix(redskilled): the ACP conformance script runs on Windows

### DIFF
--- a/.changeset/windows-conformance-script.md
+++ b/.changeset/windows-conformance-script.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The focused ACP conformance script runs on Windows
+
+`test:acp-agent-conformance` shipped with a POSIX-only `NODE_OPTIONS=... vitest`
+prefix, which `cmd` reads as a command name — the Windows CI leg failed with
+`'NODE_OPTIONS' is not recognized`, taking the aggregate `test` gate red on
+`main`. It now matches its Windows-proven sibling `test:acp-local-transport` and
+carries no prefix; the suite is 22 fast tests and never needed the heap bump.

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -46,7 +46,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "NODE_OPTIONS=--max-old-space-size=4096 vitest run",
     "test:acp-agent-catalog": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-agent-catalog.test.ts",
-    "test:acp-agent-conformance": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-agent-conformance.test.ts",
+    "test:acp-agent-conformance": "vitest run tests/acp-agent-conformance.test.ts",
     "test:acp-conformance": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-conformance.test.ts",
     "test:acp-control-plane": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-control-plane.test.ts",
     "test:acp-local-transport": "vitest run tests/acp-local-transport.test.ts",


### PR DESCRIPTION
**`main` is red** on the aggregate `test` gate, because `acp-local-transport (windows-latest)` fails — *after* its tests pass:

```
Tests  1 passed (1)
$ NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-agent-conformance.test.ts
'NODE_OPTIONS' is not recognized as an internal or external command
```

The script landed in #4072 with a POSIX-only env prefix, which `cmd` reads as a command name. My regression.

The fix is the shape already proven on that runner: `test:acp-local-transport` runs in the same job with no prefix. The conformance suite is 22 tests in under a second and never needed the 4 GB heap bump.

Verified: `pnpm -C apps/redskilled test:acp-agent-conformance` — 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789736321&installation_model_id=20659&pr_number=4075&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4075&signature=d278a8c85556afe3850a8a69394b5e562353e4bfc4be90a93a17593499ea5884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->