### PR TITLE
feat(redskilled): the queue poll keeps the identifiers it counted

### DIFF
--- a/.changeset/queue-poll-keeps-its-items.md
+++ b/.changeset/queue-poll-keeps-its-items.md
@@ -1,0 +1,19 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The queue poll keeps the identifiers it counted
+
+A poll that counts and then discards has to be asked again. The REST lane
+already held every item it counted and threw the identifiers away, so a birth
+had a depth and nothing to hand a Worker — the first slice of Spec #4097.
+
+The registration's `last_poll` now keeps them, bounded at 32 so a record cannot
+grow with the backlog, and `project_status` reports them so an operator can see
+WHAT the daemon believes is queued rather than only how much. They stay opaque
+in the sense ADR 0130 rule 3 requires: stored, echoed, never parsed.
+
+A poll that could not list carries the previous list forward — **an unreachable
+queue is not an empty one**, and erasing it would tell every later reader the
+backlog emptied at the moment the network did. A `counted` poll always
+replaces, including with an empty list, which is a real answer.

--- a/apps/plugin-dev/tests/acp-adapter-parity.test.ts
+++ b/apps/plugin-dev/tests/acp-adapter-parity.test.ts
@@ -45,6 +45,8 @@ function projectSession() {
         // A drained queue is one the daemon actually polls, which it does only
         // for a registration.
         registered: true,
+        // A drained queue listed nothing because there was nothing to list.
+        items: [],
       },
       workers: {
         total: 0,

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -135,6 +135,7 @@ import { pollRegistrationActivity } from "./registration-activity.js";
 import { REDSKILLED_ACTIVITY_STALENESS_FACTOR } from "../activity-report.js";
 import {
   DEFAULT_REDSKILLED_QUEUE_MS,
+  carryQueueItems,
   fetchQueueDiscovery,
   nextQueuePollMs,
   unconfiguredQueueDiscovery,
@@ -911,12 +912,15 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       lastQueue = unconfiguredQueueDiscovery(projects, now, queueUnconfiguredReason);
       return lastQueue;
     }
-    lastQueue = await remotePoll("queue poll", () => fetchQueueDiscovery({
+    lastQueue = carryQueueItems(
+      await remotePoll("queue poll", () => fetchQueueDiscovery({
         projects,
         transport: queueTransport!,
         now,
         ...(queueRegistration?.batchSize == null ? {} : { batchSize: queueRegistration.batchSize }),
-      }));
+      })),
+      lastQueue,
+    );
     // The depth this poll just counted is the renewal a project with open work
     // gets (Amendment 7), applied here rather than at the next read so a deadline
     // is never judged against a poll the daemon had already superseded.

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -258,6 +258,13 @@ export interface RedskilledRegistrationPoll {
   /** What that whole interval cost, however many projects it covered. */
   readonly request_count: number;
   readonly detail: string;
+  /**
+   * The identifiers the poll counted, when its transport listed them (#4098).
+   *
+   * Opaque: stored, reported and handed to a birth, never parsed. Absent when
+   * the transport counted without listing — an unknown list is not an empty one.
+   */
+  readonly items?: readonly string[];
 }
 
 /**
@@ -514,6 +521,7 @@ function buildRegistrationViews(input: BuildHostStateInput): readonly Redskilled
               depth: polled.depth,
               request_count: queue.request_count,
               detail: polled.detail,
+              ...(polled.items == null ? {} : { items: [...polled.items] }),
             },
           }),
       };

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -46,6 +46,12 @@ export interface ProjectStatusContext {
     readonly detail: string;
     /** Whether a registration — the thing the demand loop polls — is held. */
     readonly registered: boolean;
+    /**
+     * The identifiers the last poll counted (#4098), when its transport listed
+     * them. Reported so an operator can see WHAT the daemon believes is queued,
+     * not only how much. Opaque here as everywhere: never parsed.
+     */
+    readonly items: readonly string[];
   };
   readonly workers: {
     readonly total: number;
@@ -175,6 +181,7 @@ export function projectStatusSnapshot(
         ? UNREGISTERED_DRAIN_WARNING
         : intent?.detail ?? poll?.detail ?? "the daemon has not observed this Project queue",
       registered: registration != null,
+      items: [...(poll?.items ?? [])],
     },
     workers: {
       total: workers.length,

--- a/apps/redskilled/src/queue-discovery.ts
+++ b/apps/redskilled/src/queue-discovery.ts
@@ -87,6 +87,70 @@ export interface RedskilledProjectQueue {
   /** How many items the selector matched; `null` for every outcome but `counted`. */
   readonly depth: number | null;
   readonly detail: string;
+  /**
+   * The identifiers this poll counted, when the transport returned them.
+   *
+   * **A poll that counts and then discards has to be asked again.** The REST
+   * lane already holds every item it counted; throwing the identifiers away
+   * left a birth with a depth and nothing to hand a Worker (Spec #4097). These
+   * are OPAQUE strings: carrying what a poll returned is not reading it (ADR
+   * 0130 rule 3), and no code may branch on their content.
+   *
+   * Absent — never `[]` — when the transport counted without listing, because
+   * an unknown list is not an empty one. The GraphQL lane asks for a count and
+   * gets a number, so it says nothing here.
+   */
+  readonly items?: readonly string[];
+}
+
+/**
+ * How many identifiers one poll keeps.
+ *
+ * Enough to feed a target's worth of births with margin, and no more: a record
+ * that grew with the backlog would put an unbounded list in a document every
+ * status read carries.
+ */
+export const REDSKILLED_QUEUE_ITEM_CAP = 32;
+
+/**
+ * Carry the identifiers a previous poll saw across one that could not list.
+ *
+ * **An unreachable queue is not an empty one.** A poll that fails says nothing
+ * about what is queued, so erasing the last list would tell every later reader
+ * that the backlog emptied at the moment the network did. A `counted` poll
+ * always replaces — including with an empty list, which is a real answer. PURE.
+ */
+export function carryQueueItems(
+  next: RedskilledQueueDiscovery,
+  previous: RedskilledQueueDiscovery | null,
+): RedskilledQueueDiscovery {
+  if (previous == null) return next;
+  const held = new Map(previous.projects.map((project) => [project.project_label, project.items]));
+  return {
+    ...next,
+    projects: next.projects.map((project) => {
+      if (project.items != null) return project;
+      const carried = held.get(project.project_label);
+      return carried == null ? project : { ...project, items: [...carried] };
+    }),
+  };
+}
+
+/**
+ * The identifiers a REST answer listed, as opaque strings. PURE.
+ *
+ * An item the transport returned without one is skipped rather than given an
+ * invented name: a birth handed a fabricated identifier is worse than a birth
+ * the daemon declines to plan.
+ */
+export function queueItemIdentifiers(items: readonly Record<string, unknown>[]): readonly string[] {
+  const identifiers: string[] = [];
+  for (const item of items) {
+    if (identifiers.length >= REDSKILLED_QUEUE_ITEM_CAP) break;
+    const number = item.number;
+    if (typeof number === "number" && Number.isInteger(number) && number > 0) identifiers.push(String(number));
+  }
+  return identifiers;
 }
 
 /** What the token had left when the query answered; `null` when it did not say. */
@@ -364,13 +428,15 @@ async function fetchConditionalQueueDiscovery(
         operation: REDSKILLED_QUEUE_REST_OPERATION,
       });
       requestCount += answer.requestCount;
-      const depth = answer.data.filter((item) => !isRecord(item.pull_request)).length;
+      const matched = answer.data.filter((item) => !isRecord(item.pull_request));
+      const depth = matched.length;
       rateLimit = mergeRateLimit(rateLimit, queueRateLimitFromHeaders(answer.headers));
       projects.push({
         project_label: project.project_label,
         outcome: "counted",
         depth,
         detail: `project ${JSON.stringify(project.project_label)} has ${depth} item(s) matching its selector`,
+        items: queueItemIdentifiers(matched),
       });
     } catch (error) {
       const rateLimited = isGithubRateLimitError(error);

--- a/apps/redskilled/tests/queue-items.test.ts
+++ b/apps/redskilled/tests/queue-items.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  carryQueueItems,
+  queueItemIdentifiers,
+  REDSKILLED_QUEUE_ITEM_CAP,
+  type RedskilledQueueDiscovery,
+} from "../src/queue-discovery.js";
+
+/**
+ * A poll that counts and then discards has to be asked again.
+ *
+ * The REST lane already holds every item it counted; throwing the identifiers
+ * away left a birth with a depth and nothing to hand a Worker (Spec #4097).
+ */
+const discovery = (
+  projects: RedskilledQueueDiscovery["projects"],
+): RedskilledQueueDiscovery => ({
+  version: 1,
+  fetched_at: "2026-08-19T20:00:00.000Z",
+  request_count: 1,
+  project_count: projects.length,
+  batch_size: 1,
+  rate_limit: { remaining: null, reset_at: null, exhausted: false },
+  projects,
+});
+
+describe("the queue poll keeps the identifiers it counted", () => {
+  it("takes the identifiers a REST answer listed, as opaque strings", () => {
+    expect(queueItemIdentifiers([{ number: 12 }, { number: 7 }])).toEqual(["12", "7"]);
+  });
+
+  it("skips an item the transport returned without one, rather than inventing a name", () => {
+    expect(queueItemIdentifiers([{ number: 12 }, {}, { number: 0 }, { number: 1.5 }, { number: 9 }]))
+      .toEqual(["12", "9"]);
+  });
+
+  it("bounds the list so a record cannot grow with the backlog", () => {
+    const many = Array.from({ length: REDSKILLED_QUEUE_ITEM_CAP + 20 }, (_, index) => ({ number: index + 1 }));
+
+    expect(queueItemIdentifiers(many)).toHaveLength(REDSKILLED_QUEUE_ITEM_CAP);
+  });
+
+  it("carries the last list across a poll that could not list — an unreachable queue is not an empty one", () => {
+    const previous = discovery([
+      { project_label: "a/b", outcome: "counted", depth: 2, detail: "counted", items: ["4", "5"] },
+    ]);
+    const failed = discovery([
+      { project_label: "a/b", outcome: "unreachable", depth: null, detail: "the queue fetch failed" },
+    ]);
+
+    expect(carryQueueItems(failed, previous).projects[0]).toMatchObject({
+      outcome: "unreachable",
+      items: ["4", "5"],
+    });
+  });
+
+  it("lets a counted poll replace the list, including with an empty one", () => {
+    const previous = discovery([
+      { project_label: "a/b", outcome: "counted", depth: 2, detail: "counted", items: ["4", "5"] },
+    ]);
+    const drained = discovery([
+      { project_label: "a/b", outcome: "counted", depth: 0, detail: "counted", items: [] },
+    ]);
+
+    expect(carryQueueItems(drained, previous).projects[0]?.items).toEqual([]);
+  });
+
+  it("carries nothing for a project the previous poll did not cover", () => {
+    const failed = discovery([
+      { project_label: "c/d", outcome: "unreachable", depth: null, detail: "the queue fetch failed" },
+    ]);
+
+    expect(carryQueueItems(failed, discovery([])).projects[0]).not.toHaveProperty("items");
+  });
+});


### PR DESCRIPTION
Closes #4098. First slice of Spec #4097.

A poll that counts and then discards has to be asked again. The REST lane already held every item it counted (`answer.data`) and threw the identifiers away, so a birth had a depth and nothing to hand a Worker.

- `last_poll` keeps them, bounded at 32: a record that grew with the backlog would put an unbounded list in a document every status read carries.
- `project_status` reports them, so an operator sees **what** the daemon believes is queued, not only how much.
- They stay opaque in the sense ADR 0130 rule 3 requires — stored, echoed, never parsed; no code branches on their content, and an item the transport returned without a usable identifier is skipped rather than given an invented name.
- A poll that could not list carries the previous list forward: **an unreachable queue is not an empty one.** A `counted` poll always replaces, including with an empty list, which is a real answer. The GraphQL lane asks for a count and gets a number, so it says nothing here.

Verified locally: new `queue-items.test.ts` 6/6; `queue-discovery`, `host-state`, `unregistered-drain`, `project-control-arguments` 34/34; `pnpm typecheck --force` 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789767861&installation_model_id=20659&pr_number=4104&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4104&signature=d4155d1820f695700dcd11a8def3975005f57bf359052c1a5a4807cd6a5d8ecb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->