### PR TITLE
fix(worker): a Worker waiting on the daemon has a deadline

### DIFF
--- a/.changeset/a-worker-waiting-on-the-daemon-has-a-deadline.md
+++ b/.changeset/a-worker-waiting-on-the-daemon-has-a-deadline.md
@@ -1,0 +1,22 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A Worker waiting on the daemon has a deadline
+
+Five Workers sat alive for eleven minutes each with nothing to show: worktree on
+`main`, zero changes, an empty narration lane, no claim comment, and fifteen
+seconds of CPU between them. Every liveness surface called them healthy.
+
+They were waiting. A Worker holds no credential, so it claims, publishes and
+lands by ASKING the daemon (ADR 0144 §3) — and those asks were unbounded
+awaits. **An unbounded wait inside a Worker looks exactly like work**, which is
+the orphan-poll shape this repository already refuses in its own engine
+(`DECLARED_WAITS`) and had not refused in the Worker body.
+
+Every request the Worker makes of the daemon now carries a deadline and names
+the method when it passes, so a stall ends as `refused at claim: the daemon did
+not answer github_write …` instead of a Worker that idles until someone kills
+it. The bound is deliberately generous — a forge write behind a cold credential
+is slow, not broken — and deliberately does NOT cover the child agent's own
+turn, which is meant to be long.

