### PR TITLE
feat(worker-lane): add decision trail rows - typed decision event kind in TOONL log

### DIFF
--- a/apps/dev/src/core/castle-worker-lane-bridge.ts
+++ b/apps/dev/src/core/castle-worker-lane-bridge.ts
@@ -6,6 +6,7 @@ import {
   writeCastleStateSnapshot,
   type CastleLaneKind,
   type CastleStateSnapshot,
+  type DecisionTrailKind,
 } from "@reddb-io/red-castle/engine";
 import { LivenessLane, LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 import type { RedskilledWorkerDisplay } from "@reddb-io/redskilled/worker-display";
@@ -28,11 +29,20 @@ export type WorkerLifecycleKind =
   | "worker.heartbeat"
   | (string & {});
 
+export interface DecisionTrailInput {
+  kind: DecisionTrailKind;
+  decision: string;
+  why: string;
+  evidence: string;
+  result: string;
+}
+
 export interface CastleWorkerLaneBridge {
   record(kind: WorkerLifecycleKind, payload?: Record<string, unknown>, message?: string): Promise<void>;
   /** Append human-readable narration to the Worker's one structured log. */
   log(message: string): Promise<void>;
   snapshot(): Promise<void>;
+  recordDecision(input: DecisionTrailInput): Promise<void>;
 }
 
 export interface CastleWorkerLaneBridgeOptions {
@@ -256,7 +266,25 @@ export function createCastleWorkerLaneBridge(
     });
   }
 
