### PR TITLE
feat(redskilled): the daemon can run a turn for a Worker nobody is watching

### DIFF
--- a/.changeset/the-daemon-can-speak-to-the-worker-it-births.md
+++ b/.changeset/the-daemon-can-speak-to-the-worker-it-births.md
@@ -1,0 +1,32 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The daemon can run a turn for a Worker nobody is watching
+
+**A birth nobody speaks to does nothing.** Every client turn goes admission →
+session → prompt; the demand loop births a process for each unit of queue
+demand and never prompts it, which is why a registered, draining project
+produced Workers and no work (Spec #4097).
+
+This lands the half that had no home: `acp-demand-turn.ts` runs that same
+admission and turn with no client on the other end — its own session map, its
+own synthetic session id per turn, and a record where a notification would have
+gone. It deliberately does not borrow a connection's session map: an unattended
+turn living inside a client's would die when that client disconnected, which is
+the one property a drain must not have.
+
+A permission request with nobody to ask is **refused, and said out loud**: a
+daemon that answered "approved" on an operator's behalf would grant, unattended,
+exactly the reach an attached client is shown a dialog for. The Worker gets a
+refusal it can park on for `/hitl`.
+
+A registration may now carry an opaque `prompt` — expanded with the daemon's own
+facts like the argv already is, blank refused as shape, absent meaning Workers
+born and not spoken to, which is every registration that exists today.
+
+Permission resolution moves to `acp-permission.ts` on the way past: three
+answers and no fourth, and the control plane returns under its headroom target.
+
+**Nothing calls the runner yet** — the demand-loop call site is the next slice
+of #4100, so this changes no live behaviour.

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -18,7 +18,6 @@ import {
   type NewSessionRequest,
   type PromptRequest,
   type PromptResponse,
-  type RequestPermissionRequest,
   type RequestPermissionResponse,
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
@@ -35,7 +34,6 @@ import {
   requireSupportedV2Revision,
   socketStream,
   translateV1SessionUpdateToV2,
-  withTimeout,
 } from "@reddb-io/protocol-acp";
 import { bindAcpGithubReaderUpdates, bindAcpProjectGithubCustodyStatus, type AcpGithubUpdateObserver } from "./acp-github.js";
 import { connectionMethodTables } from "./acp-connection-methods.js";
@@ -48,6 +46,13 @@ import { isAcpRetakePrompt, notifyV1AcpRetakeEvidence, notifyV2AcpRetakeEvidence
 import type { RedskilledHostState } from "./host-state.js";
 import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
 import type { RedskilledPaths } from "./paths.js";
+import { resolvePermission } from "./acp-permission.js";
+import {
+  demandTurnRunnerFor,
+  type DemandTurnRecord,
+  type DemandTurnRequest,
+  type DemandTurnResult,
+} from "./acp-demand-turn.js";
 import {
   bindProjectControl,
   createProjectControlStore,
@@ -96,6 +101,8 @@ export interface PublicSession {
 
 export interface RedskillsAcpControlPlane {
   readonly socketPath: string;
+  /** Run one turn for a Worker nobody is watching (#4100, `acp-demand-turn.ts`). */
+  runDemandTurn(request: DemandTurnRequest): Promise<DemandTurnResult>;
   close(): Promise<void>;
 }
 
@@ -116,6 +123,8 @@ export interface StartRedskillsAcpControlPlaneOptions {
   readonly brainStore?: HostBrainStore;
   /** The daemon's per-Project memory holder (ADR 0152); injected only by a test. */
   readonly memoryStore?: ProjectMemoryStore;
+  /** Where an unattended turn's lifecycle goes when no client listens (#4100). */
+  readonly recordDemandTurn?: (record: DemandTurnRecord) => void;
 }
 
 /** The store handles every connection on this endpoint shares (ADR 0152). */
@@ -169,9 +178,10 @@ export async function startRedskillsAcpControlPlane(
   });
   await listen(server, paths.acpSocketPath);
 
-  let closed = false;
+  const runDemandTurn = demandTurnRunnerFor(options, sessionJournal);  let closed = false;
   return {
     socketPath: paths.acpSocketPath,
+    runDemandTurn,
     async close() {
       if (closed) return;
       closed = true;
@@ -614,84 +624,4 @@ export async function runRedskillsAcpAdapter(paths: RedskilledPaths): Promise<nu
     socket.once("error", reject);
   });
   return 0;
-}
-type PermissionDecision = Extract<
-  ReturnType<DurableAcpSessionJournal["recovery"]>["entries"][number],
-  { kind: "permission" }
->;
-
-async function resolvePermission(
-  journal: DurableAcpSessionJournal,
-  publicSessionId: string,
-  request: RequestPermissionRequest,
-  attached: () => boolean,
-  project: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>,
-): Promise<RequestPermissionResponse> {
-  const policyKey = permissionPolicyKey(request);
-  const granted = [...journal.recovery(publicSessionId).entries]
-    .reverse()
-    .find((entry): entry is PermissionDecision => entry.kind === "permission" &&
-      entry.policy_key === policyKey && entry.decision === "attached-approved" &&
-      entry.option_kind === "allow_always");
-  const preAuthorized = granted == null
-    ? undefined
-    : request.options.find((option) => option.optionId === granted.option_id && option.kind === "allow_always");
-  if (preAuthorized != null) {
-    await journal.permission(publicSessionId, request, policyKey, "policy-pre-authorized", preAuthorized.optionId);
-    return permissionAnswer(preAuthorized.optionId, "policy-pre-authorized");
-  }
-
-  if (attached()) {
-    try {
-      const response = await withTimeout(
-        project(request),
-        permissionDecisionTimeoutMs(),
-        "attached ACP permission decision",
-      );
-      const outcome = response.outcome;
-      const selected = outcome.outcome === "selected"
-        ? request.options.find((option) => option.optionId === outcome.optionId)
-        : undefined;
-      if (selected != null) {
-        const approved = selected.kind === "allow_once" || selected.kind === "allow_always";
-        const decision = approved ? "attached-approved" : "attached-denied";
-        await journal.permission(publicSessionId, request, policyKey, decision, selected.optionId);
-        return permissionAnswer(selected.optionId, decision, response._meta);
-      }
-    } catch {
-      // A disconnect or bounded timeout is an uncovered decision, never approval.
-    }
-  }
-
-  await journal.permission(publicSessionId, request, policyKey, "hitl-required");
-  return {
-    outcome: { outcome: "cancelled" },
-    _meta: { redskills: { permissionResolution: "hitl-required", durableHitl: true } },
-  };
-}
-
-function permissionAnswer(
-  optionId: string,
-  permissionResolution: "attached-approved" | "attached-denied" | "policy-pre-authorized",
-  meta?: RequestPermissionResponse["_meta"],
-): RequestPermissionResponse {
-  return {
-    outcome: { outcome: "selected", optionId },
-    _meta: {
-      ...(meta ?? {}),
-      redskills: {
-        ...((meta as { redskills?: object } | undefined)?.redskills ?? {}),
-        permissionResolution,
-      },
-    },
-  };
-}
-
-function permissionPolicyKey(request: RequestPermissionRequest): string {
-  return `${request.toolCall.kind ?? "other"}:${request.toolCall.title ?? "untitled"}`;
-}
-
-function permissionDecisionTimeoutMs(): number {
-  const configured = Number.parseInt(process.env.REDSKILLED_ACP_PERMISSION_TIMEOUT_MS ?? "30000", 10);
-  return Number.isFinite(configured) && configured >= 0 ? configured : 30_000;
 }

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -1,0 +1,228 @@
+/**
+ * acp-demand-turn — the daemon's own turn, for a Worker nobody is watching.
+ *
+ * **A birth nobody speaks to does nothing.** The demand loop births a process
+ * for each unit of queue demand and then never prompts it, while every client
+ * turn goes through admission → session → prompt (`acp-worker-admission.ts`,
+ * `acp-worker-lifecycle.ts`). That gap is the whole reason a registered,
+ * draining project produced Workers and no work (Spec #4097, #4100).
+ *
+ * This runs the same admission and the same turn with **no client on the other
+ * end**: its own session map, its own synthetic session id, and a sink that
+ * records lifecycle where a client would have been notified. It deliberately
+ * does not borrow a connection's session map — an unattended turn that lived
+ * inside a client's would die when that client disconnected, which is the one
+ * property a drain must not have (#3885).
+ *
+ * The daemon still reads nothing: the prompt is a project-authored string with
+ * the daemon's own facts expanded into it, exactly as the argv already was.
+ */
+import type { AgentConnection, RequestPermissionRequest, RequestPermissionResponse } from "@agentclientprotocol/sdk";
+
+import { admitNativeAcpWorker } from "./acp-worker-admission.js";
+import {
+  cleanupWorkflowWorker,
+  requestWorkflowTurn,
+  workflowOutcome,
+  type ActiveWorkflowWorker,
+} from "./acp-worker-lifecycle.js";
+import type { AcpSessionJournal } from "./acp-session-journal.js";
+import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
+import type { RedskilledPaths } from "./paths.js";
+import type { AcpProjectWorkspace } from "./project-workspace.js";
+import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
+
+/** What one unattended turn needs to exist. The daemon's own facts, no client's. */
+export interface DemandTurnDeps {
+  readonly paths: RedskilledPaths;
+  readonly startWorker: (spec: RedskilledWorkerSpec) => LaunchedWorker;
+  readonly hostState: () => { readonly workers: readonly { readonly worker_id: string }[] };
+  readonly sessionJournal: AcpSessionJournal;
+  readonly githubGateway?: RedskilledGithubGatewayRegistration;
+  readonly evidenceRoot?: string;
+  readonly evidenceTtlMs?: number;
+  readonly workspaceRoot?: string;
+  /**
+   * How a Worker is admitted for this turn.
+   *
+   * Defaults to the same native admission every client turn uses; a test
+   * substitutes it, because the alternative is spawning a real coder agent to
+   * assert that a prompt was sent.
+   */
+  readonly admit?: (input: DemandTurnAdmission) => Promise<ActiveWorkflowWorker>;
+  /**
+   * Where a lifecycle line goes when there is no client to notify.
+   *
+   * An unattended turn must be exactly as observable as an attended one, or the
+   * only way to learn a drain is working is to watch for commits.
+   */
+  readonly record?: (line: DemandTurnRecord) => void;
+}
+
+/** What one admission needs, whoever performs it. */
+export interface DemandTurnAdmission {
+  readonly project: AcpProjectWorkspace;
+  readonly sessionId: string;
+  readonly notify: AgentConnection["client"]["notify"];
+  readonly permission: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>;
+  readonly replacement: boolean;
+}
+
+export interface DemandTurnRecord {
+  readonly event: string;
+  readonly project_label: string;
+  readonly worker_id?: string;
+  readonly work_item?: string;
+  readonly detail?: string;
+}
+
+export interface DemandTurnRequest {
+  readonly project: AcpProjectWorkspace;
+  /** The project's prompt, with this birth's facts already written into it. */
+  readonly prompt: string;
+  /** The queue identifier this turn is for, when the birth had one. */
+  readonly workItem?: string;
+}
+
+export interface DemandTurnResult {
+  readonly workerId: string;
+  readonly outcome: string;
+}
+
+/**
+ * A permission request with nobody to ask.
+ *
+ * **Refused, and said out loud.** A daemon that answered "approved" on an
+ * operator's behalf would be granting, unattended, exactly the reach an
+ * attached client is shown a dialog for; one that hung would hold a Worker
+ * open until its idle timer. The Worker sees a refusal it can park on.
+ */
+export const DEMAND_TURN_PERMISSION_REFUSAL =
+  "this turn runs unattended: redskilled refuses permission on nobody's behalf — park the work for /hitl instead";
+
+function refusePermission(request: RequestPermissionRequest): RequestPermissionResponse {
+  const cancelled = request.options.find((option) => option.kind === "reject_once")
+    ?? request.options.find((option) => option.kind === "reject_always");
+  return cancelled == null
+    ? { outcome: { outcome: "cancelled" }, _meta: { redskills: { permissionResolution: "unattended-refused" } } }
+    : {
+      outcome: { outcome: "selected", optionId: cancelled.optionId },
+      _meta: { redskills: { permissionResolution: "unattended-refused", reason: DEMAND_TURN_PERMISSION_REFUSAL } },
+    };
+}
+
+/**
+ * Bind a runner from the control plane's own options, so the assembler states
+ * the dependency once instead of restating every optional field. PURE wiring.
+ */
+export function demandTurnRunnerFor(
+  options: {
+    readonly paths: RedskilledPaths;
+    readonly startWorker: (spec: RedskilledWorkerSpec) => LaunchedWorker;
+    readonly hostState: () => { readonly workers: readonly { readonly worker_id: string }[] };
+    readonly githubGateway?: RedskilledGithubGatewayRegistration;
+    readonly evidenceRoot?: string;
+    readonly evidenceTtlMs?: number;
+    readonly recordDemandTurn?: (record: DemandTurnRecord) => void;
+  },
+  sessionJournal: AcpSessionJournal,
+): (request: DemandTurnRequest) => Promise<DemandTurnResult> {
+  return createDemandTurnRunner({
+    paths: options.paths,
+    startWorker: options.startWorker,
+    hostState: options.hostState,
+    sessionJournal,
+    ...(options.githubGateway == null ? {} : { githubGateway: options.githubGateway }),
+    ...(options.evidenceRoot == null ? {} : { evidenceRoot: options.evidenceRoot }),
+    ...(options.evidenceTtlMs == null ? {} : { evidenceTtlMs: options.evidenceTtlMs }),
+    ...(options.recordDemandTurn == null ? {} : { record: options.recordDemandTurn }),
+  });
+}
+
+/**
+ * Bind the daemon's unattended turn runner.
+ *
+ * One `active` map per runner, held for the daemon's life: a Worker admitted
+ * for one work item is reaped when its turn ends, so the map never holds more
+ * than the turns actually in flight.
+ */
+export function createDemandTurnRunner(
+  deps: DemandTurnDeps,
+): (request: DemandTurnRequest) => Promise<DemandTurnResult> {
+  const active = new Map<string, ActiveWorkflowWorker>();
+  let sequence = 0;
+  const admit = deps.admit ?? ((input: DemandTurnAdmission) => admitNativeAcpWorker(
+    {
+      paths: deps.paths,
+      startWorker: deps.startWorker,
+      hostState: deps.hostState,
+      ...(deps.workspaceRoot == null ? {} : { workspaceRoot: deps.workspaceRoot }),
+      ...(deps.evidenceRoot == null ? {} : { evidenceRoot: deps.evidenceRoot }),
+      ...(deps.evidenceTtlMs == null ? {} : { evidenceTtlMs: deps.evidenceTtlMs }),
+      ...(deps.githubGateway == null ? {} : { githubGateway: deps.githubGateway }),
+    },
+    deps.sessionJournal,
+    { request: { cwd: input.project.workspacePath, mcpServers: [] }, project: input.project },
+    input.sessionId,
+    input.notify,
+    input.permission,
+    input.replacement,
+  ));
+
+  return async (request: DemandTurnRequest): Promise<DemandTurnResult> => {
+    sequence += 1;
+    // Synthetic and unique per turn: the session id keys the admission map and
+    // the journal, and a reused one would make two unattended turns look like
+    // one session being replaced.
+    const sessionId = `demand-${sequence}-${request.project.projectId}`;
+    const record = (event: string, worker?: ActiveWorkflowWorker, detail?: string): void => {
+      deps.record?.({
+        event,
+        project_label: request.project.projectLabel,
+        ...(worker == null ? {} : { worker_id: worker.workerId }),
+        ...(request.workItem == null ? {} : { work_item: request.workItem }),
+        ...(detail == null ? {} : { detail }),
+      });
+    };
+    // Nobody is listening, so a notification is a record. The shape is kept so
+    // the admission path cannot tell the difference between this and a client.
+    const notify: AgentConnection["client"]["notify"] = async () => {};
+
+    try {
+      const { worker, response } = await requestWorkflowTurn(
+        sessionId,
+        active,
+        {
+          sessionId,
+          prompt: [{ type: "text", text: request.prompt }],
+          _meta: {
+            redskills: {
+              unattended: true,
+              ...(request.workItem == null ? {} : { workItem: request.workItem }),
+            },
+          },
+        },
+        (replacement) => admit({
+          project: request.project,
+          sessionId,
+          notify,
+          permission: async (permission) => refusePermission(permission),
+          replacement,
+        }),
+      );
+      const outcome = workflowOutcome(response) ?? response.stopReason;
+      record("demand-turn-completed", worker, outcome);
+      // The turn is the Worker's whole life: it was admitted for one work item
+      // and has now finished it, so it is reaped here rather than left on an
+      // idle timer nobody will come back to.
+      cleanupWorkflowWorker(sessionId, worker, active, outcome);
+      return { workerId: worker.workerId, outcome };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      record("demand-turn-refused", active.get(sessionId), detail);
+      const held = active.get(sessionId);
+      if (held != null) cleanupWorkflowWorker(sessionId, held, active, "demand-turn-refused");
+      throw error;
+    }
+  };
+}

--- a/apps/redskilled/src/acp-permission.ts
+++ b/apps/redskilled/src/acp-permission.ts
@@ -1,0 +1,96 @@
+/**
+ * acp-permission — how one Worker's permission request is decided, and by whom.
+ *
+ * Three answers and no fourth: a durable `allow_always` the operator already
+ * gave, an attached client's decision inside a bounded deadline, or HITL. A
+ * disconnect and a timeout are the SAME thing here — an uncovered decision,
+ * never approval — which is the property that lets a Worker ask for reach
+ * while nobody is at the keyboard without the daemon inventing consent.
+ */
+import {
+  withTimeout,
+} from "@reddb-io/protocol-acp";
+import type { RequestPermissionRequest, RequestPermissionResponse } from "@agentclientprotocol/sdk";
+
+import type { AcpSessionJournal as DurableAcpSessionJournal } from "./acp-session-journal.js";
+
+type PermissionDecision = Extract<
+  ReturnType<DurableAcpSessionJournal["recovery"]>["entries"][number],
+  { kind: "permission" }
+>;
+
+export async function resolvePermission(
+  journal: DurableAcpSessionJournal,
+  publicSessionId: string,
+  request: RequestPermissionRequest,
+  attached: () => boolean,
+  project: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>,
+): Promise<RequestPermissionResponse> {
+  const policyKey = permissionPolicyKey(request);
+  const granted = [...journal.recovery(publicSessionId).entries]
+    .reverse()
+    .find((entry): entry is PermissionDecision => entry.kind === "permission" &&
+      entry.policy_key === policyKey && entry.decision === "attached-approved" &&
+      entry.option_kind === "allow_always");
+  const preAuthorized = granted == null
+    ? undefined
+    : request.options.find((option) => option.optionId === granted.option_id && option.kind === "allow_always");
+  if (preAuthorized != null) {
+    await journal.permission(publicSessionId, request, policyKey, "policy-pre-authorized", preAuthorized.optionId);
+    return permissionAnswer(preAuthorized.optionId, "policy-pre-authorized");
+  }
+
+  if (attached()) {
+    try {
+      const response = await withTimeout(
+        project(request),
+        permissionDecisionTimeoutMs(),
+        "attached ACP permission decision",
+      );
+      const outcome = response.outcome;
+      const selected = outcome.outcome === "selected"
+        ? request.options.find((option) => option.optionId === outcome.optionId)
+        : undefined;
+      if (selected != null) {
+        const approved = selected.kind === "allow_once" || selected.kind === "allow_always";
+        const decision = approved ? "attached-approved" : "attached-denied";
+        await journal.permission(publicSessionId, request, policyKey, decision, selected.optionId);
+        return permissionAnswer(selected.optionId, decision, response._meta);
+      }
+    } catch {
+      // A disconnect or bounded timeout is an uncovered decision, never approval.
+    }
+  }
+
+  await journal.permission(publicSessionId, request, policyKey, "hitl-required");
+  return {
+    outcome: { outcome: "cancelled" },
+    _meta: { redskills: { permissionResolution: "hitl-required", durableHitl: true } },
+  };
+}
+
+export function permissionAnswer(
+  optionId: string,
+  permissionResolution: "attached-approved" | "attached-denied" | "policy-pre-authorized",
+  meta?: RequestPermissionResponse["_meta"],
+): RequestPermissionResponse {
+  return {
+    outcome: { outcome: "selected", optionId },
+    _meta: {
+      ...(meta ?? {}),
+      redskills: {
+        ...((meta as { redskills?: object } | undefined)?.redskills ?? {}),
+        permissionResolution,
+      },
+    },
+  };
+}
+
+export function permissionPolicyKey(request: RequestPermissionRequest): string {
+  return `${request.toolCall.kind ?? "other"}:${request.toolCall.title ?? "untitled"}`;
+}
+
+function permissionDecisionTimeoutMs(): number {
+  const configured = Number.parseInt(process.env.REDSKILLED_ACP_PERMISSION_TIMEOUT_MS ?? "30000", 10);
+  return Number.isFinite(configured) && configured >= 0 ? configured : 30_000;
+}

--- a/apps/redskilled/src/project-registration.ts
+++ b/apps/redskilled/src/project-registration.ts
@@ -296,12 +296,9 @@ export function buildProjectRegistration(
   // Shape only, like every other project-authored string: present means a
   // non-empty one, and an empty prompt is a client bug the daemon can see
   // without reading a word of what a prompt says.
-  // Blank, not merely empty: a prompt of spaces is a Worker told nothing, and
-  // the daemon can see that without reading a word of what a prompt says.
-  const prompt = request.prompt === undefined
-    ? undefined
-    : requireText(request.prompt.trim(), `a prompt for project ${JSON.stringify(projectLabel)}`) &&
-      request.prompt;
+  // Blank, not merely empty: a prompt of spaces is a Worker told nothing.
+  if (request.prompt !== undefined) requireText(request.prompt.trim(), `a prompt for ${projectLabel}`);
+  const prompt = request.prompt;
   // Same shape check, same reason as the argv: a registration the host could
   // never start a Worker for is a client bug the daemon can see without reading
   // anything about what the path names.

--- a/apps/redskilled/src/project-registration.ts
+++ b/apps/redskilled/src/project-registration.ts
@@ -156,6 +156,17 @@ export interface RedskilledProjectRegistrationRequest {
   readonly log_path?: string;
   /** Project-scoped notifications keyed by the public host-event vocabulary. */
   readonly hooks?: RedskilledProjectHooks;
+  /**
+   * What to SAY to a Worker born for this project, when saying anything is the
+   * point (#4100).
+   *
+   * A registration's argv births a process; a prompt is what makes that process
+   * do the project's work. Opaque exactly as the argv is — the daemon expands
+   * its own facts (`{{work_item}}`, `{{worker_id}}`) into it and never reads a
+   * word. Absent means this project's Workers are born and not spoken to, which
+   * is the shape every registration had before this field and stays legal.
+   */
+  readonly prompt?: string;
   /** How many Workers this project wants; the host still decides how many it gets. */
   readonly target: number;
   /** Whether project policy declares this drain should remain recoverable. */
@@ -178,6 +189,8 @@ export interface RedskilledProjectRegistration {
   readonly log_path?: string;
   /** Project-scoped notifications keyed by the public host-event vocabulary. */
   readonly hooks?: RedskilledProjectHooks;
+  /** What to say to a Worker born for this project; opaque, expanded at birth. */
+  readonly prompt?: string;
   readonly target: number;
   /** True only when the project explicitly declared a standing drain policy. */
   readonly standing?: boolean;
@@ -280,6 +293,15 @@ export function buildProjectRegistration(
   const env = requireLaunchEnv(request.env, projectLabel);
   const logPath = requireLaunchLogPath(request.log_path, projectLabel);
   const hooks = requireProjectHooks(request.hooks, projectLabel);
+  // Shape only, like every other project-authored string: present means a
+  // non-empty one, and an empty prompt is a client bug the daemon can see
+  // without reading a word of what a prompt says.
+  // Blank, not merely empty: a prompt of spaces is a Worker told nothing, and
+  // the daemon can see that without reading a word of what a prompt says.
+  const prompt = request.prompt === undefined
+    ? undefined
+    : requireText(request.prompt.trim(), `a prompt for project ${JSON.stringify(projectLabel)}`) &&
+      request.prompt;
   // Same shape check, same reason as the argv: a registration the host could
   // never start a Worker for is a client bug the daemon can see without reading
   // anything about what the path names.
@@ -328,6 +350,7 @@ export function buildProjectRegistration(
     env,
     ...(logPath == null ? {} : { log_path: logPath }),
     ...(hooks == null ? {} : { hooks }),
+    ...(prompt == null ? {} : { prompt }),
     target: request.target,
     ...(request.standing === true ? { standing: true } : {}),
     registered_at: new Date(nowMs).toISOString(),

--- a/apps/redskilled/tests/demand-turn.test.ts
+++ b/apps/redskilled/tests/demand-turn.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createDemandTurnRunner,
+  DEMAND_TURN_PERMISSION_REFUSAL,
+  type DemandTurnAdmission,
+  type DemandTurnRecord,
+} from "../src/acp-demand-turn.js";
+import type { ActiveWorkflowWorker } from "../src/acp-worker-lifecycle.js";
+
+/**
+ * A birth nobody speaks to does nothing.
+ *
+ * The unattended turn runs the same admission and the same turn a client
+ * drives, with no client on the other end: its own session map, its own
+ * synthetic session id, and a record where a notification would have gone.
+ */
+const project = {
+  projectId: "github:1",
+  projectLabel: "reddb-io/red-skills",
+  workspacePath: "/tmp/project",
+} as never;
+
+function workerStub(response: unknown, workerId = "W1"): ActiveWorkflowWorker & { prompted: ReturnType<typeof vi.fn> } {
+  const prompted = vi.fn(async () => response);
+  return {
+    workerId,
+    downstreamSessionId: `down-${workerId}`,
+    connection: { agent: { request: prompted, notify: vi.fn() }, close: vi.fn() },
+    socket: { destroy: vi.fn(), destroyed: false, readable: true, writable: true, readableEnded: false, writableEnded: false },
+    endpoint: `/tmp/${workerId}.sock`,
+    publicSessionId: "",
+    notify: vi.fn(async () => {}),
+    cancelled: false,
+    cleaned: false,
+    prompted,
+  } as never;
+}
+
+function runner(
+  admit: (input: DemandTurnAdmission) => Promise<ActiveWorkflowWorker>,
+  records: DemandTurnRecord[] = [],
+) {
+  return {
+    records,
+    run: createDemandTurnRunner({
+      paths: {} as never,
+      startWorker: (() => {
+        throw new Error("an injected admission owns the birth in this test");
+      }) as never,
+      hostState: () => ({ workers: [] }),
+      sessionJournal: {} as never,
+      admit,
+      record: (line) => records.push(line),
+    }),
+  };
+}
+
+describe("the daemon's unattended turn", () => {
+  it("serves the project's prompt to the Worker it admitted", async () => {
+    const worker = workerStub({ stopReason: "end_turn" });
+    const { run } = runner(async () => worker);
+
+    const result = await run({ project, prompt: "work item 4100", workItem: "4100" });
+
+    expect(result).toMatchObject({ workerId: "W1", outcome: "end_turn" });
+    expect(worker.prompted).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ prompt: [{ type: "text", text: "work item 4100" }] }),
+    );
+  });
+
+  it("marks the turn unattended and names the item, so a reader can tell it apart", async () => {
+    const worker = workerStub({ stopReason: "end_turn" });
+    const { run } = runner(async () => worker);
+
+    await run({ project, prompt: "go", workItem: "4100" });
+
+    expect(worker.prompted.mock.calls[0]?.[1]).toMatchObject({
+      _meta: { redskills: { unattended: true, workItem: "4100" } },
+    });
+  });
+
+  it("records the outcome where a client would have been notified", async () => {
+    const { run, records } = runner(async () => workerStub({ stopReason: "end_turn" }));
+
+    await run({ project, prompt: "go", workItem: "4100" });
+
+    expect(records).toEqual([
+      expect.objectContaining({
+        event: "demand-turn-completed",
+        project_label: "reddb-io/red-skills",
+        work_item: "4100",
+        worker_id: "W1",
+      }),
+    ]);
+  });
+
+  it("records a refusal rather than losing it, and rethrows", async () => {
+    const { run, records } = runner(async () => {
+      throw new Error("the host refused this birth");
+    });
+
+    await expect(run({ project, prompt: "go" })).rejects.toThrow(/the host refused this birth/);
+    expect(records).toEqual([
+      expect.objectContaining({ event: "demand-turn-refused", detail: "the host refused this birth" }),
+    ]);
+  });
+
+  it("gives every turn its own session id, so two are never one session replaced", async () => {
+    const seen: string[] = [];
+    const { run } = runner(async (input) => {
+      seen.push(input.sessionId);
+      return workerStub({ stopReason: "end_turn" });
+    });
+
+    await run({ project, prompt: "one" });
+    await run({ project, prompt: "two" });
+
+    expect(new Set(seen).size).toBe(2);
+    expect(seen.every((id) => id.includes("github:1"))).toBe(true);
+  });
+
+  it("refuses permission on nobody's behalf, and says why", async () => {
+    let answered: unknown;
+    const { run } = runner(async (input) => {
+      answered = await input.permission({
+        sessionId: input.sessionId,
+        toolCall: { kind: "execute", title: "push" },
+        options: [
+          { optionId: "yes", name: "Allow", kind: "allow_once" },
+          { optionId: "no", name: "Deny", kind: "reject_once" },
+        ],
+      } as never);
+      return workerStub({ stopReason: "end_turn" });
+    });
+
+    await run({ project, prompt: "go" });
+
+    expect(answered).toMatchObject({
+      outcome: { outcome: "selected", optionId: "no" },
+      _meta: { redskills: { permissionResolution: "unattended-refused", reason: DEMAND_TURN_PERMISSION_REFUSAL } },
+    });
+    expect(DEMAND_TURN_PERMISSION_REFUSAL).toMatch(/hitl/i);
+  });
+});

--- a/apps/redskilled/tests/project-registration.test.ts
+++ b/apps/redskilled/tests/project-registration.test.ts
@@ -340,3 +340,46 @@ describe("redskilled project deregistration", () => {
     expect(daemon.hostState().registrations).toHaveLength(1);
   });
 });
+
+describe("a registration may say what to tell its Workers", () => {
+  it("carries an opaque prompt template", () => {
+    const registration = buildProjectRegistration(
+      {
+        project_label: "a/b",
+        selector: "is:issue",
+        argv: ["redskilled", "acp-worker"],
+        workspace_path: "/tmp/w",
+        prompt: "claim {{work_item}} and take it to a merged PR",
+        target: 1,
+      },
+      { now: "2026-08-19T20:00:00.000Z" },
+    );
+
+    expect(registration.prompt).toBe("claim {{work_item}} and take it to a merged PR");
+  });
+
+  it("refuses an empty prompt — shape, never meaning", () => {
+    expect(() =>
+      buildProjectRegistration(
+        {
+          project_label: "a/b",
+          selector: "is:issue",
+          argv: ["redskilled", "acp-worker"],
+          workspace_path: "/tmp/w",
+          prompt: "  ",
+          target: 1,
+        },
+        { now: "2026-08-19T20:00:00.000Z" },
+      )
+    ).toThrow(/prompt/);
+  });
+
+  it("stays absent for a project that says nothing — Workers born and not spoken to", () => {
+    const registration = buildProjectRegistration(
+      { project_label: "a/b", selector: "is:issue", argv: ["x"], workspace_path: "/tmp/w", target: 1 },
+      { now: "2026-08-19T20:00:00.000Z" },
+    );
+
+    expect(registration).not.toHaveProperty("prompt");
+  });
+});


### PR DESCRIPTION
Part of #4100 (Spec #4097). **Nothing calls the runner yet — this changes no live behaviour.**

**A birth nobody speaks to does nothing.** Every client turn goes admission → session → prompt; the demand loop births a process per unit of queue demand and never prompts it. That gap is why a registered, draining project produced Workers and no work.

- `acp-demand-turn.ts` runs the same admission and the same turn with **no client on the other end**: its own session map, a synthetic session id per turn, and a record where a notification would have gone. It deliberately does not borrow a connection's session map — an unattended turn living inside a client's would die when that client disconnected, which is the one property a drain must not have (#3885).
- A permission request with nobody to ask is **refused, and said out loud**. A daemon answering "approved" on an operator's behalf would grant, unattended, exactly the reach an attached client is shown a dialog for; one that hung would hold a Worker open until its idle timer. The Worker gets a refusal it can park on for `/hitl`.
- A registration may carry an opaque `prompt`, expanded with the daemon's own facts like the argv already is. Blank is refused as shape; absent means Workers born and not spoken to — every registration that exists today.
- Admission is injectable so the turn is testable without spawning a real coder agent.
- Permission resolution moves to `acp-permission.ts` on the way past (three answers and no fourth), which also returns `acp-control-plane.ts` to 627 lines, well under its 700-line headroom.

Verified locally: new `demand-turn.test.ts` 6/6; `project-registration.test.ts` 18/18 with 3 new cases; control-plane, layout and unregistered-drain suites 46/46 together; `pnpm typecheck --force` 17/17; `pnpm -C apps/plugin-dev test:invariants` 342/342 (the file-size ratchet caught my own +1 line on `project-registration.ts` — compacted rather than baselined).

Next slice: the demand loop calls it, and the turn's outcome reaches the host event lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789769328&installation_model_id=20659&pr_number=4107&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4107&signature=1b96dddcb635f6c0e55945375d5f76f1161c4e5d5e80138aa83fd770a275af57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->