### PR TITLE
fix(redskilled): a gate-blocked demand turn parks its Ticket

### DIFF
--- a/.changeset/gate-blocked-parks-ticket.md
+++ b/.changeset/gate-blocked-parks-ticket.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/redskilled": patch
+"@reddb-io/protocol-acp": patch
+---
+
+A completed unattended turn whose gate blocked now parks its Ticket: the
+daemon computes the Worker engine's own park transition under the project's
+label vocabulary and applies it as one authorized `issue-transition` GitHub
+write (labels move, one explanatory comment). A gate-blocked Ticket left in
+the ready queue was re-taken by the very next birth — claim spam, duplicate
+work, an infinite grinder on one issue.

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -24,6 +24,7 @@ import type {
   RequestPermissionResponse,
 } from "@agentclientprotocol/sdk";
 
+import { parkGateBlockedTurn } from "./demand-park.js";
 import { admitNativeAcpWorker } from "./acp-worker-admission.js";
 import { expandLaunchTemplate } from "./launch-template.js";
 import {
@@ -63,6 +64,21 @@ export interface DemandTurnDeps {
    * only way to learn a drain is working is to watch for commits.
    */
   readonly record?: (line: DemandTurnRecord) => void;
+  /**
+   * What happens to the Ticket after a completed turn whose gate blocked.
+   *
+   * Answers a one-line record of the transition it performed (or refused), or
+   * `null` for every other verdict. Absent in tests that assert the turn
+   * alone; the control plane wires `parkGateBlockedTurn` (#4160), because a
+   * gate-blocked Ticket left in the ready queue is re-taken by the very next
+   * birth — the infinite grinder the park exists to end.
+   */
+  readonly park?: (
+    project: AcpProjectWorkspace,
+    ticket: Readonly<Record<string, unknown>>,
+    response: PromptResponse,
+    workerId: string,
+  ) => Promise<string | null>;
 }
 
 /**
@@ -265,6 +281,7 @@ export function demandTurnRunnerFor(
     ...(options.evidenceRoot == null ? {} : { evidenceRoot: options.evidenceRoot }),
     ...(options.evidenceTtlMs == null ? {} : { evidenceTtlMs: options.evidenceTtlMs }),
     ...(options.recordDemandTurn == null ? {} : { record: options.recordDemandTurn }),
+    park: parkGateBlockedTurn(options.githubGateway),
   });
 }
 
@@ -349,6 +366,14 @@ export function createDemandTurnRunner(
       );
       const outcome = describeTurnOutcome(response);
       record("demand-turn-completed", worker, outcome);
+      if (deps.park != null && request.ticket != null) {
+        try {
+          const parked = await deps.park(request.project, request.ticket, response, worker.workerId);
+          if (parked != null) record("demand-park", worker, parked);
+        } catch (error) {
+          record("demand-park-failed", worker, error instanceof Error ? error.message : String(error));
+        }
+      }
       // The turn is the Worker's whole life: it was admitted for one work item
       // and has now finished it, so it is reaped here rather than left on an
       // idle timer nobody will come back to.

--- a/apps/redskilled/src/demand-park.ts
+++ b/apps/redskilled/src/demand-park.ts
@@ -1,0 +1,131 @@
+// demand-park — a gate-blocked demand turn moves its Ticket out of the queue.
+//
+// #4160: two Workers finished `gate-blocked at feedback` on one Ticket and the
+// Ticket kept `ready-for-agent`, so every freed slot re-birthed a Worker for
+// the same head item — claim spam, duplicate work, an infinite grinder on one
+// issue. A verdict that changes nothing on the tracker is indistinguishable
+// from no verdict: the park is what makes the queue advance.
+//
+// The transition itself is the Worker engine's own planner (`planTransition`,
+// the single owner of state-label mutations), fed the label vocabulary the
+// PROJECT declares in its `.red/config.yaml` — the daemon spells no label of
+// its own. The write travels as one authorized `issue-transition` mutation
+// through the Project-bound gateway, exactly like every other Worker write.
+
+import { resolve } from "node:path";
+
+import {
+  isRefused,
+  loadEngineConfig,
+  planTransition,
+  readEngineLabelVocabulary,
+} from "@reddb-io/worker/engine";
+import type { RedskilledGithubWriteRequest } from "@reddb-io/protocol-acp";
+
+import { bindAcpProjectGithubWrite } from "./acp-github.js";
+import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
+import type { AcpProjectWorkspace } from "./project-workspace.js";
+
+/** The one Ticket verdict this module acts on; every other outcome passes by. */
+export interface GateBlockedVerdict {
+  readonly failedStage: string;
+  readonly detail?: string;
+}
+
+/** Read a turn's Ticket verdict and answer only when the gate blocked. PURE. */
+export function gateBlockedVerdictOf(response: {
+  readonly _meta?: unknown;
+}): GateBlockedVerdict | null {
+  const ticket = (response._meta as { redskills?: { ticket?: unknown } } | undefined)
+    ?.redskills?.ticket;
+  if (ticket == null || typeof ticket !== "object") return null;
+  const verdict = ticket as { outcome?: unknown; failedStage?: unknown; detail?: unknown };
+  if (verdict.outcome !== "gate-blocked") return null;
+  return {
+    failedStage: typeof verdict.failedStage === "string" ? verdict.failedStage : "feedback",
+    ...(typeof verdict.detail === "string" ? { detail: verdict.detail } : {}),
+  };
+}
+
+/**
+ * Compose the one tracker mutation that parks a gate-blocked Ticket, or say
+ * why none can be composed. The refusal is a sentence, not a throw: a park the
+ * planner refuses (a dependency edge still standing, a vocabulary conflict) is
+ * an outcome the demand record must carry, never a dead Worker.
+ */
+export function gateBlockedParkWrite(input: {
+  readonly workspacePath: string;
+  readonly ticket: { readonly number: number; readonly labels: readonly string[] };
+  readonly workerId: string;
+  readonly verdict: GateBlockedVerdict;
+}): { readonly request: RedskilledGithubWriteRequest; readonly summary: string } | { readonly refusal: string } {
+  const vocabulary = readEngineLabelVocabulary(
+    loadEngineConfig(resolve(input.workspacePath, ".red"), { warn: () => undefined }),
+  );
+  const plan = planTransition(
+    input.ticket.labels,
+    { kind: "park", reason: `${vocabulary.blockedPrefix}validation` },
+    vocabulary,
+  );
+  if (isRefused(plan)) return { refusal: plan.reason };
+  const detail = input.verdict.detail == null
+    ? ""
+    : `\n\n\`\`\`\n${input.verdict.detail.slice(0, 800)}\n\`\`\``;
+  return {
+    summary: `parked #${input.ticket.number}: +[${plan.add.join(", ")}] -[${plan.remove.join(", ")}]`,
+    request: {
+      idempotency_key: `park:${input.ticket.number}:${input.workerId}`,
+      write: {
+        kind: "issue-transition",
+        issue: input.ticket.number,
+        add: plan.add,
+        remove: plan.remove,
+        comment:
+          `🤖 AFK park by worker \`${input.workerId}\`: the local gate blocked at ` +
+          `\`${input.verdict.failedStage}\`.${detail}\n\n` +
+          `Requeue with \`/retake ${input.ticket.number}\` once the blocker is repaired.`,
+      },
+    },
+  };
+}
+
+/**
+ * The executor the demand-turn runner calls after a completed Ticket turn.
+ *
+ * Answers a one-line record of what it did — a park summary, a stated refusal,
+ * or `null` when the verdict was not `gate-blocked` — and never throws for a
+ * park that could not happen: the turn already finished, and the only thing
+ * left to protect is the operator's ability to read why the queue did or did
+ * not advance.
+ */
+export function parkGateBlockedTurn(
+  gateway: RedskilledGithubGatewayRegistration | undefined,
+): (
+  project: AcpProjectWorkspace,
+  ticket: Readonly<Record<string, unknown>>,
+  response: { readonly _meta?: unknown },
+  workerId: string,
+) => Promise<string | null> {
+  return async (project, ticket, response, workerId) => {
+    const verdict = gateBlockedVerdictOf(response);
+    if (verdict == null) return null;
+    // The turn's ticket is opaque wire until read here, exactly once.
+    const number = Number(ticket.number);
+    const labels = Array.isArray(ticket.labels)
+      ? ticket.labels.filter((label): label is string => typeof label === "string")
+      : [];
+    if (!Number.isInteger(number) || number <= 0) {
+      return `park refused: the turn's ticket names no issue number`;
+    }
+    const composed = gateBlockedParkWrite({
+      workspacePath: project.workspacePath,
+      ticket: { number, labels },
+      workerId,
+      verdict,
+    });
+    if ("refusal" in composed) return `park refused for #${number}: ${composed.refusal}`;
+    const write = bindAcpProjectGithubWrite(gateway, () => project);
+    await write({ params: composed.request });
+    return composed.summary;
+  };
+}

--- a/apps/redskilled/src/github-outbox.ts
+++ b/apps/redskilled/src/github-outbox.ts
@@ -247,6 +247,21 @@ function validateWrite(write: RedskilledGithubWrite): RedskilledGithubWrite {
     const body = typeof write.body === "string" ? write.body : refuse("a pull request needs a body");
     return { kind: "pull-request", head, base, title, body };
   }
+  if (write.kind === "issue-transition") {
+    requireOnlyKeys(write, ["kind", "issue", "add", "remove", "comment"]);
+    if (!Number.isSafeInteger(write.issue) || write.issue <= 0) {
+      return refuse("an Issue transition needs one positive Issue number");
+    }
+    const add = validateLabelList(write.add, "an Issue transition add list");
+    const remove = validateLabelList(write.remove, "an Issue transition remove list");
+    if (add.length === 0 && remove.length === 0) {
+      return refuse("an Issue transition needs at least one label to add or remove");
+    }
+    const comment = write.comment == null
+      ? undefined
+      : nonEmpty(write.comment, "an Issue transition comment must not be empty");
+    return { kind: "issue-transition", issue: write.issue, add, remove, ...(comment == null ? {} : { comment }) };
+  }
   if (write.kind === "issue-publication") {
     requireOnlyKeys(write, ["kind", "issue", "title", "body", "labels"]);
     const body = typeof write.body === "string" ? write.body : refuse("an Issue publication needs a body");
@@ -312,6 +327,12 @@ function validateStoredAuthority(
     throw new RedskilledGithubAuthorityError("the daemon-owned credential profile name is not publishable");
   }
   return { ...authority };
+}
+
+/** Labels are tracker-defined names: non-empty, no exotic validation here. */
+function validateLabelList(value: unknown, label: string): readonly string[] {
+  if (!Array.isArray(value)) return refuse(`${label} must be an array of labels`);
+  return value.map((entry) => nonEmpty(entry, `${label} holds one empty label`));
 }
 
 function nonEmpty(value: unknown, message: string): string {

--- a/apps/redskilled/src/github-write.ts
+++ b/apps/redskilled/src/github-write.ts
@@ -60,8 +60,14 @@ export function createRedskilledGithubWriteUpstream(
     if (input.write.kind === "repository-push") return pushRepository(input);
     const repository = input.project.projectLabel.split("/").map(encodeURIComponent).join("/");
     const marker = githubOutboxMarker(input.idempotencyKey);
-    const request = apiWriteRequest(input.write, repository, marker);
     const headers = { ...githubHeaders(input.credential.secret), "content-type": "application/json" };
+    if (input.write.kind === "issue-transition") {
+      return applyIssueTransition(input.write, {
+        repository, marker, origin, fetchImpl, headers, clock,
+        credentialProfile: input.project.credentialProfile,
+      });
+    }
+    const request = apiWriteRequest(input.write, repository, marker);
     const lookup = await fetchImpl(`${origin}/${request.lookup}`, { method: "GET", headers });
     if (!lookup.ok) {
       throw githubUpstreamRefusal("write reconciliation", "rest", lookup, clock(), input.project.credentialProfile);
@@ -81,8 +87,62 @@ export function createRedskilledGithubWriteUpstream(
   };
 }
 
+/**
+ * Apply one Ticket state transition: label adds and removes are naturally
+ * idempotent upstream (adding a held label repeats it, deleting an absent one
+ * answers 404), so only the explanatory comment rides the outbox marker.
+ */
+async function applyIssueTransition(
+  write: Extract<RedskilledGithubWrite, { readonly kind: "issue-transition" }>,
+  ctx: {
+    readonly repository: string;
+    readonly marker: string;
+    readonly origin: string;
+    readonly fetchImpl: typeof fetch;
+    readonly headers: Record<string, string>;
+    readonly clock: () => string;
+    readonly credentialProfile: string;
+  },
+): Promise<unknown> {
+  const issuePath = `${ctx.origin}/repos/${ctx.repository}/issues/${write.issue}`;
+  if (write.add.length > 0) {
+    const added = await ctx.fetchImpl(`${issuePath}/labels`, {
+      method: "POST",
+      headers: ctx.headers,
+      body: JSON.stringify({ labels: [...write.add] }),
+    });
+    if (!added.ok) throw githubUpstreamRefusal("issue transition add", "rest", added, ctx.clock(), ctx.credentialProfile);
+  }
+  for (const label of write.remove) {
+    const removed = await ctx.fetchImpl(`${issuePath}/labels/${encodeURIComponent(label)}`, {
+      method: "DELETE",
+      headers: ctx.headers,
+    });
+    // 404 is the label already absent — the state this removal wanted.
+    if (!removed.ok && removed.status !== 404) {
+      throw githubUpstreamRefusal("issue transition remove", "rest", removed, ctx.clock(), ctx.credentialProfile);
+    }
+  }
+  let commented = false;
+  if (write.comment != null) {
+    const lookup = await ctx.fetchImpl(`${issuePath}/comments?per_page=100`, { method: "GET", headers: ctx.headers });
+    if (!lookup.ok) throw githubUpstreamRefusal("issue transition reconciliation", "rest", lookup, ctx.clock(), ctx.credentialProfile);
+    if (findMarkedPublication(await responseValue(lookup), ctx.marker) == null) {
+      const body = `${write.comment}${write.comment.endsWith("\n") ? "" : "\n\n"}${ctx.marker}`;
+      const posted = await ctx.fetchImpl(`${issuePath}/comments`, {
+        method: "POST",
+        headers: ctx.headers,
+        body: JSON.stringify({ body }),
+      });
+      if (!posted.ok) throw githubUpstreamRefusal("issue transition comment", "rest", posted, ctx.clock(), ctx.credentialProfile);
+    }
+    commented = true;
+  }
+  return { issue: write.issue, added: [...write.add], removed: [...write.remove], commented };
+}
+
 function apiWriteRequest(
-  write: Exclude<RedskilledGithubWrite, { readonly kind: "repository-push" }>,
+  write: Exclude<RedskilledGithubWrite, { readonly kind: "repository-push" | "issue-transition" }>,
   repository: string,
   marker: string,
 ): { readonly lookup: string; readonly path: string; readonly body: Record<string, unknown> } {

--- a/apps/redskilled/tests/demand-park.test.ts
+++ b/apps/redskilled/tests/demand-park.test.ts
@@ -1,0 +1,209 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { gateBlockedParkWrite, gateBlockedVerdictOf } from "../src/demand-park.js";
+import { createDemandTurnRunner, type DemandTurnAdmission, type DemandTurnRecord } from "../src/acp-demand-turn.js";
+import type { ActiveWorkflowWorker } from "../src/acp-worker-lifecycle.js";
+import { validateWriteRequest } from "../src/github-outbox.js";
+import { createRedskilledGithubWriteUpstream } from "../src/github-write.js";
+
+/**
+ * A gate-blocked verdict that changes nothing on the tracker leaves the Ticket
+ * at the head of the ready queue, so every freed slot re-births a Worker for
+ * the same item (#4160: 34 claim comments on two issues in one morning). The
+ * park is what makes the queue advance.
+ */
+describe("the gate-blocked verdict is read from the turn's ticket meta", () => {
+  it("answers only for gate-blocked", () => {
+    expect(gateBlockedVerdictOf({
+      _meta: { redskills: { ticket: { outcome: "gate-blocked", failedStage: "feedback", detail: "pnpm test: red" } } },
+    })).toEqual({ failedStage: "feedback", detail: "pnpm test: red" });
+    expect(gateBlockedVerdictOf({
+      _meta: { redskills: { ticket: { outcome: "landed", pullRequest: 7 } } },
+    })).toBeNull();
+    expect(gateBlockedVerdictOf({})).toBeNull();
+  });
+});
+
+describe("the park write moves the Ticket out of the executable queue", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "demand-park-"));
+
+  it("computes the engine planner's atomic transition under the default vocabulary", () => {
+    const composed = gateBlockedParkWrite({
+      workspacePath: workspace,
+      ticket: { number: 4154, labels: ["bug", "ready-for-agent"] },
+      workerId: "VSq1",
+      verdict: { failedStage: "feedback", detail: "pnpm test failed" },
+    });
+
+    expect(composed).toMatchObject({
+      summary: expect.stringContaining("parked #4154"),
+      request: {
+        idempotency_key: "park:4154:VSq1",
+        write: {
+          kind: "issue-transition",
+          issue: 4154,
+          add: expect.arrayContaining(["ready-for-human", "blocked:validation"]),
+          remove: ["ready-for-agent"],
+          comment: expect.stringContaining("/retake 4154"),
+        },
+      },
+    });
+  });
+
+  it("carries the failed stage and the gate detail into the comment", () => {
+    const composed = gateBlockedParkWrite({
+      workspacePath: workspace,
+      ticket: { number: 9, labels: ["ready-for-agent"] },
+      workerId: "W2",
+      verdict: { failedStage: "post_done", detail: "assert red" },
+    });
+
+    if ("refusal" in composed) throw new Error(composed.refusal);
+    expect(composed.request.write).toMatchObject({
+      kind: "issue-transition",
+      comment: expect.stringContaining("post_done"),
+    });
+    expect((composed.request.write as { comment?: string }).comment).toContain("assert red");
+  });
+});
+
+describe("the outbox validates an issue transition like every other write", () => {
+  it("passes a well-formed transition through", () => {
+    expect(validateWriteRequest({
+      idempotency_key: "park:4154:W1",
+      write: { kind: "issue-transition", issue: 4154, add: ["ready-for-human"], remove: ["ready-for-agent"] },
+    })).toMatchObject({ write: { kind: "issue-transition", issue: 4154 } });
+  });
+
+  it("refuses a transition that names no issue or moves no label", () => {
+    expect(() => validateWriteRequest({
+      idempotency_key: "k",
+      write: { kind: "issue-transition", issue: 0, add: ["x"], remove: [] } as never,
+    })).toThrow(/positive Issue number/);
+    expect(() => validateWriteRequest({
+      idempotency_key: "k",
+      write: { kind: "issue-transition", issue: 5, add: [], remove: [] } as never,
+    })).toThrow(/at least one label/);
+  });
+});
+
+describe("the upstream applies the transition as label calls plus one marked comment", () => {
+  it("adds, removes (tolerating an already-absent label), and comments once", async () => {
+    const calls: Array<{ method: string; url: string; body?: unknown }> = [];
+    const fetchImpl = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      calls.push({ method, url: String(url), ...(init?.body == null ? {} : { body: JSON.parse(String(init.body)) }) });
+      if (method === "DELETE" && String(url).endsWith("ready-for-agent")) {
+        return new Response("{}", { status: 404 });
+      }
+      if (method === "GET") return new Response("[]", { status: 200 });
+      return new Response("{}", { status: 200 });
+    });
+    const upstream = createRedskilledGithubWriteUpstream({ fetchImpl: fetchImpl as never });
+
+    const answer = await upstream({
+      project: { projectId: "github:1", projectLabel: "o/r", workspacePath: "/tmp", credentialProfile: "personal" },
+      credential: { secret: "t" } as never,
+      idempotencyKey: "park:4154:W1",
+      write: {
+        kind: "issue-transition",
+        issue: 4154,
+        add: ["ready-for-human", "blocked:validation"],
+        remove: ["ready-for-agent", "running"],
+        comment: "parked",
+      },
+    });
+
+    expect(answer).toEqual({
+      issue: 4154,
+      added: ["ready-for-human", "blocked:validation"],
+      removed: ["ready-for-agent", "running"],
+      commented: true,
+    });
+    expect(calls.map((call) => `${call.method} ${call.url.split("/repos/")[1]}`)).toEqual([
+      "POST o/r/issues/4154/labels",
+      "DELETE o/r/issues/4154/labels/ready-for-agent",
+      "DELETE o/r/issues/4154/labels/running",
+      "GET o/r/issues/4154/comments?per_page=100",
+      "POST o/r/issues/4154/comments",
+    ]);
+  });
+});
+
+/** The runner parks after the verdict is recorded, and records what the park did. */
+describe("a completed gate-blocked turn is parked by the runner", () => {
+  const project = {
+    projectId: "github:1",
+    projectLabel: "o/r",
+    workspacePath: "/tmp/project",
+  } as never;
+
+  function workerStub(response: unknown): ActiveWorkflowWorker {
+    const prompted = vi.fn(async () => response);
+    return {
+      workerId: "W1",
+      downstreamSessionId: "down-W1",
+      connection: { agent: { request: prompted, notify: vi.fn() }, close: vi.fn() },
+      socket: { destroy: vi.fn(), destroyed: false },
+      endpoint: "/tmp/W1.sock",
+      publicSessionId: "",
+      notify: vi.fn(async () => {}),
+      cancelled: false,
+      cleaned: false,
+    } as never;
+  }
+
+  function runnerWith(park: NonNullable<Parameters<typeof createDemandTurnRunner>[0]["park"]>, response: unknown) {
+    const records: DemandTurnRecord[] = [];
+    const run = createDemandTurnRunner({
+      paths: {} as never,
+      startWorker: (() => { throw new Error("injected admission owns the birth"); }) as never,
+      hostState: () => ({ workers: [] }),
+      sessionJournal: { create: async () => {} } as never,
+      admit: async (_input: DemandTurnAdmission) => workerStub(response),
+      record: (line) => void records.push(line),
+      park,
+    });
+    return { run, records };
+  }
+
+  const gateBlocked = {
+    result: {
+      stopReason: "end_turn",
+      _meta: { redskills: { ticket: { outcome: "gate-blocked", failedStage: "feedback", rounds: 1 } } },
+    },
+  };
+
+  it("passes the turn's project and ticket to the park and records its summary", async () => {
+    const park = vi.fn(async () => "parked #4154: +[ready-for-human, blocked:validation] -[ready-for-agent]");
+    const { run, records } = runnerWith(park, gateBlocked);
+
+    await run({ project, prompt: "p", workItem: "4154", ticket: { number: 4154, labels: ["ready-for-agent"] } });
+
+    expect(park).toHaveBeenCalledWith(project, { number: 4154, labels: ["ready-for-agent"] }, expect.anything(), "W1");
+    expect(records.map((record) => record.event)).toContain("demand-park");
+  });
+
+  it("records a park that failed instead of losing the turn", async () => {
+    const park = vi.fn(async () => { throw new Error("gateway offline"); });
+    const { run, records } = runnerWith(park, gateBlocked);
+
+    await run({ project, prompt: "p", ticket: { number: 4154, labels: [] } });
+
+    const failed = records.find((record) => record.event === "demand-park-failed");
+    expect(failed?.detail).toContain("gateway offline");
+  });
+
+  it("does not park a turn that carried no ticket", async () => {
+    const park = vi.fn(async () => null);
+    const { run } = runnerWith(park, gateBlocked);
+
+    await run({ project, prompt: "p" });
+
+    expect(park).not.toHaveBeenCalled();
+  });
+});

