### PR TITLE
fix(redskilled): a native Worker's turn events are its statusline pulse

### DIFF
--- a/.changeset/native-worker-pulse.md
+++ b/.changeset/native-worker-pulse.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+A native Worker's turn events are stamped as its statusline pulse: the demand
+turn records the work item at admission and each session update as it arrives,
+into the same maps the heartbeat op feeds, and the statusline payload derives
+`hb=<age of the last pulse>` when the display published none — so a live
+Worker no longer reads `hb=?` while it streams.

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -143,12 +143,11 @@ export interface StartRedskillsAcpControlPlaneOptions {
    * drain then answers exactly as it did before registrations reached it.
    */
   readonly registerProject?: (request: RedskilledProjectRegistrationRequest) => unknown;
-  /**
-   * The daemon's own release path, for the same reason: a stop must hand the
-   * self-sustaining registration back (#4159), and the lifecycle owns that
-   * record. Absent means a stop flips the intent only — legal in a test.
-   */
+  /** The matching release path: a stop hands the self-sustaining registration
+   * back (#4159). Absent means a stop flips the intent only — legal in a test. */
   readonly releaseProject?: (projectLabel: string) => unknown;
+  /** Stamp a native Worker's turn events as its statusline pulse (#4181). */
+  readonly workerPulse?: (pulse: { workerId: string; line?: string; issue?: string }) => void;
 }
 
 /** The store handles every connection on this endpoint shares (ADR 0152). */

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -79,6 +79,14 @@ export interface DemandTurnDeps {
     response: PromptResponse,
     workerId: string,
   ) => Promise<string | null>;
