### PR TITLE
feat(redskilled): a drain registers the project it drains

### DIFF
--- a/.changeset/a-drain-registers-the-project-it-drains.md
+++ b/.changeset/a-drain-registers-the-project-it-drains.md
@@ -1,0 +1,24 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A drain registers the project it drains
+
+**A drain intent nobody registered polls nothing.** The demand loop births for a
+registration — the record carrying the query, the workspace, the argv and the
+prompt — and nothing had authored one since #4031 deleted the engine that used
+to. Every drain since recorded an intention and produced no Worker.
+
+`project_drain` now accepts the work the caller carried and registers it through
+the daemon's own registration path, sweep and breaker included, under the
+project the connection is bound to — a caller cannot register work under
+another project's name. The registration happens BEFORE the intent is written,
+so a drain that could not register never records "draining".
+
+The semantics are authored where they mean something: `buildDrainRegistration`
+(`apps/plugin-dev`) turns a repo, a target and an optional selector into the
+tracker query, its typed poll plan, a canonical pinned argv and the one-sentence
+prompt a Worker carrying the dev skills needs. From the socket onward all of it
+is opaque.
+
+A drain that carries no work behaves exactly as before, warning and all.

--- a/apps/plugin-dev/src/core/drain-registration.ts
+++ b/apps/plugin-dev/src/core/drain-registration.ts
@@ -1,0 +1,83 @@
+// drain-registration — what `drain` hands the daemon so a drain drains (#4101).
+//
+// **The MCP authors the semantics; the daemon carries them.** ADR 0130
+// Amendment 4 splits the lane there, and the thin MCP (ADR 0147 §2) is exactly
+// the surface that understands what an Issue, a label and a ready lane are.
+// The daemon receives a query string, a typed poll plan, an argv and a prompt,
+// stores them and hands them back — it never learns what any of them say.
+//
+// This is the piece nobody reconnected after the dev CLI was deleted: the
+// registration used to be authored by the engine that #4031 removed, so every
+// drain since recorded an intention the demand loop had nothing to poll for.
+//
+// PURE — strings in, one record out, no daemon, no filesystem, no process.
+import { canonicalInvocation } from "@reddb-io/shared/canonical-invocation.js";
+
+import {
+  buildRegistrationPollPlan,
+  buildRegistrationQuery,
+  type RegistrationPollPlan,
+  type RegistrationQuerySelector,
+} from "./registration-query.js";
+
+export interface DrainRegistrationInput {
+  /** `owner/name` — the repository whose tracker holds this project's queue. */
+  readonly repo: string;
+  /** Where a Worker for this project runs; the project's own checkout. */
+  readonly workspacePath: string;
+  readonly target: number;
+  readonly selector?: RegistrationQuerySelector | undefined;
+  /** The coder Agent a Worker runs, named by the caller. */
+  readonly runner?: string | undefined;
+  /** The published version whose binary a birth reaches for (ADR 0091). */
+  readonly version: string;
+  /** The label that defines "queued"; the executable lane's own by default. */
+  readonly readyLabel?: string | undefined;
+}
+
+export interface DrainRegistration {
+  readonly selector: string;
+  readonly queue_poll: RegistrationPollPlan;
+  readonly argv: readonly string[];
+  readonly workspace_path: string;
+  readonly prompt: string;
+  readonly target: number;
+}
+
+/**
+ * What a Worker born for this project is told to do.
+ *
+ * One sentence, because the Worker is a coder Agent carrying the dev skills:
+ * the verbs it needs are already its own, and a prompt that restated them would
+ * be a second copy of `/afk` maintained here. `{{work_item}}` is the daemon's
+ * fact, written in at birth (#4099).
+ */
+export const DRAIN_WORKER_PROMPT =
+  "Work issue #{{work_item}} in this repository to a merged pull request, following the /afk skill: " +
+  "claim it, implement it in this workspace, run the gate, open the PR, and land it. " +
+  "If you cannot claim it or the work is blocked, say so plainly and stop.";
+
+/** Build the registration a drain carries. PURE. */
+export function buildDrainRegistration(input: DrainRegistrationInput): DrainRegistration {
+  const queryInput = {
+    repo: input.repo,
+    ...(input.selector == null ? {} : { selector: input.selector }),
+    ...(input.readyLabel == null ? {} : { readyLabel: input.readyLabel }),
+  };
+  return {
+    selector: buildRegistrationQuery(queryInput),
+    queue_poll: buildRegistrationPollPlan(queryInput),
+    // The argv still has to name something runnable: a prompt-driven birth is
+    // served by the daemon's own Worker, but the registration shape predates
+    // that and a placeholder nobody could run would be a lie the probe in
+    // #4103 is about to catch.
+    argv: canonicalInvocation(
+      "red-skills-redskilled",
+      ["acp-worker", ...(input.runner == null ? [] : ["--child-agent", input.runner])],
+      input.version,
+    ).split(" "),
+    workspace_path: input.workspacePath,
+    prompt: DRAIN_WORKER_PROMPT,
+    target: input.target,
+  };
+}

