### PR TITLE
fix(release): the set carries v1 beside v2 until the readers have flipped

### DIFF
--- a/.changeset/the-set-carries-v1-beside-v2.md
+++ b/.changeset/the-set-carries-v1-beside-v2.md
@@ -1,0 +1,29 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The Release carries v1 beside v2 until the readers have flipped
+
+**A schema bump is only landed when its readers can read it.** `red.package-set.v2`
+moved `version`, `channel` and `targets` inside the signed identity and took the
+canonical manifest name in 4.0.0 — which is exactly when red-dev, whose verifier
+mirrors v1 key-for-key, began refusing every set from that release:
+
+```
+fail red-skills package set refused (manifest): manifest shape or key order is not canonical
+     current is unchanged — the machine keeps the set it already resolves
+```
+
+A machine that cannot install the release cannot be told about the release. It
+sat on 3.22.0 with a partial update whose host reconciliation had failed for
+hours before anyone read the reason.
+
+So a Release now attaches both: `package-set.manifest.json` keeps the canonical
+name and the v1 shape every existing verifier knows, and `package-set.manifest.v2.json`
+rides beside it with its own signature. Both come from one pass over the same
+artifacts, so they cannot describe different sets, and the shipped verifier
+checks either — `--require-target` still needs v2 and says so instead of reading
+a field a v1 manifest does not have.
+
+The canonical name flips to v2 when the readers have flipped, and v1 leaves
+then, not before.

--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -764,12 +764,19 @@ jobs:
           while IFS= read -r target; do
             target_args+=(--target "$target")
           done < <(node scripts/workstation-package-set.mjs --targets)
+          # TWO manifests while the readers migrate (#4005): the canonical name
+          # keeps the v1 shape every existing verifier mirrors — red-dev refused
+          # every 4.0.x set with "manifest shape or key order is not canonical"
+          # the moment v2 took that name — and v2 rides beside it under its own
+          # name and its own signature. Both describe the same artifacts,
+          # derived from one build rather than assembled twice.
           node scripts/build-package-set.mjs \
             --source-commit "$SOURCE_COMMIT" \
             --release-version "$VERSION" \
             --channel stable \
             "${target_args[@]}" \
-            --out dist/package-set.manifest.json \
+            --out dist/package-set.manifest.v2.json \
+            --legacy-out dist/package-set.manifest.json \
             "${build_args[@]}"
           # The Sigstore bundle format (--new-bundle-format) carries the
           # certificate, signature, and Rekor entry with its inclusion proof,
@@ -787,6 +794,11 @@ jobs:
             --new-bundle-format \
             --bundle dist/package-set.manifest.sigstore.json \
             dist/package-set.manifest.json
+          cosign sign-blob \
+            --yes \
+            --new-bundle-format \
+            --bundle dist/package-set.manifest.v2.sigstore.json \
+            dist/package-set.manifest.v2.json
           cosign initialize
           trusted_root="$HOME/.sigstore/root/tuf-repo-cdn.sigstore.dev/targets/trusted_root.json"
           [ -f "$trusted_root" ] || { echo "cosign initialize did not cache $trusted_root" >&2; exit 1; }
@@ -808,6 +820,14 @@ jobs:
               --cosign-bin "$(command -v cosign)" \
               --trusted-root "$trusted_root"
           sudo rm -rf "$expansion"
+          # The v2 manifest is verified with the same offline recipe, so a set
+          # that signs it and cannot check it never leaves the runner.
+          sudo --preserve-env=HOME unshare --net -- \
+            "$(command -v node)" dist/verify-package-set.mjs \
+              --manifest dist/package-set.manifest.v2.json \
+              --bundle dist/package-set.manifest.v2.sigstore.json \
+              --cosign-bin "$(command -v cosign)" \
+              --trusted-root "$trusted_root"
 
       # ADR 0091: npm is the ONLY client transport. Stage the built bundles into
       # the packaging/npm package, pnpm pack it, then run the REAL client resolver

--- a/scripts/PACKAGE-SET-SCHEMA.md
+++ b/scripts/PACKAGE-SET-SCHEMA.md
@@ -55,9 +55,30 @@ node verify-package-set.mjs \
 without it the verifier checks everything else and reports the declared targets
 on its success line.
 
-## `red.package-set.v1` (superseded)
+## Which file carries which schema
 
