### PR TITLE
fix(redskilled): take socketAnswers from its module, not the daemon barrel

### DIFF
--- a/.changeset/dev-bundle-drops-the-daemon-body.md
+++ b/.changeset/dev-bundle-drops-the-daemon-body.md
@@ -1,0 +1,17 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The dev bundle stops pulling the daemon body through a barrel import
+
+Five modules took `socketAnswers` — a twenty-line socket probe — from
+`./daemon.js`, the barrel that re-exports the whole lifecycle. The dev CLI
+reaches one of them from `runtime/gh/band.ts`, so the daemon lifecycle, the ACP
+control plane and the MCP client SDK all landed in `dist/dev.bundle.min.mjs`.
+When #4026 gave the control plane a brain-store import, the SDK's bundled `ajv`
+came with it and left five bare `require("ajv/dist/runtime/…")` calls in the
+bundle — which the dev bundle contract forbids, so `main` went red on
+`test-shard (4)` and the 3.22.0 release PR could not merge.
+
+Each of the five now imports `./daemon/socket.js` directly. Same function, same
+behaviour; the dev CLI's module graph no longer contains the daemon body.

--- a/apps/redskilled/src/client-rendezvous.ts
+++ b/apps/redskilled/src/client-rendezvous.ts
@@ -10,7 +10,8 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { isPidAlive } from "@reddb-io/shared/resident-core.js";
-import { socketAnswers } from "./daemon.js";
+// The module, not the barrel (#4064): the barrel re-exports the lifecycle.
+import { socketAnswers } from "./daemon/socket.js";
 import {
   createRedskilledMachineClaimStore,
   currentMachineOwner,

--- a/apps/redskilled/src/client.ts
+++ b/apps/redskilled/src/client.ts
@@ -18,7 +18,12 @@ import { dirname } from "node:path";
 import { isPidAlive } from "@reddb-io/shared/resident-core.js";
 import { type RedskilledEntryLookup } from "./daemon-entry.js";
 import { redskilledDashboardRequest } from "./dashboard-request.js";
-import { socketAnswers } from "./daemon.js";
+// **Import the module, not the barrel.** `./daemon.js` re-exports the whole
+// lifecycle, which reaches the ACP control plane and through it the MCP client
+// SDK — whose bundled ajv leaves bare `require()` calls that the dev bundle
+// contract forbids. `socketAnswers` is a 20-line socket probe; taking it from
+// its own module keeps the dev CLI's graph free of the daemon body (#4064).
+import { socketAnswers } from "./daemon/socket.js";
 import {
   describeRedskilledPresence,
   type RedskilledPresence,

--- a/apps/redskilled/src/daemon-birth.ts
+++ b/apps/redskilled/src/daemon-birth.ts
@@ -14,7 +14,8 @@
 import { spawn } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
-import { socketAnswers } from "./daemon.js";
+// The module, not the barrel (#4064): the barrel re-exports the lifecycle.
+import { socketAnswers } from "./daemon/socket.js";
 import { startThroughInstalledSupervisor } from "./client-rendezvous.js";
 import { redskilledServeArgv, type ResolvedRedskilledEntry } from "./daemon-entry.js";
 import { requireRedskilledEntryWithFetch } from "./entry-fetch.js";

--- a/apps/redskilled/src/daemon-termination.ts
+++ b/apps/redskilled/src/daemon-termination.ts
@@ -6,7 +6,10 @@
  * and verifies the same socket, lease, and process boundary as a normal stop.
  */
 import { isPidAlive } from "@reddb-io/shared/resident-core.js";
-import { socketAnswers } from "./daemon.js";
+// The module, not the barrel: `./daemon.js` re-exports the lifecycle and with it
+// the ACP control plane, whose MCP client SDK bundles an ajv the dev bundle
+// contract forbids (#4064).
+import { socketAnswers } from "./daemon/socket.js";
 import { buildRedskilledUnreachableStop, type RedskilledDaemonStopped } from "./daemon-stop.js";
 import type { RedskilledPaths } from "./paths.js";
 import { readRedskilledLeaseFile } from "./session-lease.js";

--- a/apps/redskilled/src/provision.ts
+++ b/apps/redskilled/src/provision.ts
@@ -29,7 +29,8 @@ import {
   workspaceReadsRedskilledHome,
   WORKSPACE_TARGET_CONFIG_KEY,
 } from "@reddb-io/shared/worker-workspace.js";
-import { socketAnswers } from "./daemon.js";
+// The module, not the barrel (#4064): the barrel re-exports the lifecycle.
+import { socketAnswers } from "./daemon/socket.js";
 import {
   isResolvedRedskilledEntry,
   resolveRedskilledEntry,


### PR DESCRIPTION
**`main` is red on `test-shard (4)`** and the 3.22.0 release PR (#4064) cannot merge: `dev-bundle-contract` finds five bare `require("ajv/dist/runtime/…")` calls in `dist/dev.bundle.min.mjs`.

## The chain

```
src/runtime/gh/band.ts
  → @reddb-io/redskilled/client
    → daemon-termination.ts → ./daemon.js  (barrel: re-exports the lifecycle)
      → daemon/lifecycle.ts → acp-control-plane.ts → brain-store.ts
        → MCP client SDK → ajv
```

Five modules took `socketAnswers` — a twenty-line socket probe — from the barrel instead of from its own module, so the dev CLI's graph contained the entire daemon body. That was latent until #4026 gave the control plane a brain-store import and the SDK's ajv came with it.

## The fix

Each of the five imports `./daemon/socket.js` directly. Same function, same behaviour; the boundary the contract exists to protect is restored. Bisected to confirm the regression entered with #4026 and not with #4078.

## Verification

- `pnpm -C apps/dev exec vitest run tests/dev-bundle-contract.test.ts` — passes; the rebuilt bundle contains neither the ajv requires nor the SDK
- `pnpm -C apps/dev test:invariants` — **338/338**
- `pnpm -C apps/redskilled exec vitest run tests/provision.test.ts tests/daemon-birth.test.ts tests/client-reconnect.test.ts` — 28/28
- `pnpm typecheck` — 17/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789741907&installation_model_id=20659&pr_number=4080&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4080&signature=fcfc48ec5dee41a1dc6d7822ccba296b05925edb1bc9527627234f00a90c4455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->