### PR TITLE
fix(redskilled): an unattended turn says how it ended

### DIFF
--- a/.changeset/the-unattended-turn-says-how-it-ended.md
+++ b/.changeset/the-unattended-turn-says-how-it-ended.md
@@ -1,0 +1,21 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+An unattended turn says how it ended
+
+The first Worker born by a real drain lived 600 ms and exited cleanly, and no
+surface said why. `project_status` kept reporting `posture: asking`,
+`workers: 0` — which reads like a host that is busy rather than one whose turn
+already finished — because only the FAILURE path of a demand turn reached a
+surface. A turn that completed wrote nothing anywhere.
+
+The daemon now narrates every unattended turn on its own journal, naming the
+project, the work item, the Worker and the outcome. The outcome carries both
+halves: the workflow outcome when the Worker stated one, and the stop reason
+beside it either way — `completed` and `end_turn` are different sentences, and
+a turn that ends in under a second is only legible when the record says which
+one ended it.
+
+**Silence looked like health**, which is the third time this shape has cost a
+diagnosis in this lane.

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -104,6 +104,21 @@ export interface DemandTurnRecord {
   readonly detail?: string;
 }
 
+/**
+ * One unattended turn's outcome as a line an operator reads. PURE.
+ *
+ * Lives beside the record it renders rather than at the journal call site: the
+ * daemon's lifecycle decides WHERE narration goes, never what it says.
+ */
+export function describeDemandTurn(record: DemandTurnRecord): string {
+  return (
+    `redskilled: unattended turn ${record.event} for project ${JSON.stringify(record.project_label)}` +
+    `${record.work_item == null ? "" : ` on item ${record.work_item}`}` +
+    `${record.worker_id == null ? "" : ` (worker ${record.worker_id})`}` +
+    `${record.detail == null ? "" : `: ${record.detail}`}\n`
+  );
+}
+
 export interface DemandTurnRequest {
   readonly project: AcpProjectWorkspace;
   /** The project's prompt, with this birth's facts already written into it. */

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -245,7 +245,11 @@ export function createDemandTurnRunner(
           replacement,
         }),
       );
-      const outcome = workflowOutcome(response) ?? response.stopReason;
+      // The workflow outcome when the Worker stated one, and the stop reason
+      // beside it either way: "end_turn" and "completed" are different
+      // sentences, and a turn that ended in under a second is only legible if
+      // the record says which of the two it was.
+      const outcome = `${workflowOutcome(response) ?? "no-workflow-outcome"} (${response.stopReason})`;
       record("demand-turn-completed", worker, outcome);
       // The turn is the Worker's whole life: it was admitted for one work item
       // and has now finished it, so it is reaped here rather than left on an

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -76,7 +76,7 @@ import {
   launchProbeArgv,
   launchProbeRefusal,
 } from "../launch-probe.js";