--- a/apps/plugin-dev/src/project-acp-adapter.ts
+++ b/apps/plugin-dev/src/project-acp-adapter.ts
@@ -19,7 +19,7 @@ const CONTROL_TOOL = new Map<string, "drain" | "stop" | "status">([
  * recognise, so the whole thing became "run this prompt in a Worker" and came
  * back as narration with no answer in it.
  */
-const CONTROL_ARGUMENTS = new Set(["target", "runner", "scope"]);
+const CONTROL_ARGUMENTS = new Set(["target", "runner", "scope", "registration"]);
 
 /** Project MCP calls are projections; the adapter never executes a workflow. */
 export async function invokeProjectMcp(
@@ -77,12 +77,19 @@ export function invokeRedcodeProject(
 function controlRequest(input: Readonly<Record<string, unknown>>): {
   target?: number;
   runner?: string;
+  registration?: Readonly<Record<string, unknown>>;
 } {
   const target = input.target;
   const runner = input.runner;
+  // The work a drain carries (#4101): authored here, where an Issue and a ready
+  // label mean something, and opaque from the socket onward.
+  const registration = input.registration;
   return {
     ...(typeof target === "number" && Number.isInteger(target) && target >= 0 ? { target } : {}),
     ...(typeof runner === "string" && runner.length > 0 ? { runner } : {}),
+    ...(registration != null && typeof registration === "object" && !Array.isArray(registration)
+      ? { registration: registration as Readonly<Record<string, unknown>> }
+      : {}),
   };
 }
 

--- a/apps/plugin-dev/tests/drain-registration.test.ts
+++ b/apps/plugin-dev/tests/drain-registration.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDrainRegistration,
+  DRAIN_WORKER_PROMPT,
+} from "../src/core/drain-registration.js";
+
+/**
+ * The MCP authors the semantics; the daemon carries them.
+ *
+ * The registration a drain hands over is the piece nobody reconnected after
+ * the dev CLI was deleted (#4031): every drain since recorded an intention the
+ * demand loop had nothing to poll for.
+ */
+const input = {
+  repo: "reddb-io/red-skills",
+  workspacePath: "/home/op/src/red-skills",
+  target: 2,
+  version: "4.0.0",
+  runner: "redcode",
+};
+
+describe("what a drain hands the daemon", () => {
+  it("carries the tracker query and its typed poll plan together", () => {
+    const registration = buildDrainRegistration(input);
+
+    expect(registration.selector).toContain("reddb-io/red-skills");
+    expect(registration.queue_poll).toMatchObject({ owner: "reddb-io", repo: "red-skills" });
+    expect(registration.queue_poll.labels.length).toBeGreaterThan(0);
+  });
+
+  it("names a runnable argv in the canonical form, pinned to a version", () => {
+    const registration = buildDrainRegistration(input);
+
+    expect(registration.argv.slice(0, 4)).toEqual(["npx", "-y", "-p", "@reddb-io/red-skills@4.0.0"]);
+    expect(registration.argv).toContain("acp-worker");
+    expect(registration.argv).toContain("redcode");
+  });
+
+  it("tells the Worker to work the item the daemon fills in, and nothing more", () => {
+    expect(buildDrainRegistration(input).prompt).toBe(DRAIN_WORKER_PROMPT);
+    expect(DRAIN_WORKER_PROMPT).toContain("{{work_item}}");
+    expect(DRAIN_WORKER_PROMPT).toContain("/afk");
+  });
+
+  it("narrows the queue by the facets a caller stated", () => {
+    const narrowed = buildDrainRegistration({ ...input, selector: { label: "lane:go" } });
+
+    expect(narrowed.selector).toContain("lane:go");
+    expect(narrowed.queue_poll.labels).toContain("lane:go");
+  });
+
+  it("carries the width the caller asked for, and its own workspace", () => {
+    const registration = buildDrainRegistration(input);
+
+    expect(registration.target).toBe(2);
+    expect(registration.workspace_path).toBe("/home/op/src/red-skills");
+  });
+});

--- a/apps/redskilled/src/acp-client.ts
+++ b/apps/redskilled/src/acp-client.ts
@@ -35,6 +35,8 @@ export type RedskillsProjectControlOperation = "drain" | "stop" | "status";
 export interface RedskillsProjectControlRequest {
   readonly target?: number;
   readonly runner?: string;
+  /** The work this drain carries, authored by the project (#4101). */
+  readonly registration?: Readonly<Record<string, unknown>>;
 }
 
 export interface RedskillsProjectControlSnapshot {
@@ -166,6 +168,7 @@ export async function connectRedskillsProjectAcp(
     const outcome = await connection.agent.request<unknown>(PROJECT_CONTROL_METHOD[operation], {
       ...(request.target == null ? {} : { target: request.target }),
       ...(request.runner == null ? {} : { runner: request.runner }),
+      ...(request.registration == null ? {} : { registration: request.registration }),
     });
     if (!isProjectControl(outcome)) throw new Error("redskilled returned an invalid Project control outcome");
     if (operation === "status" && !isProjectStatus(outcome)) {

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -47,6 +47,7 @@ import type { RedskilledHostState } from "./host-state.js";
 import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
 import type { RedskilledPaths } from "./paths.js";
 import { resolvePermission } from "./acp-permission.js";
+import type { RedskilledProjectRegistrationRequest } from "./project-registration.js";
 import {
   demandTurnRunnerFor,
   type DemandTurnRecord,
@@ -131,6 +132,15 @@ export interface StartRedskillsAcpControlPlaneOptions {
   readonly memoryStore?: ProjectMemoryStore;
   /** Where an unattended turn's lifecycle goes when no client listens (#4100). */
   readonly recordDemandTurn?: (record: DemandTurnRecord) => void;
+  /**
+   * Register a project with the demand loop, on its own behalf (#4101).
+   *
+   * The daemon's own registration path, handed in rather than reached for: the
+   * control plane must not learn a second way to write the record the lifecycle
+   * owns. Absent means this endpoint cannot register — legal in a test, and the
+   * drain then answers exactly as it did before registrations reached it.
+   */
+  readonly registerProject?: (request: RedskilledProjectRegistrationRequest) => unknown;
 }
 
 /** The store handles every connection on this endpoint shares (ADR 0152). */
@@ -252,6 +262,9 @@ async function servePublicConnection(
     hostState: options.hostState,
     clock: () => options.clock?.() ?? new Date().toISOString(),
     readGithubCustody: bindAcpProjectGithubCustodyStatus(options.githubGateway, scopedProject),
+    ...(options.registerProject == null
+      ? {}
+      : { registerProject: (request) => options.registerProject!(request as never) }),
   });
 
   const { v1: v1Methods, v2: v2Methods } = connectionMethodTables({

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -2381,6 +2381,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       hostState,
       ...(options.githubGateway == null ? {} : { githubGateway: options.githubGateway }),
       ...(options.evidenceTtlMs == null ? {} : { evidenceTtlMs: options.evidenceTtlMs }),
+      // The one registration path, handed to the endpoint that now needs it
+      // (#4101): a drain that carries its work registers through the same
+      // function `project-register` does, sweep, breaker and all.
+      registerProject: (request) => registerProject(request),
     });
   } catch (error) {
     await stop({ reason: "requested", note: "ACP control plane failed to bind" }).catch(() => undefined);

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -517,6 +517,18 @@ function record(value: unknown): Record<string, unknown> | undefined {
 export interface ProjectControlRequest {
   readonly target?: number;
   readonly runner?: string;
+  /**
+   * The work this project wants drained, authored by the project (#4101).
+   *
+   * **A drain intent nobody registered polls nothing.** The demand loop births
+   * for a registration — the record carrying the query, the workspace, the argv
+   * and the prompt — and until a drain could carry one, every drain recorded an
+   * intention and produced no Worker. The daemon reads none of it: the fields
+   * are the ones `project-register` already carries, and they arrive here
+   * because a client that says "drain" is exactly the client that knows what
+   * its work is.
+   */
+  readonly registration?: Readonly<Record<string, unknown>>;
 }
 
 /**
@@ -537,9 +549,14 @@ export function projectControlRequest(value: unknown): ProjectControlRequest {
   if (runner !== undefined && !(typeof runner === "string" && runner.length > 0)) {
     throw RequestError.invalidParams("runner must be a non-empty string");
   }
+  const registration = params.registration;
+  if (registration !== undefined && record(registration) == null) {
+    throw RequestError.invalidParams("registration must be an object");
+  }
   return {
     ...(target === undefined ? {} : { target: target as number }),
     ...(runner === undefined ? {} : { runner: runner as string }),
+    ...(registration === undefined ? {} : { registration: registration as Readonly<Record<string, unknown>> }),
   };
 }
 
@@ -572,10 +589,22 @@ export function bindProjectControl(deps: {
   readonly hostState: () => RedskilledHostState;
   readonly clock: () => string;
   readonly readGithubCustody: () => Promise<unknown>;
+  /** The daemon's own registration path; absent means this endpoint cannot register. */
+  readonly registerProject?: (request: Readonly<Record<string, unknown>>) => unknown;
 }) {
   return {
     mutateProjectControl: async (operation: ProjectControlOperation, request: ProjectControlRequest = {}) => {
       const project = deps.scopedProject();
+      // Registered BEFORE the intent is written: a drain that recorded
+      // "draining" and then failed to register would be exactly the dead end
+      // #4094 had to announce, with the announcement now saying the opposite of
+      // what the caller was told.
+      if (operation === "drain" && request.registration != null) {
+        if (deps.registerProject == null) {
+          throw new Error("this endpoint cannot register a project: the daemon handed it no registration path");
+        }
+        deps.registerProject({ ...request.registration, project_label: project.projectLabel });
+      }
       const answer = await applyProjectControl(
         project,
         operation,

--- a/apps/redskilled/tests/unregistered-drain.test.ts
+++ b/apps/redskilled/tests/unregistered-drain.test.ts
@@ -82,3 +82,57 @@ describe("an unregistered drain is a dead end that announces itself", () => {
     expect(projectIsRegistered(hostState(false), project)).toBe(false);
   });
 });
+
+describe("a drain registers the project it drains", () => {
+  const bind = (registered: boolean, registerProject?: (request: Readonly<Record<string, unknown>>) => unknown) =>
+    bindProjectControl({
+      scopedProject: () => project,
+      projectControls: new Map<string, ProjectControlState>(),
+      persistProjectControls: async () => {},
+      hostState: () => hostState(registered),
+      clock: () => "2026-08-19T20:00:00.000Z",
+      readGithubCustody: async () => null,
+      ...(registerProject == null ? {} : { registerProject }),
+    });
+
+  it("registers the work the caller carried, under the project it is bound to", async () => {
+    const registered: Array<Readonly<Record<string, unknown>>> = [];
+
+    await bind(true, (request) => registered.push(request)).mutateProjectControl("drain", {
+      target: 2,
+      registration: { selector: "is:issue label:ready-for-agent", argv: ["redskilled", "acp-worker"], target: 2 },
+    });
+
+    expect(registered).toEqual([
+      expect.objectContaining({
+        project_label: "reddb-io/red-skills",
+        selector: "is:issue label:ready-for-agent",
+        target: 2,
+      }),
+    ]);
+  });
+
+  it("names the project itself, so a caller cannot register work under another one", async () => {
+    const registered: Array<Readonly<Record<string, unknown>>> = [];
+
+    await bind(true, (request) => registered.push(request)).mutateProjectControl("drain", {
+      registration: { project_label: "someone/else", selector: "is:issue", argv: ["x"], target: 1 },
+    });
+
+    expect(registered[0]).toMatchObject({ project_label: "reddb-io/red-skills" });
+  });
+
+  it("refuses when the endpoint was handed no registration path, rather than recording a drain nothing polls", async () => {
+    await expect(bind(false).mutateProjectControl("drain", { registration: { selector: "is:issue" } }))
+      .rejects.toThrow(/cannot register a project/);
+  });
+
+  it("leaves a drain that carries no work exactly as it was", async () => {
+    const registered: unknown[] = [];
+
+    const answer = await bind(false, (request) => registered.push(request)).mutateProjectControl("drain", {});
+
+    expect(registered).toEqual([]);
+    expect(answer).toMatchObject({ drain_intent: "draining", warning: UNREGISTERED_DRAIN_WARNING });
+  });
+});


### PR DESCRIPTION
Closes #4101. Fourth slice of Spec #4097.

**A drain intent nobody registered polls nothing.** The demand loop births for a *registration* — query, workspace, argv, prompt — and nothing had authored one since #4031 deleted the engine that used to. Every drain since recorded an intention and produced no Worker, which is what `dashboard local` was saying with `!unregistered`.

- `project_drain` accepts the work the caller carried and registers it through **the daemon's own registration path**, sweep and breaker included — the control plane does not learn a second way to write the record the lifecycle owns.
- It registers under the project the connection is bound to: a caller cannot register work under another project's name.
- Registration happens **before** the intent is written, so a drain that could not register never records "draining" — the dead end #4094 announces stays honest.
- The semantics are authored where they mean something: `buildDrainRegistration` turns a repo, a target and an optional selector into the tracker query, its typed poll plan, a canonical pinned argv (ADR 0091) and the one-sentence prompt a Worker carrying the dev skills needs. From the socket onward all of it is opaque.
- A drain that carries no work behaves exactly as before, warning and all.

Verified locally: `unregistered-drain.test.ts` 9/9 (4 new cases), new `drain-registration.test.ts` 5/5, adapter parity 5/5; `unregistered-drain`, `project-control-arguments`, `acp-control-plane` and the end-to-end `unattended-demand` suites 28/28 together; `pnpm typecheck --force` 17/17; invariants 342/342.

Remaining: #4102 (the standing drain gets its caller back, or goes) and #4103 (a registration whose launch cannot run is refused at registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789770323&installation_model_id=20659&pr_number=4109&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4109&signature=c531f50cfdb9d47152411684c78e3221977010de109f5f4b036b8c8cc5873e67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->