### PR TITLE
fix(redskilled): the drain registers under one key, and a stop releases the registration

### DIFF
--- a/.changeset/stop-releases-one-key-registers.md
+++ b/.changeset/stop-releases-one-key-registers.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The drain registers under the label its Workers carry, and a stop hands the
+self-sustaining registration back. Registration briefly keyed `projectId`
+(#4146) while #4152 records admitted Workers under `projectLabel`, so the
+demand planner never counted its own children: target 1 ran five Workers and
+the host ceiling was the only brake. And `project_stop` flipped the intent
+while the Amendment 7 sustain kept renewing the registration off open work,
+so Workers kept being born after the operator said stop.

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -143,6 +143,12 @@ export interface StartRedskillsAcpControlPlaneOptions {
    * drain then answers exactly as it did before registrations reached it.
    */
   readonly registerProject?: (request: RedskilledProjectRegistrationRequest) => unknown;
+  /**
+   * The daemon's own release path, for the same reason: a stop must hand the
+   * self-sustaining registration back (#4159), and the lifecycle owns that
+   * record. Absent means a stop flips the intent only — legal in a test.
+   */
+  readonly releaseProject?: (projectLabel: string) => unknown;
 }
 
 /** The store handles every connection on this endpoint shares (ADR 0152). */
@@ -268,6 +274,9 @@ async function servePublicConnection(
     ...(options.registerProject == null
       ? {}
       : { registerProject: (request) => options.registerProject!(request as never) }),
+    ...(options.releaseProject == null
+      ? {}
+      : { releaseProject: (projectLabel) => options.releaseProject!(projectLabel) }),
   });
 
   const { v1: v1Methods, v2: v2Methods } = connectionMethodTables({

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -2404,6 +2404,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       // The one registration path (#4101): a drain that carries its work
       // registers through the same function `project-register` does.
       registerProject: (request) => registerProject(request),
+      // The matching release path: `project_stop` hands the self-sustaining
+      // registration back through the same function `project-deregister` uses,
+      // so a stopped drain actually stops being polled and birthed for (#4159).
+      releaseProject: (projectLabel) => deregisterProject(projectLabel),
       recordDemandTurn: (record) => void process.stderr.write(describeDemandTurn(record)),
     });
   } catch (error) {

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -2401,12 +2401,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       hostState,
       ...(options.githubGateway == null ? {} : { githubGateway: options.githubGateway }),
       ...(options.evidenceTtlMs == null ? {} : { evidenceTtlMs: options.evidenceTtlMs }),
-      // The one registration path (#4101): a drain that carries its work
-      // registers through the same function `project-register` does.
+      // One registration path (#4101); a stop hands the record back too (#4159).
       registerProject: (request) => registerProject(request),
-      // The matching release path: `project_stop` hands the self-sustaining
-      // registration back through the same function `project-deregister` uses,
-      // so a stopped drain actually stops being polled and birthed for (#4159).
       releaseProject: (projectLabel) => deregisterProject(projectLabel),
       recordDemandTurn: (record) => void process.stderr.write(describeDemandTurn(record)),
     });

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -596,6 +596,8 @@ export function bindProjectControl(deps: {
   readonly readGithubCustody: () => Promise<unknown>;
   /** The daemon's own registration path; absent means this endpoint cannot register. */
   readonly registerProject?: (request: Readonly<Record<string, unknown>>) => unknown;
+  /** The daemon's own release path; a stop hands the registration back through it. */
+  readonly releaseProject?: (projectLabel: string) => unknown;
 }) {
   return {
     mutateProjectControl: async (operation: ProjectControlOperation, request: ProjectControlRequest = {}) => {
@@ -609,15 +611,15 @@ export function bindProjectControl(deps: {
           throw new Error("this endpoint cannot register a project: the daemon handed it no registration path");
         }
         try {
-          // **One key, both sides of the ledger.** Workers are labelled by
-          // `projectId` — the authority key that survives a repository rename —
-          // while this registration was keyed by the display label. The demand
-          // planner counts live Workers against the REGISTRATION's key, so it
-          // never saw its own children: target 1 birthed five Workers, two of
-          // which claimed the same Ticket, until the host ceiling stopped the
-          // sixth. The registration registers under the same key its Workers
-          // will carry.
-          deps.registerProject({ ...request.registration, project_label: project.projectId });
+          // **One key, both sides of the ledger — and the label IS the key.**
+          // #4152 records the admitted Worker under `project.projectLabel`,
+          // which is what the registration store, the demand loop's live count
+          // and queue discovery all key by. This site briefly registered under
+          // `projectId` (#4146) while Workers carried the label, so the planner
+          // never counted its own children: target 1 ran five Workers and the
+          // host ceiling was the only brake (#4158). The registration registers
+          // under the same key its Workers carry.
+          deps.registerProject({ ...request.registration, project_label: project.projectLabel });
         } catch (error) {
           // **A drain is idempotent; a registration is not.** `project-register`
           // refuses a second record so two sessions cannot silently replace each
@@ -634,6 +636,15 @@ export function bindProjectControl(deps: {
         deps.persistProjectControls,
         request,
       );
+      // **A stop hands the registration back, not only the intent.** The
+      // registration is self-sustained off open work (ADR 0130 Amendment 7), so
+      // a stop that flips the intent and leaves the record standing is a drain
+      // the operator cannot end: the sustain renews it, the demand loop keeps
+      // planning off it, and Workers keep being born after the operator said
+      // stop (#4159). Released through the same path `project-deregister` uses;
+      // releasing an already-released project states the outcome and is not an
+      // error, which is what makes a repeated stop safe.
+      if (operation === "stop") deps.releaseProject?.(project.projectLabel);
       // Told at the moment of asking, not only to whoever thinks to read status
       // afterwards: a caller who ran `drain` and got a clean answer has every
       // reason to believe Workers are coming.

--- a/apps/redskilled/tests/unregistered-drain.test.ts
+++ b/apps/redskilled/tests/unregistered-drain.test.ts
@@ -105,10 +105,10 @@ describe("a drain registers the project it drains", () => {
 
     expect(registered).toEqual([
       expect.objectContaining({
-        // The authority key, not the display label: Workers are labelled by
-        // projectId, and a registration keyed any other way is one whose
-        // planner never counts its own children.
-        project_label: "github:1",
+        // The label, matching #4152: admitted Workers are recorded under
+        // `projectLabel`, and a registration keyed any other way is one whose
+        // planner never counts its own children (#4158).
+        project_label: "reddb-io/red-skills",
         selector: "is:issue label:ready-for-agent",
         target: 2,
       }),
@@ -122,7 +122,7 @@ describe("a drain registers the project it drains", () => {
       registration: { project_label: "someone/else", selector: "is:issue", argv: ["x"], target: 1 },
     });
 
-    expect(registered[0]).toMatchObject({ project_label: "github:1" });
+    expect(registered[0]).toMatchObject({ project_label: "reddb-io/red-skills" });
   });
 
   it("refuses when the endpoint was handed no registration path, rather than recording a drain nothing polls", async () => {
@@ -137,6 +137,45 @@ describe("a drain registers the project it drains", () => {
 
     expect(registered).toEqual([]);
     expect(answer).toMatchObject({ drain_intent: "draining", warning: UNREGISTERED_DRAIN_WARNING });
+  });
+});
+
+describe("a stop hands the registration back, not only the intent", () => {
+  const bindStop = (releaseProject?: (projectLabel: string) => unknown) =>
+    bindProjectControl({
+      scopedProject: () => project,
+      projectControls: new Map<string, ProjectControlState>([
+        ["github:1", { drainIntent: "draining", revision: 1, updates: [] }],
+      ]),
+      persistProjectControls: async () => {},
+      hostState: () => hostState(true),
+      clock: () => "2026-08-19T20:00:00.000Z",
+      readGithubCustody: async () => null,
+      ...(releaseProject == null ? {} : { releaseProject }),
+    });
+
+  it("releases through the daemon's own path, under the same label the registration carries", async () => {
+    const released: string[] = [];
+
+    const answer = await bindStop((projectLabel) => released.push(projectLabel)).mutateProjectControl("stop", {});
+
+    // The self-sustaining registration (Amendment 7) renews itself off open
+    // work, so a stop that leaves it standing is a drain the operator cannot
+    // end: Workers kept being born after the stop (#4159).
+    expect(released).toEqual(["reddb-io/red-skills"]);
+    expect(answer).toMatchObject({ drain_intent: "stopped" });
+  });
+
+  it("does not release on a drain", async () => {
+    const released: string[] = [];
+
+    await bindStop((projectLabel) => released.push(projectLabel)).mutateProjectControl("drain", {});
+
+    expect(released).toEqual([]);
+  });
+
+  it("still stops when the endpoint was handed no release path", async () => {
+    expect(await bindStop().mutateProjectControl("stop", {})).toMatchObject({ drain_intent: "stopped" });
   });
 });
 


### PR DESCRIPTION
Two halves of the 2026-08-20 live-drain runaway.

## One key, and the label is it (#4158)

#4152 records the admitted Worker under `project.projectLabel` — the key the registration store, the demand loop's live count and queue discovery all share — while the drain's registration site still keyed `project.projectId` (#4146, written when Workers carried the id). The two fixes crossed: `live` stayed 0 under the registration's key, the planner asked for a Worker every tick, and target 1 ran five Workers with the host ceiling as the only brake.

The registration now registers under `projectLabel`, which also makes `projectIsRegistered` find it — the drain answer no longer carries the false "holds no registration" warning (#4162 part 1).

## A stop hands the registration back (#4159)

`project_stop` flipped the control intent while the Amendment 7 sustain renewed the registration off open work (observed live: `renewals: 129, sustained_by: open-work`, Workers born after the stop). The control surface now releases through the daemon's own `deregisterProject` on stop — the same path `project-deregister` uses — so a stopped drain stops being polled, sustained, and birthed for. Release of an already-released project states the outcome, keeping a repeated stop safe.

## Tests

- `unregistered-drain.test.ts`: registration key expectations repointed to the label; new describe block pins stop→release (fires on stop under the label, not on drain, and stop still answers without a release path).
- `demand-turn`, `project-control-arguments`, `worker-project-identity`: green (36 tests).
- `acp-control-plane` / `acp-project-status`: the 3 failures reproduce on clean main (pre-existing environment failures, documented in #4152).

Closes #4158. Closes #4159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789834587&installation_model_id=20659&pr_number=4163&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4163&signature=34edc014867a0772af1f0f6b4c8b3984aa8092672f76568d47889d2d35b0f915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->