-v1 carried `schema`, `sourceCommit`, `artifacts`, `wholeSetDigest` and nothing
+While readers migrate, a Release attaches **both**:
+
+| File | Schema | Who reads it |
+| --- | --- | --- |
+| `package-set.manifest.json` | v1 | every existing verifier, including red-dev's mirror |
+| `package-set.manifest.v2.json` | v2 | readers that need version, channel or targets |
+
+Each has its own Sigstore bundle (`…sigstore.json` beside it), and both are
+built from one pass over the same artifacts, so they cannot describe different
+sets. **The canonical name flips to v2 when the readers have flipped, and v1
+leaves then — not before.** v2 taking that name in 4.0.0 is what made red-dev
+refuse every set from that release with `manifest shape or key order is not
+canonical`, and a machine that cannot install the release cannot be told about
+the release.
+
+The shipped `verify-package-set.mjs` verifies either one. `--require-target`
+needs v2 and says so against a v1 manifest rather than reading a field that is
+absent.
+
+## `red.package-set.v1` (still canonical during the transition)
+
+v1 carries `schema`, `sourceCommit`, `artifacts`, `wholeSetDigest` and nothing
 else. **Adding a key could not be a compatible change**: the canonical key-set
 check makes any addition a different shape, and a key outside the identity would
 sit outside the signature — which is exactly the flaw v2 repairs. `version`,

--- a/scripts/build-package-set.mjs
+++ b/scripts/build-package-set.mjs
@@ -8,6 +8,23 @@ import { pathToFileURL } from "node:url";
 export const PACKAGE_SET_SCHEMA = "red.package-set.v2";
 
 /**
+ * The schema every existing consumer still reads.
+ *
+ * **A schema bump is only landed when its readers can read it.** v2 moved
+ * `version`, `channel` and `targets` inside the signed identity (#4005) and
+ * went out as the canonical manifest in 4.0.0 — which is exactly when red-dev,
+ * whose verifier mirrors v1 key-for-key, began refusing every set with
+ * `manifest shape or key order is not canonical`. A machine that could not
+ * install the release could not be told about the release.
+ *
+ * So the set carries BOTH during the transition: `package-set.manifest.json`
+ * stays v1, the name and shape every reader already knows, and v2 rides beside
+ * it under its own name and its own signature. The canonical name flips when
+ * the readers have flipped, and v1 leaves then — not before.
+ */
+export const PACKAGE_SET_LEGACY_SCHEMA = "red.package-set.v1";
+
+/**
  * The closed channel vocabulary (#4005). A consumer that reads `channel` has to
  * be able to decide on it, so the value is one of a named set rather than free
  * text: `stable` is what the release publishes, `canary` is the opt-in dist-tag
@@ -107,6 +124,20 @@ export function createPackageSet({ sourceCommit, version, channel, targets, arti
   };
 }
 
+/**
+ * The v1 view of the same artifacts: the identity v1 readers verify, byte for
+ * byte as they have always seen it. Derived from the same inputs rather than
+ * built a second time, so the two manifests cannot describe different sets.
+ */
+export function legacyPackageSet(manifest) {
+  const identity = {
+    schema: PACKAGE_SET_LEGACY_SCHEMA,
+    sourceCommit: manifest.sourceCommit,
+    artifacts: manifest.artifacts,
+  };
+  return { ...identity, wholeSetDigest: sha256(packageSetIdentityBytes(identity)) };
+}
+
 export function encodePackageSet(manifest) {
   return Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
 }
