### PR TITLE
feat(dev): `drain` builds the registration it carries

### DIFF
--- a/.changeset/the-drain-tool-builds-its-registration.md
+++ b/.changeset/the-drain-tool-builds-its-registration.md
@@ -1,0 +1,22 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+`drain` builds the registration it carries
+
+#4101 taught the daemon to accept a registration on a drain and taught the
+adapter to carry one — and nothing built it. Called from a session, `rs_dev`'s
+`drain` still reached the daemon with a target and a runner and no work, so the
+daemon recorded the intent and answered with the warning that nobody would act
+on it. Verified on a live machine: `registered: false` after a successful
+`drain`.
+
+The MCP server now builds it. That is the right place: this process is the one
+that knows what the project's work IS — which repository the checkout is, where
+it stands, which version a birth should reach for — while the tool stays a
+schema and `buildDrainRegistration` stays pure.
+
+**Absent is a real answer.** A directory with no `owner/name` cannot state a
+tracker query, and inventing an owner would register a project the daemon then
+polls for nothing; the drain still records its intent and the daemon still says
+nobody will act on it, which is the truth.

--- a/apps/plugin-dev/src/core/drain-registration-resolve.ts
+++ b/apps/plugin-dev/src/core/drain-registration-resolve.ts
@@ -1,0 +1,55 @@
+// drain-registration-resolve — the checkout half of a registering drain (#4101).
+//
+// `buildDrainRegistration` is pure and knows nothing about where it runs. This
+// is the one place that asks the machine: which repository this checkout is,
+// where it stands, and which version a birth should reach for. Kept apart from
+// the pure builder so the rule stays testable without a git checkout, and kept
+// out of the tool handlers so a tool remains a schema.
+import { resolveProjectIdentityForDir } from "@reddb-io/shared/project-identity-resolve.js";
+import { DEFAULT_FLEET_WIDTH } from "@reddb-io/shared/default-fleet-width.js";
+
+import { buildDrainRegistration, type DrainRegistration } from "./drain-registration.js";
+
+/**
+ * The registration this checkout's drain carries, or `undefined` when the
+ * checkout cannot name a repository.
+ *
+ * **Absent is a real answer.** A directory with no `owner/name` — no git remote
+ * and no declared project — cannot state a tracker query, and inventing one
+ * would register a project the daemon would then poll for nothing. The drain
+ * still records its intent, and the daemon's own warning says nobody will act
+ * on it, which is the truth.
+ */
+export function drainRegistrationFor(
+  root: string,
+  version: string,
+  input: Readonly<Record<string, unknown>> = {},
+  resolve = resolveProjectIdentityForDir,
+): DrainRegistration | undefined {
+  const repo = repositoryOf(root, resolve);
+  if (repo == null) return undefined;
+  const target = typeof input.target === "number" && Number.isInteger(input.target) && input.target >= 0
+    ? input.target
+    : DEFAULT_FLEET_WIDTH;
+  const runner = typeof input.runner === "string" && input.runner.length > 0 ? input.runner : undefined;
+  return buildDrainRegistration({
+    repo,
+    workspacePath: root,
+    target,
+    version,
+    ...(runner == null ? {} : { runner }),
+  });
+}
+
+/** `owner/name` for this checkout, or `undefined` when it has no such identity. PURE-ish. */
+export function repositoryOf(root: string, resolve = resolveProjectIdentityForDir): string | undefined {
+  let name: string;
+  try {
+    name = resolve(root).name;
+  } catch {
+    return undefined;
+  }
+  // A tracker query needs `owner/name`; a bare basename is a checkout nobody
+  // can turn into a repository query, and guessing an owner would be worse.
+  return /^[^/\s]+\/[^/\s]+$/.test(name) ? name : undefined;
+}

--- a/apps/plugin-dev/src/mcp-server.ts
+++ b/apps/plugin-dev/src/mcp-server.ts
@@ -14,6 +14,7 @@ import {
 } from "./mcp-tools/index.js";
 import { encodeRedskilledMcpToon } from "./mcp-toon.js";
 import { invokeProjectMcp } from "./project-acp-adapter.js";
+import { drainRegistrationFor } from "./core/drain-registration-resolve.js";
 import {
   registerLaneEventSubscription,
   type LaneSubscriptionServer,
@@ -46,6 +47,15 @@ export function createRedskilledMcpServer(
     throw new Error("REDSKILLED_ACP_UNAVAILABLE: the stdio adapter has no ACP client");
   });
   const dependencies = {} as CastleMcpDependencies;
