### PR TITLE
fix(redskilled): a busy Worker whose client left is finished or it is leaked

### DIFF
--- a/.changeset/a-detached-turn-ends.md
+++ b/.changeset/a-detached-turn-ends.md
@@ -1,0 +1,19 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+A busy Worker whose client left is finished or it is leaked
+
+The connection-close loop reaped idle Workers and SKIPPED busy ones, so a turn
+that never completed — an answer notified to a dead upstream, a child that
+never ends — held a host slot forever. Measured live: Workers alive 56 minutes
+for clients gone 55 of them, while other projects were refused with "past a
+host ceiling of 5 Worker(s)". A stuck Worker does not waste its own slot; it
+starves every project on the machine.
+
+On close, an ordinary prompt turn with no client is now cancelled — its answer
+has no reader — and the cancellation carries a deadline, because a cancel
+nobody bounds is the same eternal wait wearing a politer name. A DISPATCHED
+Ticket turn is deliberately spared: it publishes through the daemon and its PR
+is useful with nobody watching (#3885). The grace wait is declared in
+`DECLARED_WAITS`, which is the ratchet that caught it being undeclared.

--- a/apps/plugin-dev/src/core/declared-wait-guard.ts
+++ b/apps/plugin-dev/src/core/declared-wait-guard.ts
@@ -672,6 +672,14 @@ export const DECLARED_WAITS: readonly DeclaredWait[] = [
     heartbeat: { silent: "a seconds-long drain whose boolean return is the report" },
   },
   {
+    path: "apps/redskilled/src/acp-control-plane.ts",
+    fn: "servePublicConnection",
+    subject: "a cancelled, client-less prompt turn ending on its own after the upstream connection closed",
+    deadline: "DETACHED_TURN_GRACE_MS (120 seconds) after the cancel is sent",
+    escalation: "reapWorkflowWorker with `detached-turn-deadline`, returning the host slot other projects were refused against",
+    heartbeat: { silent: "one unref'd grace timer per detached busy session; the reap itself is the report" },
+  },
+  {
     path: "apps/redskilled/src/acp-workflow-turn.ts",
     fn: "runAcpWorkflowTurn",
     subject: "the targeted Worker's admission becoming observable before its first prompt is forwarded",

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -542,10 +542,44 @@ async function servePublicConnection(
     await observer.settled();
   }
   for (const [sessionId, worker] of active) {
-    if (busy.has(sessionId) || v2Turns.has(sessionId)) continue;
+    if (busy.has(sessionId) || v2Turns.has(sessionId)) {
+      // **A busy Worker whose client left is finished or it is leaked.** The
+      // turn paths already reap on completion when `attached()` is false — the
+      // hole was a turn that never completes: an answer notified to a dead
+      // upstream, a child that never ends. Measured on 2026-08-20 as Workers
+      // alive 56 minutes for clients gone 55 of them, each holding a host slot
+      // other projects were refused against.
+      //
+      // A DISPATCHED Ticket turn is the one busy shape that outlives its
+      // client on purpose (#3885): it publishes through the daemon and its PR
+      // is useful with nobody watching. An ordinary prompt turn's answer has
+      // no reader, so it is cancelled — and cancellation gets a deadline,
+      // because a cancel nobody bounds is the same eternal wait wearing a
+      // politer name.
+      if (worker.dispatch == null) {
+        worker.cancelled = true;
+        void worker.connection.agent
+          .notify(methods.agent.session.cancel, { sessionId: worker.downstreamSessionId })
+          .catch(() => undefined);
+        const grace = setTimeout(() => {
+          if (active.get(sessionId) === worker) {
+            void reapWorkflowWorker(sessionId, worker, active, "detached-turn-deadline");
+          }
+        }, DETACHED_TURN_GRACE_MS);
+        grace.unref();
+      }
+      continue;
+    }
     cleanupWorkflowWorker(sessionId, worker, active);
   }
 }
+
+/**
+ * How long a cancelled, client-less turn may take to end on its own before the
+ * daemon reaps it. Generous: a child agent mid-tool-call finishes the call
+ * before honouring cancellation. What it buys is that the slot RETURNS.
+ */
+const DETACHED_TURN_GRACE_MS = 120_000;
 
 async function runV2PublicTurn(
   options: StartRedskillsAcpControlPlaneOptions,

--- a/apps/redskilled/tests/detached-turn.test.ts
+++ b/apps/redskilled/tests/detached-turn.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * A busy Worker whose client left is finished or it is leaked.
+ *
+ * The close loop reaps idle Workers and used to SKIP busy ones — so a turn
+ * that never completed (an answer notified to a dead upstream, a child that
+ * never ends) held a host slot forever. Measured live: Workers alive 56
+ * minutes for clients gone 55 of them, while other projects were refused with
+ * "past a host ceiling of 5 Worker(s)".
+ */
+const SOURCE = readFileSync(
+  join(import.meta.dirname, "..", "src", "acp-control-plane.ts"),
+  "utf8",
+);
+
+describe("a detached turn ends", () => {
+  it("cancels a busy client-less prompt turn instead of skipping it forever", () => {
+    expect(SOURCE).toContain("worker.cancelled = true;");
+    expect(SOURCE).toContain("methods.agent.session.cancel");
+    // The old shape — skip busy sessions with a bare continue — must not return.
+    expect(SOURCE).not.toMatch(/if \(busy\.has\(sessionId\) \|\| v2Turns\.has\(sessionId\)\) continue;/);
+  });
+
+  it("bounds the cancellation, because an unbounded cancel is the same eternal wait", () => {
+    expect(SOURCE).toContain("DETACHED_TURN_GRACE_MS");
+    expect(SOURCE).toContain('"detached-turn-deadline"');
+  });
+
+  it("spares a dispatched Ticket turn — its PR is useful with nobody watching (#3885)", () => {
+    expect(SOURCE).toContain("if (worker.dispatch == null) {");
+  });
+});


### PR DESCRIPTION
Measured live on 2026-08-20: Workers alive **56 minutes** for clients gone 55 of them, each holding a host slot while other projects were refused with *"past a host ceiling of 5 Worker(s)"*. **A stuck Worker does not waste its own slot; it starves every project on the machine.**

The connection-close loop reaped idle Workers and **skipped busy ones** with a bare `continue`. The turn paths already reap on completion when `attached()` is false — the hole was a turn that never completes: an answer notified to a dead upstream, a child that never ends.

- On close, an ordinary prompt turn with no client is **cancelled** — its answer has no reader.
- The cancellation carries a **deadline** (`DETACHED_TURN_GRACE_MS`, 120s, then `reapWorkflowWorker("detached-turn-deadline")`): a cancel nobody bounds is the same eternal wait wearing a politer name.
- A **dispatched Ticket turn is spared**: it publishes through the daemon and its PR is useful with nobody watching (#3885).
- The grace wait is declared in `DECLARED_WAITS` — the ratchet caught it undeclared on the first gate run, which is exactly its job.

Pairs with #4143 (every Worker→daemon ask has a deadline): together, the two families of silent stalls observed tonight both end by themselves, naming why.

Verified locally: new `detached-turn.test.ts` 3/3; `acp-control-plane.test.ts` 9/9; layout guard green (690 lines); `pnpm typecheck --force` 17/17; invariants 342/342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789820857&installation_model_id=20659&pr_number=4145&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4145&signature=c75bd5204a1caf784b7cb84ce1b7917ceff255bc9beaa7ba4b995c4f868aebe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->