### PR TITLE
feat(redskilled): a registration whose launch cannot run is refused at registration

### DIFF
--- a/.changeset/a-launch-that-cannot-run-is-refused.md
+++ b/.changeset/a-launch-that-cannot-run-is-refused.md
@@ -1,0 +1,25 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A registration whose launch cannot run is refused at registration
+
+#4006 birthed 22 Workers from an argv that could not run, and a human found it
+by reading a log — after the project's birth breaker latched. The daemon now
+asks at registration instead: **every shipped binary answers `--version` offline
+without a working machine**, which is exactly what makes it usable as a probe.
+One process, no work, no side effect, and a truthful answer about whether the
+thing the registration names exists at all.
+
+Refusal is reserved for *nothing ran* — a spawn error, or the 126/127 a shell
+gives for a command it could not find or execute. A binary that ran and disliked
+a trailing `--version` still exists, and refusing that would be the probe
+inventing a defect. A timeout or a permission error is **inconclusive**: a cold
+npx cache is not a broken launch, and refusing on it would trade one silent
+failure for a louder wrong one. The refusal names the canonical invocation form
+(ADR 0091), so an operator reads the shape that works.
+
+The probe is **off unless the host asks for it**: running a registration's argv
+is the one place the daemon touches a string it otherwise only carries, so the
+reach is granted by the entry that serves a real machine rather than assumed by
+every daemon a test constructs.

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -8,6 +8,7 @@
  * bundle versions. A path it needs is a path it was given.
  */
 import { execFileSync } from "node:child_process";
+import { defaultLaunchProbe } from "./launch-probe.js";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { encode as encodeToon } from "@reddb-io/toon";
@@ -532,6 +533,11 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
         // baked into this build rather than a placeholder, because "what version is
         // answering" is the first fact a skew investigation needs.
         daemonVersion: values["daemon-version"] ?? readBuildInfo("redskilled").version,
+        // The serving daemon is the one that births from a registration, so it
+        // is the one that asks whether the launch can run at all (#4103): a
+        // refusal here costs one process; discovering it at birth cost #4006
+        // twenty-two deaths.
+        probeLaunch: defaultLaunchProbe,
         // The verdicts reach the statusline and both dashboards from here, because
         // this is the only moment they exist in memory: the reaper clears the
         // anchors it read, so a surface asking later would find a lane it would

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -71,6 +71,11 @@ import {
 } from "../machine-scope.js";
 import { createRedskilledOrphanReaperRuntime } from "../orphan-reaper.js";
 import { workerSpecFromLaunch, type RedskilledLaunchTemplate } from "../launch-template.js";
+import {
+  classifyLaunchProbe,
+  launchProbeArgv,
+  launchProbeRefusal,
+} from "../launch-probe.js";
 import { demandTurnForBirth } from "../acp-demand-turn.js";
 import { createRedskilledRegistrationIntentStore } from "../registration-intent-store.js";
 import {
@@ -378,6 +383,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   const activityMs = activityRegistration?.intervalMs ?? DEFAULT_REDSKILLED_ACTIVITY_MS;
   const balanceRegistration = options.githubBalance;
   const queueRegistration = options.queueDiscovery;
+  // **Off unless a host asks for it.** Running a registration's argv is the one
+  // place the daemon touches a string it otherwise only carries, so the reach is
+  // granted by the entry that serves a real machine rather than assumed by every
+  // daemon a test constructs.
+  const probeLaunch = options.probeLaunch;
   // Not `const`: an unarmed poller asks again before every poll, so the daemon
   // that was spawned from a session without a credential still counts once one
   // exists (#3056).
@@ -1418,6 +1428,15 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       now,
       held: registrations.get(request.project_label),
     });
+    // Asked here, because 22 deaths later is too late (#4006, #4103). A launch
+    // that cannot answer `--version` is one no Worker could have been born
+    // from; a probe that could not run at all says so and changes nothing.
+    if (probeLaunch != null) {
+      const verdict = classifyLaunchProbe(probeLaunch(launchProbeArgv(registration.argv)));
+      if (verdict === "unrunnable") {
+        throw new Error(launchProbeRefusal(registration.project_label, registration.argv));
+      }
+    }
     registrations.set(registration.project_label, registration);
     persistRegistrationIntent();
     // Somebody is watching now: a poll waiting out an idle window comes forward.

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -1,5 +1,6 @@
 // The daemon's option, registration and handle shapes — its contract with
 // every caller, kept apart from the lifecycle that implements it.
