### PR TITLE
fix(redskilled): the unattended turn reads the verdict the Worker already wrote

### DIFF
--- a/.changeset/the-turn-reads-the-ticket-verdict.md
+++ b/.changeset/the-turn-reads-the-ticket-verdict.md
@@ -1,0 +1,15 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The unattended turn reads the verdict the Worker already wrote
+
+A Ticket turn states its verdict in `_meta.redskills.ticket` — landed,
+gate-blocked with the failed stage, refused with the stage and the reason — and
+sets `workflowOutcome` only when it LANDED. The daemon's narration read the
+workflow outcome alone, so a refusal and an ordinary prompt turn printed the
+same sentence: `no-workflow-outcome (end_turn)`. The Worker had already written
+down why; nobody read it.
+
+The record now reads the verdict first and falls back to the stop reason for
+the ordinary turns that carry none.

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -17,7 +17,12 @@
  * The daemon still reads nothing: the prompt is a project-authored string with
  * the daemon's own facts expanded into it, exactly as the argv already was.
  */
-import type { AgentConnection, RequestPermissionRequest, RequestPermissionResponse } from "@agentclientprotocol/sdk";
+import type {
+  AgentConnection,
+  PromptResponse,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+} from "@agentclientprotocol/sdk";
 
 import { admitNativeAcpWorker } from "./acp-worker-admission.js";
 import { expandLaunchTemplate } from "./launch-template.js";
@@ -58,6 +63,30 @@ export interface DemandTurnDeps {
    * only way to learn a drain is working is to watch for commits.
    */
   readonly record?: (line: DemandTurnRecord) => void;
+}
+
+/**
+ * What one turn's answer says happened. PURE.
+ *
+ * **A Ticket turn states its verdict in `_meta.redskills.ticket`, and sets
+ * `workflowOutcome` only when it LANDED** — so a record that read the workflow
+ * outcome alone printed `no-workflow-outcome (end_turn)` for a landed-less
+ * turn and for a refusal alike, hiding the stage and the reason the Worker had
+ * already written down. Read the verdict first; fall back to the stop reason
+ * for the ordinary prompt turns that carry none.
+ */
+export function describeTurnOutcome(response: PromptResponse): string {
+  const ticket = (response._meta as { redskills?: { ticket?: unknown } } | undefined)?.redskills?.ticket;
+  const verdict = ticket == null || typeof ticket !== "object"
+    ? undefined
+    : (ticket as { outcome?: unknown; stage?: unknown; failedStage?: unknown; detail?: unknown });
+  if (verdict?.outcome != null) {
+    const where = verdict.stage ?? verdict.failedStage;
+    return `${String(verdict.outcome)}` +
+      `${where == null ? "" : ` at ${String(where)}`}` +
+      `${verdict.detail == null ? "" : `: ${String(verdict.detail)}`}`;
+  }
+  return `${workflowOutcome(response) ?? "no-workflow-outcome"} (${response.stopReason})`;
 }
 
 /**
@@ -318,11 +347,7 @@ export function createDemandTurnRunner(
           replacement,
         }),
       );
-      // The workflow outcome when the Worker stated one, and the stop reason
-      // beside it either way: "end_turn" and "completed" are different
-      // sentences, and a turn that ended in under a second is only legible if
-      // the record says which of the two it was.
-      const outcome = `${workflowOutcome(response) ?? "no-workflow-outcome"} (${response.stopReason})`;
+      const outcome = describeTurnOutcome(response);
       record("demand-turn-completed", worker, outcome);
       // The turn is the Worker's whole life: it was admitted for one work item
       // and has now finished it, so it is reaped here rather than left on an

--- a/apps/redskilled/tests/demand-turn.test.ts
+++ b/apps/redskilled/tests/demand-turn.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createDemandTurnRunner,
   demandTurnForBirth,
+  describeTurnOutcome,
   queueBriefing,
   DEMAND_TURN_PERMISSION_REFUSAL,
   type DemandTurnAdmission,
@@ -225,5 +226,29 @@ describe("the birth briefs its Worker with a Ticket", () => {
     expect(queueBriefing(projects, "a/b", "4119")).toBeUndefined();
     expect(queueBriefing(projects, "c/d", "4118")).toBeUndefined();
     expect(queueBriefing(projects, "a/b", undefined)).toBeUndefined();
+  });
+});
+
+describe("what a turn's answer says happened", () => {
+  it("reads a Ticket verdict, with the stage and the reason the Worker wrote down", () => {
+    expect(describeTurnOutcome({
+      stopReason: "end_turn",
+      _meta: { redskills: { ticket: { outcome: "refused", stage: "claim", detail: "the lane implies scout" } } },
+    } as never)).toBe("refused at claim: the lane implies scout");
+
+    expect(describeTurnOutcome({
+      stopReason: "end_turn",
+      _meta: { redskills: { ticket: { outcome: "gate-blocked", failedStage: "typecheck", detail: "2 errors" } } },
+    } as never)).toBe("gate-blocked at typecheck: 2 errors");
+
+    expect(describeTurnOutcome({
+      stopReason: "end_turn",
+      _meta: { redskills: { ticket: { outcome: "landed" }, workflowOutcome: "completion" } },
+    } as never)).toBe("landed");
+  });
+
+  it("falls back to the stop reason for an ordinary prompt turn that states no verdict", () => {
+    expect(describeTurnOutcome({ stopReason: "end_turn", _meta: {} } as never))
+      .toBe("no-workflow-outcome (end_turn)");
   });
 });


### PR DESCRIPTION
A Ticket turn states its verdict in `_meta.redskills.ticket` — `landed`, `gate-blocked` with the failed stage, `refused` with the stage and the reason — and sets `workflowOutcome` **only when it landed** (`ticketResponse`, `native-worker.ts`).

The daemon narration added in #4121 read the workflow outcome alone, so a refusal and an ordinary prompt turn printed the same sentence:

```
no-workflow-outcome (end_turn)
```

The Worker had already written down what happened and why. Nobody read it.

The record now reads the verdict first — `refused at claim: <reason>` — and falls back to the stop reason for the ordinary prompt turns that carry none.

Verified locally: `demand-turn.test.ts` 15/15 with four new cases; `pnpm typecheck --force` 17/17; invariants 342/342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789800354&installation_model_id=20659&pr_number=4125&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4125&signature=25be22c4e2662eba658cd161d92572095620e373c45587138e918096be60e623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->