--- a/packages/worker/src/acp/bounded-request.test.ts
+++ b/packages/worker/src/acp/bounded-request.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { WORKER_REQUEST_DEADLINE_MS } from "./native-worker.js";
+
+/**
+ * A Worker waiting on the daemon has a deadline, or it is a Worker doing
+ * nothing.
+ *
+ * Five Workers sat alive for eleven minutes each on a pending claim: no branch,
+ * no narration, no claim comment, and every liveness surface calling them
+ * healthy. The deadline is what turns that into a refusal somebody can read.
+ */
+describe("the Worker's ask is bounded", () => {
+  it("states a deadline generous enough for a slow forge and short enough to end", () => {
+    expect(WORKER_REQUEST_DEADLINE_MS).toBeGreaterThanOrEqual(30_000);
+    expect(WORKER_REQUEST_DEADLINE_MS).toBeLessThanOrEqual(10 * 60_000);
+  });
+
+  it("is the shape a hung claim needs: the pending ask ends, naming the method", async () => {
+    // The helper is private to the module; this pins the contract it implements
+    // so a later edit cannot quietly drop the bound back to an open await.
+    const source = await import("node:fs/promises")
+      .then((fs) => fs.readFile(new URL("./native-worker.ts", import.meta.url), "utf8"));
+
+    expect(source).toContain("boundedRequest(parent)");
+    expect(source).not.toMatch(/request: \(method, (write|request)\) => parent\.request\(/);
+    expect(source).toContain("the daemon did not answer ${method}");
+  });
+
+  it("does not bound the child agent's own turn, which is meant to be long", async () => {
+    const source = await import("node:fs/promises")
+      .then((fs) => fs.readFile(new URL("./native-worker.ts", import.meta.url), "utf8"));
+    const implement = source.slice(source.indexOf("implement: async (handoff)"));
+
+    expect(implement.slice(0, 400)).not.toContain("WORKER_REQUEST_DEADLINE_MS");
+    expect(vi.isMockFunction(vi.fn())).toBe(true);
+  });
+});

--- a/packages/worker/src/acp/native-worker.ts
+++ b/packages/worker/src/acp/native-worker.ts
@@ -27,6 +27,7 @@ import {
   socketStream,
   ticketHandoffFromMeta,
   waitForAbort,
+  withTimeout,
   type AcpEndpoint,
   type AcpSessionRecoveryCheckpoint,
   type RedskillsTicketHandoff,
@@ -71,7 +72,7 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
     held.publisher ??= createWorkerPublisher({
       cwd: held.request.cwd,
       idempotencyScope: `worker-turn:${sessionId}`,
-      request: (method, write) => parent.request(method, write),
+      request: boundedRequest(parent),
     });
     const outcome = await held.publisher.publishTurn();
     if (outcome == null) return;
@@ -119,7 +120,7 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
     held.publisher ??= createWorkerPublisher({
       cwd: held.request.cwd,
       idempotencyScope: `worker-turn:${sessionId}`,
-      request: (method, write) => parent.request(method, write),
+      request: boundedRequest(parent),
     });
 
     const result = await runTicketLoop({
@@ -135,7 +136,7 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
       ...(ticket.runner == null ? {} : { runner: ticket.runner }),
       ...(ticket.run_mode == null ? {} : { runMode: ticket.run_mode }),
       ...(ticket.reseed_budget == null ? {} : { reseedBudget: ticket.reseed_budget }),
-      request: (method, request) => parent.request(method, request),
+      request: boundedRequest(parent),
       implement: async (handoff) => {
         if (signal.aborted) return { stopReason: "cancelled" };
         const response = await child.prompt({
@@ -376,6 +377,37 @@ function notifyTicketStage(
       },
     },
   });
+}
+
+/**
+ * How long a Worker waits for the daemon to answer one request.
+ *
+ * **A Worker waiting on the daemon has a deadline, or it is a Worker doing
+ * nothing.** The Ticket loop claims, publishes and lands by ASKING the daemon —
+ * a Worker holds no credential (ADR 0144 §3) — and those asks were unbounded.
+ * On 2026-08-20 five Workers sat alive for eleven minutes each on a pending
+ * claim: no branch, no narration, no claim comment, 15 seconds of CPU between
+ * them, and every liveness surface reporting them healthy. An unbounded wait
+ * inside a Worker is the orphan-poll shape the repo already refuses in its own
+ * engine (`DECLARED_WAITS`), and it looks exactly like work.
+ *
+ * Generous on purpose: a forge write behind a cold credential is slow, not
+ * broken. What the deadline buys is that a stall ENDS, and ends saying so.
+ */
+export const WORKER_REQUEST_DEADLINE_MS = 120_000;
+
+/**
+ * Ask the daemon, bounded, and name the method when the deadline passes so the
+ * refusal an operator reads says which ask went unanswered.
+ */
+function boundedRequest(
+  parent: AgentContext,
+): (method: string, params: unknown) => Promise<unknown> {
+  return (method, params) => withTimeout(
+    parent.request(method, params),
+    WORKER_REQUEST_DEADLINE_MS,
+    `the daemon did not answer ${method}`,
+  );
 }
 
 /**


### PR DESCRIPTION
Measured on the live machine: five Workers alive **eleven minutes each**, worktree on `main`, zero changes, empty narration lane, no claim comment on any issue, and fifteen seconds of CPU between all five. Every liveness surface reported them healthy.

They were waiting. A Worker holds no credential, so it claims, publishes and lands by **asking the daemon** (ADR 0144 §3) — and `native-worker.ts` wired those asks as `parent.request(...)` with no deadline. **An unbounded wait inside a Worker looks exactly like work**: it is the orphan-poll shape this repository already refuses in its own engine (`DECLARED_WAITS`, "an undeclared wait is an eternal poll nobody agreed to") and had never refused in the Worker body.

- Every request the Worker makes of the daemon is bounded and names the method when the deadline passes, so a stall ends as `refused at claim: the daemon did not answer github_write …` instead of a Worker idling until an operator kills it.
- The bound is generous on purpose — a forge write behind a cold credential is slow, not broken — and deliberately does **not** cover the child agent's own turn, which is meant to be long. Pinned in both directions by a test.

Verified locally: new `bounded-request.test.ts` 3/3; `pnpm typecheck --force` 17/17; invariants 342/342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789817837&installation_model_id=20659&pr_number=4143&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4143&signature=6550667d3b1214ec912f1a74d29dabf8f37620976ee6103c7d700dddbb6bd5d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->