### PR TITLE
feat(redskilled): the demand loop prompts the Worker it births

### DIFF
--- a/.changeset/the-demand-loop-prompts-its-worker.md
+++ b/.changeset/the-demand-loop-prompts-its-worker.md
@@ -1,0 +1,20 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The demand loop prompts the Worker it births
+
+The last wire of #4100. A project whose registration states a prompt now gets
+the daemon's own unattended turn — admission, session and prompt, exactly as an
+attached client would drive it — instead of a process nobody speaks to.
+
+The turn is **not awaited**: it is the Worker's whole life, and a demand tick
+that blocked on one would stop planning for every other project on the host. A
+turn that fails records the reason on the host event lane, where a stall is
+already read. A prompt naming a fact this birth does not have is refused before
+anything is spawned, and a project that states no prompt births exactly as it
+always did.
+
+`demandTurnForBirth` holds that decision as a pure function, because the
+interesting part is not the plumbing — it is which births change and which do
+not.

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -50,9 +50,15 @@ import { resolvePermission } from "./acp-permission.js";
 import {
   demandTurnRunnerFor,
   type DemandTurnRecord,
-  type DemandTurnRequest,
   type DemandTurnResult,
 } from "./acp-demand-turn.js";
+
+/** One demand birth's turn, named the way the demand loop holds a project. */
+export interface DemandBirthTurn {
+  readonly workspacePath: string;
+  readonly prompt: string;
+  readonly workItem?: string;
+}
 import {
   bindProjectControl,
   createProjectControlStore,
@@ -102,7 +108,7 @@ export interface PublicSession {
 export interface RedskillsAcpControlPlane {
   readonly socketPath: string;
   /** Run one turn for a Worker nobody is watching (#4100, `acp-demand-turn.ts`). */
-  runDemandTurn(request: DemandTurnRequest): Promise<DemandTurnResult>;
+  runDemandTurn(request: DemandBirthTurn): Promise<DemandTurnResult>;
   close(): Promise<void>;
 }
 
@@ -178,7 +184,14 @@ export async function startRedskillsAcpControlPlane(
   });
   await listen(server, paths.acpSocketPath);
 
-  const runDemandTurn = demandTurnRunnerFor(options, sessionJournal);  let closed = false;
+  const runTurn = demandTurnRunnerFor(options, sessionJournal);
+  // The demand loop holds a label and a path, never a bound Project: resolving
+  // here keeps the one workspace resolver in the one place that owns it.
+  const runDemandTurn = async (request: DemandBirthTurn): Promise<DemandTurnResult> => runTurn({
+    project: await workspaceFor(await resolveAcpProjectIdentity(request.workspacePath)),
+    prompt: request.prompt,
+    ...(request.workItem == null ? {} : { workItem: request.workItem }),
+  });  let closed = false;
   return {
     socketPath: paths.acpSocketPath,
     runDemandTurn,

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -20,6 +20,7 @@
 import type { AgentConnection, RequestPermissionRequest, RequestPermissionResponse } from "@agentclientprotocol/sdk";
 
 import { admitNativeAcpWorker } from "./acp-worker-admission.js";
+import { expandLaunchTemplate } from "./launch-template.js";
 import {
   cleanupWorkflowWorker,
   requestWorkflowTurn,
@@ -57,6 +58,33 @@ export interface DemandTurnDeps {
    * only way to learn a drain is working is to watch for commits.
    */
   readonly record?: (line: DemandTurnRecord) => void;
+}
+
+/**
+ * The turn one birth owes, or `null` when this project states no prompt.
+ *
+ * Pure and separate from the loop that calls it, because the interesting part
+ * is not the plumbing: it is that a project which said nothing births exactly
+ * as it always did, and a template naming a fact this birth does not have is
+ * refused BEFORE anything is spawned. PURE.
+ */
+export function demandTurnForBirth(
+  registration: { readonly prompt?: string } | undefined,
+  birth: { readonly workspace_path: string; readonly index: number; readonly work_item?: string },
+  workerId: string,
+): { readonly workspacePath: string; readonly prompt: string; readonly workItem?: string } | null {
+  if (registration?.prompt == null) return null;
+  const expanded = expandLaunchTemplate({ argv: [registration.prompt] }, {
+    worker_id: workerId,
+    slot: birth.index,
+    workspace_path: birth.workspace_path,
+    ...(birth.work_item == null ? {} : { work_item: birth.work_item }),
+  }).argv[0]!;
+  return {
+    workspacePath: birth.workspace_path,
+    prompt: expanded,
+    ...(birth.work_item == null ? {} : { workItem: birth.work_item }),
+  };
 }
 
 /** What one admission needs, whoever performs it. */

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -71,6 +71,7 @@ import {
 } from "../machine-scope.js";
 import { createRedskilledOrphanReaperRuntime } from "../orphan-reaper.js";
 import { workerSpecFromLaunch, type RedskilledLaunchTemplate } from "../launch-template.js";
+import { demandTurnForBirth } from "../acp-demand-turn.js";
 import { createRedskilledRegistrationIntentStore } from "../registration-intent-store.js";
 import {
   buildRegistrationLapse,
@@ -1009,12 +1010,39 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       let refusal: string | null = null;
       for (const birth of plan.births) {
         let launched: LaunchedWorker;
+        const registered = registrations.get(birth.project_label);
+        // **A birth nobody speaks to does nothing** (#4100). A project that
+        // stated a prompt gets the daemon's own unattended turn: admission,
+        // session and prompt, exactly as an attached client would drive it.
+        // The turn is not awaited — it is the Worker's whole life, and a demand
+        // tick that blocked on one would stop planning for every other project
+        // on the host.
+        if (registered?.prompt != null && acpControlPlane != null) {
+          try {
+            const turn = demandTurnForBirth(registered, birth, mintHostWorkerId(workers.keys()))!;
+            void acpControlPlane.runDemandTurn(turn).catch(async (error: unknown) => {
+              await eventLane.recordDemandRefusal({
+                ts: clock(),
+                projectLabel: birth.project_label,
+                detail: `the unattended turn for project ${JSON.stringify(birth.project_label)} failed: ` +
+                  `${error instanceof Error ? error.message : String(error)}`,
+              }).catch(() => undefined);
+            });
+          } catch (err) {
+            // A template naming a fact this birth does not have is refused
+            // before anything is spawned, and stated where a stall is read.
+            refusal = err instanceof Error ? err.message : String(err);
+            demandBackoffUntilMs = (Number.isFinite(nowMs) ? nowMs : Date.now()) + demandBackoffMs;
+            break;
+          }
+          continue;
+        }
         // The id is minted HERE rather than inside the launch, because the launch
         // template may mention it: an id substituted into an argv, an env or a log
         // path and a different id on the record would be one Worker the host and
         // the work disagree about.
         const workerId = mintHostWorkerId(workers.keys());
-        const registration = registrations.get(birth.project_label);
+        const registration = registered;
         const spec = workerSpecFromLaunch(
           // The argv comes from the plan (it is the registration's, copied), and
           // the env and the log path from the registration itself: the planner

--- a/apps/redskilled/tests/demand-turn.test.ts
+++ b/apps/redskilled/tests/demand-turn.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createDemandTurnRunner,
+  demandTurnForBirth,
   DEMAND_TURN_PERMISSION_REFUSAL,
   type DemandTurnAdmission,
   type DemandTurnRecord,
@@ -142,5 +143,32 @@ describe("the daemon's unattended turn", () => {
       _meta: { redskills: { permissionResolution: "unattended-refused", reason: DEMAND_TURN_PERMISSION_REFUSAL } },
     });
     expect(DEMAND_TURN_PERMISSION_REFUSAL).toMatch(/hitl/i);
+  });
+});
+
+describe("what one birth owes its Worker", () => {
+  it("says nothing for a project that stated no prompt — it births as it always did", () => {
+    expect(demandTurnForBirth(undefined, { workspace_path: "/tmp/w", index: 0 }, "W1")).toBeNull();
+    expect(demandTurnForBirth({}, { workspace_path: "/tmp/w", index: 0 }, "W1")).toBeNull();
+  });
+
+  it("writes this birth's facts into the project's prompt", () => {
+    expect(demandTurnForBirth(
+      { prompt: "claim {{work_item}} as {{worker_id}} in {{workspace_path}}" },
+      { workspace_path: "/tmp/w", index: 2, work_item: "4100" },
+      "W7",
+    )).toEqual({
+      workspacePath: "/tmp/w",
+      prompt: "claim 4100 as W7 in /tmp/w",
+      workItem: "4100",
+    });
+  });
+
+  it("refuses a prompt naming a fact this birth does not have, before anything is spawned", () => {
+    expect(() => demandTurnForBirth(
+      { prompt: "claim {{work_item}}" },
+      { workspace_path: "/tmp/w", index: 0 },
+      "W1",
+    )).toThrow(/work_item/);
   });
 });


### PR DESCRIPTION
Closes #4100. The last wire of Spec #4097's third slice.

A project whose registration states a prompt now gets the daemon's own unattended turn — admission, session and prompt, exactly as an attached client would drive it — instead of a process nobody speaks to.

- The turn is **not awaited**: it is the Worker's whole life, and a demand tick that blocked on one would stop planning for every other project on the host.
- A turn that fails records the reason on the host event lane, where a stall is already read.
- A prompt naming a fact this birth does not have is refused **before anything is spawned**, and stated as a demand refusal rather than discovered by a Worker that dies.
- A project that states no prompt births exactly as it always did — which is every registration in existence today.
- `demandTurnForBirth` holds the decision as a pure function: the interesting part is not the plumbing, it is which births change and which do not.

Verified locally: `demand-turn.test.ts` 9/9 (3 new cases for the birth decision); `unattended-demand.test.ts`, `demand-loop.test.ts` and `acp-control-plane.test.ts` 30/30 together — including the existing end-to-end proof that a registered project births on the daemon's own clock with no session alive; `pnpm typecheck --force` 17/17; `pnpm -C apps/plugin-dev test:invariants` 342/342.

Remaining in the Spec: #4101 (a drain registers — deliberately after this one, because registering a project whose Worker cannot work is how #4006 produced 22 deaths), #4102, #4103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789769784&installation_model_id=20659&pr_number=4108&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4108&signature=59a27f7379db2b23151b66a43cac5deca0aa6e2f01a1f93f4736e9a4e13666d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->