### PR TITLE
fix(release): the vendored-bundle guard compares code, not the release number

### DIFF
--- a/.changeset/vendored-guard-version-blind.md
+++ b/.changeset/vendored-guard-version-blind.md
@@ -1,0 +1,8 @@
+---
+"@reddb-io/release": patch
+---
+
+The vendored-bundle guard compares code, not the release number: the
+embedded build version and git sha are normalized like the build time
+already was, so the version train no longer reddens every Worker gate one
+release after each vendored refresh.

--- a/apps/release/tests/vendored-bundle.test.ts
+++ b/apps/release/tests/vendored-bundle.test.ts
@@ -27,15 +27,23 @@ afterEach(() => {
  * source read correct, the tests passed, and the thing that ran was neither.
  */
 /**
- * Drop the wall-clock stamp esbuild bakes in, so the comparison is about CODE.
+ * Drop the build stamps esbuild bakes in, so the comparison is about CODE.
  *
- * Every build writes its own `__RED_BUILD_TIME__`, which is the one byte range
- * that legitimately differs between two builds of identical source. Comparing
- * with it in place would fail on every run and teach the reader to ignore this
- * test — which is worse than not having it.
+ * Three byte ranges legitimately differ between two builds of identical
+ * source: `__RED_BUILD_TIME__` (every build has its own clock),
+ * `__RED_BUILD_VERSION__` and `__RED_BUILD_GIT_SHA__` (the version train
+ * moves the anchor every release, so a vendored copy always trails the next
+ * rebuild by exactly its release number — observed as an 8-byte "4.1.1" vs
+ * "4.1.4" diff that reddened every Worker gate after every train). Comparing
+ * with any of them in place fails on every run for a reason that is not a
+ * code change, and teaches the reader to ignore this test — worse than not
+ * having it.
  */
 function withoutBuildStamp(source: string): string {
-  return source.replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/g, "<build-time>");
+  return source
+    .replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/g, "<build-time>")
+    .replace(/\("__RED_BUILD_VERSION__",\(\)=>"[^"]*"\)/g, '("__RED_BUILD_VERSION__",()=>"<version>")')
+    .replace(/\("__RED_BUILD_GIT_SHA__",\(\)=>"[^"]*"\)/g, '("__RED_BUILD_GIT_SHA__",()=>"<git-sha>")');
 }
 
 describe("vendored release engine (#3466)", () => {


### PR DESCRIPTION
The guard normalized the build TIME but compared the embedded `__RED_BUILD_VERSION__` and `__RED_BUILD_GIT_SHA__` verbatim — and the version train moves the anchor every release, so the vendored copy always trails the next rebuild by exactly its release number.

Observed live on 4.1.4: an **8-byte `"4.1.1"` vs `"4.1.4"` diff** (nothing under `apps/release/src` changed since the #4184 refresh) reddened every Worker gate after every release train — a treadmill where refreshing the bundle (#4184) buys exactly one train of green. Today it parked Tickets #4166/#4167 repeatedly on a failure that was never a code change.

All three stamps are the same class of legitimate difference the test's own doc describes; the comparison is about CODE. The stamp sites are unique, precisely-matchable patterns (`("__RED_BUILD_VERSION__",()=>"…")`), so the normalization cannot mask a real source change.

`apps/release` suite green (55/55) on a tree where the verbatim comparison fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789844791&installation_model_id=20659&pr_number=4194&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4194&signature=febb7d796f1311804cf62833ec468d4ddc2de488077ce0bb4be958646dc3677d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->