@@ -130,6 +161,9 @@ function parseArgs(argv) {
       index += 1;
     } else if (argument === "--target" && value) {
       options.targets.push(value);
+      index += 1;
+    } else if (argument === "--legacy-out" && value) {
+      options.legacyOut = value;
       index += 1;
     } else if (argument === "--out" && value) {
       options.out = value;
@@ -158,6 +192,13 @@ export function main(argv = process.argv.slice(2)) {
   const out = resolve(options.out);
   mkdirSync(dirname(out), { recursive: true });
   writeFileSync(out, encodePackageSet(manifest));
+  if (options.legacyOut) {
+    const legacy = legacyPackageSet(manifest);
+    const legacyPath = resolve(options.legacyOut);
+    mkdirSync(dirname(legacyPath), { recursive: true });
+    writeFileSync(legacyPath, encodePackageSet(legacy));
+    process.stdout.write(`${legacy.wholeSetDigest}\n`);
+  }
   process.stdout.write(`${manifest.wholeSetDigest}\n`);
 }
 

--- a/scripts/test-package-set-contract.sh
+++ b/scripts/test-package-set-contract.sh
@@ -258,6 +258,53 @@ if grep -Eq 'fetch\(|https?\.request|node:(http|https|net|tls|dns)' scripts/expa
 fi
 pass "expander has no network client"
 
+# --- both schemas ride together while the readers migrate (#4005) ------------
+#
+# v2 took the canonical manifest name in 4.0.0 and red-dev — whose verifier
+# mirrors v1 key-for-key — refused every set from that release with "manifest
+# shape or key order is not canonical". A machine that cannot install the
+# release cannot be told about the release. So the canonical name keeps the v1
+# shape until the readers have flipped, and v2 rides beside it.
+
+build_both() {
+  node scripts/build-package-set.mjs \
+    --source-commit "$source_commit" \
+    --release-version "$fixture_version" \
+    --channel "$fixture_channel" \
+    --target "$fixture_target" \
+    --out "$tmp/both.v2.json" \
+    --legacy-out "$tmp/both.v1.json" \
+    --asset "$tmp/assets/alpha.bin" \
+    --asset "$tmp/assets/beta.bin" >/dev/null
+}
+
+build_both
+node -e "
+  const v1 = require('$tmp/both.v1.json');
+  const v2 = require('$tmp/both.v2.json');
+  if (v1.schema !== 'red.package-set.v1') process.exit(11);
+  if (v2.schema !== 'red.package-set.v2') process.exit(12);
+  if (JSON.stringify(Object.keys(v1)) !== JSON.stringify(['schema','sourceCommit','artifacts','wholeSetDigest'])) process.exit(13);
+  if (JSON.stringify(v1.artifacts) !== JSON.stringify(v2.artifacts)) process.exit(14);
+  if (v1.wholeSetDigest === v2.wholeSetDigest) process.exit(15);
+" || fail "the two manifests must describe the same artifacts under their own identities"
+pass "one build emits both schemas over the same artifacts"
+
+cp "$tmp/both.v1.json" "$tmp/assets/package-set.manifest.json"
+sign_fixture "$tmp/assets/package-set.manifest.json" "$tmp/assets/legacy.sigstore.json"
+verify "$tmp/assets/package-set.manifest.json" "$tmp/assets/legacy.sigstore.json" >/dev/null ||
+  fail "the shipped verifier must still verify a v1 manifest"
+pass "the shipped verifier verifies the v1 manifest a migrating reader still reads"
+
+if node scripts/verify-package-set.mjs \
+  --manifest "$tmp/assets/package-set.manifest.json" \
+  --bundle "$tmp/assets/legacy.sigstore.json" \
+  --cosign-bin "$tmp/bin/cosign" \
+  --require-target linux-x64 >/dev/null 2>&1; then
+  fail "--require-target must refuse a v1 manifest, which states no targets"
+fi
+pass "a target requirement refuses a v1 manifest rather than reading one that is absent"
+
 # --- the signed identity carries version, channel and targets (#4005) --------
 #
 # red-dev verifies the published set before it moves `~/.red/skills/current`,
@@ -467,7 +514,8 @@ pass "developer-only artifacts stay out of the workstation package set"
 # The upload is a superset: it also carries the published developer-only
 # evidence and the signed manifest with its Sigstore bundle.
 mapfile -t release_assets < <(node scripts/workstation-package-set.mjs --github-release --version 9.9.9)
-for asset in "${declared_workstation[@]}" dist/package-set.manifest.json dist/package-set.manifest.sigstore.json; do
+for asset in "${declared_workstation[@]}" dist/package-set.manifest.json dist/package-set.manifest.sigstore.json \
+  dist/package-set.manifest.v2.json dist/package-set.manifest.v2.sigstore.json; do
   printf '%s\n' "${release_assets[@]}" | grep -qxF "$asset" || fail "release upload must carry $asset"
 done
 if printf '%s\n' "${release_assets[@]}" | grep -qxF dist/release.bundle.min.mjs; then

--- a/scripts/verify-package-set.mjs
+++ b/scripts/verify-package-set.mjs
@@ -6,6 +6,10 @@ import { basename, dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 
 const SCHEMA = "red.package-set.v2";
+// The schema every existing reader still verifies. A set carries both while the
+// readers migrate (#4005): refusing v1 here would make the shipped verifier
+// unable to check the manifest the release still names canonically.
+const LEGACY_SCHEMA = "red.package-set.v1";
 const COMMIT = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
 const VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
@@ -15,6 +19,7 @@ const VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
 const CHANNELS = ["stable", "canary", "next", "pinned"];
 const TARGETS = ["linux-x64", "windows-x64"];
 const EXPECTED_KEYS = ["schema", "sourceCommit", "version", "channel", "targets", "artifacts", "wholeSetDigest"];
+const LEGACY_EXPECTED_KEYS = ["schema", "sourceCommit", "artifacts", "wholeSetDigest"];
 const EXPECTED_ARTIFACT_KEYS = ["name", "sourceCommit", "size", "sha256"];
 const GITHUB_ISSUER = "https://token.actions.githubusercontent.com";
 const RELEASE_IDENTITY =
@@ -80,19 +85,26 @@ function parseAndValidateManifest(manifestPath) {
   } catch {
     fail("manifest is not valid JSON");
   }
-  if (!sameKeys(manifest, EXPECTED_KEYS)) fail("manifest shape or key order is not canonical");
-  if (manifest.schema !== SCHEMA) fail(`unsupported manifest schema: ${String(manifest.schema)}`);
-  if (!COMMIT.test(manifest.sourceCommit)) fail("manifest source commit is invalid");
-  if (typeof manifest.version !== "string" || !VERSION.test(manifest.version)) fail("manifest version is invalid");
-  if (!CHANNELS.includes(manifest.channel)) fail(`manifest channel is not a known channel: ${String(manifest.channel)}`);
-  if (!Array.isArray(manifest.targets) || manifest.targets.length === 0) {
-    fail("manifest must declare at least one target");
+  const legacy = manifest?.schema === LEGACY_SCHEMA;
+  if (!sameKeys(manifest, legacy ? LEGACY_EXPECTED_KEYS : EXPECTED_KEYS)) {
+    fail("manifest shape or key order is not canonical");
   }
-  let priorTarget = "";
-  for (const target of manifest.targets) {
-    if (!TARGETS.includes(target)) fail(`manifest declares an unknown target: ${String(target)}`);
-    if (priorTarget && priorTarget.localeCompare(target, "en") >= 0) fail("targets must be unique and sorted");
-    priorTarget = target;
+  if (manifest.schema !== SCHEMA && !legacy) fail(`unsupported manifest schema: ${String(manifest.schema)}`);
+  if (!COMMIT.test(manifest.sourceCommit)) fail("manifest source commit is invalid");
+  if (!legacy) {
+    if (typeof manifest.version !== "string" || !VERSION.test(manifest.version)) fail("manifest version is invalid");
+    if (!CHANNELS.includes(manifest.channel)) {
+      fail(`manifest channel is not a known channel: ${String(manifest.channel)}`);
+    }
+    if (!Array.isArray(manifest.targets) || manifest.targets.length === 0) {
+      fail("manifest must declare at least one target");
+    }
+    let priorTarget = "";
+    for (const target of manifest.targets) {
+      if (!TARGETS.includes(target)) fail(`manifest declares an unknown target: ${String(target)}`);
+      if (priorTarget && priorTarget.localeCompare(target, "en") >= 0) fail("targets must be unique and sorted");
+      priorTarget = target;
+    }
   }
   if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length === 0) {
     fail("manifest must declare at least one artifact");
@@ -124,14 +136,16 @@ function parseAndValidateManifest(manifestPath) {
     if (!SHA256.test(artifact.sha256)) fail(`artifact ${artifact.name} has an invalid checksum`);
   }
 
-  const identity = {
-    schema: manifest.schema,
-    sourceCommit: manifest.sourceCommit,
-    version: manifest.version,
-    channel: manifest.channel,
-    targets: manifest.targets,
-    artifacts: manifest.artifacts,
-  };
+  const identity = legacy
+    ? { schema: manifest.schema, sourceCommit: manifest.sourceCommit, artifacts: manifest.artifacts }
+    : {
+      schema: manifest.schema,
+      sourceCommit: manifest.sourceCommit,
+      version: manifest.version,
+      channel: manifest.channel,
+      targets: manifest.targets,
+      artifacts: manifest.artifacts,
+    };
   const expectedDigest = sha256(Buffer.from(`${JSON.stringify(identity)}\n`));
   if (manifest.wholeSetDigest !== expectedDigest) fail("whole-set digest does not match the manifest identity");
   const canonicalBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
@@ -194,12 +208,17 @@ try {
   if (!existsSync(options.manifestPath)) fail("manifest is missing");
   verifySignature(options);
   const manifest = parseAndValidateManifest(options.manifestPath);
+  if (options.requireTarget && manifest.schema === LEGACY_SCHEMA) {
+    fail("--require-target needs a v2 manifest: a v1 set states no targets");
+  }
   if (options.requireTarget && !manifest.targets.includes(options.requireTarget)) {
     fail(`package set was not built for ${options.requireTarget} (targets: ${manifest.targets.join(", ")})`);
   }
   verifyArtifacts(manifest, options.manifestPath);
   process.stdout.write(
-    `verified package set ${manifest.wholeSetDigest} (${manifest.version}, ${manifest.channel}, ${manifest.targets.join(" ")})\n`,
+    manifest.schema === LEGACY_SCHEMA
+      ? `verified package set ${manifest.wholeSetDigest} (${LEGACY_SCHEMA})\n`
+      : `verified package set ${manifest.wholeSetDigest} (${manifest.version}, ${manifest.channel}, ${manifest.targets.join(" ")})\n`,
   );
 } catch (error) {
   process.stderr.write(`package-set verification failed: ${error instanceof Error ? error.message : String(error)}\n`);

--- a/scripts/workstation-package-set.mjs
+++ b/scripts/workstation-package-set.mjs
@@ -100,7 +100,20 @@ export const DEVELOPER_ONLY_ARTIFACTS = [
 ];
 
 /** The signed manifest and its Sigstore bundle: attached, never members of the set they describe. */
-export const PACKAGE_SET_SIGNATURE_ASSETS = ["dist/package-set.manifest.json", "dist/package-set.manifest.sigstore.json"];
+/**
+ * The manifests the Release attaches, each with its own signature.
+ *
+ * Two, while the readers migrate (#4005): `package-set.manifest.json` keeps the
+ * canonical name and the v1 shape every existing verifier mirrors, and the v2
+ * manifest — the one whose identity covers version, channel and targets — rides
+ * beside it. The canonical name flips when the readers have flipped.
+ */
+export const PACKAGE_SET_SIGNATURE_ASSETS = [
+  "dist/package-set.manifest.json",
+  "dist/package-set.manifest.sigstore.json",
+  "dist/package-set.manifest.v2.json",
+  "dist/package-set.manifest.v2.sigstore.json",
+];
 
 const VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
 


### PR DESCRIPTION
**A schema bump is only landed when its readers can read it.**

`red.package-set.v2` (#4090) moved `version`, `channel` and `targets` inside the signed identity and took the canonical manifest name in 4.0.0 — which is exactly when red-dev, whose verifier mirrors v1 key-for-key, began refusing every set from that release. Observed on a live machine tonight:

```
$ red-dev red-skills install 4.0.1
fail red-skills package set refused (manifest): manifest shape or key order is not canonical
     current is unchanged — the machine keeps the set it already resolves
```

That machine sat on 3.22.0 for hours with `outcome: partial` and its host reconciliation failed — **a machine that cannot install the release cannot be told about the release.**

- A Release attaches **both** manifests: `package-set.manifest.json` keeps the canonical name and the v1 shape every existing verifier knows; `package-set.manifest.v2.json` rides beside it with its own Sigstore bundle.
- Both come from **one pass over the same artifacts** (`legacyPackageSet` derives the v1 identity from the v2 model), so they cannot describe different sets — pinned by a contract case that compares their artifact lists and requires their digests to differ.
- The shipped `verify-package-set.mjs` verifies either. `--require-target` needs v2 and says so against a v1 manifest rather than reading a field that is absent.
- The publish signs and offline-verifies both, so a set that signs a manifest it cannot check never leaves the runner.
- `PACKAGE-SET-SCHEMA.md` states which file carries which schema and when the canonical name flips — when the readers have flipped, and v1 leaves then, not before.

Verified locally: `scripts/test-package-set-contract.sh` 30/30 including three new cases; `scripts/rehearse-release-pack.sh` → *"OK — the package set at 0.0.0-rehearsal.0 is installable"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789783900&installation_model_id=20659&pr_number=4117&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4117&signature=db7c0be370daf20ce60a19a822702497c46728a91c5bceaf60fef07777a6a6df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->