--- a/packages/protocol-acp/github-write.ts
+++ b/packages/protocol-acp/github-write.ts
@@ -15,6 +15,21 @@ export type RedskilledGithubWrite =
       readonly body: string;
     }
   | {
+      /**
+       * Move a Ticket's state labels as one authorized mutation (#4160).
+       *
+       * A gate-blocked verdict that changes nothing on the tracker leaves the
+       * Ticket at the head of the ready queue, so every freed slot re-births a
+       * Worker for the same item. The transition is what makes the queue
+       * advance; the optional comment explains it in the same write.
+       */
+      readonly kind: "issue-transition";
+      readonly issue: number;
+      readonly add: readonly string[];
+      readonly remove: readonly string[];
+      readonly comment?: string;
+    }
+  | {
       readonly kind: "issue-publication";
       /** Absent to open a Ticket; present to publish a comment on that Ticket. */
       readonly issue?: number;

--- a/packages/worker/src/Orchestrator.ts
+++ b/packages/worker/src/Orchestrator.ts
@@ -9,7 +9,7 @@ import {
 } from "./errors.js";
 import type { SandboxError } from "./errors.js";
 import type { SandboxService } from "./SandboxFactory.js";
-import { SandboxFactory, SANDBOX_REPO_DIR } from "./SandboxFactory.js";
+import { SandboxFactory } from "./SandboxFactory.js";
 import { withSandboxLifecycle, type SandboxHooks } from "./SandboxLifecycle.js";
 import type { AgentProvider, IterationUsage } from "./AgentProvider.js";
 import type { Timeouts } from "./run.js";

--- a/packages/worker/src/SandboxFactory.ts
+++ b/packages/worker/src/SandboxFactory.ts
@@ -9,7 +9,6 @@ import {
   ExecError,
   SyncError,
   WorktreeError,
-  type DockerError,
   type SandboxError,
 } from "./errors.js";
 import type { Timeouts } from "./run.js";

--- a/packages/worker/src/engine/tracker/github/adapter.ts
+++ b/packages/worker/src/engine/tracker/github/adapter.ts
@@ -13,7 +13,6 @@ import type {
   TrackerIssue,
   TrackerPort,
   TrackerIssueCreateSpec,
-  TrackerLabelMutation,
   TrackerIssueReference,
 } from "../port.js";
 import {

--- a/packages/worker/src/startSandbox.ts
+++ b/packages/worker/src/startSandbox.ts
@@ -11,7 +11,6 @@ import {
   type DockerError,
 } from "./errors.js";
 import type {
-  SandboxProvider,
   BindMountSandboxProvider,
   BindMountSandboxHandle,
   IsolatedSandboxProvider,


### PR DESCRIPTION
A verdict that changes nothing on the tracker is indistinguishable from no verdict (#4160): two Workers finished `gate-blocked at feedback` on #4154 and the Ticket kept `ready-for-agent`, so every freed slot re-birthed a Worker for the same head item — 34 claim comments across two issues in one morning, duplicate work, and an infinite grinder.

## What this adds

- **`demand-park.ts`**: reads the turn's Ticket verdict; computes the transition with the Worker engine's own `planTransition` (`park` with `blocked:validation`) under the label vocabulary the PROJECT declares in `.red/config.yaml` — the daemon spells no label of its own; sends one authorized write through the Project-bound gateway (`bindAcpProjectGithubWrite`). A park the planner refuses is a recorded sentence, never a dead Worker.
- **Wire**: `issue-transition` joins `RedskilledGithubWrite` — label adds and removes as one authorized mutation plus an explanatory comment. Adds/removes are naturally idempotent upstream (a 404 on remove is the state the removal wanted); only the comment rides the outbox marker. Outbox validation covers it like every other kind.
- **Runner**: after recording `demand-turn-completed`, the runner calls the park and records `demand-park` / `demand-park-failed`, so the operator can read why the queue did or did not advance.

## Tests

`demand-park.test.ts` (9 tests): verdict extraction; the composed transition under the default vocabulary (`+[ready-for-human, blocked:validation] -[ready-for-agent]`, idempotency key, `/retake` hint in the comment); outbox validation accept/refuse; upstream call sequence with a tolerated 404; runner-level park invocation, park-failure recording, and no-ticket bypass. `demand-turn` and `unregistered-drain` stay green (35 total).

Pre-existing on clean main, not touched here: worker-package TS6133/TS6196 warnings and the plugin-gate TS2532.

Closes #4160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789835449&installation_model_id=20659&pr_number=4177&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4177&signature=6ead4fa84b53e8e101a1285424deb8855d7c2ff71671fc1722ad8a65e89ec512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->