-  return { record, log, snapshot };
+  async function recordDecision(input: DecisionTrailInput): Promise<void> {
+    const state = readAttemptState(options.attemptDir());
+    const issue = state ? currentIssue(state) : undefined;
+    await writers.worker(options.workerId).append({
+      kind: input.kind,
+      worker_id: options.workerId,
+      issue,
+      attempt: 1,
+      payload: {
+        decision: input.decision,
+        why: input.why,
+        evidence: input.evidence,
+        result: input.result,
+      },
+    });
+    await snapshot();
+  }
+
+  return { record, log, snapshot, recordDecision };
 }
 
 /**

--- a/apps/dev/tests/linked-subagent.test.ts
+++ b/apps/dev/tests/linked-subagent.test.ts
@@ -12,6 +12,7 @@ describe("runLinkedSubagent", () => {
       },
       log: async () => {},
       snapshot: async () => {},
+      recordDecision: async () => {},
     };
     const exec: ExecFn = async (_command, _args, options) => {
       options?.onStdoutLine?.(JSON.stringify({
@@ -83,6 +84,7 @@ describe("runLinkedSubagent", () => {
       },
       log: async () => {},
       snapshot: async () => {},
+      recordDecision: async () => {},
     };
     const exec: ExecFn = async (_command, _args, options) => {
       options?.onStdoutLine?.(JSON.stringify({

--- a/packages/red-castle/src/engine/contracts/index.ts
+++ b/packages/red-castle/src/engine/contracts/index.ts
@@ -26,6 +26,30 @@ export const CASTLE_VALIDATION_SCHEMA_ID = "red.castle.validation.v2" as const;
 export const CASTLE_ENVELOPE_SCHEMA_ID = "red.castle.envelope.v1" as const;
 export const CASTLE_HITL_CARD_SCHEMA_ID = "red.castle.hitl-card.v1" as const;
 
+export const DECISION_TRAIL_SCHEMA_ID = "red.castle.decision-trail.v1" as const;
+
+export type DecisionTrailKind =
+  | "decision.fork"
+  | "decision.pivot"
+  | "decision.revert"
+  | "decision.blocker"
+  | "decision.verified";
+
+export const DECISION_TRAIL_KINDS = [
+  "decision.fork",
+  "decision.pivot",
+  "decision.revert",
+  "decision.blocker",
+  "decision.verified",
+] as const satisfies readonly DecisionTrailKind[];
+
+export interface DecisionTrailPayload {
+  decision: string;
+  why: string;
+  evidence: string;
+  result: string;
+}
+
 export type CastleLaneKind =
   | "worker.claimed"
   | "worker.steered"

--- a/packages/red-castle/src/engine/lane-writers.test.ts
+++ b/packages/red-castle/src/engine/lane-writers.test.ts
@@ -212,4 +212,187 @@ describe("castle lane writers", () => {
 
     expect(existsSync(path)).toBe(false);
   });
+
+  it("writes and reads valid decision trail records", async () => {
+    const paths = createEnginePaths(redRoot);
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-16T20:00:00.000Z",
+    });
+
+    await writers.worker("wAB12").append({
+      kind: "decision.fork",
+      worker_id: "wAB12",
+      issue: 4167,
+      attempt: 1,
+      payload: {
+        decision: "fork to handle issue #4167",
+        why: "the issue requires parallel implementation tracks",
+        evidence: "https://github.com/reddb-io/red-skills/issues/4167",
+        result: "forked for parallel work",
+      },
+    });
+
+    const records = await readCastleLaneRecords(castleLanePath(paths, "worker", "wAB12"));
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      kind: "decision.fork",
+      worker_id: "wAB12",
+      issue: 4167,
+      payload: {
+        decision: "fork to handle issue #4167",
+        why: "the issue requires parallel implementation tracks",
+        evidence: "https://github.com/reddb-io/red-skills/issues/4167",
+        result: "forked for parallel work",
+      },
+    });
+  });
+
+  it("rejects decision trail records with unknown decision kind", async () => {
+    const paths = createEnginePaths(redRoot);
+    const path = castleLanePath(paths, "worker", "wAB12");
+
+    await expect(
+      appendCastleLaneRecord(path, {
+        at: "2026-07-16T20:00:00.000Z",
+        kind: "decision.unknown",
+        worker_id: "wAB12",
+        issue: 4167,
+        attempt: 1,
+        payload: {
+          decision: "some decision",
+          why: "reason",
+          evidence: "https://example.com",
+          result: "outcome",
+        },
+      }),
+    ).rejects.toThrow(/decision trail kind "decision.unknown" is not in the declared vocabulary/);
+  });
+
+  it("rejects decision trail records when evidence is prose, not a pointer", async () => {
+    const paths = createEnginePaths(redRoot);
+    const path = castleLanePath(paths, "worker", "wAB12");
+
+    await expect(
+      appendCastleLaneRecord(path, {
+        at: "2026-07-16T20:00:00.000Z",
+        kind: "decision.fork",
+        worker_id: "wAB12",
+        issue: 4167,
+        attempt: 1,
+        payload: {
+          decision: "fork to handle issue #4167",
+          why: "the issue requires parallel implementation tracks",
+          evidence: "I think this is the right approach based on my analysis",
+          result: "forked for parallel work",
+        },
+      }),
+    ).rejects.toThrow(/decision trail evidence must be a pointer/);
+  });
+
+  it("accepts file path as evidence pointer", async () => {
+    const paths = createEnginePaths(redRoot);
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-16T20:00:00.000Z",
+    });
+
+    await writers.worker("wAB12").append({
+      kind: "decision.revert",
+      worker_id: "wAB12",
+      issue: 4167,
+      attempt: 1,
+      payload: {
+        decision: "revert the previous change",
+        why: "the change introduced a regression",
+        evidence: "/repo/src/feature.ts",
+        result: "reverted",
+      },
+    });
+
+    const records = await readCastleLaneRecords(castleLanePath(paths, "worker", "wAB12"));
+    expect(records).toHaveLength(1);
+    expect(records[0].kind).toBe("decision.revert");
+  });
+
+  it("accepts SHA as evidence pointer", async () => {
+    const paths = createEnginePaths(redRoot);
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-16T20:00:00.000Z",
+    });
+
+    await writers.worker("wAB12").append({
+      kind: "decision.blocker",
+      worker_id: "wAB12",
+      issue: 4167,
+      attempt: 1,
+      payload: {
+        decision: "block on external dependency",
+        why: "the feature depends on an upstream change",
+        evidence: "abc123def456789012345678901234567890abcd",
+        result: "blocked",
+      },
+    });
+
+    const records = await readCastleLaneRecords(castleLanePath(paths, "worker", "wAB12"));
+    expect(records).toHaveLength(1);
+    expect(records[0].kind).toBe("decision.blocker");
+  });
+
+  it("accepts issue reference as evidence pointer", async () => {
+    const paths = createEnginePaths(redRoot);
+    const writers = createCastleLaneWriters(paths, {
+      clock: () => "2026-07-16T20:00:00.000Z",
+    });
+
+    await writers.worker("wAB12").append({
+      kind: "decision.verified",
+      worker_id: "wAB12",
+      issue: 4167,
+      attempt: 1,
+      payload: {
+        decision: "verified the fix works",
+        why: "the tests pass",
+        evidence: "#4167",
+        result: "verified",
+      },
+    });
+
+    const records = await readCastleLaneRecords(castleLanePath(paths, "worker", "wAB12"));
+    expect(records).toHaveLength(1);
+    expect(records[0].kind).toBe("decision.verified");
+  });
+
+  it("rejects decision trail records missing required payload fields", async () => {
+    const paths = createEnginePaths(redRoot);
+    const path = castleLanePath(paths, "worker", "wAB12");
+
+    await expect(
+      appendCastleLaneRecord(path, {
+        at: "2026-07-16T20:00:00.000Z",
+        kind: "decision.fork",
+        worker_id: "wAB12",
+        issue: 4167,
+        attempt: 1,
+        payload: {
+          decision: "some decision",
+          why: "reason",
+          evidence: "https://example.com",
+        },
+      }),
+    ).rejects.toThrow(/decision trail payload must have non-empty string result/);
+  });
+
+  it("rejects decision trail records without a payload", async () => {
+    const paths = createEnginePaths(redRoot);
+    const path = castleLanePath(paths, "worker", "wAB12");
+
+    await expect(
+      appendCastleLaneRecord(path, {
+        at: "2026-07-16T20:00:00.000Z",
+        kind: "decision.fork",
+        worker_id: "wAB12",
+        issue: 4167,
+        attempt: 1,
+      }),
+    ).rejects.toThrow(/decision trail record must have a payload object/);
+  });
 });

--- a/packages/red-castle/src/engine/lane-writers.ts
+++ b/packages/red-castle/src/engine/lane-writers.ts
@@ -24,6 +24,7 @@ import {
   CASTLE_LANE_SCHEMA_ID,
   CASTLE_PUBLISHED_CONTRACTS,
   CASTLE_STATE_SCHEMA_ID,
+  DECISION_TRAIL_KINDS,
   type CastleHistoryRecord,
   type CastleLaneRecord,
   type CastleStateKind,
@@ -138,6 +139,67 @@ function assertOptionalObject(
   }
 }
 
+const POINTER_PREFIXES = [
+  "https://",
+  "http://",
+  "file://",
+  "git://",
+  "gh:",
+  "file:",
+] as const;
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/i;
+const ISSUE_REF_PATTERN = /^#\d+$/;
+
+function isEvidencePointer(value: string): boolean {
+  if (POINTER_PREFIXES.some((prefix) => value.startsWith(prefix))) {
+    return true;
+  }
+  if (value.startsWith("/") || /^[a-z]:\\/i.test(value)) {
+    return true;
+  }
+  if (SHA_PATTERN.test(value)) {
+    return true;
+  }
+  if (ISSUE_REF_PATTERN.test(value)) {
+    return true;
+  }
+  return false;
+}
+
+function validateDecisionTrailPayload(payload: Record<string, unknown>): void {
+  const decision = payload.decision;
+  const why = payload.why;
+  const evidence = payload.evidence;
+  const result = payload.result;
+
+  if (typeof decision !== "string" || decision.length === 0) {
+    throw new CastleLaneValidationError(
+      "decision trail payload must have non-empty string decision",
+    );
+  }
+  if (typeof why !== "string" || why.length === 0) {
+    throw new CastleLaneValidationError(
+      "decision trail payload must have non-empty string why",
+    );
+  }
+  if (typeof evidence !== "string" || evidence.length === 0) {
+    throw new CastleLaneValidationError(
+      "decision trail payload must have non-empty string evidence",
+    );
+  }
+  if (!isEvidencePointer(evidence)) {
+    throw new CastleLaneValidationError(
+      "decision trail evidence must be a pointer (URL, file path, SHA, or issue ref), not prose",
+    );
+  }
+  if (typeof result !== "string" || result.length === 0) {
+    throw new CastleLaneValidationError(
+      "decision trail payload must have non-empty string result",
+    );
+  }
+}
+
 export function validateCastleLaneRecord(
   record: CastleLaneRecord,
 ): CastleLaneRecord {
@@ -154,6 +216,20 @@ export function validateCastleLaneRecord(
     throw new CastleLaneValidationError("castle record msg must be string");
   }
   assertOptionalObject(raw, "payload");
+  const kind = String(raw.kind);
+  if (kind.startsWith("decision.")) {
+    if (!DECISION_TRAIL_KINDS.includes(kind as (typeof DECISION_TRAIL_KINDS)[number])) {
+      throw new CastleLaneValidationError(
+        `decision trail kind ${JSON.stringify(kind)} is not in the declared vocabulary: ${DECISION_TRAIL_KINDS.join(", ")}`,
+      );
+    }
+    if (raw.payload == null || typeof raw.payload !== "object") {
+      throw new CastleLaneValidationError(
+        "decision trail record must have a payload object",
+      );
+    }
+    validateDecisionTrailPayload(raw.payload as Record<string, unknown>);
+  }
   return record;
 }
 


### PR DESCRIPTION
Implements issue #4167: Decision trail rows in the Worker's TOONL log.

## Changes

- Add DecisionTrailKind type and DECISION_TRAIL_KINDS declaration
- Valid kinds: decision.fork, decision.pivot, decision.revert, decision.blocker, decision.verified
- Evidence field validates as pointer (URL, file path, SHA, or issue ref), not prose
- Ratchet fails when live writer emits kind absent from declaration
- Expose recordDecision method in CastleWorkerLaneBridge

The decision payload carries: decision (one line), why, evidence pointer, and result.

## Acceptance Criteria

- [x] A fixture Worker run writes decision rows that the existing log readers parse; evidence fields validate as pointers, not prose.
- [x] The ratchet fails when the live writer emits a kind absent from the declaration
- [x] Lifecycle/narration events are unchanged — decision rows are additive to the existing log vocabulary.

## Tests

Added comprehensive tests in lane-writers.test.ts covering:
- Valid decision trail records
- Unknown decision kind rejection
- Evidence pointer validation (URL, file path, SHA, issue ref)
- Evidence prose rejection
- Missing payload field rejection

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789840999&installation_model_id=20659&pr_number=4185&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4185&signature=1e5cb9345369f0eef71302c9ed06b680f117a71a551abc850cd8daeb6da0ad51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->