### PR TITLE
fix(redskilled): record the admitted Worker under the project label, not the project id

### DIFF
--- a/.changeset/fix-worker-project-label.md
+++ b/.changeset/fix-worker-project-label.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The admitted native Worker is recorded under the project label the
+registration store, the demand loop, and queue discovery all key by — not
+under the project id. Recording the id split the identity: the demand loop
+read live=0 forever, birthed a Worker every tick, and the host ceiling filled
+with connected Workers no ticket route could find.

--- a/apps/redskilled/src/acp-worker-admission.ts
+++ b/apps/redskilled/src/acp-worker-admission.ts
@@ -272,7 +272,7 @@ export async function admitNativeAcpWorker(
   return admitted;
 }
 
-function nativeWorkerSpec(
+export function nativeWorkerSpec(
   project: AcpProjectWorkspace,
   workspace: MaterializedWorkerWorkspace,
   endpoint: string,
@@ -284,9 +284,12 @@ function nativeWorkerSpec(
   const childAgent = pinChildAgentExecutable(defaultChildAgentEndpoint());
   return {
     worker_id: workspace.workerId,
-    // The host's authority key must survive a repository rename. The current
-    // GitHub full name remains display metadata on the public session.
-    project_label: project.projectId,
+    // The registration store, the demand loop's live count, and queue discovery
+    // all key a project by the registration's project_label. A Worker recorded
+    // under projectId is invisible to every one of them: the demand loop reads
+    // live=0 forever, births another Worker each tick, and the host ceiling
+    // fills with connected Workers no ticket route can find (#4129 drain).
+    project_label: project.projectLabel,
     // The Worker stands in ITS OWN worktree in temporary storage (ADR 0149 §1);
     // the Project workspace is what that worktree was forked from, never a cwd
     // two Workers could share.

--- a/apps/redskilled/tests/worker-project-identity.test.ts
+++ b/apps/redskilled/tests/worker-project-identity.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { nativeWorkerSpec } from "../src/acp-worker-admission.js";
+import type { AcpProjectWorkspace } from "../src/project-workspace.js";
+import type { MaterializedWorkerWorkspace } from "../src/worker-workspace.js";
+
+// The registration store, the demand loop's live count (daemon/lifecycle.ts),
+// and queue discovery all key a project by the registration's project_label.
+// Recording the admitted Worker under projectId split that identity: the
+// demand loop read live=0 forever, birthed a Worker every tick, and the host
+// ceiling filled with connected Workers no ticket route could find. This pins
+// the one identity every consumer agrees on.
+describe("native Worker project identity", () => {
+  it("records the admitted Worker under the project label, never the project id", () => {
+    const project: AcpProjectWorkspace = {
+      projectId: "remote:reddb-io/red-skills",
+      projectLabel: "reddb-io/red-skills",
+      checkoutRoot: "/tmp/checkout",
+      workspacePath: "/tmp/project-workspace",
+    };
+    const workspace: MaterializedWorkerWorkspace = {
+      workerId: "VStest01",
+      root: "/tmp/workers",
+      workspacePath: "/tmp/workers/VStest01",
+      worktreePath: "/tmp/workers/VStest01/worktree",
+    } as MaterializedWorkerWorkspace;
+
+    const spec = nativeWorkerSpec(project, workspace, "/tmp/sock/x.sock", "/tmp/runtime", "afk");
+
+    expect(spec.project_label).toBe(project.projectLabel);
+    expect(spec.project_label).not.toBe(project.projectId);
+  });
+});


### PR DESCRIPTION
Fixes the split-brain that has the #4129 drain sitting at 5 silent Workers: native admission recorded each Worker under \`project.projectId\` (\`remote:owner/repo\`) while the registration store, the demand loop's live count (\`daemon/lifecycle.ts:622/958\`), and queue discovery all key by the registration's \`project_label\` (\`owner/repo\`). Every admitted Worker was therefore invisible to its own project's accounting: \`live=0\` forever → a new birth every tick → host ceiling full of connected Workers no ticket route could find → endless \`would be Worker 6 past a host ceiling\` refusals beside \`holds 0 Worker(s)\`.

One-line fix in \`nativeWorkerSpec\` (+ export for the test). New regression test \`worker-project-identity.test.ts\` pins \`spec.project_label === project.projectLabel\`. Verified: acp-agent-conformance 22/22, ticket-loop, go-dispatch green; the two failing suites (\`worker-birth\` container-engine probe, \`acp-project-status\` adapter-health fixture) reproduce identically on clean \`origin/main\` on this WSL host.

Operator note: after release, the stuck generation self-heals on the daemon's bundle handover; the wedged Workers from the old identity are reclaimed by the liveness sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789826108&installation_model_id=20659&pr_number=4152&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4152&signature=7b9396a6fea445394bbd3da177099901bdf19692d44fb0a344966f76b61a1993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->