### PR TITLE
fix(acp): a Project control verb carries its arguments

### DIFF
--- a/.changeset/acp-control-verbs-carry-arguments.md
+++ b/.changeset/acp-control-verbs-carry-arguments.md
@@ -1,0 +1,29 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A Project control verb carries its arguments across the ACP wire
+
+`drain {"target":2}` did nothing and said nothing was wrong. The client renders
+every parameterised control call as `/<verb> {json}`, the daemon's verb matcher
+demanded a BARE verb, so the call matched nothing, fell through to "execute this
+prompt in a Worker", and came back as narration with no answer in it —
+indistinguishable from a Worker that failed. The adapter had the mirror-image
+rule: it only routed a control tool to the control method when the input was
+empty, so any argument silently turned the call into prose.
+
+- The matcher reads the verb AND its argument object, and the control methods
+  take `target` and `runner` as typed params (shape checked, meaning never
+  read). A width the caller asked for is stored on the control record and
+  echoed back as `requested_target` / `requested_runner`, because an argument
+  that vanishes silently is indistinguishable from one that was honoured.
+- Restating the width is a new revision rather than `already-draining`.
+- The adapter routes a control tool with arguments to the control method, and
+  **refuses** an argument the control surface cannot express instead of
+  degrading it to a prompt.
+- Two pre-existing red assertions in `acp-control-plane.test.ts` are repointed:
+  a status answer is a drain answer plus its projections, so the record is what
+  must survive a daemon replacement.
+- `acp-control-plane.ts` is back under its headroom target (697 lines, from 719
+  on main) by moving the v1 control turn beside its v2 twin and the control
+  binding beside the record it operates on.

