### PR TITLE
feat(redskilled): a launch template can name the work item it was born for

### DIFF
--- a/.changeset/launch-template-names-the-work-item.md
+++ b/.changeset/launch-template-names-the-work-item.md
@@ -1,0 +1,19 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A launch template can name the work item its Worker was born for
+
+The poll keeps identifiers (#4098); the launch is where one reaches a Worker.
+`{{work_item}}` joins `{{worker_id}}`, `{{slot}}`, `{{workspace_path}}` and
+`{{log_path}}` as a fact a birth supplies, and the planner hands each birth one
+identifier — never the same one twice in a tick, and skipping as many as the
+project already has Workers, because the planner cannot see which item a live
+Worker claimed but can at least decline to create a collision on purpose.
+
+**Deliberately not the log path's rule.** A blank log path is a Worker that says
+nothing; a blank work item is a Worker that would claim whatever it found, or
+nothing at all. So a template that names `{{work_item}}` while the birth has
+none fails closed, naming the missing fact.
+
+Second slice of Spec #4097.

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -972,14 +972,25 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
           birthHealth[projectLabel] = resetBirthHealth();
         }
       }
-      const planCurrentDemand = () =>
-        planHostDemand({
+      // Read inside the closure, never above it: the planner runs again after a
+      // fresh poll, and a list captured before that poll would hand out items
+      // the daemon has since replaced.
+      const planCurrentDemand = () => {
+        const queueItems = new Map(
+          (lastQueue?.projects ?? [])
+            .filter((project) => project.items != null)
+            .map((project) => [project.project_label, project.items!] as const),
+        );
+        return planHostDemand({
           projects: [...registrations.values()].map((registration) => ({
             project_label: registration.project_label,
             selector: registration.selector,
             argv: registration.argv,
             workspace_path: registration.workspace_path,
             target: registration.target,
+            ...(queueItems.get(registration.project_label) == null
+              ? {}
+              : { items: queueItems.get(registration.project_label) }),
           })),
           queue: Object.fromEntries((lastQueue?.projects ?? []).map((project) => [project.project_label, project.depth])),
           live,
@@ -987,6 +998,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
           backoffUntilMs: demandBackoffUntilMs,
           birthHealth,
         });
+      };
       let plan = planCurrentDemand();
       if (plan.births.length > 0) {
         await pollQueueDiscovery();
@@ -1012,7 +1024,12 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
             ...(registration?.env == null ? {} : { env: registration.env }),
             ...(registration?.log_path == null ? {} : { log_path: registration.log_path }),
           },
-          { worker_id: workerId, slot: birth.index, workspace_path: birth.workspace_path },
+          {
+            worker_id: workerId,
+            slot: birth.index,
+            workspace_path: birth.workspace_path,
+            ...(birth.work_item == null ? {} : { work_item: birth.work_item }),
+          },
           { project_label: birth.project_label },
         );
         try {

--- a/apps/redskilled/src/demand-loop.ts
+++ b/apps/redskilled/src/demand-loop.ts
@@ -113,6 +113,15 @@ export interface RedskilledDemandProject {
   /** Used verbatim as the Worker's working directory. */
   readonly workspace_path: string;
   readonly target: number;
+  /**
+   * The identifiers the last poll kept (#4098), in the order it saw them.
+   *
+   * The planner hands ONE to each birth and never the same one twice in a tick:
+   * two Workers on one item is the collision the claim exists to resolve, and
+   * paying for it with two Workers when the planner could see it is waste the
+   * host chose. Carried, never read.
+   */
+  readonly items?: readonly string[];
 }
 
 /** What the loop decided about one project this tick, and why. */
@@ -146,6 +155,8 @@ export interface RedskilledDemandBirth {
   readonly index: number;
   readonly argv: readonly string[];
   readonly workspace_path: string;
+  /** The queue identifier this birth is for, when the poll kept one (#4099). */
+  readonly work_item?: string;
 }
 
 export interface RedskilledDemandPlan {
@@ -307,13 +318,20 @@ export function planHostDemand(input: PlanHostDemandInput): RedskilledDemandPlan
         : `project ${JSON.stringify(project.project_label)} holds ${live} Worker(s) against a target of ` +
           `${project.target} and a queue of ${depth}, so it asks for ${wanted} more`,
     });
+    // Workers already alive hold the head of the list: the planner cannot see
+    // WHICH item each one claimed (that is semantics), so it skips as many as
+    // are live and hands out from there. An overlap is still resolved by the
+    // claim; this only stops the planner from creating one on purpose.
+    const available = (project.items ?? []).slice(live);
     for (let index = 0; index < admitted; index += 1) {
       const round = rounds[index] ?? (rounds[index] = []);
+      const workItem = available[index];
       round.push({
         project_label: project.project_label,
         index: live + index,
         argv: project.argv,
         workspace_path: project.workspace_path,
+        ...(workItem == null ? {} : { work_item: workItem }),
       });
     }
   }

