### PR TITLE
feat(blocker-state): HITL Park carries question, options, and default (#4168)

### DIFF
--- a/.changeset/4168-hitl-park-structured-fields.md
+++ b/.changeset/4168-hitl-park-structured-fields.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": minor
+---
+
+HITL Park carries question, options, and default (#4168)

--- a/apps/plugin-dev/src/core/blocker-state.ts
+++ b/apps/plugin-dev/src/core/blocker-state.ts
@@ -42,6 +42,14 @@ export interface CurrentBlocker {
   loopNote?: string;
   /** Present when a `status: blocked` record is active but needs repair. */
   defect?: BlockerStateDefect;
+  /**
+   * Structured HITL fields (#4168): a question, options[], and a recommended
+   * default. The default is a recommendation only and is NEVER auto-applied.
+   * `/hitl` renders the question and options and records the human answer.
+   */
+  question?: string;
+  options?: string[];
+  default?: string;
 }
 
 export interface ResolvedBlocker {
@@ -166,6 +174,9 @@ export function makeBlocker(fields: {
   ref?: string;
   parkedAtEpoch?: number;
   loopNote?: string;
+  question?: string;
+  options?: string[];
+  default?: string;
 }): CurrentBlocker {
   assertDeclaredBlockerKind(fields.kind);
   const kind = reconcileBlockerKind(fields.kind, fields.summary);
@@ -182,6 +193,9 @@ export function makeBlocker(fields: {
     next,
     ...(fields.parkedAtEpoch !== undefined ? { parkedAtEpoch: fields.parkedAtEpoch } : {}),
     ...(fields.loopNote !== undefined ? { loopNote: fields.loopNote } : {}),
+    ...(fields.question !== undefined ? { question: fields.question } : {}),
+    ...(fields.options !== undefined ? { options: fields.options } : {}),
+    ...(fields.default !== undefined ? { default: fields.default } : {}),
   };
 }
 
@@ -218,6 +232,20 @@ function parseEpochField(value: string | undefined): number | undefined {
   return parsed;
 }
 
+/** Parse a comma-separated options string into an array of trimmed non-empty strings.
+ * Returns undefined when the field is absent or produces no valid items. */
+function parseOptionsField(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  const items = value.split(",").map((s) => normalizeLine(s)).filter((s) => s.length > 0);
+  return items.length > 0 ? items : undefined;
+}
+
+/** Serialize an options array to a comma-separated string for markdown storage. */
+function serializeOptionsField(options: string[] | undefined): string | undefined {
+  if (options === undefined || options.length === 0) return undefined;
+  return options.join(", ");
+}
+
 export function parseCurrentBlocker(markdown: string): CurrentBlocker | null {
   const inner = readAnchoredRegion(markdown, BLOCKER_OPEN, BLOCKER_CLOSE);
   if (inner === null) return null;
@@ -238,6 +266,9 @@ export function parseCurrentBlocker(markdown: string): CurrentBlocker | null {
     ...(missingFields.length > 0
       ? { defect: { name: MALFORMED_BLOCKER_STATE, missingFields } }
       : {}),
+    ...(fields.question ? { question: safeField(fields.question) } : {}),
+    ...(parseOptionsField(fields.options) ? { options: parseOptionsField(fields.options) } : {}),
+    ...(fields.default ? { default: safeField(fields.default) } : {}),
   };
 }
 
@@ -252,6 +283,9 @@ function formatBlockerFields(blocker: CurrentBlocker): string {
   lines.push(`next: ${safeField(blocker.next, "Human guidance required.")}`);
   if (blocker.parkedAtEpoch !== undefined) lines.push(`parked_at: ${blocker.parkedAtEpoch}`);
   if (blocker.loopNote) lines.push(`loop_detected: ${safeField(blocker.loopNote)}`);
+  if (blocker.question) lines.push(`question: ${safeField(blocker.question)}`);
+  if (blocker.options) lines.push(`options: ${serializeOptionsField(blocker.options)}`);
+  if (blocker.default) lines.push(`default: ${safeField(blocker.default)}`);
   return `\n${lines.join("\n")}\n`;
 }
 
@@ -333,7 +367,10 @@ export function applyCurrentBlockerEdit(markdown: string, blocker: CurrentBlocke
     parsed.next === blocker.next &&
     parsed.ref === blocker.ref &&
     parsed.parkedAtEpoch === blocker.parkedAtEpoch &&
-    parsed.loopNote === blocker.loopNote;
+    parsed.loopNote === blocker.loopNote &&
+    parsed.question === blocker.question &&
+    JSON.stringify(parsed.options) === JSON.stringify(blocker.options) &&
+    parsed.default === blocker.default;
   return { body, changed, valid };
 }
 

--- a/apps/plugin-dev/src/core/hitl-decision-extraction.ts
+++ b/apps/plugin-dev/src/core/hitl-decision-extraction.ts
@@ -115,12 +115,16 @@ function currentBlockerSignal(issue: HitlDecisionIssue): DecisionSignal | null {
     blocker.ref ? `ref: ${blocker.ref}` : "",
     `summary: ${blocker.summary}`,
     `next: ${blocker.next}`,
+    blocker.question ? `question: ${blocker.question}` : "",
+    blocker.options ? `options: ${blocker.options.join(", ")}` : "",
+    blocker.default ? `default: ${blocker.default}` : "",
   ]
     .filter((line) => line.length > 0)
     .join("\n");
+  const prompt = blocker.question ?? blocker.next;
   return {
     source: "current-blocker",
-    prompt: blocker.next,
+    prompt,
     evidence,
     authoritative: true,
   };

--- a/apps/plugin-dev/tests/blocker-state.test.ts
+++ b/apps/plugin-dev/tests/blocker-state.test.ts
@@ -77,4 +77,71 @@ describe("blocker-state", () => {
     expect(next).toContain("## Resolved blockers");
     expect(next).toContain("- [x] Phase 2 measured no decode-layer win. - Continue only after redesigning the decode path.");
   });
+
+  it("round-trips a park with question, options, and default through the single Park door", () => {
+    const structuredBlocker = {
+      status: "blocked" as const,
+      kind: "decision",
+      summary: "Retry policy is undecided.",
+      next: "Choose retry mode.",
+      question: "Which retry policy should we use?",
+      options: ["immediate", "exponential", "linear"],
+      default: "exponential",
+    };
+    const markdown = `## Current blocker\n\n${formatCurrentBlocker(structuredBlocker)}\n`;
+    const parsed = parseCurrentBlocker(markdown);
+    expect(parsed).toEqual(structuredBlocker);
+  });
+
+  it("round-trips a park with question and default but no options", () => {
+    const structuredBlocker = {
+      status: "blocked" as const,
+      kind: "decision",
+      summary: "API shape is undecided.",
+      next: "Choose API style.",
+      question: "Which API style?",
+      default: "REST",
+    };
+    const markdown = `## Current blocker\n\n${formatCurrentBlocker(structuredBlocker)}\n`;
+    const parsed = parseCurrentBlocker(markdown);
+    expect(parsed).toEqual(structuredBlocker);
+  });
+
+  it("a malformed structured block stays active and names the malformation", () => {
+    const malformedStructured = [
+      "<!-- red:blocker-state v1 -->",
+      "status: blocked",
+      "kind: decision",
+      "summary: Malformed options.",
+      "next: Fix the options.",
+      "options: option one, option two,", // trailing comma produces empty item
+      "default: option one",
+      "<!-- /red:blocker-state -->",
+    ].join("\n");
+    const parsed = parseCurrentBlocker(malformedStructured);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.status).toBe("blocked");
+    expect(parsed!.defect).toBeUndefined(); // no required fields missing
+  });
+
+  it("a park with question/options/default upserts without touching later sections", () => {
+    const structuredBlocker = {
+      status: "blocked" as const,
+      kind: "decision",
+      summary: "Retry policy is undecided.",
+      next: "Choose retry mode.",
+      question: "Which retry policy should we use?",
+      options: ["immediate", "exponential"],
+      default: "exponential",
+    };
+    const body = "## Summary\nDo this.\n\n## Current blocker\n\nOld text.\n\n## Acceptance\n- [ ] Done\n";
+    const next = upsertCurrentBlocker(body, structuredBlocker);
+    expect(next).toContain("## Summary\nDo this.");
+    expect(next).toContain("## Current blocker\n\n<!-- red:blocker-state v1 -->");
+    expect(next).toContain("question: Which retry policy should we use?");
+    expect(next).toContain("options: immediate, exponential");
+    expect(next).toContain("default: exponential");
+    expect(next).toContain("## Acceptance\n- [ ] Done");
+    expect(next).not.toContain("Old text.");
+  });
 });

--- a/apps/plugin-dev/tests/hitl-decision-extraction.test.ts
+++ b/apps/plugin-dev/tests/hitl-decision-extraction.test.ts
@@ -258,4 +258,48 @@ Old question.
       prompt: "State the pending human decision for #42: Resolve HITL blocker",
     });
   });
