### PR TITLE
fix(redskilled): the fork's trunk fetch speaks HTTPS, and a stale fork is loud

### DIFF
--- a/.changeset/fork-fetch-https.md
+++ b/.changeset/fork-fetch-https.md
@@ -1,0 +1,8 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The mirror trunk refresh fetches over anonymous HTTPS when the checkout's
+remote is a GitHub SSH URL, and a fork that proceeds stale says so in the
+journal. The daemon has no ssh-agent, so the SSH fetch failed silently and
+every Worker still forked a days-old tree despite the refresh.

--- a/apps/redskilled/src/worker-workspace.ts
+++ b/apps/redskilled/src/worker-workspace.ts
@@ -154,13 +154,19 @@ export async function materializeWorkerWorkspace(
   if (input.trunk != null) {
     // Loud-but-non-fatal: a network flake must not stop the drain, and a fork
     // that proceeds stale is the stated exception rather than the invisible
-    // rule — the clone below records the base commit either way.
+    // rule — the journal line below is what makes it stated.
     const branch = input.trunk.branch
       ?? await git(input.projectWorkspacePath, ["symbolic-ref", "--short", "HEAD"])
       ?? "main";
-    const fetched = await git(input.projectWorkspacePath, ["fetch", "--quiet", input.trunk.remoteUrl, branch]);
+    const fetchUrl = anonymousFetchUrl(input.trunk.remoteUrl);
+    const fetched = await git(input.projectWorkspacePath, ["fetch", "--quiet", fetchUrl, branch]);
     if (fetched !== undefined) {
       await git(input.projectWorkspacePath, ["reset", "--hard", "FETCH_HEAD"]);
+    } else {
+      process.stderr.write(
+        `redskilled: Worker ${input.workerId} forks a STALE mirror — the trunk fetch from ` +
+        `${fetchUrl} failed, so this Worker's base and its origin predate today's ${branch}\n`,
+      );
     }
   }
 
@@ -180,6 +186,22 @@ export async function materializeWorkerWorkspace(
     worktreePath,
     ...(baseCommit == null ? {} : { baseCommit }),
   };
+}
+
+/**
+ * The URL the mirror refresh fetches from, credentials not assumed (#4188).
+ *
+ * The checkout's remote is often SSH (`git@github.com:o/r.git`), which the
+ * daemon — a systemd user service with no ssh-agent — cannot speak, so the
+ * refresh silently failed and every fork stayed days stale. GitHub SSH forms
+ * are rewritten to anonymous HTTPS; any other URL passes through untouched.
+ */
+export function anonymousFetchUrl(remoteUrl: string): string {
+  const scp = /^git@github\.com:(.+?)(?:\.git)?$/.exec(remoteUrl);
+  if (scp != null) return `https://github.com/${scp[1]}.git`;
+  const ssh = /^ssh:\/\/git@github\.com\/(.+?)(?:\.git)?$/.exec(remoteUrl);
+  if (ssh != null) return `https://github.com/${ssh[1]}.git`;
+  return remoteUrl;
 }
 
 /**

--- a/apps/redskilled/tests/worker-workspace.test.ts
+++ b/apps/redskilled/tests/worker-workspace.test.ts
@@ -18,6 +18,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { evaluateWorkerAdmission, UNBOUNDED_HOST_CEILING } from "../src/admission.js";
 import { launchWorker, mintHostWorkerId } from "../src/worker-launch.js";
 import {
+  anonymousFetchUrl,
   materializeWorkerWorkspace,
   releaseWorkerWorkspace,
   workerWorkspaceDir,
@@ -78,6 +79,29 @@ describe("the fork refreshes the mirror's trunk first", () => {
     const verbs = calls.map((args) => args[0]);
     expect(verbs).not.toContain("reset");
     expect(verbs).toContain("clone");
+  });
+
+  it("rewrites a GitHub SSH remote to anonymous HTTPS for the fetch", async () => {
+    const { calls, git } = recordedGit((args) =>
+      args[0] === "rev-parse" ? "true" : args[0] === "symbolic-ref" ? "main" : "");
+
+    await materializeWorkerWorkspace({
+      root: await scratch("redskilled-fresh-fork-"),
+      workerId: "VSfresh4",
+      projectWorkspacePath: "/tmp/mirror",
+      git,
+      trunk: { remoteUrl: "git@github.com:reddb-io/red-skills.git" },
+    });
+
+    // The daemon has no ssh-agent; an SSH fetch fails silently and every fork
+    // stays days stale — the rewrite is what makes the refresh actually run.
+    expect(calls).toContainEqual(["fetch", "--quiet", "https://github.com/reddb-io/red-skills.git", "main"]);
+  });
+
+  it("passes non-GitHub and HTTPS URLs through untouched", () => {
+    expect(anonymousFetchUrl("https://github.com/o/r.git")).toBe("https://github.com/o/r.git");
+    expect(anonymousFetchUrl("ssh://git@github.com/o/r.git")).toBe("https://github.com/o/r.git");
+    expect(anonymousFetchUrl("git@gitlab.example:o/r.git")).toBe("git@gitlab.example:o/r.git");
   });
 
   it("touches nothing without a declared trunk", async () => {


### PR DESCRIPTION
Follow-up to #4189, from live evidence minutes after it shipped: the refresh fetched from the checkout's remote verbatim — on this machine `git@github.com:reddb-io/red-skills.git` — and the daemon, a systemd user service with no ssh-agent, cannot speak SSH. The fetch failed, the "loud-but-non-fatal" degradation was in fact **silent** (the comment promised a loudness the code never had), and the very next Worker gate-blocked on the same already-fixed release test with the mirror still at its Aug 18 tip.

- GitHub SSH forms (scp-style `git@github.com:o/r.git` and `ssh://git@github.com/o/r`) are rewritten to anonymous HTTPS for the fetch (`anonymousFetchUrl`, exported and pinned); any other URL passes through untouched.
- A fetch that still fails writes one journal line naming the Worker, the URL, and the consequence — the stated exception the first fix only claimed to be.

Tests: SSH→HTTPS rewrite drives the actual fetch argv; pass-through pinned for HTTPS/ssh-github/non-GitHub; suite green (12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789843010&installation_model_id=20659&pr_number=4191&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4191&signature=1e041ac380b685ab2d827982b8517e8bb1fc7911ab0306f7d0f10f6c176c30f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->