### PR TITLE
feat(redskilled): announce servedVersion on the ACP handshake

### DIFF
--- a/.changeset/daemon-served-version.md
+++ b/.changeset/daemon-served-version.md
@@ -1,0 +1,14 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The daemon announces the version it serves on the ACP handshake
+
+ADR 0151 makes `redskilled` the owner of the version that runs on a machine. The
+`initialize` response now carries `_meta.redskills.servedVersion` on both wires,
+and `agentInfo.version` stops being the hardcoded `"1"`, so a launcher can ask
+the daemon which version to run instead of resolving a bundle from its own cache
+— the shape that let one machine hold 3.17.1, 3.18.12 and 3.19.3 at once. Read
+fresh per handshake, so a handover is visible immediately. A differing minor
+inside one wire major stays compatible by contract (ADR 0145 §3) and is not a
+refusal.

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -185,6 +185,8 @@ async function servePublicConnection(
   persistProjectControls: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>,
   sessionJournal: DurableAcpSessionJournal,
 ): Promise<void> {
+  /** What this daemon is serving, read fresh so a handover is visible at once. */
+  const servedVersion = (): string => options.hostState().daemon_version;
   const sessions = new Map<string, PublicSession>();
   const active = new Map<string, ActiveWorkflowWorker>();
   const busy = new Set<string>();
@@ -264,10 +266,17 @@ async function servePublicConnection(
           ? params.protocolVersion
           : ACP_PROTOCOL_VERSION,
         agentCapabilities: { promptCapabilities: {} },
-        agentInfo: { name: "RedSkills", version: "1" },
+        agentInfo: { name: "RedSkills", version: servedVersion() },
         _meta: {
           redskills: {
             wireMajor: REDSKILLS_WIRE_MAJOR,
+            // **The daemon says which version it serves** (ADR 0151). A client
+            // that resolves a bundle from its own cache is one of three caches
+            // deciding independently, which is how one machine came to hold
+            // 3.17.1, 3.18.12 and 3.19.3 at once. Announced on the handshake so
+            // a launcher can ask instead of guessing; a differing MINOR is
+            // compatible by contract (ADR 0145 §3) and is not a refusal.
+            servedVersion: servedVersion(),
             workerBacked: true,
             ...v1Methods.capabilities,
           },
@@ -394,11 +403,13 @@ async function servePublicConnection(
       requireSupportedV2Revision(params._meta);
       return {
         protocolVersion: acpV2.PROTOCOL_VERSION,
-        info: { name: "RedSkills", version: "1" },
+        info: { name: "RedSkills", version: servedVersion() },
         capabilities: { session: {} },
         _meta: {
           redskills: {
             wireMajor: REDSKILLS_WIRE_MAJOR,
+            // Same answer on both wires: the daemon owns the version (ADR 0151).
+            servedVersion: servedVersion(),
             workerBacked: true,
             acpDraftRevision: ACP_V2_DRAFT_REVISION,
             ...v2Methods.capabilities,

--- a/apps/redskilled/tests/acp-local-transport.test.ts
+++ b/apps/redskilled/tests/acp-local-transport.test.ts
@@ -70,7 +70,7 @@ describe("the host-native local ACP authority transport", () => {
     let workerSequence = 0;
     const controlPlane = await startRedskillsAcpControlPlane({
       paths,
-      hostState: () => ({ workers: [] }) as never,
+      hostState: () => ({ workers: [], daemon_version: "9.9.9" }) as never,
       startWorker: (spec) => launchTestWorker(spec, env, assignedWorkerEndpoints, ++workerSequence),
     });
 
@@ -83,6 +83,10 @@ describe("the host-native local ACP authority transport", () => {
       );
 
       const first = await openStdioProjection(env, "first");
+      // #4029 / ADR 0151: the daemon says which version it serves, so a launcher
+      // can ask instead of resolving a bundle from its own cache — the shape
+      // that let one machine hold three versions at once.
+      expect(first.initialized._meta?.redskills?.servedVersion).toBe("9.9.9");
       await exerciseWorkflow(first.connection, root, "first turn");
       await closeStdioProjection(first);
 
@@ -154,6 +158,7 @@ function launchTestWorker(
 async function openStdioProjection(env: NodeJS.ProcessEnv, label: string): Promise<{
   child: ChildProcess;
   connection: ReturnType<ReturnType<typeof client>["connect"]>;
+  initialized: { readonly _meta?: { readonly redskills?: { readonly servedVersion?: string } } };
 }> {
   const child = spawn(process.execPath, [
     "--import", tsxLoader,
@@ -165,12 +170,12 @@ async function openStdioProjection(env: NodeJS.ProcessEnv, label: string): Promi
   });
   children.push(child);
   const connection = client({ name: `${label}-stdio-projection` }).connect(childStream(child));
-  await connection.agent.request(methods.agent.initialize, {
+  const initialized = await connection.agent.request(methods.agent.initialize, {
     protocolVersion: 1,
     clientCapabilities: {},
     clientInfo: { name: `${label}-transport-client`, version: "1" },
   });
-  return { child, connection };
+  return { child, connection, initialized };
 }
 
 async function exerciseWorkflow(

--- a/apps/redskilled/tests/acp-local-transport.test.ts
+++ b/apps/redskilled/tests/acp-local-transport.test.ts
@@ -86,7 +86,8 @@ describe("the host-native local ACP authority transport", () => {
       // #4029 / ADR 0151: the daemon says which version it serves, so a launcher
       // can ask instead of resolving a bundle from its own cache — the shape
       // that let one machine hold three versions at once.
-      expect(first.initialized._meta?.redskills?.servedVersion).toBe("9.9.9");
+      const handshake = first.initialized as { _meta?: { redskills?: { servedVersion?: string } } };
+      expect(handshake._meta?.redskills?.servedVersion).toBe("9.9.9");
       await exerciseWorkflow(first.connection, root, "first turn");
       await closeStdioProjection(first);
 
@@ -158,7 +159,7 @@ function launchTestWorker(
 async function openStdioProjection(env: NodeJS.ProcessEnv, label: string): Promise<{
   child: ChildProcess;
   connection: ReturnType<ReturnType<typeof client>["connect"]>;
-  initialized: { readonly _meta?: { readonly redskills?: { readonly servedVersion?: string } } };
+  initialized: Awaited<ReturnType<ReturnType<ReturnType<typeof client>["connect"]>["agent"]["request"]>>;
 }> {
   const child = spawn(process.execPath, [
     "--import", tsxLoader,


### PR DESCRIPTION
Refs #4029 (ADR 0151, ADR 0145 §3).

The daemon owns the version that runs on a machine, so it has to **say** which one. `initialize` now carries `_meta.redskills.servedVersion` on both wires, and `agentInfo.version` stops being the hardcoded `"1"`. Read fresh from `hostState()` per handshake, so a handover is visible to the next client immediately.

What this closes is the three-independent-caches shape observed on this machine: 3.17.1 in the plugin cache, 3.18.12 in the npx cache, 3.19.3 on main — because every client resolved a bundle for itself. With the daemon announcing, a launcher can ask.

The assertion lands in `acp-local-transport` deliberately: that is the leg which also runs on **Windows**, so the contract is proven on both hosts.

### Not in this slice

The launcher side of #4029 — *resolve the version from the daemon, never from the npx or plugin cache* — is the consumer half and lands separately; this PR supplies the answer it will ask for. The Ticket stays open.

### Pre-existing failures, not from this change

`acp-conformance` (4) and `acp-control-plane` (1) fail identically on `main` with this branch stashed — the control-plane one is a status payload that gained a `context` key. Flagged rather than folded in.

### Verification

- `pnpm -C apps/redskilled test:acp-local-transport` — passes, asserting `servedVersion`
- `pnpm -C apps/dev test:invariants` — green
- `pnpm typecheck` — 17/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789738702&installation_model_id=20659&pr_number=4076&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4076&signature=f0a61d0d67de178ca7afbd617581d103756088dd19704f9e44fb920458c403a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->