+  // **A drain that carries no work registers nothing** (#4101). The daemon
+  // births only for a registration, and this process is the one that knows what
+  // this project's work IS — a repository, a ready label, a target. Building it
+  // here rather than in a tool handler keeps the tool a schema and the semantics
+  // where the checkout is.
+  const enrich = (tool: string, input: Record<string, unknown>): Record<string, unknown> =>
+    tool === "drain" && input.registration == null
+      ? { ...input, registration: drainRegistrationFor(root, buildInfo.version, input) }
+      : input;
   for (const tool of createCastleMcpTools(dependencies)) {
     registerTool(
       tool.name,
@@ -59,7 +69,7 @@ export function createRedskilledMcpServer(
           {
             type: "text" as const,
             text: encodeRedskilledMcpToon(
-              await invoke(tool.name, input),
+              await invoke(tool.name, enrich(tool.name, input)),
             ),
           },
         ],

--- a/apps/plugin-dev/tests/drain-registration-resolve.test.ts
+++ b/apps/plugin-dev/tests/drain-registration-resolve.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { drainRegistrationFor, repositoryOf } from "../src/core/drain-registration-resolve.js";
+import { DRAIN_WORKER_PROMPT } from "../src/core/drain-registration.js";
+
+/**
+ * A drain that carries no work registers nothing.
+ *
+ * The daemon births only for a registration, and the checkout is the one thing
+ * that knows what this project's work IS. This is the seam that asks the
+ * machine; the builder it calls stays pure.
+ */
+describe("the registration a checkout's drain carries", () => {
+  it("names the repository, the workspace and the version a birth reaches for", () => {
+    const registration = drainRegistrationFor(
+      "/home/op/src/red-skills",
+      "4.0.1",
+      { target: 2, runner: "redcode" },
+      () => ({ name: "reddb-io/red-skills" }) as never,
+    );
+
+    expect(registration).toMatchObject({
+      workspace_path: "/home/op/src/red-skills",
+      target: 2,
+      prompt: DRAIN_WORKER_PROMPT,
+    });
+    expect(registration?.argv).toContain("@reddb-io/red-skills@4.0.1");
+    expect(registration?.argv).toContain("redcode");
+  });
+
+  it("falls back to the default width when the caller states none", () => {
+    expect(drainRegistrationFor("/home/op/src/red-skills", "4.0.1", {}, () => ({ name: "a/b" }) as never)?.target)
+      .toBe(1);
+  });
+
+  it("says nothing for a checkout that cannot name a repository", () => {
+    // Absent is a real answer: inventing an owner would register a project the
+    // daemon then polls for nothing.
+    expect(repositoryOf("/tmp/scratch", () => ({ name: "scratch" }) as never)).toBeUndefined();
+    expect(repositoryOf("/tmp/scratch", () => { throw new Error("not a checkout"); })).toBeUndefined();
+  });
+
+  it("accepts the owner/name a checkout does state", () => {
+    expect(repositoryOf("/x", () => ({ name: "reddb-io/red-skills" }) as never)).toBe("reddb-io/red-skills");
+  });
+});


### PR DESCRIPTION
Found by running it on a live machine at 4.0.1: `rs_dev drain { target: 1, runner: "redcode" }` reached the daemon, echoed both arguments — and came back with

> `registered: false` · *"this Project holds no registration, so the daemon polls no queue and births no Worker for it"*

#4101 taught the daemon to accept a registration on a drain, and the adapter to carry one. **Nothing built it.** The tool sent a target and a runner and no work.

- The MCP server builds it now, from the checkout it runs in: repository identity, workspace path, the version a birth reaches for, the caller's target and runner. That is the right place — this process is the one that knows what the project's work IS, while the tool stays a schema and `buildDrainRegistration` stays pure.
- **Absent is a real answer.** A directory with no `owner/name` cannot state a tracker query, and inventing an owner would register a project the daemon then polls for nothing. The drain still records its intent, and the daemon still says nobody will act on it.
- The identity resolver is injectable, so the rule is tested without a git checkout.

Verified locally: new `drain-registration-resolve.test.ts` 4/4; adapter parity and `drain-registration` suites 10/10; `pnpm typecheck --force` 17/17; invariants 342/342.

After this lands and ships, a `drain` from a session registers, the daemon polls, and a queued issue becomes a Worker — the last wire of Spec #4097 in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789783158&installation_model_id=20659&pr_number=4116&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4116&signature=1d8aeaed225b180f60023b7cbe328014c11ced831e011b97172c189bc6149bec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->