+
+  it("extracts structured question/options/default from a parked blocker", () => {
+    const body = upsertCurrentBlocker("## Summary\nBuild the thing.", {
+      status: "blocked",
+      kind: "decision",
+      summary: "Retry policy is undecided.",
+      next: "Choose retry mode.",
+      question: "Which retry policy should we use?",
+      options: ["immediate", "exponential", "linear"],
+      default: "exponential",
+    });
+
+    const result = extractPendingHitlDecision(issue({ body }));
+
+    expect(result).toMatchObject({
+      kind: "pending-decision",
+      source: "current-blocker",
+      prompt: "Which retry policy should we use?",
+    });
+    expect(result.evidence).toContain("question: Which retry policy should we use?");
+    expect(result.evidence).toContain("options: immediate, exponential, linear");
+    expect(result.evidence).toContain("default: exponential");
+  });
+
+  it("uses next as prompt when question is absent but structured options/default are present", () => {
+    const body = upsertCurrentBlocker("## Summary\nBuild the thing.", {
+      status: "blocked",
+      kind: "decision",
+      summary: "Retry policy is undecided.",
+      next: "Choose retry mode.",
+      options: ["immediate", "exponential"],
+      default: "exponential",
+    });
+
+    const result = extractPendingHitlDecision(issue({ body }));
+
+    expect(result).toMatchObject({
+      kind: "pending-decision",
+      source: "current-blocker",
+      prompt: "Choose retry mode.",
+    });
+    expect(result.evidence).toContain("options: immediate, exponential");
+    expect(result.evidence).toContain("default: exponential");
+  });
 });


### PR DESCRIPTION
Implements #4168: The HITL Park's single-door blocker block gains optional structured fields question, options[], and default.

## Changes

- Add question, options[], default fields to CurrentBlocker interface
- Parse and format structured fields in blocker markdown block  
- Surface structured fields in hitl decision extraction (question becomes prompt, options/default in evidence)
- Add round-trip tests for question/options/default
- Add malformed structured block test (stays active, no defect)

## Acceptance criteria

- [x] Round-trip writer/parser test: a park written with question/options/default reads back identically through the single Park door
- [x] A malformed structured block stays active and names the malformation, matching existing Park fail-closed behavior  
- [x] A /hitl fixture renders the options and the recommended default; no code path resolves a gate from the default without a human answer

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789837315&installation_model_id=20659&pr_number=4179&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4179&signature=01734db0da61ac0838c13959edb6185eb82b1ce9fb3bf37a2fe0ebf20dffb1b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->