### PR TITLE
feat(redskilled): the demand birth hands its Worker a Ticket, not a sentence

### DIFF
--- a/.changeset/the-demand-birth-hands-over-its-ticket.md
+++ b/.changeset/the-demand-birth-hands-over-its-ticket.md
@@ -1,0 +1,28 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The demand birth hands its Worker a Ticket, not a sentence
+
+With #4121's narration in place, the first real drain finally said what it had
+been doing all along:
+
+```
+unattended turn demand-turn-completed for project "reddb-io/red-skills"
+  on item 4118 (worker VSob7Cr): no-workflow-outcome (end_turn)
+```
+
+A fresh Worker every fifteen seconds, each ending in under a second having done
+nothing. **The Worker body enters its Ticket loop only through a handoff**
+(`ticketHandoffFromMeta`); given a bare prompt it takes its third path — echo
+the prompt, end the turn — which is exactly what the daemon was asking for.
+
+So the daemon states the handoff the contract already describes: the Ticket
+number and title, its labels, the trunk, the briefing, and the Worker's own id.
+The poll keeps title and labels beside the identifiers it already kept (#4098),
+carried and never read, and the project's registered prompt becomes the
+`handoff` text — which is what it always was.
+
+A handoff is stated only when every fact it requires is present: a Ticket with
+an empty title or no trunk is one the Worker refuses, and **a refusal the
+daemon could have avoided is a Worker born to fail.**

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -59,6 +59,8 @@ export interface DemandBirthTurn {
   readonly workspacePath: string;
   readonly prompt: string;
   readonly workItem?: string;
+  /** The Ticket handoff that puts the Worker in its Ticket loop (#4118). */
+  readonly ticket?: Readonly<Record<string, unknown>>;
 }
 import {
   bindProjectControl,
@@ -201,6 +203,7 @@ export async function startRedskillsAcpControlPlane(
     project: await workspaceFor(await resolveAcpProjectIdentity(request.workspacePath)),
     prompt: request.prompt,
     ...(request.workItem == null ? {} : { workItem: request.workItem }),
+    ...(request.ticket == null ? {} : { ticket: request.ticket }),
   });  let closed = false;
   return {
     socketPath: paths.acpSocketPath,

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -61,6 +61,25 @@ export interface DemandTurnDeps {
 }
 
 /**
+ * What the last poll knows about the item a birth is for. PURE.
+ *
+ * Beside the handoff it feeds rather than in the demand loop: the lifecycle
+ * decides that a birth happens, never what the Worker is told about it.
+ */
+export function queueBriefing(
+  projects: readonly {
+    readonly project_label: string;
+    readonly tickets?: readonly { readonly id: string; readonly title: string; readonly labels: readonly string[] }[];
+  }[],
+  projectLabel: string,
+  workItem: string | undefined,
+): { readonly id: string; readonly title: string; readonly labels: readonly string[] } | undefined {
+  if (workItem == null) return undefined;
+  return projects.find((project) => project.project_label === projectLabel)
+    ?.tickets?.find((candidate) => candidate.id === workItem);
+}
+
+/**
  * The turn one birth owes, or `null` when this project states no prompt.
  *
  * Pure and separate from the loop that calls it, because the interesting part
@@ -69,10 +88,19 @@ export interface DemandTurnDeps {
  * refused BEFORE anything is spawned. PURE.
  */
 export function demandTurnForBirth(
-  registration: { readonly prompt?: string } | undefined,
+  registration: {
+    readonly prompt?: string;
+    readonly trunk?: { readonly branch: string };
+  } | undefined,
   birth: { readonly workspace_path: string; readonly index: number; readonly work_item?: string },
   workerId: string,
-): { readonly workspacePath: string; readonly prompt: string; readonly workItem?: string } | null {
+  ticket?: { readonly id: string; readonly title: string; readonly labels: readonly string[] },
+): {
+  readonly workspacePath: string;
+  readonly prompt: string;
+  readonly workItem?: string;
+  readonly ticket?: Readonly<Record<string, unknown>>;
+} | null {
   if (registration?.prompt == null) return null;
   const expanded = expandLaunchTemplate({ argv: [registration.prompt] }, {
     worker_id: workerId,
@@ -80,10 +108,29 @@ export function demandTurnForBirth(
     workspace_path: birth.workspace_path,
     ...(birth.work_item == null ? {} : { work_item: birth.work_item }),
   }).argv[0]!;
+  // The handoff is stated only when every fact it requires is present: a Ticket
+  // briefed with an empty title or no trunk is one the Worker refuses, and a
+  // refusal the daemon could have avoided is a Worker born to fail.
+  const number = Number(ticket?.id);
+  const base = registration.trunk?.branch;
+  const briefed = ticket != null && Number.isInteger(number) && number > 0 &&
+    ticket.title !== "" && base != null && base !== "";
   return {
     workspacePath: birth.workspace_path,
     prompt: expanded,
     ...(birth.work_item == null ? {} : { workItem: birth.work_item }),
+    ...(briefed
+      ? {
+        ticket: {
+          number,
+          title: ticket!.title,
+          labels: [...ticket!.labels],
+          base: base!,
+          handoff: expanded,
+          worker_id: workerId,
+        },
+      }
+      : {}),
   };
 }
 
@@ -125,6 +172,16 @@ export interface DemandTurnRequest {
   readonly prompt: string;
   /** The queue identifier this turn is for, when the birth had one. */
   readonly workItem?: string;
+  /**
+   * The Ticket this Worker is briefed with (#4118's first drain).
+   *
+   * **A Worker enters its Ticket loop only through a handoff.** Without one the
+   * body takes its third path — echo the prompt back and end the turn — which
+   * is exactly what every unattended turn did: `no-workflow-outcome (end_turn)`
+   * in under a second, a fresh Worker every fifteen. The handoff is the same
+   * wire a client dispatch uses; the daemon states it and reads none of it.
+   */
+  readonly ticket?: Readonly<Record<string, unknown>>;
 }
 
 export interface DemandTurnResult {
@@ -249,6 +306,7 @@ export function createDemandTurnRunner(
             redskills: {
               unattended: true,
               ...(request.workItem == null ? {} : { workItem: request.workItem }),
+              ...(request.ticket == null ? {} : { ticket: request.ticket }),
             },
           },
         },

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -76,7 +76,7 @@ import {
   launchProbeArgv,
   launchProbeRefusal,
 } from "../launch-probe.js";
-import { demandTurnForBirth, describeDemandTurn } from "../acp-demand-turn.js";
+import { demandTurnForBirth, describeDemandTurn, queueBriefing } from "../acp-demand-turn.js";
 import { createRedskilledRegistrationIntentStore } from "../registration-intent-store.js";
 import {
   buildRegistrationLapse,
@@ -1029,7 +1029,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         // on the host.
         if (registered?.prompt != null && acpControlPlane != null) {
           try {
-            const turn = demandTurnForBirth(registered, birth, mintHostWorkerId(workers.keys()))!;
+            const turn = demandTurnForBirth(registered, birth, mintHostWorkerId(workers.keys()),
+              queueBriefing(lastQueue?.projects ?? [], birth.project_label, birth.work_item))!;
             void acpControlPlane.runDemandTurn(turn).catch(async (error: unknown) => {
               await eventLane.recordDemandRefusal({
                 ts: clock(),
@@ -2403,7 +2404,6 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       // The one registration path (#4101): a drain that carries its work
       // registers through the same function `project-register` does.
       registerProject: (request) => registerProject(request),
-      // **A turn that completes says so** — only its failure path had a surface.
       recordDemandTurn: (record) => void process.stderr.write(describeDemandTurn(record)),
     });
   } catch (error) {

--- a/apps/redskilled/src/queue-discovery.ts
+++ b/apps/redskilled/src/queue-discovery.ts
@@ -101,6 +101,23 @@ export interface RedskilledProjectQueue {
    * gets a number, so it says nothing here.
    */
   readonly items?: readonly string[];
+  /**
+   * What each counted item is, as the handoff needs it (#4118's first drain).
+   *
+   * The Worker's Ticket loop is entered only through a handoff, and that
+   * contract names the Ticket, its labels and its trunk — so a poll that kept
+   * only numbers left the daemon able to plan a birth it could not brief. These
+   * are opaque like every other project-authored string here: carried into the
+   * handoff verbatim, never read. Same order and same cap as `items`.
+   */
+  readonly tickets?: readonly RedskilledQueueTicket[];
+}
+
+/** One counted item, in the three facts a Ticket handoff has to state. */
+export interface RedskilledQueueTicket {
+  readonly id: string;
+  readonly title: string;
+  readonly labels: readonly string[];
 }
 
 /**
@@ -125,13 +142,15 @@ export function carryQueueItems(
   previous: RedskilledQueueDiscovery | null,
 ): RedskilledQueueDiscovery {
   if (previous == null) return next;
-  const held = new Map(previous.projects.map((project) => [project.project_label, project.items]));
+  const held = new Map(previous.projects
+    .filter((project) => project.items != null)
+    .map((project) => [project.project_label, { items: project.items!, tickets: project.tickets ?? [] }] as const));
   return {
     ...next,
     projects: next.projects.map((project) => {
       if (project.items != null) return project;
       const carried = held.get(project.project_label);
-      return carried == null ? project : { ...project, items: [...carried] };
+      return carried == null ? project : { ...project, items: [...carried.items], tickets: [...carried.tickets] };
     }),
   };
 }
@@ -144,13 +163,35 @@ export function carryQueueItems(
  * the daemon declines to plan.
  */
 export function queueItemIdentifiers(items: readonly Record<string, unknown>[]): readonly string[] {
-  const identifiers: string[] = [];
+  return queueTickets(items).map((ticket) => ticket.id);
+}
+
+/**
+ * The counted items in the three facts a handoff states. PURE.
+ *
+ * An item the transport returned without a usable number is skipped for the
+ * same reason as before — a birth briefed with a fabricated Ticket is worse
+ * than a birth the daemon declines to plan — and a missing title becomes an
+ * empty string rather than an invented one, because the handoff refuses an
+ * empty title and refusing loudly beats briefing wrongly.
+ */
+export function queueTickets(items: readonly Record<string, unknown>[]): readonly RedskilledQueueTicket[] {
+  const tickets: RedskilledQueueTicket[] = [];
   for (const item of items) {
-    if (identifiers.length >= REDSKILLED_QUEUE_ITEM_CAP) break;
+    if (tickets.length >= REDSKILLED_QUEUE_ITEM_CAP) break;
     const number = item.number;
-    if (typeof number === "number" && Number.isInteger(number) && number > 0) identifiers.push(String(number));
+    if (typeof number !== "number" || !Number.isInteger(number) || number <= 0) continue;
+    tickets.push({
+      id: String(number),
+      title: typeof item.title === "string" ? item.title : "",
+      labels: Array.isArray(item.labels)
+        ? item.labels
+          .map((label) => (typeof label === "string" ? label : (label as { name?: unknown } | null)?.name))
+          .filter((name): name is string => typeof name === "string")
+        : [],
+    });
   }
-  return identifiers;
+  return tickets;
 }
 
 /** What the token had left when the query answered; `null` when it did not say. */
@@ -437,6 +478,7 @@ async function fetchConditionalQueueDiscovery(
         depth,
         detail: `project ${JSON.stringify(project.project_label)} has ${depth} item(s) matching its selector`,
         items: queueItemIdentifiers(matched),
+        tickets: queueTickets(matched),
       });
     } catch (error) {
       const rateLimited = isGithubRateLimitError(error);

--- a/apps/redskilled/tests/demand-turn.test.ts
+++ b/apps/redskilled/tests/demand-turn.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createDemandTurnRunner,
   demandTurnForBirth,
+  queueBriefing,
   DEMAND_TURN_PERMISSION_REFUSAL,
   type DemandTurnAdmission,
   type DemandTurnRecord,
@@ -187,5 +188,42 @@ describe("what one birth owes its Worker", () => {
       { workspace_path: "/tmp/w", index: 0 },
       "W1",
     )).toThrow(/work_item/);
+  });
+});
+
+describe("the birth briefs its Worker with a Ticket", () => {
+  const briefing = { id: "4118", title: "worker-container invokes a deleted binary", labels: ["bug", "ready-for-agent"] };
+  const registration = { prompt: "Work issue #{{work_item}} to a merged PR", trunk: { branch: "main" } };
+  const birth = { workspace_path: "/tmp/w", index: 0, work_item: "4118" };
+
+  it("states the handoff the Worker's Ticket loop is entered through", () => {
+    const turn = demandTurnForBirth(registration, birth, "W7", briefing);
+
+    expect(turn?.ticket).toEqual({
+      number: 4118,
+      title: "worker-container invokes a deleted binary",
+      labels: ["bug", "ready-for-agent"],
+      base: "main",
+      // The prompt IS the briefing: one sentence, with the daemon's fact in it.
+      handoff: "Work issue #4118 to a merged PR",
+      worker_id: "W7",
+    });
+  });
+
+  it("states no handoff when a fact it requires is missing, rather than briefing a refusal", () => {
+    // A Worker refuses an empty title or a Ticket with no trunk; a refusal the
+    // daemon could have avoided is a Worker born to fail.
+    expect(demandTurnForBirth(registration, birth, "W7", { ...briefing, title: "" })?.ticket).toBeUndefined();
+    expect(demandTurnForBirth({ prompt: registration.prompt }, birth, "W7", briefing)?.ticket).toBeUndefined();
+    expect(demandTurnForBirth(registration, birth, "W7")?.ticket).toBeUndefined();
+  });
+
+  it("finds the briefing the last poll kept for that item, and nothing for another", () => {
+    const projects = [{ project_label: "a/b", tickets: [briefing] }];
+
+    expect(queueBriefing(projects, "a/b", "4118")).toEqual(briefing);
+    expect(queueBriefing(projects, "a/b", "4119")).toBeUndefined();
+    expect(queueBriefing(projects, "c/d", "4118")).toBeUndefined();
+    expect(queueBriefing(projects, "a/b", undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
With #4121's narration in place, the first real drain finally said what it had been doing all along:

```
unattended turn demand-turn-completed for project "reddb-io/red-skills"
  on item 4118 (worker VSob7Cr): no-workflow-outcome (end_turn)
```

A fresh Worker every fifteen seconds, each ending in under a second having done nothing.

**The Worker body enters its Ticket loop only through a handoff.** `native-worker.ts` branches three ways on a turn: a `ticketHandoffFromMeta` Ticket runs the arc (claim → implement → gate → publish), a prompt containing `delegate child` reaches the child Agent, and anything else is echoed back and ended. The daemon was sending the third.

- The daemon now states the handoff the contract already describes — number, title, labels, trunk, briefing, Worker id — and reads none of it.
- The poll keeps title and labels beside the identifiers it already kept (#4098), same order, same cap, carried verbatim.
- The project's registered prompt becomes the `handoff` text, which is what it always was.
- A handoff is stated **only when every fact it requires is present**: a Ticket with an empty title or no trunk is one the Worker refuses, and a refusal the daemon could have avoided is a Worker born to fail.
- The briefing lookup lives beside the handoff it feeds, not in the demand loop: the lifecycle decides that a birth happens, never what the Worker is told about it.

Verified locally: `demand-turn.test.ts` and `queue-items.test.ts` 19/19 with three new cases; `unattended-demand` and `acp-control-plane` green; `pnpm typecheck --force` 17/17; invariants 342/342 — including the file-size ratchet, which caught my growth of `lifecycle.ts` twice and got the extraction it was asking for both times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789799145&installation_model_id=20659&pr_number=4123&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4123&signature=4535cc8f9897756358aa890b9c7ba9b58b454922cc72f7d9e44519c56a267d43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->