### PR TITLE
fix(acp): a drain that cannot drain says so

### DIFF
--- a/.changeset/unregistered-drain-says-so.md
+++ b/.changeset/unregistered-drain-says-so.md
@@ -1,0 +1,18 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A drain that cannot drain says so
+
+Drain intent lives on the Project control record; the demand loop births only
+for a REGISTRATION, which names the work query and the argv a Worker launches
+with. A project that is `draining` with no registration therefore polls no
+queue and births no Worker — and reported that as *"the daemon has not observed
+this Project queue"*, which reads like a freshness lag that will clear on its
+own. It never clears: nothing is going to observe it.
+
+The dead end now announces itself in both places a caller can be standing: on
+the `drain` answer itself (`warning`), because someone who ran drain and got a
+clean answer has every reason to expect Workers; and in status, where
+`queue.registered` states plainly whether the thing the demand loop polls
+exists at all. The wording is declared once so the two accounts cannot drift.

--- a/apps/plugin-dev/tests/acp-adapter-parity.test.ts
+++ b/apps/plugin-dev/tests/acp-adapter-parity.test.ts
@@ -42,6 +42,9 @@ function projectSession() {
         age_ms: 1_000,
         freshness: "fresh",
         detail: "the Project queue is drained",
+        // A drained queue is one the daemon actually polls, which it does only
+        // for a registration.
+        registered: true,
       },
       workers: {
         total: 0,

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -44,6 +44,8 @@ export interface ProjectStatusContext {
     readonly age_ms: number | null;
     readonly freshness: ProjectStatusFreshness;
     readonly detail: string;
+    /** Whether a registration — the thing the demand loop polls — is held. */
+    readonly registered: boolean;
   };
   readonly workers: {
     readonly total: number;
@@ -146,6 +148,15 @@ export function projectStatusSnapshot(
       : "fresh";
   const depth = poll?.outcome === "counted" ? poll.depth : null;
   const posture = intent?.outcome ?? (depth == null ? "unknown" : depth === 0 ? "queue-drained" : "queued");
+  // **A drain that cannot drain has to say so.** Drain intent lives on the
+  // control record; the demand loop births only for a REGISTRATION, which names
+  // the work query and the argv a Worker is launched with. A project that is
+  // `draining` with no registration therefore polls nothing and births nothing
+  // — and reported that as "the daemon has not observed this Project queue",
+  // which reads like a freshness lag that will clear on its own. It never
+  // clears: nothing is going to observe it.
+  const drainIntent = (projectControls.get(project.projectId)?.drainIntent) ?? "inactive";
+  const unregisteredDrain = registration == null && drainIntent === "draining";
   const health = host.request_health;
 
   const context: ProjectStatusContext = {
@@ -160,7 +171,10 @@ export function projectStatusSnapshot(
       observed_at: poll?.at ?? null,
       age_ms: ageMs,
       freshness,
-      detail: intent?.detail ?? poll?.detail ?? "the daemon has not observed this Project queue",
+      detail: unregisteredDrain
+        ? UNREGISTERED_DRAIN_WARNING
+        : intent?.detail ?? poll?.detail ?? "the daemon has not observed this Project queue",
+      registered: registration != null,
     },
     workers: {
       total: workers.length,
@@ -529,6 +543,21 @@ export function projectControlRequest(value: unknown): ProjectControlRequest {
  * persistence, so they belong beside the record they operate on rather than in
  * the connection assembler — which is a wiring file, not a control surface.
  */
+/**
+ * What a `drain` answers when nothing will act on it.
+ *
+ * Stated once, so the status projection and the control answer cannot drift
+ * into two different accounts of one dead end.
+ */
+export const UNREGISTERED_DRAIN_WARNING =
+  "this Project holds no registration, so the daemon polls no queue and births no Worker for it;" +
+  " the drain intent is recorded and nothing acts on it";
+
+/** Whether the daemon holds the registration its demand loop would poll. PURE. */
+export function projectIsRegistered(host: RedskilledHostState, project: AcpProjectWorkspace): boolean {
+  return (host.registrations ?? []).some((entry) => entry.project_label === project.projectLabel);
+}
+
 export function bindProjectControl(deps: {
   readonly scopedProject: () => AcpProjectWorkspace;
   readonly projectControls: Map<string, ProjectControlState>;
@@ -538,14 +567,22 @@ export function bindProjectControl(deps: {
   readonly readGithubCustody: () => Promise<unknown>;
 }) {
   return {
-    mutateProjectControl: (operation: ProjectControlOperation, request: ProjectControlRequest = {}) =>
-      applyProjectControl(
-        deps.scopedProject(),
+    mutateProjectControl: async (operation: ProjectControlOperation, request: ProjectControlRequest = {}) => {
+      const project = deps.scopedProject();
+      const answer = await applyProjectControl(
+        project,
         operation,
         deps.projectControls,
         deps.persistProjectControls,
         request,
-      ),
+      );
+      // Told at the moment of asking, not only to whoever thinks to read status
+      // afterwards: a caller who ran `drain` and got a clean answer has every
+      // reason to believe Workers are coming.
+      return operation === "drain" && !projectIsRegistered(deps.hostState(), project)
+        ? { ...answer, warning: UNREGISTERED_DRAIN_WARNING }
+        : answer;
+    },
     readProjectStatus: async (project: AcpProjectWorkspace) => {
       const control = projectStatusSnapshot(project, deps.projectControls, deps.hostState(), deps.clock());
       const mergeCustody = await deps.readGithubCustody();

--- a/apps/redskilled/tests/acp-control-plane.test.ts
+++ b/apps/redskilled/tests/acp-control-plane.test.ts
@@ -1044,7 +1044,10 @@ function projectControlMeta(meta: unknown): ProjectControlSnapshot {
   const control = (meta as { redskills?: { projectControl?: unknown } } | undefined)
     ?.redskills?.projectControl;
   expect(control).toMatchObject({ version: 1, project_id: expect.any(String) });
-  const { status: _status, ...snapshot } = control as ProjectControlOperationResult;
+  // `status` and `warning` belong to the ANSWER a mutation gives, not to the
+  // record it leaves behind: status reports the same dead end as `detail`.
+  const { status: _status, warning: _warning, ...snapshot } =
+    control as ProjectControlOperationResult & { warning?: string };
   return snapshot;
 }
 

--- a/apps/redskilled/tests/unregistered-drain.test.ts
+++ b/apps/redskilled/tests/unregistered-drain.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bindProjectControl,
+  projectIsRegistered,
+  projectStatusSnapshot,
+  UNREGISTERED_DRAIN_WARNING,
+  type ProjectControlState,
+} from "../src/project-control.js";
+
+/**
+ * A drain that cannot drain has to say so.
+ *
+ * Drain intent lives on the control record; the demand loop births only for a
+ * REGISTRATION, which names the work query and the argv a Worker is launched
+ * with. A project draining without one polls nothing and births nothing — and
+ * said so as "the daemon has not observed this Project queue", which reads like
+ * a freshness lag that clears on its own. It never clears.
+ */
+const project = {
+  projectId: "github:1",
+  projectLabel: "reddb-io/red-skills",
+  workspacePath: "/tmp/workspace",
+} as never;
+
+const hostState = (registered: boolean) => ({
+  workers: [],
+  registrations: registered ? [{ project_label: "reddb-io/red-skills", target: 2 }] : [],
+} as never);
+
+describe("an unregistered drain is a dead end that announces itself", () => {
+  it("warns on the drain answer itself, not only to whoever reads status later", async () => {
+    const controls = new Map<string, ProjectControlState>();
+    const { mutateProjectControl } = bindProjectControl({
+      scopedProject: () => project,
+      projectControls: controls,
+      persistProjectControls: async () => {},
+      hostState: () => hostState(false),
+      clock: () => "2026-08-19T20:00:00.000Z",
+      readGithubCustody: async () => null,
+    });
+
+    const answer = await mutateProjectControl("drain", { target: 2 });
+
+    expect(answer).toMatchObject({ drain_intent: "draining", warning: UNREGISTERED_DRAIN_WARNING });
+  });
+
+  it("says nothing of the sort once a registration is held", async () => {
+    const controls = new Map<string, ProjectControlState>();
+    const { mutateProjectControl } = bindProjectControl({
+      scopedProject: () => project,
+      projectControls: controls,
+      persistProjectControls: async () => {},
+      hostState: () => hostState(true),
+      clock: () => "2026-08-19T20:00:00.000Z",
+      readGithubCustody: async () => null,
+    });
+
+    expect(await mutateProjectControl("drain", {})).not.toHaveProperty("warning");
+  });
+
+  it("reports the dead end in status instead of a freshness lag that never clears", () => {
+    const controls = new Map<string, ProjectControlState>([
+      ["github:1", { drainIntent: "draining", revision: 1, updates: [] }],
+    ]);
+
+    const status = projectStatusSnapshot(project, controls, hostState(false), "2026-08-19T20:00:00.000Z");
+
+    expect(status.context.queue.registered).toBe(false);
+    expect(status.context.queue.detail).toBe(UNREGISTERED_DRAIN_WARNING);
+  });
+
+  it("keeps the old wording for a project that is simply not draining", () => {
+    const status = projectStatusSnapshot(project, new Map(), hostState(false), "2026-08-19T20:00:00.000Z");
+
+    expect(status.context.queue.detail).toBe("the daemon has not observed this Project queue");
+    expect(status.context.queue.registered).toBe(false);
+  });
+
+  it("answers the registration question off the host's own record", () => {
+    expect(projectIsRegistered(hostState(true), project)).toBe(true);
+    expect(projectIsRegistered(hostState(false), project)).toBe(false);
+  });
+});


### PR DESCRIPTION
Drain intent lives on the Project control record; the demand loop births only for a **registration**, which names the work query and the argv a Worker launches with. A project that is `draining` with no registration polls no queue and births no Worker — and reported that as *"the daemon has not observed this Project queue"*, which reads like a freshness lag that will clear on its own. It never clears: nothing is going to observe it. That is the exact reading that cost this session an hour of diagnosis on a live host.

- The `drain` answer carries a `warning` when no registration is held: someone who ran drain and got a clean answer has every reason to expect Workers.
- Status states `queue.registered` and uses the same wording, declared once so the two accounts cannot drift.
- `projectControlMeta` in the control-plane suite drops `warning` with `status`: both belong to the ANSWER a mutation gives, not to the record it leaves behind.

Verified locally: new `unregistered-drain.test.ts` 5/5; `acp-control-plane.test.ts` 9/9; `project-control-arguments.test.ts` 6/6; layout guard green (697 lines); `pnpm -C apps/plugin-dev test:invariants` 342/342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789765489&installation_model_id=20659&pr_number=4094&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4094&signature=c4be4c696306c5134d56e425c74329e0a73ea054c67ea5432ca1ebc7d192638e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->