--- a/apps/redskilled/src/launch-template.ts
+++ b/apps/redskilled/src/launch-template.ts
@@ -53,7 +53,7 @@
  * frozen: a fifth entry would have to be a fact the daemon owns, and there is no
  * runner, model or effort among those.
  */
-export const REDSKILLED_LAUNCH_FACTS = ["worker_id", "slot", "workspace_path", "log_path"] as const;
+export const REDSKILLED_LAUNCH_FACTS = ["worker_id", "slot", "workspace_path", "log_path", "work_item"] as const;
 
 export type RedskilledLaunchFactName = (typeof REDSKILLED_LAUNCH_FACTS)[number];
 
@@ -63,6 +63,17 @@ export interface RedskilledLaunchFacts {
   readonly slot: number;
   readonly workspace_path: string;
   readonly log_path?: string | undefined;
+  /**
+   * The queue identifier THIS birth is for (#4099), when the demand loop chose
+   * one from what the last poll kept (#4098).
+   *
+   * Opaque like every other project-authored string: the daemon writes it into
+   * the argv and never asks what it names. Absent is a legal state — an ordinary
+   * workflow Worker is born for no queue item — but a template that NAMES it
+   * while a birth has none fails closed, because a Worker started with a blank
+   * where its work should be is one nobody meant to start.
+   */
+  readonly work_item?: string | undefined;
 }
 
 /**
@@ -148,6 +159,15 @@ export function expandLaunchTemplate(
           // "undefined": a client that mentioned it and did not supply it wants
           // an empty value, not a filename spelled after a JavaScript keyword.
           return facts.log_path ?? "";
+        case "work_item":
+          // Deliberately NOT the log path's rule. A blank log path is a Worker
+          // that says nothing; a blank work item is a Worker that would claim
+          // whatever it found, or nothing at all, and either way the operator
+          // asked for one specific thing.
+          if (facts.work_item == null || facts.work_item === "") {
+            throw new RedskilledLaunchFactError("work_item", where);
+          }
+          return facts.work_item;
         default:
           throw new RedskilledLaunchFactError(name, where);
       }

--- a/apps/redskilled/tests/work-item-launch.test.ts
+++ b/apps/redskilled/tests/work-item-launch.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { planHostDemand } from "../src/demand-loop.js";
+import { expandLaunchTemplate, REDSKILLED_LAUNCH_FACTS } from "../src/launch-template.js";
+
+/**
+ * A birth carries the item it is for.
+ *
+ * The poll keeps identifiers (#4098) and the launch is where they reach a
+ * Worker: a template that names `{{work_item}}` is filled with the identifier
+ * the planner chose for that birth, and a template that names it while the
+ * birth has none fails closed — a Worker started with a blank where its work
+ * should be is one nobody meant to start.
+ */
+const facts = {
+  worker_id: "W1",
+  slot: 0,
+  workspace_path: "/tmp/w",
+};
+
+describe("a launch template can name the work item it was born for", () => {
+  it("declares work_item among the facts a birth supplies", () => {
+    expect(REDSKILLED_LAUNCH_FACTS).toContain("work_item");
+  });
+
+  it("writes the identifier into the argv", () => {
+    const launch = expandLaunchTemplate(
+      { argv: ["redskilled", "work", "--work-item", "{{work_item}}", "--worker", "{{worker_id}}"] },
+      { ...facts, work_item: "4100" },
+    );
+
+    expect(launch.argv).toEqual(["redskilled", "work", "--work-item", "4100", "--worker", "W1"]);
+  });
+
+  it("fails closed when a template names it and the birth has none", () => {
+    expect(() =>
+      expandLaunchTemplate({ argv: ["redskilled", "work", "--work-item", "{{work_item}}"] }, facts),
+    ).toThrow(/work_item/);
+    expect(() =>
+      expandLaunchTemplate({ argv: ["redskilled", "work", "--work-item", "{{work_item}}"] }, {
+        ...facts,
+        work_item: "",
+      }),
+    ).toThrow(/work_item/);
+  });
+
+  it("leaves a template that never names it untouched", () => {
+    expect(expandLaunchTemplate({ argv: ["redskilled", "acp-worker"] }, facts).argv)
+      .toEqual(["redskilled", "acp-worker"]);
+  });
+
+  it("hands two births in one tick two different items", () => {
+    const plan = planHostDemand({
+      projects: [{
+        project_label: "a/b",
+        selector: "is:issue",
+        argv: ["redskilled", "work", "--work-item", "{{work_item}}"],
+        workspace_path: "/tmp/w",
+        target: 2,
+        items: ["11", "12", "13"],
+      }],
+      queue: { "a/b": 3 },
+      live: {},
+      nowMs: 0,
+    });
+
+    expect(plan.births.map((birth) => birth.work_item)).toEqual(["11", "12"]);
+  });
+
+  it("skips as many items as the project already has Workers", () => {
+    const plan = planHostDemand({
+      projects: [{
+        project_label: "a/b",
+        selector: "is:issue",
+        argv: ["redskilled", "work"],
+        workspace_path: "/tmp/w",
+        target: 3,
+        items: ["11", "12", "13"],
+      }],
+      queue: { "a/b": 3 },
+      live: { "a/b": 2 },
+      nowMs: 0,
+    });
+
+    expect(plan.births.map((birth) => birth.work_item)).toEqual(["13"]);
+  });
+
+  it("plans a birth with no item when the poll kept none — the claim still decides", () => {
+    const plan = planHostDemand({
+      projects: [{
+        project_label: "a/b",
+        selector: "is:issue",
+        argv: ["redskilled", "work"],
+        workspace_path: "/tmp/w",
+        target: 1,
+      }],
+      queue: { "a/b": 5 },
+      live: {},
+      nowMs: 0,
+    });
+
+    expect(plan.births).toHaveLength(1);
+    expect(plan.births[0]).not.toHaveProperty("work_item");
+  });
+});


### PR DESCRIPTION
Closes #4099. Second slice of Spec #4097.

The poll keeps identifiers (#4098); the launch is where one reaches a Worker.

- `{{work_item}}` joins the facts a birth supplies. The planner hands each birth one identifier, never the same one twice in a tick, and skips as many as the project already has Workers — it cannot see *which* item a live Worker claimed (that is semantics), but it can decline to create a collision on purpose. The claim still decides.
- **Deliberately not the log path's rule.** A blank log path is a Worker that says nothing; a blank work item is a Worker that would claim whatever it found, or nothing at all — so a template naming `{{work_item}}` with no item fails closed, naming the missing fact.
- A template that never names it is untouched, and a birth with no item is still planned: an ordinary workflow Worker is born for no queue item.
- The item map is read inside the planning closure, not above it: the planner runs again after a fresh poll, and a list captured before that poll would hand out items the daemon has since replaced.

Verified locally: new `work-item-launch.test.ts` 7/7; `demand-loop`, `launch-template`, `queue-items` 35/35; `pnpm typecheck --force` 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789768224&installation_model_id=20659&pr_number=4106&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4106&signature=86b3ffcacd4ecec90fe5078c156ddb78b8ec0af42d755506c81725cffb0a0d3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->