### PR TITLE
fix(redskilled): the drain registers under the key its Workers will carry

### DIFF
--- a/.changeset/one-key-both-sides-of-the-ledger.md
+++ b/.changeset/one-key-both-sides-of-the-ledger.md
@@ -1,0 +1,15 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The drain registers under the key its Workers will carry
+
+Workers are labelled by `projectId` — the authority key that survives a
+repository rename — while a drain's registration was keyed by the display
+label. The demand planner counts live Workers against the registration's key,
+so it never saw its own children: a target of 1 birthed five Workers, two of
+which claimed the same Ticket, until the host ceiling refused the sixth — and
+every other project on the machine with it.
+
+One key, both sides of the ledger: the registration a drain carries registers
+under `projectId`.

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -609,7 +609,15 @@ export function bindProjectControl(deps: {
           throw new Error("this endpoint cannot register a project: the daemon handed it no registration path");
         }
         try {
-          deps.registerProject({ ...request.registration, project_label: project.projectLabel });
+          // **One key, both sides of the ledger.** Workers are labelled by
+          // `projectId` — the authority key that survives a repository rename —
+          // while this registration was keyed by the display label. The demand
+          // planner counts live Workers against the REGISTRATION's key, so it
+          // never saw its own children: target 1 birthed five Workers, two of
+          // which claimed the same Ticket, until the host ceiling stopped the
+          // sixth. The registration registers under the same key its Workers
+          // will carry.
+          deps.registerProject({ ...request.registration, project_label: project.projectId });
         } catch (error) {
           // **A drain is idempotent; a registration is not.** `project-register`
           // refuses a second record so two sessions cannot silently replace each

--- a/apps/redskilled/tests/unregistered-drain.test.ts
+++ b/apps/redskilled/tests/unregistered-drain.test.ts
@@ -105,7 +105,10 @@ describe("a drain registers the project it drains", () => {
 
     expect(registered).toEqual([
       expect.objectContaining({
-        project_label: "reddb-io/red-skills",
+        // The authority key, not the display label: Workers are labelled by
+        // projectId, and a registration keyed any other way is one whose
+        // planner never counts its own children.
+        project_label: "github:1",
         selector: "is:issue label:ready-for-agent",
         target: 2,
       }),
@@ -119,7 +122,7 @@ describe("a drain registers the project it drains", () => {
       registration: { project_label: "someone/else", selector: "is:issue", argv: ["x"], target: 1 },
     });
 
-    expect(registered[0]).toMatchObject({ project_label: "reddb-io/red-skills" });
+    expect(registered[0]).toMatchObject({ project_label: "github:1" });
   });
 
   it("refuses when the endpoint was handed no registration path, rather than recording a drain nothing polls", async () => {


### PR DESCRIPTION
Observed live on 4.0.8, minutes after the first autonomous claim in v4's history:

```
target: 1 → five Workers born; two claimed issue #4133; sixth refused at the host ceiling
```

Workers are labelled by **`projectId`** — the authority key that survives a repository rename (`nativeWorkerSpec`) — while the drain's registration was keyed by the **display label** (`projectLabel`). The demand planner counts live Workers against the registration's key, so it never saw its own children: `live = 0` every tick, one more birth every tick, duplicate claims on the same Ticket, and the whole machine starved once the ceiling latched.

**One key, both sides of the ledger.** The registration a drain carries now registers under `projectId`, the same key its Workers will be labelled with.

Verified locally: `unregistered-drain.test.ts` and `acp-control-plane.test.ts` 20/20 (assertions repointed at the key, with the reason written beside them); `pnpm typecheck --force` 17/17; invariants 342/342.

With #4143 (bounded asks) and #4145 (detached turns end), this is the third of the three stall/starvation defects the first real drains exposed — and the one that turns "it claims" into "it claims exactly once".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789822094&installation_model_id=20659&pr_number=4146&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4146&signature=229301115a580f20daef666d2a2e812a66aa6effd60cc48e9b33c1cb0e6afc40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->