+import type { LaunchProbeResult } from "../launch-probe.js";
 import type { DeathAttribution } from "@reddb-io/shared/death-attribution.js";
 import { type RedskilledAdmissionVerdict,
   type RedskilledHostCeiling,
@@ -274,6 +275,14 @@ export interface RedskilledDaemonOptions {
    * would spend more quota than the batching saves.
    */
   readonly queueDiscovery?: RedskilledQueueRegistration;
+  /**
+   * Ask a registration's launch whether it can run at all (#4103).
+   *
+   * Injected so a test can answer without spawning, and so a host that wants no
+   * probe simply hands none — the registration then behaves exactly as it did
+   * before the probe existed.
+   */
+  readonly probeLaunch?: (argv: readonly string[]) => LaunchProbeResult;
   /**
    * Window between demand ticks; 0 or below leaves the loop unarmed.
    *

--- a/apps/redskilled/src/launch-probe.ts
+++ b/apps/redskilled/src/launch-probe.ts
@@ -1,0 +1,89 @@
+/**
+ * launch-probe — asked at registration, because 22 deaths later is too late.
+ *
+ * A registration names an argv the daemon will birth Workers from. When that
+ * argv cannot run — a version that was never published, a package that no
+ * longer carries the binary, a shim pointing at a deleted bundle — the daemon
+ * discovers it one birth at a time: #4006 died 22 times in a row before a human
+ * read a log, and only then because the project's birth breaker latched.
+ *
+ * **Every shipped binary answers `--version` offline without a working machine**
+ * (the shipped-binary guard), which is exactly what makes it usable as a probe:
+ * one process, no work, no side effect, and a truthful answer about whether the
+ * thing the registration names exists at all.
+ *
+ * Inconclusive is a first-class answer. A cold npx cache or a slow disk is not
+ * a broken launch, and refusing a registration because a probe timed out would
+ * trade one silent failure for a louder wrong one.
+ *
+ * PURE except for the injected prober.
+ */
+import { spawnSync } from "node:child_process";
+
+export type LaunchProbeVerdict = "runnable" | "unrunnable" | "inconclusive";
+
+export interface LaunchProbeResult {
+  readonly status: number | null;
+  readonly timedOut?: boolean;
+  readonly error?: string;
+}
+
+/** The argv that asks a registered launch to identify itself. PURE. */
+export function launchProbeArgv(argv: readonly string[]): readonly string[] {
+  return [...argv, "--version"];
+}
+
+/**
+ * What one probe answer means for the registration that produced it. PURE.
+ *
+ * A non-zero exit is the interesting case and it is deliberately NOT a refusal
+ * on its own: a binary that ran and disliked its arguments still exists, and
+ * the registration's argv may carry flags this probe appended `--version` to.
+ * Refusal is reserved for "nothing ran" — a spawn error, or an exit status the
+ * shell uses for a command it could not find.
+ */
+export function classifyLaunchProbe(result: LaunchProbeResult): LaunchProbeVerdict {
+  if (result.timedOut === true) return "inconclusive";
+  if (result.error != null) {
+    return /ENOENT|not found|no such file/i.test(result.error) ? "unrunnable" : "inconclusive";
+  }
+  if (result.status === 0) return "runnable";
+  // 127 is "command not found" and 126 is "found but not executable", the two
+  // answers a shell gives for a launch nobody could have run.
+  return result.status === 127 || result.status === 126 ? "unrunnable" : "runnable";
+}
+
+/**
+ * The default prober: one bounded process that asks the launch to name itself.
+ *
+ * Bounded twice — a deadline and no shell — because this runs inside the
+ * registration path a client is waiting on, and a probe that hung would turn a
+ * cold npx cache into a hung `drain`.
+ */
+export function defaultLaunchProbe(argv: readonly string[]): LaunchProbeResult {
+  const [command, ...args] = argv;
+  if (command == null) return { status: null, error: "the launch named no command" };
+  const probe = spawnSync(command, args, {
+    timeout: LAUNCH_PROBE_TIMEOUT_MS,
+    stdio: ["ignore", "ignore", "pipe"],
+    encoding: "utf8",
+  });
+  return {
+    status: probe.status,
+    ...(probe.signal === "SIGTERM" && probe.status == null ? { timedOut: true } : {}),
+    ...(probe.error == null ? {} : { error: probe.error.message }),
+  };
+}
+
+/** How long a probe may take before its answer stops being worth waiting for. */
+export const LAUNCH_PROBE_TIMEOUT_MS = 20_000;
+
+/** The refusal a client reads when its launch could not run. PURE. */
+export function launchProbeRefusal(projectLabel: string, argv: readonly string[]): string {
+  return (
+    `redskilled refuses to register project ${JSON.stringify(projectLabel)}: the launch it named cannot run — ` +
+    `${JSON.stringify(argv.join(" "))} did not answer \`--version\`. Every shipped binary answers it offline, so ` +
+    `a launch that cannot is one no Worker could have been born from. The canonical form is ` +
+    `\`npx -y -p @reddb-io/red-skills@<version> <binary>\` (ADR 0091).`
+  );
+}

--- a/apps/redskilled/tests/launch-probe.test.ts
+++ b/apps/redskilled/tests/launch-probe.test.ts
@@ -1,0 +1,74 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyLaunchProbe,
+  defaultLaunchProbe,
+  launchProbeArgv,
+  launchProbeRefusal,
+} from "../src/launch-probe.js";
+
+/**
+ * Asked at registration, because 22 deaths later is too late.
+ *
+ * #4006 birthed 22 Workers from an argv that could not run, and a human found
+ * it by reading a log. Every shipped binary answers `--version` offline without
+ * a working machine, which is what makes it usable as a probe: one process, no
+ * work, no side effect.
+ */
+describe("a launch that cannot run is refused at registration", () => {
+  it("asks the launch to identify itself, and nothing more", () => {
+    expect(launchProbeArgv(["npx", "-y", "-p", "@reddb-io/red-skills@4.0.0", "red-skills-redskilled"]))
+      .toEqual(["npx", "-y", "-p", "@reddb-io/red-skills@4.0.0", "red-skills-redskilled", "--version"]);
+  });
+
+  it("calls an answer of zero runnable", () => {
+    expect(classifyLaunchProbe({ status: 0 })).toBe("runnable");
+  });
+
+  it("refuses only when nothing ran", () => {
+    expect(classifyLaunchProbe({ status: 127 })).toBe("unrunnable");
+    expect(classifyLaunchProbe({ status: 126 })).toBe("unrunnable");
+    expect(classifyLaunchProbe({ status: null, error: "spawn ENOENT" })).toBe("unrunnable");
+  });
+
+  it("keeps a binary that ran and disliked its arguments", () => {
+    // It exists; the registration's own flags may simply not accept a trailing
+    // `--version`, and refusing that would be the probe inventing a defect.
+    expect(classifyLaunchProbe({ status: 2 })).toBe("runnable");
+  });
+
+  it("treats a slow cache as inconclusive, never as a refusal", () => {
+    expect(classifyLaunchProbe({ status: null, timedOut: true })).toBe("inconclusive");
+    expect(classifyLaunchProbe({ status: null, error: "EACCES: permission denied" })).toBe("inconclusive");
+  });
+
+  it("names the canonical form in its refusal, so an operator sees what works", () => {
+    const refusal = launchProbeRefusal("a/b", ["red-skills-dev", "run"]);
+
+    expect(refusal).toContain("npx -y -p @reddb-io/red-skills@<version>");
+    expect(refusal).toContain("ADR 0091");
+    expect(refusal).toContain("a/b");
+  });
+
+  it("probes a real command without a shell, and answers about a missing one", () => {
+    expect(classifyLaunchProbe(defaultLaunchProbe([process.execPath]))).toBe("runnable");
+    expect(classifyLaunchProbe(defaultLaunchProbe(["red-skills-a-binary-that-was-never-published"])))
+      .toBe("unrunnable");
+    expect(classifyLaunchProbe(defaultLaunchProbe([]))).toBe("inconclusive");
+  });
+});
+
+describe("who asks the probe", () => {
+  it("is the serving daemon, not every daemon a test constructs", async () => {
+    const cli = await readFile(join(import.meta.dirname, "..", "src", "cli.ts"), "utf8");
+    const lifecycle = await readFile(join(import.meta.dirname, "..", "src", "daemon", "lifecycle.ts"), "utf8");
+
+    // Running a registration's argv is the one place the daemon touches a
+    // string it otherwise only carries, so the reach is granted by the entry
+    // that serves a real machine rather than assumed by the lifecycle.
+    expect(cli).toContain("probeLaunch: defaultLaunchProbe");
+    expect(lifecycle).not.toContain("options.probeLaunch ?? defaultLaunchProbe");
+  });
+});


### PR DESCRIPTION
Closes #4103. Last slice of Spec #4097.

#4006 birthed 22 Workers from an argv that could not run, and a human found it by reading a log — after the birth breaker latched. The daemon asks at registration instead: **every shipped binary answers `--version` offline without a working machine**, which is what makes it usable as a probe. One process, no work, no side effect.

- Refusal is reserved for *nothing ran*: a spawn error, or the 126/127 a shell gives for a command it could not find or execute. A binary that ran and disliked a trailing `--version` still exists — refusing that would be the probe inventing a defect.
- A timeout or a permission error is **inconclusive**, never a refusal: a cold npx cache is not a broken launch, and refusing on it trades one silent failure for a louder wrong one.
- The refusal names the canonical invocation form (ADR 0091), so an operator reads the shape that works.
- The probe is **off unless the host asks for it.** Running a registration's argv is the one place the daemon touches a string it otherwise only carries, so `serve` grants that reach and the lifecycle never assumes it — which is also why the opacity fixture that registers a deliberately unrunnable argv still passes. Pinned by a test in both directions.

Verified locally: new `launch-probe.test.ts` 8/8; `project-registration`, `unattended-demand` and `daemon-birth` suites green; `pnpm typecheck --force` 17/17; invariants 342/342.

**This closes Spec #4097** — the queue reaches a Worker again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789771207&installation_model_id=20659&pr_number=4111&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4111&signature=37c693d10825e54f0553dea9b00f77b382e7894bd18abac7844a1b7a6dbae7cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->