### PR TITLE
fix(dev): the drain prompt says the Worker is already in its worktree

### DIFF
--- a/.changeset/drain-prompt-states-worktree.md
+++ b/.changeset/drain-prompt-states-worktree.md
@@ -1,0 +1,7 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The drain Worker prompt states that the Worker already stands in its own
+materialised worktree on the Ticket's base, so the inner agent stops building
+a nested worktree by following the repository's interactive-mode rules.

--- a/apps/plugin-dev/src/core/drain-registration.ts
+++ b/apps/plugin-dev/src/core/drain-registration.ts
@@ -67,6 +67,14 @@ export interface DrainRegistration {
 export const DRAIN_WORKER_PROMPT =
   "Work issue #{{work_item}} in this repository to a merged pull request, following the /afk skill: " +
   "claim it, implement it in this workspace, run the gate, open the PR, and land it. " +
+  // #4162: an inner agent reading the repository's interactive-mode rules built
+  // a NESTED worktree under .red/tmp/worktrees/manual inside its own worktree.
+  // The Worker's workspace was already materialised by the daemon on the
+  // Ticket's base, so the prompt says so — the worktree rules it would
+  // otherwise follow govern a human's checkout, not a Worker.
+  "You are already standing in your own dedicated worktree on the Ticket's base branch: work and " +
+  "commit right here, and never create another worktree — the repository's worktree lanes govern " +
+  "interactive sessions, not Workers. " +
   "If you cannot claim it or the work is blocked, say so plainly and stop.";
 
 /** Build the registration a drain carries. PURE. */

--- a/apps/plugin-dev/tests/drain-registration.test.ts
+++ b/apps/plugin-dev/tests/drain-registration.test.ts
@@ -41,6 +41,10 @@ describe("what a drain hands the daemon", () => {
     expect(buildDrainRegistration(input).prompt).toBe(DRAIN_WORKER_PROMPT);
     expect(DRAIN_WORKER_PROMPT).toContain("{{work_item}}");
     expect(DRAIN_WORKER_PROMPT).toContain("/afk");
+    // #4162: the Worker's workspace is already materialised on the Ticket's
+    // base; an inner agent told nothing builds a nested worktree by following
+    // the repository's interactive-mode rules.
+    expect(DRAIN_WORKER_PROMPT).toContain("never create another worktree");
   });
 
   it("narrows the queue by the facets a caller stated", () => {


### PR DESCRIPTION
#4162 part 2: the inner agent received the Ticket and then ran `git worktree add .red/tmp/worktrees/manual/4154-mcp-reconnect -b fix/4154-mcp-reconnect origin/main` INSIDE its Worker worktree — it followed the repository CLAUDE.md's interactive-mode worktree rules because nothing told it those govern a human's checkout, not a Worker whose workspace the daemon already materialised on the Ticket's base. The prompt now states it plainly ("work and commit right here, and never create another worktree"), and `drain-registration.test.ts` pins the sentence.

Part 1 of #4162 (the drain answer's false "holds no registration" warning) was fixed by #4163's one-key registration.

Closes #4162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789835559&installation_model_id=20659&pr_number=4178&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4178&signature=0df364b972d72f2c8bcbeb45a8098b4100ac373e2513553df170692fbbd6f6f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->