### PR TITLE
fix(scripts): the publish contract fixture follows emitted bundles, not app directories

### DIFF
--- a/.changeset/publish-contract-emitted-bundles.md
+++ b/.changeset/publish-contract-emitted-bundles.md
@@ -1,0 +1,14 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The publish contract fixture asks the same question the boundary checker asks
+
+`check-npm-tarball-boundaries.mjs` now decides "does this plugin ship a bundle?"
+by reading the app's own bundle script for the emitted filename, because #4031
+left `apps/dev` in place — it holds the MCP adapter and the cores — while
+deleting the `dev.bundle.min.mjs` it used to emit. The contract test still built
+its fixture from the old proxy (does `apps/<name>/` exist?), so it staged a
+bundle the checker no longer expects and `workflow-security` went red on `main`.
+
+Both sides now read the emitted name.

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -188,8 +188,19 @@ while IFS= read -r plugin_json; do
   plugin_tree="$contract_fixture/plugin-$plugin/package"
   mkdir -p "$plugin_tree/skills/core/example" "$plugin_tree/dist"
   : > "$plugin_tree/skills/core/example/SKILL.md"
-  # Only a plugin with a runtime app carries a bundle; `internal` is skills-only.
-  if [ -f "apps/$plugin/package.json" ]; then
+  # A plugin carries a bundle iff its app EMITS one — the same question
+  # check-npm-tarball-boundaries.mjs asks. `internal` is skills-only, and since
+  # #4031 `apps/dev` exists without emitting `dev.bundle.min.mjs`, so the mere
+  # presence of the app directory stopped being the answer.
+  if [ -f "apps/$plugin/package.json" ] && node -e '
+    const fs = require("node:fs");
+    const [manifest, name] = process.argv.slice(1);
+    const scripts = JSON.parse(fs.readFileSync(manifest, "utf8")).scripts ?? {};
+    const emits = Object.values(scripts).some(
+      (c) => typeof c === "string" && c.includes(`${name}.bundle.min.mjs`),
+    );
+    process.exit(emits ? 0 : 1);
+  ' "apps/$plugin/package.json" "$plugin"; then
     : > "$plugin_tree/dist/$plugin.bundle.min.mjs"
   else
     skills_only_plugin="$plugin"


### PR DESCRIPTION
**`main` is red on `workflow-security`.** #4081 taught `check-npm-tarball-boundaries.mjs` to decide *does this plugin ship a bundle?* by reading the app's own bundle script — necessary because #4031 left `apps/dev` in place (it holds the MCP adapter and the cores) while deleting the `dev.bundle.min.mjs` it used to emit.

The contract test still built its fixture from the old proxy — *does `apps/<name>/` exist?* — so it staged a bundle the checker no longer expects and the assertion inverted.

Both sides now ask the same question.

Verified: `bash scripts/test-red-release-npm-publish-contract.sh` → `red-publish npm publish contract ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789749646&installation_model_id=20659&pr_number=4085&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4085&signature=c469bd169dba6cdc6720d8a2a339b1e0ed6d0f96bc5987a8fd15b879390eff64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->