### PR TITLE
fix(redskilled): the Worker fork refreshes the mirror's trunk first

### DIFF
--- a/.changeset/fresh-worker-fork.md
+++ b/.changeset/fresh-worker-fork.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The Worker fork refreshes the Project mirror's trunk from the canonical
+remote before cloning. The mirror was cloned once and never fetched again —
+its own origin is the human checkout — so every Worker forked a days-old
+tree, the agent's `git fetch origin` fetched the past, and the gate judged
+code main no longer had (three Tickets parked on a failure that was already
+fixed). A failed fetch degrades to a stale fork instead of refusing the
+birth.

--- a/apps/redskilled/src/acp-worker-admission.ts
+++ b/apps/redskilled/src/acp-worker-admission.ts
@@ -115,6 +115,9 @@ export async function admitNativeAcpWorker(
     root: options.workspaceRoot ?? workerWorkspaceRoot(),
     workerId,
     projectWorkspacePath: session.project.workspacePath,
+    // #4188: refresh the mirror's trunk from the canonical remote before the
+    // fork, so the Worker's base — and its `origin` — are today's main.
+    ...(session.project.remoteUrl == null ? {} : { trunk: { remoteUrl: session.project.remoteUrl } }),
   });
   const rendezvous = await bindWorkerRendezvous(endpoint);
   // Every failure from here on releases the workspace: a Worker that never

--- a/apps/redskilled/src/project-workspace.ts
+++ b/apps/redskilled/src/project-workspace.ts
@@ -23,6 +23,8 @@ export interface AcpProjectIdentity {
   readonly projectId: string;
   readonly projectLabel: string;
   readonly checkoutRoot: string;
+  /** The checkout's canonical remote, when it has one — the fetch source for fresh forks (#4188). */
+  readonly remoteUrl?: string;
 }
 
 export interface AcpProjectWorkspace extends AcpProjectIdentity {
@@ -51,6 +53,7 @@ export async function resolveAcpProjectIdentity(
       projectId: `github:${github.id}`,
       projectLabel: github.fullName,
       checkoutRoot,
+      ...(remoteUrl == null ? {} : { remoteUrl }),
     };
   }
 
@@ -66,6 +69,7 @@ export async function resolveAcpProjectIdentity(
     projectId: remoteSlug == null ? `local:${fallback.hash}` : `remote:${remoteSlug}`,
     projectLabel: fallback.name,
     checkoutRoot,
+    ...(remoteUrl == null ? {} : { remoteUrl }),
   };
 }
 