+  /**
+   * Where a turn's session updates land as Worker liveness (#4181).
+   *
+   * A native Worker publishes no heartbeat op, so without this every statusline
+   * row reads `hb=?` while the turn streams. The runner stamps the work item at
+   * admission and each update's text line as it arrives.
+   */
+  readonly pulse?: (pulse: { workerId: string; line?: string; issue?: string }) => void;
 }
 
 /**
@@ -269,6 +277,7 @@ export function demandTurnRunnerFor(
     readonly evidenceRoot?: string;
     readonly evidenceTtlMs?: number;
     readonly recordDemandTurn?: (record: DemandTurnRecord) => void;
+    readonly workerPulse?: (pulse: { workerId: string; line?: string; issue?: string }) => void;
   },
   sessionJournal: AcpSessionJournal,
 ): (request: DemandTurnRequest) => Promise<DemandTurnResult> {
@@ -281,6 +290,7 @@ export function demandTurnRunnerFor(
     ...(options.evidenceRoot == null ? {} : { evidenceRoot: options.evidenceRoot }),
     ...(options.evidenceTtlMs == null ? {} : { evidenceTtlMs: options.evidenceTtlMs }),
     ...(options.recordDemandTurn == null ? {} : { record: options.recordDemandTurn }),
+    ...(options.workerPulse == null ? {} : { pulse: options.workerPulse }),
     park: parkGateBlockedTurn(options.githubGateway),
   });
 }
@@ -330,9 +340,14 @@ export function createDemandTurnRunner(
         ...(detail == null ? {} : { detail }),
       });
     };
-    // Nobody is listening, so a notification is a record. The shape is kept so
-    // the admission path cannot tell the difference between this and a client.
-    const notify: AgentConnection["client"]["notify"] = async () => {};
+    // Nobody is listening, so a notification is a record — and a pulse (#4181):
+    // the turn's own updates are the only liveness a native Worker ever emits.
+    let born: ActiveWorkflowWorker | null = null;
+    const notify: AgentConnection["client"]["notify"] = async (_method: string, params?: unknown) => {
+      if (born == null || deps.pulse == null) return;
+      const line = sessionUpdateLine(params);
+      deps.pulse({ workerId: born.workerId, ...(line == null ? {} : { line }) });
+    };
 
     try {
       // **A turn nobody opened is a turn the journal refuses.** Admission and
@@ -362,6 +377,10 @@ export function createDemandTurnRunner(
           notify,
           permission: async (permission) => refusePermission(permission),
           replacement,
+        }).then((worker) => {
+          born = worker;
+          deps.pulse?.({ workerId: worker.workerId, ...(request.workItem == null ? {} : { issue: `#${request.workItem}` }) });
+          return worker;
         }),
       );
       const outcome = describeTurnOutcome(response);
@@ -387,4 +406,11 @@ export function createDemandTurnRunner(
       throw error;
     }
   };
+}
+
+/** The text a session update carries, when it carries any. PURE. */
+function sessionUpdateLine(params: unknown): string | null {
+  const update = (params as { update?: { content?: { text?: unknown } } } | undefined)?.update;
+  const text = update?.content?.text;
+  return typeof text === "string" && text.trim() !== "" ? text.trim() : null;
 }

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -618,12 +618,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   /**
    * Hold every registration up that the project's own work still speaks for.
    *
-   * ADR 0130 Amendment 7: the renewal's owner is this process. It runs off the
-   * facts the daemon already holds at the instant it holds them — the depth its
-   * last poll counted and the Workers it is itself running — so a drain survives
-   * the terminal that started it without one message from a session, and a project
-   * with neither still lapses at its deadline. Nothing here reads a selector: the
-   * decision is made from one integer per project (ADR 0130 rule 3).
+   * ADR 0130 Amendment 7: the renewal's owner is this process, off the facts it
+   * already holds — the depth its last poll counted and the Workers it runs —
+   * so a drain survives its terminal, a project with neither lapses at its
+   * deadline, and no selector is read (ADR 0130 rule 3).
    */
   function sustainRegistrations(now: string): void {
     if (registrations.size === 0) return;
@@ -637,9 +635,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     const polled = new Map((lastQueue?.projects ?? []).map((project) => [project.project_label, project]));
     let changed = false;
     for (const held of [...registrations.values()]) {
-      // A read is not a new observation. Reusing a positive depth forever would
-      // let status reads keep a closed project alive; one registration window is
-      // the most an observed queue may speak for without another poll.
+      // A read is not a new observation: one registration window is the most an
+      // observed queue may speak for without another poll.
       const pollFresh = Number.isFinite(pollAt) && nowMs - pollAt <= held.renew_within_ms;
       const poll = pollFresh ? polled.get(held.project_label) : undefined;
       const sustained = sustainProjectRegistration(held, {
@@ -663,8 +660,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     const polled = new Map((lastQueue?.projects ?? []).map((project) => [project.project_label, project]));
     let changed = false;
     for (const [label, lapsed] of [...recoverableRegistrations]) {
-      // Recovery is a belt, not immortal intent. After one original window there
-      // is no live statement left to restore, so the extra polling stops.
+      // Recovery is a belt, not immortal intent: one original window, no more.
       if (!mayRecoverRegistration(lapsed, nowMs)) {
         recoverableRegistrations.delete(label);
         changed = true;
@@ -1021,12 +1017,9 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       for (const birth of plan.births) {
         let launched: LaunchedWorker;
         const registered = registrations.get(birth.project_label);
-        // **A birth nobody speaks to does nothing** (#4100). A project that
-        // stated a prompt gets the daemon's own unattended turn: admission,
-        // session and prompt, exactly as an attached client would drive it.
-        // The turn is not awaited — it is the Worker's whole life, and a demand
-        // tick that blocked on one would stop planning for every other project
-        // on the host.
+        // **A birth nobody speaks to does nothing** (#4100): a project with a
+        // prompt gets the daemon's own unattended turn, not awaited — it is the
+        // Worker's whole life, and a blocked tick would stop every project.
         if (registered?.prompt != null && acpControlPlane != null) {
           try {
             const turn = demandTurnForBirth(registered, birth, mintHostWorkerId(workers.keys()),
@@ -1048,10 +1041,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
           }
           continue;
         }
-        // The id is minted HERE rather than inside the launch, because the launch
-        // template may mention it: an id substituted into an argv, an env or a log
-        // path and a different id on the record would be one Worker the host and
-        // the work disagree about.
+        // Minted HERE because the launch template may mention the id; a different
+        // id on the record would be one Worker the host and the work disagree about.
         const workerId = mintHostWorkerId(workers.keys());
         const registration = registered;
         const spec = workerSpecFromLaunch(
@@ -1257,12 +1248,26 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     void resourceLeases.releaseHolder(workerId).catch(() => undefined);
   }
 
+  // #4181: a native Worker publishes no heartbeat op; its turn events ARE its
+  // pulse, stamped into the same maps the op feeds, so every read path works.
+  function recordWorkerPulse(pulse: { workerId: string; line?: string; issue?: string }): void {
+    if (workers.get(pulse.workerId) == null) return;
+    const publishedAt = clock();
+    const line = pulse.line?.trim();
+    if (line != null && line !== "") {
+      logLines.set(pulse.workerId, { line, published_at: publishedAt, source: "heartbeat" });
+    }
+    const display = coerceWorkerDisplay({
+      ...(displays.get(pulse.workerId)?.display ?? {}),
+      ...(pulse.issue == null ? {} : { issue: pulse.issue }),
+    });
+    if (display != null) displays.set(pulse.workerId, { display, published_at: publishedAt });
+  }
+
   /**
-   * Record one heartbeat's line, once reach has permitted it.
-   *
-   * Reach is checked against the TARGET's project, exactly as a command is, so a
-   * session cannot publish a line into another project's statusline. A refusal
-   * throws and stores nothing.
+   * Record one heartbeat's line, once reach has permitted it. Reach is checked
+   * against the TARGET's project, exactly as a command is, so a session cannot
+   * publish a line into another project's statusline; a refusal stores nothing.
    */
   function publishWorkerHeartbeat(request: RedskilledWorkerHeartbeatRequest): RedskilledWorkerHeartbeatAck {
     const target = workers.get(request.worker_id);
@@ -1285,17 +1290,14 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     }
     const publishedAt = clock();
     logLines.set(request.worker_id, { line: request.last_log_line, published_at: publishedAt, source: "heartbeat" });
-    // Shape-checked and stored, exactly as the line above it is. A record whose
-    // fields the daemon cannot recognise degrades field by field rather than
-    // failing the heartbeat: a project shipping a newer bundle than its neighbour
-    // is the ordinary state of a host-scoped daemon (ADR 0130 rule 3).
+    // Shape-checked and stored; unrecognised fields degrade field by field,
+    // because mixed bundle versions are a host daemon's ordinary state (rule 3).
     const display = request.display === undefined ? null : coerceWorkerDisplay(request.display);
     if (display != null) {
       const previous = displays.get(request.worker_id)?.display;
       const stored = { display, published_at: publishedAt };
       displays.set(request.worker_id, stored);
-      // Kept as well as stored: the map answers "what is it doing now" and the
-      // history answers "how fast", and one cannot be recovered from the other.
+      // Kept as well as stored: "what now" and "how fast" need both records.
       observeWorkerCounters(stored, target);
       if (display.phase !== previous?.phase || display.step !== previous?.step) {
         record("worker-activity", target, null, { phase: display.phase, step: display.step });
@@ -1521,12 +1523,9 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   /**
-   * Give one project's registration back.
-   *
-   * Reach is checked against the project being released — its own label, exactly
-   * as at registration — so a session cannot stop another project's work. What is
-   * NOT checked is whether a record stood: a release states the outcome and lets
-   * the caller decide what an already-released project means to it.
+   * Give one project's registration back. Reach is checked against the project
+   * being released, so a session cannot stop another project's work; whether a
+   * record stood is NOT checked — a release states the outcome to its caller.
    */
   function deregisterProject(projectLabel: string, sessionProject?: string): RedskilledProjectDeregistered {
     const reach = authorize("project-deregister", sessionProject, projectLabel);
@@ -2404,6 +2403,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       // One registration path (#4101); a stop hands the record back too (#4159).
       registerProject: (request) => registerProject(request),
       releaseProject: (projectLabel) => deregisterProject(projectLabel),
+      workerPulse: (pulse) => recordWorkerPulse(pulse),
       recordDemandTurn: (record) => void process.stderr.write(describeDemandTurn(record)),
     });
   } catch (error) {

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -43,7 +43,7 @@ import {
 } from "./remote-counters.js";
 import type { RedskilledRepositoryActivity } from "./repository-activity.js";
 import type { RedskilledStatuslineExtra } from "./statusline-extras.js";
-import type { RedskilledWorkerDisplay, RedskilledWorkerDisplayRecord } from "./worker-display.js";
+import { displayWithDerivedHeartbeat, type RedskilledWorkerDisplay, type RedskilledWorkerDisplayRecord } from "./worker-display.js";
 import {
   buildDeaths,
   REDSKILLED_RECENT_DEATH_LIMIT,
@@ -666,7 +666,7 @@ function buildWorker(
       enforceable: enforced != null,
     },
     log: workerLog(ctx.log),
-    display: ctx.display?.display ?? null,
+    display: displayWithDerivedHeartbeat(ctx.display, ctx.nowMs),
     display_published_at: ctx.display?.published_at ?? null,
   };
 }

--- a/apps/redskilled/src/worker-display.ts
+++ b/apps/redskilled/src/worker-display.ts
@@ -247,3 +247,23 @@ export function isRedskilledWorkerDisplay(value: unknown): value is RedskilledWo
   }
   return true;
 }
+
+/**
+ * A display that published no heartbeat gets the age of its last pulse (#4181).
+ *
+ * The native Worker's pulse is stamped by the daemon on every turn update, so
+ * `published_at` IS its last sign of life; deriving at payload-build time keeps
+ * the wire shape and every renderer untouched while `hb=?` becomes an honest age.
+ */
+export function displayWithDerivedHeartbeat(
+  record: RedskilledWorkerDisplayRecord | undefined,
+  nowMs: number | null,
+): RedskilledWorkerDisplay | null {
+  if (record == null) return null;
+  if (record.display.heartbeat != null || nowMs == null) return record.display;
+  const at = Date.parse(record.published_at);
+  if (!Number.isFinite(at)) return record.display;
+  const seconds = Math.max(0, Math.round((nowMs - at) / 1000));
+  const heartbeat = seconds < 60 ? `${seconds}s` : `${Math.floor(seconds / 60)}m${seconds % 60}s`;
+  return { ...record.display, heartbeat };
+}

--- a/apps/redskilled/tests/worker-pulse.test.ts
+++ b/apps/redskilled/tests/worker-pulse.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createDemandTurnRunner, type DemandTurnAdmission } from "../src/acp-demand-turn.js";
+import type { ActiveWorkflowWorker } from "../src/acp-worker-lifecycle.js";
+import { displayWithDerivedHeartbeat } from "../src/worker-display.js";
+import { coerceWorkerDisplay } from "../src/worker-display.js";
+
+/**
+ * A native Worker publishes no heartbeat op — its turn events ARE its pulse
+ * (#4181). Without this, every statusline row read `hb=?` while the turn
+ * streamed, and a live Worker was indistinguishable from a hung one.
+ */
+describe("a demand turn stamps its Worker's pulse", () => {
+  const project = { projectId: "github:1", projectLabel: "o/r", workspacePath: "/tmp/p" } as never;
+
+  function workerStub(): ActiveWorkflowWorker {
+    return {
+      workerId: "W1",
+      downstreamSessionId: "down-W1",
+      connection: {
+        agent: {
+          request: vi.fn(async () => ({ stopReason: "end_turn", _meta: {} })),
+          notify: vi.fn(),
+        },
+        close: vi.fn(),
+      },
+      socket: { destroy: vi.fn(), destroyed: false },
+      endpoint: "/tmp/W1.sock",
+      publicSessionId: "",
+      notify: vi.fn(async () => {}),
+      cancelled: false,
+      cleaned: false,
+    } as never;
+  }
+
+  it("pulses the work item at admission and each update's text line after it", async () => {
+    const pulses: Array<{ workerId: string; line?: string; issue?: string }> = [];
+    let seenNotify: ((method: string, params?: unknown) => Promise<void>) | null = null;
+    const run = createDemandTurnRunner({
+      paths: {} as never,
+      startWorker: (() => { throw new Error("injected admission owns the birth"); }) as never,
+      hostState: () => ({ workers: [] }),
+      sessionJournal: { create: async () => {} } as never,
+      admit: async (input: DemandTurnAdmission) => {
+        seenNotify = input.notify as never;
+        return workerStub();
+      },
+      pulse: (pulse) => void pulses.push(pulse),
+    });
+
+    await run({ project, prompt: "p", workItem: "4167" });
+
+    expect(pulses[0]).toEqual({ workerId: "W1", issue: "#4167" });
+
+    await seenNotify!("session/update", {
+      sessionId: "s",
+      update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "gate round 1\n" } },
+    });
+    expect(pulses[1]).toEqual({ workerId: "W1", line: "gate round 1" });
+
+    // An update with no text still bumps the pulse — liveness without content.
+    await seenNotify!("session/update", { sessionId: "s", update: { sessionUpdate: "plan" } });
+    expect(pulses[2]).toEqual({ workerId: "W1" });
+  });
+});
+
+describe("a display that published no heartbeat gets the age of its last pulse", () => {
+  const display = coerceWorkerDisplay({ issue: "#4167" })!;
+
+  it("derives hb from published_at at payload-build time", () => {
+    const derived = displayWithDerivedHeartbeat(
+      { display, published_at: "2026-08-20T17:00:00.000Z" },
+      Date.parse("2026-08-20T17:00:12.000Z"),
+    );
+    expect(derived?.heartbeat).toBe("12s");
+    expect(derived?.issue).toBe("#4167");
+  });
+
+  it("speaks minutes past the first one", () => {
+    const derived = displayWithDerivedHeartbeat(
+      { display, published_at: "2026-08-20T17:00:00.000Z" },
+      Date.parse("2026-08-20T17:07:05.000Z"),
+    );
+    expect(derived?.heartbeat).toBe("7m5s");
+  });
+
+  it("never overrides a heartbeat the publisher stated", () => {
+    const published = coerceWorkerDisplay({ heartbeat: "3s" })!;
+    const derived = displayWithDerivedHeartbeat(
+      { display: published, published_at: "2026-08-20T17:00:00.000Z" },
+      Date.parse("2026-08-20T17:09:00.000Z"),
+    );
+    expect(derived?.heartbeat).toBe("3s");
+  });
+
+  it("stays honest with no record and no clock", () => {
+    expect(displayWithDerivedHeartbeat(undefined, Date.now() as never)).toBeNull();
+    expect(displayWithDerivedHeartbeat({ display, published_at: "2026-08-20T17:00:00.000Z" }, null)?.heartbeat)
+      .toBeNull();
+  });
+});


### PR DESCRIPTION
A native Worker publishes no `worker-heartbeat` op — only the deleted dev-bundle Workers spoke it — so every statusline row read `hb=?` while the turn streamed, and a live Worker was indistinguishable from a hung one (#4181, observed on 4.0.12 while a Worker was actively implementing #4167).

The daemon already receives the pulse; now it stamps it:

- **lifecycle** gains `recordWorkerPulse`, writing the turn's text lines and work item into the same `logLines`/`displays` maps the heartbeat op feeds — every read path (statusline, dashboard, live metrics) works unchanged.
- **The unattended demand turn** pulses the work item at admission (`iss=#4167` appears on the row) and each session update's text line as it arrives; an update with no text still bumps the pulse — liveness without content.
- **The statusline payload** derives `hb=<age of the last pulse>` at build time when the display published no heartbeat (`displayWithDerivedHeartbeat`, housed in `worker-display.ts`), leaving a publisher-stated heartbeat untouched.

`lifecycle.ts` (2475) and `acp-control-plane.ts` (≤700) stay inside their shrink-only size baselines by compressing prose comments, never by removing content.

## Tests

`worker-pulse.test.ts` (5): admission pulse carries the item; update pulses carry the line; a no-text update still pulses; hb derivation in seconds and minutes; a publisher-stated heartbeat is never overridden; honest nulls. Guards green (file-size, declared-wait, adapter-ownership: 39), neighboring suites green (demand-turn, demand-park, unregistered-drain, statusline-dashboard/bound: 50).

Closes #4181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789839042&installation_model_id=20659&pr_number=4182&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4182&signature=24f532074fa001a5af48f23bddcd9febab843e8fd5f7950ed23e89ac2e504171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->