-import { demandTurnForBirth } from "../acp-demand-turn.js";
+import { demandTurnForBirth, describeDemandTurn } from "../acp-demand-turn.js";
 import { createRedskilledRegistrationIntentStore } from "../registration-intent-store.js";
 import {
   buildRegistrationLapse,
@@ -2400,23 +2400,11 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       hostState,
       ...(options.githubGateway == null ? {} : { githubGateway: options.githubGateway }),
       ...(options.evidenceTtlMs == null ? {} : { evidenceTtlMs: options.evidenceTtlMs }),
-      // The one registration path, handed to the endpoint that now needs it
-      // (#4101): a drain that carries its work registers through the same
-      // function `project-register` does, sweep, breaker and all.
+      // The one registration path (#4101): a drain that carries its work
+      // registers through the same function `project-register` does.
       registerProject: (request) => registerProject(request),
-      // **A turn that completes says so.** Only the failure path reached a
-      // surface, so an unattended turn that ended in 600ms looked exactly like
-      // one still working: `posture: asking`, `workers: 0`, and nothing
-      // anywhere naming the outcome. The daemon's own journal is where an
-      // operator already reads its narration, and it costs no lane schema.
-      recordDemandTurn: (record) => {
-        process.stderr.write(
-          `redskilled: unattended turn ${record.event} for project ${JSON.stringify(record.project_label)}` +
-            `${record.work_item == null ? "" : ` on item ${record.work_item}`}` +
-            `${record.worker_id == null ? "" : ` (worker ${record.worker_id})`}` +
-            `${record.detail == null ? "" : `: ${record.detail}`}\n`,
-        );
-      },
+      // **A turn that completes says so** — only its failure path had a surface.
+      recordDemandTurn: (record) => void process.stderr.write(describeDemandTurn(record)),
     });
   } catch (error) {
     await stop({ reason: "requested", note: "ACP control plane failed to bind" }).catch(() => undefined);

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -2404,6 +2404,19 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       // (#4101): a drain that carries its work registers through the same
       // function `project-register` does, sweep, breaker and all.
       registerProject: (request) => registerProject(request),
+      // **A turn that completes says so.** Only the failure path reached a
+      // surface, so an unattended turn that ended in 600ms looked exactly like
+      // one still working: `posture: asking`, `workers: 0`, and nothing
+      // anywhere naming the outcome. The daemon's own journal is where an
+      // operator already reads its narration, and it costs no lane schema.
+      recordDemandTurn: (record) => {
+        process.stderr.write(
+          `redskilled: unattended turn ${record.event} for project ${JSON.stringify(record.project_label)}` +
+            `${record.work_item == null ? "" : ` on item ${record.work_item}`}` +
+            `${record.worker_id == null ? "" : ` (worker ${record.worker_id})`}` +
+            `${record.detail == null ? "" : `: ${record.detail}`}\n`,
+        );
+      },
     });
   } catch (error) {
     await stop({ reason: "requested", note: "ACP control plane failed to bind" }).catch(() => undefined);

--- a/apps/redskilled/tests/demand-turn.test.ts
+++ b/apps/redskilled/tests/demand-turn.test.ts
@@ -68,7 +68,7 @@ describe("the daemon's unattended turn", () => {
 
     const result = await run({ project, prompt: "work item 4100", workItem: "4100" });
 
-    expect(result).toMatchObject({ workerId: "W1", outcome: "end_turn" });
+    expect(result).toMatchObject({ workerId: "W1", outcome: "no-workflow-outcome (end_turn)" });
     expect(worker.prompted).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ prompt: [{ type: "text", text: "work item 4100" }] }),
@@ -97,6 +97,9 @@ describe("the daemon's unattended turn", () => {
         project_label: "reddb-io/red-skills",
         work_item: "4100",
         worker_id: "W1",
+        // The stop reason rides along: a turn that ended in under a second is
+        // only legible when the record says which sentence ended it.
+        detail: "no-workflow-outcome (end_turn)",
       }),
     ]);
   });


### PR DESCRIPTION
The first Worker born by a real drain (issue #4118, on 4.0.3) lived **600 ms** and exited cleanly — and no surface said why.

```
05:35:08  worker-birth   VSoQIio  /tmp/red-skills-1000/workers/VSoQIio/worktree
05:35:09  worker-death   VSoQIio  systemd result=success
```

`project_status` kept reporting `posture: asking`, `workers: 0`, which reads like a host that is busy rather than one whose turn already finished. The cause is that only the **failure** path of a demand turn reached a surface (#4108 wired the catch to the event lane); a turn that completed wrote nothing anywhere.

- The daemon narrates every unattended turn on its own journal — project, work item, Worker, outcome — where an operator already reads its narration, and at no lane-schema cost.
- The outcome carries **both halves**: the workflow outcome when the Worker stated one, and the stop reason beside it either way. `completed` and `end_turn` are different sentences, and a turn that ends in under a second is only legible when the record says which one ended it.

**Silence looked like health** — the third time this shape has cost a diagnosis in this lane (see #4094 and #4119).

Verified locally: `demand-turn.test.ts` 10/10 with the outcome assertion tightened; `acp-control-plane` green (19/19 together); `pnpm typecheck --force` 17/17.

Next probe this unblocks: the child agent is proven healthy on this host (`redcode 0.3.2` answered a prompt over ACP with real token usage), so the remaining question is what the Worker's own turn returned — which this makes readable in one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789796840&installation_model_id=20659&pr_number=4121&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4121&signature=fb1d6ba08959978b5f1b29400a67b996621aa2d0609bfcded6e64615cba3537a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->