--- a/apps/redskilled/src/worker-workspace.ts
+++ b/apps/redskilled/src/worker-workspace.ts
@@ -113,6 +113,16 @@ export interface MaterializeWorkerWorkspaceInput {
    * testable without a clone.
    */
   readonly git?: (cwd: string, args: readonly string[], required?: boolean) => Promise<string | undefined>;
+  /**
+   * The canonical remote this fork's trunk is refreshed from (#4188).
+   *
+   * The Project mirror is cloned once and never fetched again, and its own
+   * `origin` is the human checkout — so without this, every Worker forks a
+   * days-old tree, the agent's `git fetch origin` fetches the past, and the
+   * gate judges code main no longer has. Absent means fork as-is (a generic
+   * ACP client may bind a directory with no remote at all).
+   */
+  readonly trunk?: { readonly remoteUrl: string; readonly branch?: string };
 }
 
 /**
@@ -139,6 +149,19 @@ export async function materializeWorkerWorkspace(
   if (!isRepository) {
     await mkdir(worktreePath, { recursive: true, mode: 0o700 });
     return { workerId: input.workerId, root: input.root, workspacePath, worktreePath };
+  }
+
+  if (input.trunk != null) {
+    // Loud-but-non-fatal: a network flake must not stop the drain, and a fork
+    // that proceeds stale is the stated exception rather than the invisible
+    // rule — the clone below records the base commit either way.
+    const branch = input.trunk.branch
+      ?? await git(input.projectWorkspacePath, ["symbolic-ref", "--short", "HEAD"])
+      ?? "main";
+    const fetched = await git(input.projectWorkspacePath, ["fetch", "--quiet", input.trunk.remoteUrl, branch]);
+    if (fetched !== undefined) {
+      await git(input.projectWorkspacePath, ["reset", "--hard", "FETCH_HEAD"]);
+    }
   }
 
   await git(input.projectWorkspacePath, [

--- a/apps/redskilled/tests/worker-workspace.test.ts
+++ b/apps/redskilled/tests/worker-workspace.test.ts
@@ -29,6 +29,73 @@ import { workerModeEnv } from "@reddb-io/shared/working-mode.js";
 
 const roots: string[] = [];
 
+/**
+ * #4188: the Project mirror is cloned once and never fetched again, so without
+ * a refresh every Worker forks a days-old tree and the gate judges code main
+ * no longer has. The trunk refresh runs against the CANONICAL remote, before
+ * the clone, and a failed fetch degrades to a stale fork instead of a refusal.
+ */
+describe("the fork refreshes the mirror's trunk first", () => {
+  const recordedGit = (answers: (args: readonly string[]) => string | undefined) => {
+    const calls: string[][] = [];
+    const git = async (_cwd: string, args: readonly string[]) => {
+      calls.push([...args]);
+      return answers(args);
+    };
+    return { calls, git };
+  };
+
+  it("fetches the canonical trunk and advances the mirror before cloning", async () => {
+    const { calls, git } = recordedGit((args) =>
+      args[0] === "rev-parse" ? "true" : args[0] === "symbolic-ref" ? "main" : "");
+
+    await materializeWorkerWorkspace({
+      root: await scratch("redskilled-fresh-fork-"),
+      workerId: "VSfresh1",
+      projectWorkspacePath: "/tmp/mirror",
+      git,
+      trunk: { remoteUrl: "https://github.com/o/r.git" },
+    });
+
+    const verbs = calls.map((args) => args[0]);
+    expect(calls).toContainEqual(["fetch", "--quiet", "https://github.com/o/r.git", "main"]);
+    expect(calls).toContainEqual(["reset", "--hard", "FETCH_HEAD"]);
+    expect(verbs.indexOf("fetch")).toBeLessThan(verbs.indexOf("clone"));
+  });
+
+  it("forks stale rather than refusing when the fetch fails", async () => {
+    const { calls, git } = recordedGit((args) =>
+      args[0] === "rev-parse" ? "true" : args[0] === "fetch" ? undefined : args[0] === "symbolic-ref" ? "main" : "");
+
+    await materializeWorkerWorkspace({
+      root: await scratch("redskilled-fresh-fork-"),
+      workerId: "VSfresh2",
+      projectWorkspacePath: "/tmp/mirror",
+      git,
+      trunk: { remoteUrl: "https://github.com/o/r.git" },
+    });
+
+    const verbs = calls.map((args) => args[0]);
+    expect(verbs).not.toContain("reset");
+    expect(verbs).toContain("clone");
+  });
+
+  it("touches nothing without a declared trunk", async () => {
+    const { calls, git } = recordedGit((args) => (args[0] === "rev-parse" ? "true" : ""));
+
+    await materializeWorkerWorkspace({
+      root: await scratch("redskilled-fresh-fork-"),
+      workerId: "VSfresh3",
+      projectWorkspacePath: "/tmp/mirror",
+      git,
+    });
+
+    expect(calls.map((args) => args[0])).not.toContain("fetch");
+  });
+});
+
+
+
 afterEach(async () => {
   for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
 });


### PR DESCRIPTION
The Project workspace mirror is cloned once and never fetched again, and its own `origin` is the human checkout — so every Worker forked a days-old tree (observed live on 4.1.1: a mirror at an Aug 18 tip on Aug 20, and Worker `VSrUlUK` whose gate failed on a test #4184 had already fixed on main). The agent's dutiful `git fetch origin` fetched the past, and the demand grant's `fork_sha` doc promised a fetch no code path performed. Full story in #4188.

## What this changes

- `AcpProjectIdentity` gains the optional `remoteUrl` the resolution already computed (both return sites carry it).
- `materializeWorkerWorkspace` accepts `trunk: { remoteUrl, branch? }`: fetch the mirror's trunk branch from the canonical remote and `reset --hard FETCH_HEAD` **before** cloning. A failed fetch degrades to a stale fork instead of a refused birth — a network flake must not stop the drain.
- Native admission passes the trunk whenever the project has a remote; a generic ACP client binding a remoteless directory forks as-is.

## Tests

`worker-workspace.test.ts`: fetch+advance happen before the clone; a failed fetch skips the reset and still forks; no trunk → no fetch. Suite green (12).

Closes #4188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789842113&installation_model_id=20659&pr_number=4189&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4189&signature=3ce58027d6db196498efc43be6678632006956b720219413ec61249e7a7281bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->