### PR TITLE
fix(memory): local vector maintenance writes its index once per pass

### DIFF
--- a/.changeset/memory-vector-index-write-amplification.md
+++ b/.changeset/memory-vector-index-write-amplification.md
@@ -1,0 +1,20 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Local vector maintenance writes its index once per pass, not once per vector
+
+`memory vector maintain --local` rewrote the aggregate local-vector index after
+**every** record. The index names every projected vector, so a pass over N
+vectors wrote O(N²) bytes into a store that keeps every version: #3970 measured
+2233 vectors turning a 186 KB store into 3.75 GB while `memory doctor` reported
+healthy at every step — because nothing was corrupt, only amplified.
+
+A maintenance pass now holds the index open and flushes it exactly once, in a
+`finally` so a pass that dies under `--strict` still records the vectors it did
+project (an index that forgot them is worse than a large one: recall would not
+find records that are physically there). A single projection outside a pass
+still writes through, so nothing that projects one vector loses its entry.
+
+The remaining footprint is RedDB's physical version retention, which this
+repository does not own; the amplification it was multiplying is gone.

--- a/apps/plugin-memory/src/graph-store/vector-projection.ts
+++ b/apps/plugin-memory/src/graph-store/vector-projection.ts
@@ -247,6 +247,19 @@ function localVectorKey(sourceCollection: string, rid: number): string {
 export class MemoryVectorProjection {
   constructor(private readonly ctx: MemoryVectorProjectionContext) {}
 
+  /**
+   * The aggregate local-vector index, held open while a whole maintenance pass
+   * runs. `null` means "no pass is open — write the index through immediately".
+   *
+   * **A maintenance pass over N vectors must not write the index N times.** The
+   * index names every projected vector, so writing it after each record makes
+   * the pass quadratic in BYTES on a store that keeps every version: a 2233
+   * vector run rewrote a 2233-entry map 2233 times and the graph store grew to
+   * 3.75 GB (#3970). One flush per pass costs one write and describes the same
+   * end state.
+   */
+  private openIndex: Map<string, string> | null = null;
+
   private get db(): RedDB {
     return this.ctx.db;
   }
@@ -470,11 +483,22 @@ export class MemoryVectorProjection {
 
   async maintainVectorProjection(opts: { strict?: boolean } = {}): Promise<VectorStatusReport> {
     const strict = opts.strict === true;
-    for (const node of await this.listNodes()) {
-      await this.projectNodeVector(node.rid, node, strict);
-    }
-    for (const doc of await this.listDocs()) {
-      await this.projectDocVector(doc.rid, doc, strict);
+    // The pass holds the index open and owes exactly one write, even when a
+    // projection throws under --strict: a pass that died halfway still
+    // projected vectors, and an index that forgot them is worse than a large
+    // one — recall would not find records that are physically there.
+    this.openIndex = await this.readLocalVectorIndex();
+    try {
+      for (const node of await this.listNodes()) {
+        await this.projectNodeVector(node.rid, node, strict);
+      }
+      for (const doc of await this.listDocs()) {
+        await this.projectDocVector(doc.rid, doc, strict);
+      }
+    } finally {
+      const index = this.openIndex;
+      this.openIndex = null;
+      if (index != null) await this.writeLocalVectorIndex(index);
     }
     const report = await this.vectorStatus();
     if (strict && report.overall !== "ready") {
@@ -611,12 +635,15 @@ export class MemoryVectorProjection {
       record.source_collection === COLLECTIONS.docs ? record.doc_rid : record.node_rid;
     if (!Number.isFinite(targetRid)) return;
     await this.kv().put(localVectorKey(record.source_collection, Number(targetRid)), record);
-    const index = await this.readLocalVectorIndex();
+    const index = this.openIndex ?? (await this.readLocalVectorIndex());
     index.set(
       vectorTargetKey(record.source_collection, Number(targetRid)),
       localVectorKey(record.source_collection, Number(targetRid)),
     );
-    await this.writeLocalVectorIndex(index);
+    // Inside an open pass the flush is owed at the end, once, by whoever opened
+    // it. A single projection outside a pass still writes through, so nothing
+    // that projects one vector loses its index entry.
+    if (this.openIndex == null) await this.writeLocalVectorIndex(index);
   }
 
   private async readLocalVectorIndex(): Promise<Map<string, string>> {

--- a/apps/plugin-memory/tests/vector-index-write-amplification.test.ts
+++ b/apps/plugin-memory/tests/vector-index-write-amplification.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { MemoryVectorProjection } from "../src/graph-store/vector-projection.js";
+
+/**
+ * A maintenance pass over N vectors must write the aggregate local index ONCE.
+ *
+ * The index names every projected vector, so writing it after each record makes
+ * the pass quadratic in bytes on a store that keeps every version: #3970
+ * reported 2233 vectors turning a 186 KB store into 3.75 GB. Counting index
+ * puts is the honest observation — it is the amplification itself, not a
+ * proxy for it.
+ */
+const INDEX_KEY = "vector:local:index";
+
+class CountingKv {
+  readonly puts: string[] = [];
+  private readonly store = new Map<string, unknown>();
+
+  async get(key: string): Promise<unknown> {
+    return this.store.has(key) ? this.store.get(key) : null;
+  }
+
+  async put(key: string, value: unknown): Promise<void> {
+    this.puts.push(key);
+    this.store.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  indexWrites(): number {
+    return this.puts.filter((key) => key === INDEX_KEY).length;
+  }
+}
+
+function nodes(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    rid: index + 1,
+    label: `node-${index + 1}`,
+    node_type: "note",
+    properties: { content: `content ${index + 1}`, project: "test" },
+  }));
+}
+
+let previousProvider: string | undefined;
+
+beforeEach(() => {
+  previousProvider = process.env.RED_MEMORY_VECTOR_PROVIDER;
+  process.env.RED_MEMORY_VECTOR_PROVIDER = "local";
+});
+
+afterEach(() => {
+  if (previousProvider === undefined) delete process.env.RED_MEMORY_VECTOR_PROVIDER;
+  else process.env.RED_MEMORY_VECTOR_PROVIDER = previousProvider;
+});
+
+function projectionOver(kv: CountingKv, count: number): MemoryVectorProjection {
+  return new MemoryVectorProjection({
+    // The local path never reaches the database: a query here is the test
+    // telling us the provider was not honoured.
+    db: {
+      query: () => {
+        throw new Error("the local vector path must not query the database");
+      },
+    } as never,
+    kv: () => kv as never,
+    project: "test",
+    listNodes: async () => nodes(count) as never,
+    listDocs: async () => [],
+  });
+}
+
+describe("local vector maintenance writes its index once per pass", () => {
+  test("one pass over many vectors writes the aggregate index exactly once", async () => {
+    const kv = new CountingKv();
+
+    await projectionOver(kv, 50).maintainVectorProjection();
+
+    expect(kv.indexWrites()).toBe(1);
+    // Every vector is still individually written — the batching is the index,
+    // never the records.
+    expect(kv.puts.filter((key) => key !== INDEX_KEY)).toHaveLength(50);
+  });
+
+  test("the index the pass leaves behind names every projected vector", async () => {
+    const kv = new CountingKv();
+
+    await projectionOver(kv, 8).maintainVectorProjection();
+
+    const index = (await kv.get(INDEX_KEY)) as Record<string, string>;
+    expect(Object.keys(index)).toHaveLength(8);
+  });
+
+  test("index cost does not grow with the square of the vector count", async () => {
+    const small = new CountingKv();
+    const large = new CountingKv();
+
+    await projectionOver(small, 10).maintainVectorProjection();
+    await projectionOver(large, 100).maintainVectorProjection();
+
+    expect(small.indexWrites()).toBe(1);
+    expect(large.indexWrites()).toBe(1);
+  });
+});


### PR DESCRIPTION
Refs #3970.

`memory vector maintain --local` rewrote the aggregate local-vector index after **every** record. The index names every projected vector, so a pass over N vectors wrote O(N²) bytes into a store that keeps every version — 2233 vectors turned a 186 KB store into 3.75 GB while `memory doctor` reported healthy at every step, because nothing was corrupt, only amplified.

- A pass now holds the index open and flushes it **exactly once**, in a `finally`: a pass that dies under `--strict` still records the vectors it did project. An index that forgot them would be worse than a large one — recall would not find records that are physically there.
- A single projection outside a pass still writes through, so nothing that projects one vector loses its entry.
- The batching is the **index**, never the records: each vector is still individually written, asserted by the test.

Verified locally: the new `vector-index-write-amplification.test.ts` fails 2/3 against the current code and passes 3/3 with the fix; the whole `apps/plugin-memory` unit suite is 931 passed / 1 skipped across 100 files.

The remaining footprint on that report is RedDB's physical version retention, which this repository does not own. I have left #3970 open for that half and said so there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789763052&installation_model_id=20659&pr_number=4092&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4092&signature=5924c31633528b103123b508e0041547087a3cbdd2195d88508c7a4505fa0ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->