### PR TITLE
fix(redskilled): the unattended turn opens the session it prompts in

### DIFF
--- a/.changeset/the-unattended-turn-opens-its-session.md
+++ b/.changeset/the-unattended-turn-opens-its-session.md
@@ -1,0 +1,23 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The unattended turn opens the session it prompts in
+
+The first real drain on 4.0.2 got all the way to the birth and stopped there.
+The daemon polled, kept the identifier, planned the Worker — `depth: 1`,
+`posture: asking`, `items: ["4118"]` — and then the host lane said:
+
+```
+the unattended turn for project "reddb-io/red-skills" failed:
+unknown durable RedSkills ACP session
+```
+
+**A turn nobody opened is a turn the journal refuses.** Admission and every
+checkpoint key off a durable session record, and the demand turn invented a
+synthetic session id without opening one — so every unattended turn died at
+admission, in a way no surface could explain from the outside.
+
+It now opens its own session exactly as `session/new` opens a client's, before
+admitting. Pinned by a test, because this failure is invisible in every
+projection except the host event lane.

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -217,6 +217,13 @@ export function createDemandTurnRunner(
     const notify: AgentConnection["client"]["notify"] = async () => {};
 
     try {
+      // **A turn nobody opened is a turn the journal refuses.** Admission and
+      // every checkpoint key off a durable session record, so an unattended
+      // turn has to open its own exactly as `session/new` opens a client's —
+      // otherwise the demand loop reaches admission and dies on "unknown
+      // durable RedSkills ACP session", which is a birth nobody can explain
+      // from the outside (observed on 4.0.2, issue #4118's first drain).
+      await deps.sessionJournal.create(sessionId, request.project);
       const { worker, response } = await requestWorkflowTurn(
         sessionId,
         active,

--- a/apps/redskilled/tests/demand-turn.test.ts
+++ b/apps/redskilled/tests/demand-turn.test.ts
@@ -41,16 +41,20 @@ function workerStub(response: unknown, workerId = "W1"): ActiveWorkflowWorker & 
 function runner(
   admit: (input: DemandTurnAdmission) => Promise<ActiveWorkflowWorker>,
   records: DemandTurnRecord[] = [],
+  opened: Array<{ sessionId: string }> = [],
 ) {
   return {
     records,
+    opened,
     run: createDemandTurnRunner({
       paths: {} as never,
       startWorker: (() => {
         throw new Error("an injected admission owns the birth in this test");
       }) as never,
       hostState: () => ({ workers: [] }),
-      sessionJournal: {} as never,
+      sessionJournal: {
+        create: async (sessionId: string) => void opened.push({ sessionId }),
+      } as never,
       admit,
       record: (line) => records.push(line),
     }),
@@ -120,6 +124,16 @@ describe("the daemon's unattended turn", () => {
 
     expect(new Set(seen).size).toBe(2);
     expect(seen.every((id) => id.includes("github:1"))).toBe(true);
+  });
+
+  it("opens its own durable session before admitting — the journal refuses a turn nobody opened", async () => {
+    const opened: Array<{ sessionId: string }> = [];
+    const { run } = runner(async () => workerStub({ stopReason: "end_turn" }), [], opened);
+
+    await run({ project, prompt: "go", workItem: "4118" });
+
+    expect(opened).toHaveLength(1);
+    expect(opened[0]?.sessionId).toContain("github:1");
   });
 
   it("refuses permission on nobody's behalf, and says why", async () => {


### PR DESCRIPTION
Found by the first real drain, on 4.0.2, against issue #4118.

The daemon did everything right up to the birth: polled the queue, kept the identifier (#4098), planned the Worker — `registered: true`, `depth: 1`, `posture: asking`, `items: ["4118"]` — and then the host event lane said:

```
the unattended turn for project "reddb-io/red-skills" failed: unknown durable RedSkills ACP session
```

**A turn nobody opened is a turn the journal refuses.** Admission and every checkpoint key off a durable session record; the demand turn invented a synthetic session id and never opened one, so every unattended turn died at admission — and died invisibly: `project_status` just kept saying `asking` with `workers: 0`, which reads like a host that is busy rather than one that is failing.

It now calls `sessionJournal.create(sessionId, project)` before admitting, exactly as `session/new` does for a client. Pinned by a test, because the only surface that showed this was the event lane.

Verified locally: `demand-turn.test.ts` 10/10 with the new case; `acp-control-plane` and the end-to-end `unattended-demand` suites green (23/23 together); `pnpm typecheck --force` 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789788439&installation_model_id=20659&pr_number=4119&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4119&signature=33192850fe3671e4e0fb24b71bfefbe6ee8b192a3e2b0b74e20caeb33730d0a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->