### PR TITLE
fix(redskilled): serialize the mirror refresh and name the fetch failure

### DIFF
--- a/.changeset/fork-fetch-detail-serial.md
+++ b/.changeset/fork-fetch-detail-serial.md
@@ -1,0 +1,8 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The mirror trunk refresh runs one-at-a-time per mirror and a stale fork's
+journal line carries git's own words. Two Workers materializing together
+raced two fetches on one FETCH_HEAD lock (the loser forked stale), and the
+loud line said only "failed" — the diagnosis needed the reason.

--- a/apps/redskilled/src/worker-workspace.ts
+++ b/apps/redskilled/src/worker-workspace.ts
@@ -154,20 +154,33 @@ export async function materializeWorkerWorkspace(
   if (input.trunk != null) {
     // Loud-but-non-fatal: a network flake must not stop the drain, and a fork
     // that proceeds stale is the stated exception rather than the invisible
-    // rule — the journal line below is what makes it stated.
-    const branch = input.trunk.branch
-      ?? await git(input.projectWorkspacePath, ["symbolic-ref", "--short", "HEAD"])
-      ?? "main";
-    const fetchUrl = anonymousFetchUrl(input.trunk.remoteUrl);
-    const fetched = await git(input.projectWorkspacePath, ["fetch", "--quiet", fetchUrl, branch]);
-    if (fetched !== undefined) {
-      await git(input.projectWorkspacePath, ["reset", "--hard", "FETCH_HEAD"]);
-    } else {
-      process.stderr.write(
-        `redskilled: Worker ${input.workerId} forks a STALE mirror — the trunk fetch from ` +
-        `${fetchUrl} failed, so this Worker's base and its origin predate today's ${branch}\n`,
-      );
-    }
+    // rule — the journal line below is what makes it stated. Serialized per
+    // mirror, because a read Worker and a demand birth materializing together
+    // race two `git fetch` on one FETCH_HEAD lock and the loser forks stale.
+    const trunk = input.trunk;
+    const previous = mirrorRefreshes.get(input.projectWorkspacePath) ?? Promise.resolve();
+    const refresh = previous.then(async () => {
+      const branch = trunk.branch
+        ?? await git(input.projectWorkspacePath, ["symbolic-ref", "--short", "HEAD"])
+        ?? "main";
+      const fetchUrl = anonymousFetchUrl(trunk.remoteUrl);
+      const fetched = input.git != null
+        ? ((await git(input.projectWorkspacePath, ["fetch", "--quiet", fetchUrl, branch])) !== undefined
+          ? { ok: true as const }
+          : { ok: false as const, detail: "the injected git runner refused" })
+        : await gitCapture(input.projectWorkspacePath, ["fetch", "--quiet", fetchUrl, branch]);
+      if (fetched.ok) {
+        await git(input.projectWorkspacePath, ["reset", "--hard", "FETCH_HEAD"]);
+      } else {
+        process.stderr.write(
+          `redskilled: Worker ${input.workerId} forks a STALE mirror — the trunk fetch from ` +
+          `${fetchUrl} failed (${fetched.detail}), so this Worker's base and its origin predate ` +
+          `today's ${branch}\n`,
+        );
+      }
+    }).catch(() => undefined);
+    mirrorRefreshes.set(input.projectWorkspacePath, refresh);
+    await refresh;
   }
 
   await git(input.projectWorkspacePath, [
@@ -186,6 +199,23 @@ export async function materializeWorkerWorkspace(
     worktreePath,
     ...(baseCommit == null ? {} : { baseCommit }),
   };
+}
+
+/** One refresh at a time per mirror; the map holds only the newest tail. */
+const mirrorRefreshes = new Map<string, Promise<void | undefined>>();
+
+/** Run git capturing the failure's own words — the refresh's loud line needs them. */
+async function gitCapture(
+  cwd: string,
+  args: readonly string[],
+): Promise<{ readonly ok: true } | { readonly ok: false; readonly detail: string }> {
+  return await new Promise((resolve) => {
+    execFile("git", [...args], { cwd, encoding: "utf8", timeout: GIT_TIMEOUT_MS, windowsHide: true },
+      (error, _stdout, stderr) => {
+        if (error == null) resolve({ ok: true });
+        else resolve({ ok: false, detail: (stderr.trim() || error.message).slice(0, 300) });
+      });
+  });
 }
 
 /**


### PR DESCRIPTION
Live on 4.1.3 the stale-fork loud line fired — `the trunk fetch from https://github.com/reddb-io/red-skills.git failed` — while the same fetch succeeded by hand (622ms) and under a scratch systemd unit. Two gaps:

1. **The line had no reason in it**: the shared git runner discards the error. The refresh now captures git's own stderr (`gitCapture`) and prints it in the journal line, so the next failure names itself instead of being reproduced by guesswork.
2. **Concurrent materializations race the mirror**: a read Worker and a demand birth materializing together run two `git fetch` on one mirror's `FETCH_HEAD` lock, and the loser forks stale. The refresh now runs one-at-a-time per mirror — a promise chain keyed by the mirror path; the second materialize waits for the first refresh instead of racing it.

Suite green (12); declared-wait and file-size guards green (a promise chain is not a poll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789843853&installation_model_id=20659&pr_number=4193&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4193&signature=19e9438de3f6caff970b71b0d0b40b065830fa76dd3921be64eb519024b13c6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->