--- a/apps/plugin-dev/src/project-acp-adapter.ts
+++ b/apps/plugin-dev/src/project-acp-adapter.ts
@@ -6,10 +6,20 @@ import type {
 
 const CONTROL_TOOL = new Map<string, "drain" | "stop" | "status">([
   ["drain", "drain"],
+  ["project_drain", "drain"],
   ["project_stop", "stop"],
   ["project_status", "status"],
   ["status", "status"],
 ]);
+
+/**
+ * What a control call may carry. **A control tool with arguments must still be
+ * a control call**: routing it to a prompt instead turned `drain {target:2}`
+ * into the text `/drain {"target":2}`, which the daemon's verb matcher did not
+ * recognise, so the whole thing became "run this prompt in a Worker" and came
+ * back as narration with no answer in it.
+ */
+const CONTROL_ARGUMENTS = new Set(["target", "runner", "scope"]);
 
 /** Project MCP calls are projections; the adapter never executes a workflow. */
 export async function invokeProjectMcp(
@@ -18,9 +28,18 @@ export async function invokeProjectMcp(
   input: Readonly<Record<string, unknown>>,
 ): Promise<unknown> {
   const operation = CONTROL_TOOL.get(tool);
-  if (operation != null && Object.keys(input).length === 0) {
+  if (operation != null) {
+    const unsupported = Object.keys(input).filter((key) => !CONTROL_ARGUMENTS.has(key));
+    if (unsupported.length > 0) {
+      // Refuse loudly rather than degrade to prose. A caller that asked for
+      // something the control surface cannot express deserves to be told, not
+      // to read a healthy-looking answer that dropped its request.
+      throw new Error(
+        `the Project control surface cannot express ${JSON.stringify(unsupported.sort())} for ${JSON.stringify(tool)}`,
+      );
+    }
     if (operation === "status") return await session.control("status");
-    return await session.control(operation);
+    return await session.control(operation, controlRequest(input));
   }
   if (!isPublicCapability(tool)) {
     throw new Error(`unsupported ACP Project capability ${JSON.stringify(tool)}`);
@@ -53,6 +72,18 @@ export function invokeRedcodeProject(
   prompt: string,
 ): Promise<RedskillsProjectPromptResult> {
   return session.prompt(prompt);
+}
+
+function controlRequest(input: Readonly<Record<string, unknown>>): {
+  target?: number;
+  runner?: string;
+} {
+  const target = input.target;
+  const runner = input.runner;
+  return {
+    ...(typeof target === "number" && Number.isInteger(target) && target >= 0 ? { target } : {}),
+    ...(typeof runner === "string" && runner.length > 0 ? { runner } : {}),
+  };
 }
 
 function renderCapabilityPrompt(tool: string, input: Readonly<Record<string, unknown>>): string {

--- a/apps/plugin-dev/tests/acp-adapter-parity.test.ts
+++ b/apps/plugin-dev/tests/acp-adapter-parity.test.ts
@@ -110,7 +110,9 @@ describe("ACP Project adapter parity", () => {
         adapter_health: { status: "healthy" },
       },
     });
-    expect(mcp.control).toHaveBeenCalledWith("drain");
+    // The MCP call carries a request object even when it is empty: the control
+    // surface takes what the caller asked for, and "nothing" is an answer too.
+    expect(mcp.control).toHaveBeenCalledWith("drain", {});
     expect(cli.control).toHaveBeenCalledWith("drain");
     expect(redcode.prompt).toHaveBeenCalledWith("/drain");
   });
@@ -137,5 +139,36 @@ describe("ACP Project adapter parity", () => {
       .rejects.toThrow(/ACP Project capability/);
     await expect(invokeProjectCli(client.session, ["project", "github", "issues"]))
       .rejects.toThrow(/ACP Project command/);
+  });
+});
+
+describe("a control tool with arguments stays a control call", () => {
+  it("routes a width to the control method instead of rendering it as prose", async () => {
+    const calls: Array<{ operation: string; request: unknown }> = [];
+    const session = {
+      control: async (operation: string, request?: unknown) => {
+        calls.push({ operation, request });
+        return { version: 1, drain_intent: "draining" };
+      },
+      prompt: async () => {
+        throw new Error("a control tool must not reach the prompt path");
+      },
+    } as never;
+
+    await invokeProjectMcp(session, "drain", { target: 2, runner: "redcode" });
+
+    expect(calls).toEqual([{ operation: "drain", request: { target: 2, runner: "redcode" } }]);
+  });
+
+  it("refuses an argument the control surface cannot express, rather than dropping it", async () => {
+    const session = {
+      control: async () => ({ version: 1 }),
+      prompt: async () => {
+        throw new Error("a control tool must not reach the prompt path");
+      },
+    } as never;
+
+    await expect(invokeProjectMcp(session, "drain", { selector: { label: "ready-for-agent" } }))
+      .rejects.toThrow(/cannot express \["selector"\]/);
   });
 });

--- a/apps/redskilled/src/acp-client.ts
+++ b/apps/redskilled/src/acp-client.ts
@@ -31,6 +31,12 @@ import type { ProjectStatusContext } from "./project-control.js";
 
 export type RedskillsProjectControlOperation = "drain" | "stop" | "status";
 
+/** What a control call may ask for, opaque to the daemon beyond its shape. */
+export interface RedskillsProjectControlRequest {
+  readonly target?: number;
+  readonly runner?: string;
+}
+
 export interface RedskillsProjectControlSnapshot {
   readonly version: 1;
   readonly project_id: string;
@@ -59,7 +65,15 @@ export interface RedskillsProjectPromptResult {
 
 export interface RedskillsProjectAcpSession {
   control(operation: "status"): Promise<RedskillsProjectStatusSnapshot>;
-  control(operation: "drain" | "stop"): Promise<RedskillsProjectControlSnapshot>;
+  /**
+   * A control call CARRIES its request. A width the caller asked for that the
+   * wire drops is worse than a refusal: the caller reads a healthy answer and
+   * believes a number that never arrived.
+   */
+  control(
+    operation: "drain" | "stop",
+    request?: RedskillsProjectControlRequest,
+  ): Promise<RedskillsProjectControlSnapshot>;
   /**
    * Forward one forge-shaped request to the daemon's Project gateway.
    *
@@ -145,8 +159,14 @@ export async function connectRedskillsProjectAcp(
     mcpServers: [],
   })).sessionId;
 
-  const control = (async (operation: RedskillsProjectControlOperation) => {
-    const outcome = await connection.agent.request<unknown>(PROJECT_CONTROL_METHOD[operation], {});
+  const control = (async (
+    operation: RedskillsProjectControlOperation,
+    request: RedskillsProjectControlRequest = {},
+  ) => {
+    const outcome = await connection.agent.request<unknown>(PROJECT_CONTROL_METHOD[operation], {
+      ...(request.target == null ? {} : { target: request.target }),
+      ...(request.runner == null ? {} : { runner: request.runner }),
+    });
     if (!isProjectControl(outcome)) throw new Error("redskilled returned an invalid Project control outcome");
     if (operation === "status" && !isProjectStatus(outcome)) {
       throw new Error("redskilled returned Project status without a valid RedSkills context");

--- a/apps/redskilled/src/acp-connection-methods.ts
+++ b/apps/redskilled/src/acp-connection-methods.ts
@@ -47,7 +47,11 @@ import type { ProjectMemoryStore } from "./memory-store.js";
 import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
 import type { RedskilledHostState } from "./host-state.js";
 import type { RedskilledPaths } from "./paths.js";
-import { projectControlMethodDomain, type ProjectControlOperation } from "./project-control.js";
+import {
+  projectControlMethodDomain,
+  type ProjectControlOperation,
+  type ProjectControlRequest,
+} from "./project-control.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
 
@@ -79,7 +83,10 @@ export interface ConnectionMethodDeps {
   readonly scopedProject: () => AcpProjectWorkspace;
   /** The daemon's own state, read for the registration a worktree stands on. */
   readonly hostState: () => RedskilledHostState;
-  readonly mutateProjectControl: (operation: ProjectControlOperation) => Promise<unknown>;
+  readonly mutateProjectControl: (
+    operation: ProjectControlOperation,
+    request: ProjectControlRequest,
+  ) => Promise<unknown>;
   readonly readProjectStatus: () => Promise<unknown>;
   /** Observe the reader the first GitHub read resolves, to stream its updates. */
   readonly onGithubReader: (reader: unknown) => void;

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -49,14 +49,12 @@ import type { RedskilledHostState } from "./host-state.js";
 import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
 import type { RedskilledPaths } from "./paths.js";
 import {
-  applyProjectControl,
-  coreProjectOperation,
+  bindProjectControl,
   createProjectControlStore,
-  notifyV1ProjectControl,
-  projectStatusSnapshot,
+  coreProjectInvocation,
+  runV1ProjectControlTurn,
   projectControlStorePath,
   runV2ProjectControlTurn,
-  type ProjectControlOperation,
   type ProjectControlState,
 } from "./project-control.js";
 import {
@@ -224,19 +222,14 @@ async function servePublicConnection(
     }
     return connectionProject;
   };
-  const mutateProjectControl = (operation: ProjectControlOperation) =>
-    applyProjectControl(scopedProject(), operation, projectControls, persistProjectControls);
-  const readGithubCustody = bindAcpProjectGithubCustodyStatus(options.githubGateway, scopedProject);
-  const readProjectStatus = async (project: AcpProjectWorkspace) => {
-    const control = projectStatusSnapshot(
-      project,
-      projectControls,
-      options.hostState(),
-      options.clock?.() ?? new Date().toISOString(),
-    );
-    const mergeCustody = await readGithubCustody();
-    return mergeCustody == null ? control : { ...control, merge_custody: mergeCustody };
-  };
+  const { mutateProjectControl, readProjectStatus } = bindProjectControl({
+    scopedProject,
+    projectControls,
+    persistProjectControls,
+    hostState: options.hostState,
+    clock: () => options.clock?.() ?? new Date().toISOString(),
+    readGithubCustody: bindAcpProjectGithubCustodyStatus(options.githubGateway, scopedProject),
+  });
 
   const { v1: v1Methods, v2: v2Methods } = connectionMethodTables({
     paths: options.paths,
@@ -344,22 +337,13 @@ async function servePublicConnection(
         } satisfies PromptResponse;
       }
 
-      const controlOperation = coreProjectOperation(params.prompt);
-      if (controlOperation != null) {
-        const control = controlOperation === "status"
-          ? await readProjectStatus(session.project)
-          : await applyProjectControl(
-              session.project,
-              controlOperation,
-              projectControls,
-              persistProjectControls,
-            );
-        await notifyV1ProjectControl(upstream, params.sessionId, controlOperation, control);
-        return {
-          stopReason: "end_turn",
-          _meta: { redskills: { authority: "redskilled", projectControl: control } },
-        } satisfies PromptResponse;
-      }
+      const controlTurn = await runV1ProjectControlTurn(
+        params,
+        upstream,
+        session.project,
+        { mutate: mutateProjectControl, read: readProjectStatus },
+      );
+      if (controlTurn != null) return controlTurn;
 
       busy.add(params.sessionId);
       try {
@@ -467,7 +451,7 @@ async function servePublicConnection(
       }
 
       const accepted = new Promise<void>((resolve) => setTimeout(resolve, 0));
-      const controlOperation = coreProjectOperation(params.prompt);
+      const invocation = coreProjectInvocation(params.prompt);
       const retake = isAcpRetakePrompt(params.prompt);
       const turn = accepted
         .then(async () => {
@@ -483,16 +467,10 @@ async function servePublicConnection(
             await notifyV2AcpRetakeEvidence(upstream, params.sessionId, projection);
             return;
           }
-          return controlOperation == null
+          return invocation == null
             ? runV2PublicTurn(options, sessionJournal, sessions, active, params, upstream, () => attached)
             : runV2ProjectControlTurn(
-              sessions,
-              params,
-              upstream,
-              controlOperation,
-              projectControls,
-              persistProjectControls,
-              readProjectStatus,
+              sessions, params, upstream, invocation, projectControls, persistProjectControls, readProjectStatus,
             );
         })
         .catch(() => {})

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import {
   methods,
+  RequestError,
   type AgentConnection,
 } from "@agentclientprotocol/sdk";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
@@ -76,6 +77,10 @@ export interface ProjectControlState {
   readonly drainIntent: ProjectDrainIntent;
   readonly revision: number;
   readonly updates: readonly ProjectControlUpdate[];
+  /** The width the caller asked for, carried and echoed, never interpreted. */
+  readonly target?: number;
+  /** The runner the caller named, opaque in exactly the sense the argv is. */
+  readonly runner?: string;
 }
 
 interface ProjectControlStoreSnapshot {
@@ -111,6 +116,11 @@ export function projectControlSnapshot(
     workspace_path: project.workspacePath,
     drain_intent: control.drainIntent,
     revision: control.revision,
+    // Echoed so a caller can SEE that the width it asked for arrived. A control
+    // call whose argument vanished silently is indistinguishable from one that
+    // was honoured.
+    requested_target: control.target ?? null,
+    requested_runner: control.runner ?? null,
     updates: [...control.updates],
   };
 }
@@ -189,6 +199,7 @@ export async function applyProjectControl(
   operation: ProjectControlOperation,
   projectControls: Map<string, ProjectControlState>,
   persist: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>,
+  request: { readonly target?: number; readonly runner?: string } = {},
 ) {
   const held = projectControls.get(project.projectId);
   if (held == null && operation === "stop") {
@@ -200,7 +211,10 @@ export async function applyProjectControl(
     updates: [],
   };
   const requestedIntent = operation === "drain" ? "draining" as const : "stopped" as const;
-  if (observed.drainIntent === requestedIntent) {
+  const target = request.target ?? observed.target;
+  const runner = request.runner ?? observed.runner;
+  const restated = target !== observed.target || runner !== observed.runner;
+  if (observed.drainIntent === requestedIntent && !restated) {
     const status = operation === "drain" ? "already-draining" as const : "already-stopped" as const;
     return { ...projectControlSnapshot(project, projectControls), status };
   }
@@ -210,6 +224,8 @@ export async function applyProjectControl(
     drainIntent: requestedIntent,
     revision,
     updates: [...observed.updates, { sequence: revision, operation, drain_intent: requestedIntent }],
+    ...(target == null ? {} : { target }),
+    ...(runner == null ? {} : { runner }),
   });
   await persist(next);
   projectControls.set(project.projectId, next.get(project.projectId)!);
@@ -256,12 +272,65 @@ export function createProjectControlStore(path: string): ProjectControlStore {
   };
 }
 
+/**
+ * The verb a control prompt names, and the arguments it carries.
+ *
+ * **A verb and its arguments arrive on one line, so the matcher must read
+ * both.** The client renders every parameterised call as `/<verb> {json}`
+ * (`project-acp-adapter.ts`), while this matcher used to demand a BARE verb —
+ * so `/drain {"target":2}` matched nothing, fell through to "execute this
+ * prompt in a Worker", and came back as narration with no answer in it. Two
+ * halves of one wire disagreeing is not a Worker failure; it reads like one.
+ *
+ * Arguments stay OPAQUE in the sense rule 3 requires: the daemon carries a
+ * target width and a runner name, and asks nothing about what either means.
+ */
+export interface ProjectControlInvocation {
+  readonly operation: ProjectControlCommand;
+  readonly target?: number;
+  readonly runner?: string;
+}
+
+const CONTROL_VERB: ReadonlyMap<string, ProjectControlCommand> = new Map([
+  ["drain", "drain"],
+  ["project_drain", "drain"],
+  ["stop", "stop"],
+  ["project_stop", "stop"],
+  ["status", "status"],
+  ["project_status", "status"],
+]);
+
 export function coreProjectOperation(prompt: unknown): ProjectControlCommand | undefined {
-  const text = promptBlocksText(prompt).trim().toLowerCase();
-  if (text === "/drain" || text === "drain") return "drain";
-  if (text === "/stop" || text === "stop" || text === "/project_stop") return "stop";
-  if (text === "/status" || text === "status" || text === "/project_status") return "status";
-  return undefined;
+  return coreProjectInvocation(prompt)?.operation;
+}
+
+/** The verb plus whatever the caller passed with it. PURE. */
+export function coreProjectInvocation(prompt: unknown): ProjectControlInvocation | undefined {
+  const text = promptBlocksText(prompt).trim();
+  const brace = text.indexOf("{");
+  const head = (brace < 0 ? text : text.slice(0, brace)).trim().toLowerCase();
+  const operation = CONTROL_VERB.get(head.startsWith("/") ? head.slice(1) : head);
+  if (operation == null) return undefined;
+  if (brace < 0) return { operation };
+  const args = record(parseJson(text.slice(brace)));
+  if (args == null) return { operation };
+  const target = typeof args.target === "number" && Number.isInteger(args.target) && args.target >= 0
+    ? args.target
+    : undefined;
+  const runner = typeof args.runner === "string" && args.runner.length > 0 ? args.runner : undefined;
+  return {
+    operation,
+    ...(target == null ? {} : { target }),
+    ...(runner == null ? {} : { runner }),
+  };
+}
+
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
 }
 
 function promptBlocksText(prompt: unknown): string {
@@ -304,20 +373,58 @@ export async function notifyV1ProjectControl(
   });
 }
 
+/**
+ * Answer one v1 prompt that IS a control verb, or `null` when it is not.
+ *
+ * The v1 twin of {@link runV2ProjectControlTurn}, and it lives beside it for
+ * the same reason: a control verb is answered by the control surface, never by
+ * birthing a Worker to read the prompt back to the caller.
+ */
+export async function runV1ProjectControlTurn(
+  params: { readonly sessionId: string; readonly prompt: unknown },
+  upstream: AgentConnection["client"],
+  project: AcpProjectWorkspace,
+  control: {
+    readonly mutate: (
+      operation: ProjectControlOperation,
+      request: ProjectControlRequest,
+    ) => Promise<{ readonly drain_intent: ProjectDrainIntent; readonly revision: number }>;
+    readonly read: (project: AcpProjectWorkspace) => Promise<
+      { readonly drain_intent: ProjectDrainIntent; readonly revision: number }
+    >;
+  },
+): Promise<{ stopReason: "end_turn"; _meta: Record<string, unknown> } | null> {
+  const invocation = coreProjectInvocation(params.prompt);
+  if (invocation == null) return null;
+  const operation = invocation.operation;
+  const answer = operation === "status"
+    ? await control.read(project)
+    : await control.mutate(operation, { target: invocation.target, runner: invocation.runner });
+  await notifyV1ProjectControl(upstream, params.sessionId, operation, answer);
+  return {
+    stopReason: "end_turn",
+    _meta: { redskills: { authority: "redskilled", projectControl: answer } },
+  };
+}
+
 export async function runV2ProjectControlTurn(
   sessions: ReadonlyMap<string, ProjectControlSession>,
   params: acpV2.PromptRequest,
   upstream: acpV2.AgentContext,
-  operation: ProjectControlCommand,
+  invocation: ProjectControlInvocation,
   projectControls: Map<string, ProjectControlState>,
   persist: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>,
   readStatus: (project: AcpProjectWorkspace) => Promise<ReturnType<typeof projectStatusSnapshot>>,
 ): Promise<void> {
   const session = sessions.get(params.sessionId);
   if (session == null) return;
+  const operation = invocation.operation;
   const control = operation === "status"
     ? await readStatus(session.project)
-    : await applyProjectControl(session.project, operation, projectControls, persist);
+    : await applyProjectControl(session.project, operation, projectControls, persist, {
+        target: invocation.target,
+        runner: invocation.runner,
+      });
   await upstream.notify(acpV2.methods.client.session.update, {
     sessionId: params.sessionId,
     update: {
@@ -385,9 +492,71 @@ function record(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+/** What a control method may be asked for. Shape is checked; meaning never is. */
+export interface ProjectControlRequest {
+  readonly target?: number;
+  readonly runner?: string;
+}
+
+/**
+ * Read a control request off the wire.
+ *
+ * Permissive in the same way `acpNoParams` is — an unknown key is not an error,
+ * because tightening a method that has accepted any object is its own slice —
+ * but a `target` or `runner` that IS present must be usable, or the caller
+ * would read a healthy answer for a width that never arrived.
+ */
+export function projectControlRequest(value: unknown): ProjectControlRequest {
+  const params = record(value);
+  if (params == null) return {};
+  const { target, runner } = params;
+  if (target !== undefined && !(typeof target === "number" && Number.isInteger(target) && target >= 0)) {
+    throw RequestError.invalidParams("target must be a non-negative integer");
+  }
+  if (runner !== undefined && !(typeof runner === "string" && runner.length > 0)) {
+    throw RequestError.invalidParams("runner must be a non-empty string");
+  }
+  return {
+    ...(target === undefined ? {} : { target: target as number }),
+    ...(runner === undefined ? {} : { runner: runner as string }),
+  };
+}
+
+/**
+ * Bind one connection's Project control pair: the mutation and the status read.
+ *
+ * Both close over the same scoped Project, the same control map and the same
+ * persistence, so they belong beside the record they operate on rather than in
+ * the connection assembler — which is a wiring file, not a control surface.
+ */
+export function bindProjectControl(deps: {
+  readonly scopedProject: () => AcpProjectWorkspace;
+  readonly projectControls: Map<string, ProjectControlState>;
+  readonly persistProjectControls: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>;
+  readonly hostState: () => RedskilledHostState;
+  readonly clock: () => string;
+  readonly readGithubCustody: () => Promise<unknown>;
+}) {
+  return {
+    mutateProjectControl: (operation: ProjectControlOperation, request: ProjectControlRequest = {}) =>
+      applyProjectControl(
+        deps.scopedProject(),
+        operation,
+        deps.projectControls,
+        deps.persistProjectControls,
+        request,
+      ),
+    readProjectStatus: async (project: AcpProjectWorkspace) => {
+      const control = projectStatusSnapshot(project, deps.projectControls, deps.hostState(), deps.clock());
+      const mergeCustody = await deps.readGithubCustody();
+      return mergeCustody == null ? control : { ...control, merge_custody: mergeCustody };
+    },
+  };
+}
+
 export interface AcpProjectControlDomainDeps {
-  /** Apply drain or stop to the Project this connection bound. */
-  mutate: (operation: ProjectControlOperation) => Promise<unknown>;
+  /** Apply drain or stop to the Project this connection bound, as asked. */
+  mutate: (operation: ProjectControlOperation, request: ProjectControlRequest) => Promise<unknown>;
   /** Read the Project's control status, custody included when observable. */
   read: () => Promise<unknown>;
 }
@@ -403,8 +572,10 @@ export function projectControlMethodDomain(deps: AcpProjectControlDomainDeps): R
   return {
     domain: "project",
     bindings: [
-      redskillsAcpMethod(PROJECT_CONTROL_METHODS[0], acpNoParams, () => deps.mutate("drain")),
-      redskillsAcpMethod(PROJECT_CONTROL_METHODS[1], acpNoParams, () => deps.mutate("stop")),
+      redskillsAcpMethod(PROJECT_CONTROL_METHODS[0], projectControlRequest, ({ params }) =>
+        deps.mutate("drain", params)),
+      redskillsAcpMethod(PROJECT_CONTROL_METHODS[1], projectControlRequest, ({ params }) =>
+        deps.mutate("stop", params)),
       redskillsAcpMethod(PROJECT_CONTROL_METHODS[2], acpNoParams, () => deps.read()),
     ],
     capability: { projectControl: { version: 1, methods: PROJECT_CONTROL_METHODS } },

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -965,7 +965,11 @@ describe("the public RedSkills ACP v1 control plane", () => {
     });
     await second.agent.request(methods.agent.session.new, { cwd: root, mcpServers: [] });
     const observed = await second.agent.request<ProjectControlSnapshot>("_redskills/project_status", {});
-    expect(observed).toEqual(projectControlMeta(coreDrain._meta));
+    // A status answer is a drain answer PLUS its projections (`context`, and
+    // merge custody when observable). What survives the daemon replacement is
+    // the control record, so this compares the record and lets status carry
+    // what only status has.
+    expect(observed).toMatchObject(projectControlMeta(coreDrain._meta));
 
     const stopped = await second.agent.request<ProjectControlOperationResult>("_redskills/project_stop", {});
     expect(stopped).toMatchObject({
@@ -1008,7 +1012,9 @@ describe("the public RedSkills ACP v1 control plane", () => {
       ],
     });
     expect(await third.agent.request<ProjectControlSnapshot>("_redskills/project_status", {}))
-      .toEqual(projectControlMeta(coreDrainAgain._meta));
+      // Same reason as above: status carries its projections, the record is
+      // what must survive.
+      .toMatchObject(projectControlMeta(coreDrainAgain._meta));
 
     third.close();
     thirdAdapter.stdin?.end();

--- a/apps/redskilled/tests/project-control-arguments.test.ts
+++ b/apps/redskilled/tests/project-control-arguments.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyProjectControl,
+  coreProjectInvocation,
+  projectControlRequest,
+  type ProjectControlState,
+} from "../src/project-control.js";
+
+/**
+ * A verb and its arguments arrive on ONE line, and both halves of the wire must
+ * read the same line.
+ *
+ * The client renders every parameterised control call as `/<verb> {json}`. The
+ * daemon's matcher demanded a bare verb, so `/drain {"target":2}` matched
+ * nothing, fell through to "execute this prompt in a Worker", and answered with
+ * narration and no payload — which reads exactly like a Worker that failed.
+ */
+const promptOf = (text: string) => [{ type: "text", text }];
+
+const project = {
+  projectId: "github:1",
+  projectLabel: "reddb-io/red-skills",
+  workspacePath: "/tmp/workspace",
+} as never;
+
+function detailOf(run: () => unknown): string {
+  try {
+    run();
+  } catch (error) {
+    const data = (error as { data?: unknown }).data;
+    return typeof data === "string" ? data : JSON.stringify(data ?? (error as Error).message);
+  }
+  return "";
+}
+
+describe("a control verb carries its arguments", () => {
+  it("reads the verb the client actually sends, argument object included", () => {
+    expect(coreProjectInvocation(promptOf('/drain {"target":2}'))).toEqual({ operation: "drain", target: 2 });
+    expect(coreProjectInvocation(promptOf('/status {"scope":"project"}'))).toEqual({ operation: "status" });
+    expect(coreProjectInvocation(promptOf('/project_drain {"runner":"redcode","target":5}'))).toEqual({
+      operation: "drain",
+      runner: "redcode",
+      target: 5,
+    });
+  });
+
+  it("still reads a bare verb, and still refuses a prompt that is not one", () => {
+    expect(coreProjectInvocation(promptOf("drain"))?.operation).toBe("drain");
+    expect(coreProjectInvocation(promptOf("/stop"))?.operation).toBe("stop");
+    expect(coreProjectInvocation(promptOf("please drain the project"))).toBeUndefined();
+    expect(coreProjectInvocation(promptOf("/gate_run"))).toBeUndefined();
+  });
+
+  it("keeps a malformed argument object from swallowing the verb", () => {
+    expect(coreProjectInvocation(promptOf("/drain {not json"))).toEqual({ operation: "drain" });
+  });
+
+  it("carries the requested width into the stored control state and echoes it back", async () => {
+    const controls = new Map<string, ProjectControlState>();
+    const persisted: ProjectControlState[] = [];
+
+    const answer = await applyProjectControl(
+      project,
+      "drain",
+      controls,
+      async (next) => void persisted.push(next.get("github:1")!),
+      { target: 3, runner: "redcode" },
+    );
+
+    expect(answer.requested_target).toBe(3);
+    expect(answer.requested_runner).toBe("redcode");
+    expect(controls.get("github:1")?.target).toBe(3);
+    expect(persisted.at(-1)?.runner).toBe("redcode");
+  });
+
+  it("treats a restated width as a new revision, not as already-draining", async () => {
+    const controls = new Map<string, ProjectControlState>();
+    const persist = async () => {};
+
+    const first = await applyProjectControl(project, "drain", controls, persist, { target: 1 });
+    const widened = await applyProjectControl(project, "drain", controls, persist, { target: 4 });
+    const repeated = await applyProjectControl(project, "drain", controls, persist, { target: 4 });
+
+    expect(first.revision).toBe(1);
+    expect(widened.revision).toBe(2);
+    expect(widened.requested_target).toBe(4);
+    expect(repeated).toMatchObject({ status: "already-draining", revision: 2 });
+  });
+
+  it("refuses a width no caller could have meant, instead of carrying it", () => {
+    expect(projectControlRequest({ target: 2, runner: "redcode" })).toEqual({ target: 2, runner: "redcode" });
+    expect(projectControlRequest({})).toEqual({});
+    // The refusal is an ACP invalid-params error: the reason travels in `data`,
+    // where a client can read it, rather than in a generic message.
+    expect(() => projectControlRequest({ target: -1 })).toThrow();
+    expect(detailOf(() => projectControlRequest({ target: -1 }))).toMatch(/non-negative integer/);
+    expect(detailOf(() => projectControlRequest({ target: 1.5 }))).toMatch(/non-negative integer/);
+    expect(detailOf(() => projectControlRequest({ runner: "" }))).toMatch(/non-empty string/);
+  });
+});


### PR DESCRIPTION
`drain {"target":2}` did nothing, and said nothing was wrong.

Found by driving the daemon directly: the client renders every parameterised control call as `/<verb> {json}` (`project-acp-adapter.ts`), while `coreProjectOperation` matched only a **bare** verb. So the call matched nothing, fell through to "execute this prompt in a Worker", and answered with narration and no payload — indistinguishable from a Worker that failed. The adapter had the mirror-image rule: it routed a control tool to the control method **only when the input was empty**, so any argument silently became prose.

- The matcher now reads the verb and its argument object. The control methods take `target` and `runner` as typed params — shape checked, meaning never read, per ADR 0130 rule 3.
- The requested width is stored on the control record and echoed as `requested_target` / `requested_runner`: an argument that vanishes silently is indistinguishable from one that was honoured.
- Restating the width is a new revision, not `already-draining`.
- The adapter **refuses** an argument the control surface cannot express, rather than degrading the call to a prompt.
- Two pre-existing red assertions in `acp-control-plane.test.ts` are repointed (a status answer is a drain answer *plus* its projections), so that suite goes 9/9 — it was 8/9 on `main`.
- `acp-control-plane.ts` returns under its 700-line headroom (697, from 719 on `main`, which was already failing that guard) by moving the v1 control turn beside its v2 twin and the control binding beside the record it operates on.

Verified locally: new `project-control-arguments.test.ts` 6/6; `acp-adapter-parity.test.ts` 5/5 with 2 new cases; `acp-control-plane.test.ts` 9/9; layout, body-control-cut and agent-catalog green; `pnpm -C apps/plugin-dev test:invariants` 342/342. `acp-conformance.test.ts` fails 4/9 on this host **identically on `origin/main`** (worker-death events time out here) — pre-existing and environmental, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789764719&installation_model_id=20659&pr_number=4093&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4093&signature=a3d280bf39b0807cc702c2f3472a0be4c09ffdca0c9791de15b11178b73bad84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->