### PR TITLE
fix(redskilled): each Worker's redcode child gets its own database

### DIFF
--- a/.changeset/redcode-db-per-worker.md
+++ b/.changeset/redcode-db-per-worker.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Each Worker's redcode child gets its own database: the daemon sets
+`OPENCODE_DB` to a file in the Worker's disposable workspace, because
+concurrent redcode instances sharing one opencode.db die on "database is
+locked" mid-turn (redcode#58) — one agent's write aborted another's whole
+turn on every multi-Worker machine.

--- a/apps/redskilled/src/acp-worker-admission.ts
+++ b/apps/redskilled/src/acp-worker-admission.ts
@@ -296,7 +296,13 @@ export function nativeWorkerSpec(
     workspace_path: workspace.worktreePath,
     // ADR 0150 §2: the run declares its Working mode, so a skill written for a
     // human's checkout refuses inside a Worker instead of running there.
-    env: workerModeEnv(workerKind),
+    // redcode#58: concurrent redcode instances sharing one opencode.db die on
+    // "database is locked" mid-turn, so each Worker's child gets its own DB in
+    // the Worker's disposable workspace — it dies with the workspace.
+    env: {
+      ...workerModeEnv(workerKind),
+      ...(childAgent.agent === "redcode" ? { OPENCODE_DB: join(workspace.workspacePath, "redcode.db") } : {}),
+    },
     command: process.execPath,
     args: [
       ...process.execArgv,

--- a/apps/redskilled/tests/worker-project-identity.test.ts
+++ b/apps/redskilled/tests/worker-project-identity.test.ts
@@ -29,4 +29,26 @@ describe("native Worker project identity", () => {
     expect(spec.project_label).toBe(project.projectLabel);
     expect(spec.project_label).not.toBe(project.projectId);
   });
+
+  it("gives a redcode child its own database inside the Worker's workspace (redcode#58)", () => {
+    const project: AcpProjectWorkspace = {
+      projectId: "remote:reddb-io/red-skills",
+      projectLabel: "reddb-io/red-skills",
+      checkoutRoot: "/tmp/checkout",
+      workspacePath: "/tmp/project-workspace",
+    };
+    const workspace: MaterializedWorkerWorkspace = {
+      workerId: "VStest02",
+      root: "/tmp/workers",
+      workspacePath: "/tmp/workers/VStest02",
+      worktreePath: "/tmp/workers/VStest02/worktree",
+    } as MaterializedWorkerWorkspace;
+
+    const spec = nativeWorkerSpec(project, workspace, "/tmp/sock/x.sock", "/tmp/runtime", "afk");
+
+    // Concurrent redcode instances sharing one opencode.db die on "database is
+    // locked" mid-turn; the DB lives beside (not inside) the worktree, so it
+    // never dirties the git tree and dies with the disposable workspace.
+    expect(spec.env?.OPENCODE_DB).toBe("/tmp/workers/VStest02/redcode.db");
+  });
 });


### PR DESCRIPTION
Concurrent redcode instances share one `~/.red/redcode/data/opencode.db` and die on `SQLiteError: database is locked` mid-turn (reddb-io/redcode#58, reproduced live on 4.1.1: a drain Worker at step 94 of its implement loop while a second redcode — spawned by an `rs_dev` read's native Worker — crash-looped on lock timeouts). One agent's write aborting another's whole turn makes every multi-Worker machine flaky by construction.

The redcode binary honors `OPENCODE_DB` (verified empirically: the override path received the `db`/`-shm`/`-wal` triple), so native admission now sets it to `<worker workspace>/redcode.db` when the child agent is redcode — **beside** the worktree, never inside it, so it cannot dirty the git tree, and it dies with the disposable workspace. Other child agents get no new env.

Daemon-side mitigation; the upstream fix (busy_timeout/retry or first-class isolation) remains reddb-io/redcode#58.

Test: `worker-project-identity.test.ts` pins `spec.env.OPENCODE_DB === "<workspace>/redcode.db"` for a redcode child.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789841681&installation_model_id=20659&pr_number=4186&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4186&signature=8ee9a57ad1ec659a8d813e1e87c9437ae56eed8d19721fc7a0ae5ca82dada840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->