### PR TITLE
fix(release): the publish stops demanding the deleted dev CLI bundle

### DIFF
--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -294,13 +294,19 @@ jobs:
       # channel stays retired; the package-set signature below authenticates the
       # complete workstation release contract instead.
 
-      # ADR 0039: the two committed, dependency-free entrypoints —
-      # plugins/dev/hooks/red-fetch.mjs (fetch role) and
-      # plugins/dev/skills/engineering/afk/bin/afk.mjs (run:dev role) — are built
-      # from ONE source, packages/shared/entrypoint-cli.ts, and are committed on
-      # main. `build` re-emits them plus the dist/dev.bundle.min.mjs asset
-      # (ADR 0034); esbuild output is deterministic, so the tagged tree already
-      # carries the bytes this rebuild produces.
+      # ADR 0039: the committed, dependency-free entrypoint —
+      # plugins/dev/hooks/red-fetch.mjs (fetch role) — is built from
+      # packages/shared/entrypoint-cli.ts and committed on main; `build`
+      # re-emits it, and esbuild output is deterministic, so the tagged tree
+      # already carries the bytes this rebuild produces.
+      #
+      # **No dev CLI bundle and no manifest for one.** #4031 deleted
+      # `dist/dev.bundle.min.mjs` (ADR 0147 §1: `redskilled` is the one binary of
+      # the execution chain), and `scripts/rehearse-release-pack.sh` refuses its
+      # return — while this step still checksummed it, so v4.0.0's publish died
+      # on ENOENT at the first release after the deletion. The dev plugin ships
+      # its MCP through the npm package (`red-skills-redskilled-mcp`), which
+      # carries npm's own integrity, so there is nothing here to pin.
       - name: Build dev runtime bundle
         if: steps.target.outputs.publish == 'true'
         working-directory: apps/plugin-dev
@@ -309,23 +315,7 @@ jobs:
           RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
           RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
           RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
-        run: |
-          set -euo pipefail
-          pnpm build
-          # Checksum manifest the dynamic-fetch hook (packages/shared/bundle-fetch.ts)
-          # verifies before caching. Mirrors memory-runtime-manifest.json.
-          node --input-type=module <<'EOF'
-          import { createHash } from 'node:crypto';
-          import { readFileSync, writeFileSync } from 'node:fs';
-          const bytes = readFileSync('../../dist/dev.bundle.min.mjs');
-          const manifest = {
-            plugin: 'dev',
-            version: process.env.NEXT.replace(/^v/, ''),
-            sha256: createHash('sha256').update(bytes).digest('hex'),
-          };
-          writeFileSync('../../dist/dev.manifest.json', JSON.stringify(manifest, null, 2));
-          console.log('dev runtime manifest:', JSON.stringify(manifest));
-          EOF
+        run: pnpm build
 
       # ADR 0029: the Memory runtime ships as release assets, not committed
       # build output. esbuild bundles the CLI (all JS deps inlined) into one

--- a/scripts/test-package-set-contract.sh
+++ b/scripts/test-package-set-contract.sh
@@ -378,8 +378,6 @@ expected_workstation=(
   dist/build-gemini-extension.mjs
   dist/validate-gemini-extension.mjs
   dist/install-hermes-skills.mjs
-  dist/dev.bundle.min.mjs
-  dist/dev.manifest.json
   dist/redskilled-mcp.bundle.min.mjs
   dist/code-nav.bundle.min.mjs
   dist/code-nav.manifest.json

--- a/scripts/workstation-package-set.mjs
+++ b/scripts/workstation-package-set.mjs
@@ -53,8 +53,9 @@ export const WORKSTATION_PAYLOADS = [
   { asset: "dist/install-hermes-skills.mjs", kind: "host-generator" },
 
   // Runtime bundles, each with the checksum manifest its dynamic fetch verifies.
-  { asset: "dist/dev.bundle.min.mjs", kind: "runtime-bundle" },
-  { asset: "dist/dev.manifest.json", kind: "runtime-bundle" },
+  // No `dev.bundle.min.mjs`: #4031 deleted the dev CLI (ADR 0147 §1) and the
+  // dev plugin now reaches its MCP through the npm package. A set that still
+  // demanded it would sign a payload the release cannot build.
   { asset: "dist/redskilled-mcp.bundle.min.mjs", kind: "runtime-bundle" },
   { asset: "dist/code-nav.bundle.min.mjs", kind: "runtime-bundle" },
   { asset: "dist/code-nav.manifest.json", kind: "runtime-bundle" },


### PR DESCRIPTION
**v4.0.0 died on ENOENT.** #4031 deleted `dist/dev.bundle.min.mjs` (ADR 0147 §1 — `redskilled` is the one binary of the execution chain) and `scripts/rehearse-release-pack.sh` refuses its return, while `red-publish.yml` still read those exact bytes to write a checksum manifest, and the signed workstation set still listed the bundle and its manifest as payloads. Three places, one deletion, two of them never updated: the first release after the cut was always going to fail.

- The publish step is now just `pnpm build`. There is nothing to pin: the dev plugin reaches its MCP through the npm package (`red-skills-redskilled-mcp`), which carries npm's own integrity — nothing fetches a dev bundle from a release asset any more.
- `workstation-package-set.mjs` drops both entries, with the reason written where the next reader will be looking; `test-package-set-contract.sh` restates the shorter list, because that literal is the contract.

Verified locally: `bash scripts/test-package-set-contract.sh` 27/27 PASS; `bash scripts/rehearse-release-pack.sh` → *"OK — the package set at 0.0.0-rehearsal.0 is installable"*, with the OpenCode host carrying 69 skills over the composed set.

Once this lands, re-run `red-publish` for `v4.0.0` — the tag is already cut and the version PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789766541&installation_model_id=20659&pr_number=4096&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4096&signature=03fbfc3cf1c185c1ad968971d9c8837c04899965c7dde1e98acbe665eed50d73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->