### PR TITLE
fix: the root test aggregate excludes rsp, matching the removed CI gate

### DIFF
--- a/.changeset/root-test-excludes-rsp.md
+++ b/.changeset/root-test-excludes-rsp.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+The root `test` aggregate excludes `@reddb-io/rsp`, matching the #3878 CI
+posture: rsp's broad gates were removed from CI, but the same aggregate ran
+inside every Worker's local gate whenever a branch touched a root-level file
+(every changeset does), and rsp's resident suite is red without REDDB_BIN —
+so whole Tickets gate-blocked on a suite CI decided not to run.

--- a/apps/plugin-dev/tests/acp-ci-posture.test.ts
+++ b/apps/plugin-dev/tests/acp-ci-posture.test.ts
@@ -121,6 +121,19 @@ describe("focused ACP CI posture", () => {
     }
   });
 
+  it("keeps rsp out of the root test aggregate, matching the removed CI gate", () => {
+    // #3878 removed the broad rsp gates from CI; the root `test` script is the
+    // same aggregate seen by the Worker's local gate whenever a branch touches
+    // a root-level file (every changeset does). rsp riding it re-created the
+    // removed gate for Workers only: telemetry-resident is red without
+    // REDDB_BIN (#4196), so whole Tickets gate-blocked on a suite CI decided
+    // not to run.
+    const rootManifest = JSON.parse(
+      readFileSync(join(ROOT, "package.json"), "utf8"),
+    ) as { scripts?: Record<string, string> };
+    expect(rootManifest.scripts?.test).toContain("--filter=!@reddb-io/rsp");
+  });
+
   it("leaves the retired engine package name absent from the workflow entirely", () => {
     // `packages/red-castle` became `packages/worker` in #4013. A workflow that
     // still names the old path is not a gate — it is a step that never runs.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "turbo run build --filter=!@reddb-io/worker --only",
     "bundle": "turbo run bundle --filter=!@reddb-io/worker --only",
     "typecheck": "turbo run typecheck --filter=!@reddb-io/worker --only",
-    "test": "turbo run test --filter=!@reddb-io/worker --only",
+    "test": "turbo run test --filter=!@reddb-io/worker --filter=!@reddb-io/rsp --only",
     "audit:hooks": "bash scripts/audit-hook-hardening-contract.sh",
     "generate-manifests": "node scripts/generate-codex-manifests.mjs && node scripts/generate-gemini-manifests.mjs && node scripts/generate-pi-manifests.mjs",
     "codex:manifests": "node scripts/generate-codex-manifests.mjs",


### PR DESCRIPTION
#3878 removed the broad rsp gates from CI, and the `acp-ci-posture` guard pins that removal — in the workflow. But the root `test` script is the same aggregate the Worker's local gate reaches whenever a branch carries a root-level file (every changeset does), so **the removed gate lived on for Workers only**: `apps/rsp`'s telemetry-resident suite is red on any machine without `REDDB_BIN` or a populated warm cache (#4196 — the bundled resident loses the SDK's package-relative binary resolution), and whole Tickets gate-blocked today on a suite CI decided not to run (#4166, #4167).

- Root `test` gains `--filter=!@reddb-io/rsp`, joining the existing `!@reddb-io/worker`.
- `acp-ci-posture.test.ts` gains the assertion that keeps it out — a removal nothing pins is a removal that grows back.

Posture suite green (9/9). rsp's own focused invocations are untouched; the package's suite still runs via `pnpm -C apps/rsp test` for whoever asks for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789846035&installation_model_id=20659&pr_number=4197&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4197&signature=87c253454b56f08c9cb2fbeece2df8f976a966eea151a315dc0e947160be6d2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->