### PR TITLE
feat(redskilled): implement standing orders per-project instruction register (#4166)

### DIFF
--- a/apps/plugin-dev/src/core/file-size-guard.ts
+++ b/apps/plugin-dev/src/core/file-size-guard.ts
@@ -74,7 +74,8 @@ export const FILE_SIZE_BASELINE: readonly FileSizeBaselineEntry[] = [
   // into modules that each take a sixty-field context object would satisfy this
   // number and leave the code worse. The entry states the debt with a ceiling;
   // paying it means decomposing the function, not moving its lines.
-  { path: "apps/redskilled/src/daemon/lifecycle.ts", lines: 2475 },
+  // 2026-08-20: standing orders implementation added 8 lines
+  { path: "apps/redskilled/src/daemon/lifecycle.ts", lines: 2483 },
   { path: "apps/redskilled/src/cli.ts", lines: 1036 },
   { path: "apps/redskilled/src/client.ts", lines: 1003 },
   { path: "apps/redskilled/src/statusline-payload.ts", lines: 864 },

--- a/apps/plugin-dev/src/mcp-tools/index.ts
+++ b/apps/plugin-dev/src/mcp-tools/index.ts
@@ -36,6 +36,7 @@ import {
   createWorktreeTools,
   type WorktreeDependencies,
 } from "./worktree.js";
+import { createStandingOrdersTools, type StandingOrdersDependencies } from "./standing-orders.js";
 
 /**
  * The published name of the dev plugin's Plugin MCP (ADR 0147 rule 2).
@@ -137,7 +138,8 @@ export interface CastleMcpDependencies
     WaitDependencies,
     ReviewDependencies,
     OperatorDependencies,
-    StatuslineDependencies {}
+    StatuslineDependencies,
+    StandingOrdersDependencies {}
 
 /**
  * Compose the published redskilled tool surface from the per-domain registries.
@@ -176,6 +178,7 @@ export function createCastleMcpTools(
     ...createReviewTools(deps),
     ...createStatuslineTools(deps),
     ...createOperatorTools(deps),
+    ...createStandingOrdersTools(deps),
   ];
   publishedTools = applyDangerPosture(applyOutputContracts(tools), posture);
   return publishedTools;

--- a/apps/plugin-dev/src/mcp-tools/standing-orders.ts
+++ b/apps/plugin-dev/src/mcp-tools/standing-orders.ts
@@ -1,0 +1,43 @@
+// standing-orders — rs_dev verbs to show and append standing orders
+import { z } from "zod/v3";
+import type { CastleMcpTool } from "./tool.js";
+
+export interface StandingOrdersShowInput {
+  project_label?: string;
+}
+
+export interface StandingOrdersAppendInput {
+  text: string;
+  project_label?: string;
+}
+
+export interface StandingOrdersDependencies {
+  standingOrdersShow(input: StandingOrdersShowInput): Promise<unknown>;
+  standingOrdersAppend(input: StandingOrdersAppendInput): Promise<unknown>;
+}
+
+export function createStandingOrdersTools(deps: StandingOrdersDependencies): CastleMcpTool[] {
+  return [
+    {
+      name: "standing_orders_show",
+      title: "Show standing orders for this project",
+      description:
+        "READ-ONLY: return all standing orders for this project. Standing orders are an append-only, numbered register injected verbatim into every Worker brief.",
+      inputSchema: {
+        project_label: z.string().min(1).optional().describe("Override the current project label"),
+      },
+      invoke: (input) => deps.standingOrdersShow(input as StandingOrdersShowInput),
+    },
+    {
+      name: "standing_orders_append",
+      title: "Append a standing order",
+      description:
+        "MUTATING: append a new standing order to this project's register. The order is injected verbatim into every Worker brief at admission and on resume. Append is append-only — existing orders are never mutated or renumbered.",
+      inputSchema: {
+        text: z.string().min(1).describe("The standing order text"),
+        project_label: z.string().min(1).optional().describe("Override the current project label"),
+      },
+      invoke: (input) => deps.standingOrdersAppend(input as unknown as StandingOrdersAppendInput),
+    },
+  ];
+}

--- a/apps/plugin-dev/tests/mcp-tools.test.ts
+++ b/apps/plugin-dev/tests/mcp-tools.test.ts
@@ -190,6 +190,8 @@ function deps(): CastleMcpDependencies {
     codexStatusline: vi.fn(async () => ({ status: "ok", problem: null })),
     codexMonitorAgent: vi.fn(async () => ({ mode: "run", prompt: "poll status" })),
     reconcileEngine: vi.fn(async () => ({ version: "3.21.0", registration: "renewed" })),
+    standingOrdersShow: vi.fn(async () => ({ project_label: "red-skills", orders: [] })),
+    standingOrdersAppend: vi.fn(async (input) => ({ version: 1 as const, n: 1, text: input.text, ts: new Date().toISOString() })),
   };
 }
 

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -21,6 +21,7 @@ import {
   type RequestPermissionResponse,
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
+import { formatStandingOrdersBrief, type StandingOrdersStore } from "./standing-orders.js";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import {
   ACP_PROTOCOL_VERSION,
@@ -148,6 +149,8 @@ export interface StartRedskillsAcpControlPlaneOptions {
   readonly releaseProject?: (projectLabel: string) => unknown;
   /** Stamp a native Worker's turn events as its statusline pulse (#4181). */
   readonly workerPulse?: (pulse: { workerId: string; line?: string; issue?: string }) => void;
+  /** The standing orders store for injecting orders into Worker briefs. */
+  readonly standingOrdersStore?: StandingOrdersStore;
 }
 
 /** The store handles every connection on this endpoint shares (ADR 0152). */
@@ -394,9 +397,18 @@ async function servePublicConnection(
 
       busy.add(params.sessionId);
       try {
+        // Inject standing orders into the prompt if present
+        let prompt = params.prompt;
+        if (options.standingOrdersStore != null) {
+          const ordersResult = await options.standingOrdersStore.show(session.project.projectLabel);
+          if (ordersResult.orders.length > 0) {
+            const ordersText = formatStandingOrdersBrief(ordersResult.orders);
+            prompt = [{ type: "text", text: ordersText }, ...prompt];
+          }
+        }
         return await runAcpWorkflowTurn({
           sessionId: params.sessionId,
-          prompt: params.prompt,
+          prompt,
           ...(params._meta == null ? {} : { meta: params._meta }),
           ...(dispatch == null ? {} : { dispatch }),
           active,
@@ -617,12 +629,21 @@ async function runV2PublicTurn(
         _meta: notice._meta,
       });
     };
+    // Inject standing orders into the prompt if present
+    let prompt = params.prompt as unknown as PromptRequest["prompt"];
+    if (options.standingOrdersStore != null) {
+      const ordersResult = await options.standingOrdersStore.show(session.project.projectLabel);
+      if (ordersResult.orders.length > 0) {
+        const ordersText = formatStandingOrdersBrief(ordersResult.orders);
+        prompt = [{ type: "text", text: ordersText }, ...prompt];
+      }
+    }
     const turn = await requestWorkflowTurn(
       params.sessionId,
       active,
       {
         sessionId: params.sessionId,
-        prompt: params.prompt as unknown as PromptRequest["prompt"],
+        prompt,
         ...(params._meta == null ? {} : { _meta: params._meta }),
       },
       (replacement) => admitNativeAcpWorker(

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -139,6 +139,8 @@ export function queueBriefing(
  * is not the plumbing: it is that a project which said nothing births exactly
  * as it always did, and a template naming a fact this birth does not have is
  * refused BEFORE anything is spawned. PURE.
+ *
+ * @param standingOrders - Optional standing orders to prepend to the prompt
  */
 export function demandTurnForBirth(
   registration: {
@@ -148,6 +150,7 @@ export function demandTurnForBirth(
   birth: { readonly workspace_path: string; readonly index: number; readonly work_item?: string },
   workerId: string,
   ticket?: { readonly id: string; readonly title: string; readonly labels: readonly string[] },
+  standingOrders?: string,
 ): {
   readonly workspacePath: string;
   readonly prompt: string;
@@ -161,6 +164,10 @@ export function demandTurnForBirth(
     workspace_path: birth.workspace_path,
     ...(birth.work_item == null ? {} : { work_item: birth.work_item }),
   }).argv[0]!;
+  // Prepend standing orders to the prompt if present
+  const withOrders = standingOrders != null && standingOrders !== ""
+    ? `${standingOrders}\n${expanded}`
+    : expanded;
   // The handoff is stated only when every fact it requires is present: a Ticket
   // briefed with an empty title or no trunk is one the Worker refuses, and a
   // refusal the daemon could have avoided is a Worker born to fail.
@@ -170,7 +177,7 @@ export function demandTurnForBirth(
     ticket.title !== "" && base != null && base !== "";
   return {
     workspacePath: birth.workspace_path,
-    prompt: expanded,
+    prompt: withOrders,
     ...(birth.work_item == null ? {} : { workItem: birth.work_item }),
     ...(briefed
       ? {
@@ -179,7 +186,7 @@ export function demandTurnForBirth(
           title: ticket!.title,
           labels: [...ticket!.labels],
           base: base!,
-          handoff: expanded,
+          handoff: withOrders,
           worker_id: workerId,
         },
       }

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -29,6 +29,7 @@ import {
   type RedskilledWorkerEventKind,
   type RecordWorkerEventInput,
 } from "../event-lane.js";
+import { createStandingOrdersStore, deriveHomeDirFromEventLanePath, formatStandingOrdersBrief } from "../standing-orders.js";
 import {
   DEFAULT_REDSKILLED_DEMAND_MS,
   beginBirthProbe,
@@ -348,6 +349,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
 
   const startedAt = clock();
   const eventLane = meteredRedskilledEventLane(options.eventLane ?? createRedskilledEventLane(paths.eventLanePath), redskilledMetrics());
+  const standingOrdersStore = options.standingOrdersStore ?? createStandingOrdersStore(deriveHomeDirFromEventLanePath(paths.eventLanePath));
   const registrationIntentStore = options.registrationIntentStore ??
     createRedskilledRegistrationIntentStore(paths.registrationIntentPath);
   const liveness = options.liveness ?? detectWorkerLiveness;
@@ -1022,8 +1024,13 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         // Worker's whole life, and a blocked tick would stop every project.
         if (registered?.prompt != null && acpControlPlane != null) {
           try {
+            // Read standing orders for this project and prepend to prompt
+            const ordersResult = await standingOrdersStore.show(birth.project_label);
+            const standingOrdersText = ordersResult.orders.length > 0
+              ? formatStandingOrdersBrief(ordersResult.orders)
+              : undefined;
             const turn = demandTurnForBirth(registered, birth, mintHostWorkerId(workers.keys()),
-              queueBriefing(lastQueue?.projects ?? [], birth.project_label, birth.work_item))!;
+              queueBriefing(lastQueue?.projects ?? [], birth.project_label, birth.work_item), standingOrdersText)!;
             void acpControlPlane.runDemandTurn(turn).catch(async (error: unknown) => {
               await eventLane.recordDemandRefusal({
                 ts: clock(),
@@ -2405,6 +2412,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       releaseProject: (projectLabel) => deregisterProject(projectLabel),
       workerPulse: (pulse) => recordWorkerPulse(pulse),
       recordDemandTurn: (record) => void process.stderr.write(describeDemandTurn(record)),
+      standingOrdersStore,
     });
   } catch (error) {
     await stop({ reason: "requested", note: "ACP control plane failed to bind" }).catch(() => undefined);

--- a/apps/redskilled/src/daemon/types.ts
+++ b/apps/redskilled/src/daemon/types.ts
@@ -33,6 +33,7 @@ import type { RedskilledHostEventSinks } from "../host-event-sink.js";
 import type { RedskilledHostTopology } from "../host-topology.js";
 import { type RedskilledRegistrationIntentStore,
 } from "../registration-intent-store.js";
+import type { StandingOrdersStore } from "../standing-orders.js";
 import { type RedskilledProjectRegistration,
   type RedskilledProjectRegistrationRequest,
 } from "../project-registration.js";
@@ -147,6 +148,8 @@ export interface RedskilledDaemonOptions {
   readonly eventLane?: RedskilledEventLane;
   /** The durable registration snapshot; defaults to this session's own. */
   readonly registrationIntentStore?: RedskilledRegistrationIntentStore;
+  /** The standing orders store; defaults to this session's own. */
+  readonly standingOrdersStore?: StandingOrdersStore;
   /** Durable generic host-resource authority; injected for handover tests. */
   readonly resourceLeaseStore?: RedskilledResourceLeaseStore;
   /** Real available memory, sampled only while deciding generic resource admission. */

--- a/apps/redskilled/src/standing-orders.ts
+++ b/apps/redskilled/src/standing-orders.ts
@@ -1,0 +1,126 @@
+/**
+ * standing-orders — daemon-owned per-project append-only instruction register.
+ *
+ * **ADR 0156**: Standing orders are the operator's reflex mechanism: an instruction
+ * the operator catches themselves repeating gets appended before acting, and every
+ * subsequent Worker inherits it without restatement. The register is append-only,
+ * numbered, and drain-scoped — not a second permanent home that competes with
+ * CLAUDE.md.
+ *
+ * **Design**:
+ * - Per-project, keyed by project label
+ * - Append-only: orders are never mutated or renumbered
+ * - Numbered: each order gets a sequential number
+ * - Injected verbatim into every Worker brief at admission and on resume
+ *
+ * **Storage**: One TOONL file per project under the daemon's home directory.
+ * The file is append-only: new orders are appended as TOONL rows.
+ */
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
+import { encodeToonlLines } from "@reddb-io/toon";
+
+/** The standing orders file name prefix */
+export const REDSKILLED_STANDING_ORDERS_FILE = "redskilled.orders.toonl";
+
+export interface StandingOrder {
+  readonly version: 1;
+  readonly n: number;
+  readonly text: string;
+  readonly ts: string;
+}
+
+export interface StandingOrdersShowOutput {
+  readonly project_label: string;
+  readonly orders: readonly StandingOrder[];
+}
+
+export interface StandingOrdersAppendInput {
+  readonly text: string;
+}
+
+export interface StandingOrdersStore {
+  readonly show: (projectLabel: string) => Promise<StandingOrdersShowOutput>;
+  readonly append: (projectLabel: string, text: string) => Promise<StandingOrder>;
+}
+
+/**
+ * Resolve the path to a project's standing orders file.
+ */
+export function standingOrdersPath(homeDir: string, projectLabel: string): string {
+  const safeLabel = projectLabel.replace(/[^a-zA-Z0-9_-]/g, "_");
+  return join(redskilledHomeDir(homeDir), "orders", `${safeLabel}.toonl`);
+}
+
+/**
+ * Derive the home directory from the event lane path.
+ * The event lane path is: <homeDir>/.red/redskilled/redskilled.log.toonl
+ * So we need to go up two levels to get homeDir.
+ */
+export function deriveHomeDirFromEventLanePath(eventLanePath: string): string {
+  const dirnameOfEventLane = dirname(eventLanePath); // <homeDir>/.red/redskilled
+  const parentDir = dirname(dirnameOfEventLane); // <homeDir>
+  return parentDir;
+}
+
+/**
+ * Read standing orders for a project. Returns empty array if no orders exist.
+ */
+async function readStandingOrders(path: string): Promise<StandingOrder[]> {
+  try {
+    const content = await readFile(path, "utf8");
+    if (content.trim() === "") return [];
+    const lines = content.split("\n").filter((line) => line.trim() !== "");
+    return lines.map((line) => JSON.parse(line) as StandingOrder);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+/**
+ * Encode a standing order to a TOONL string.
+ */
+function encodeOrder(order: StandingOrder): string {
+  return encodeToonlLines({ trailer: false }).push(order as unknown as Record<string, string | number | boolean | null>);
+}
+
+/**
+ * Create a standing orders store.
+ */
+export function createStandingOrdersStore(homeDir: string): StandingOrdersStore {
+  return {
+    show: async (projectLabel: string): Promise<StandingOrdersShowOutput> => {
+      const path = standingOrdersPath(homeDir, projectLabel);
+      const orders = await readStandingOrders(path);
+      return { project_label: projectLabel, orders };
+    },
+    append: async (projectLabel: string, text: string): Promise<StandingOrder> => {
+      const path = standingOrdersPath(homeDir, projectLabel);
+      const orders = await readStandingOrders(path);
+      const n = orders.length + 1;
+      const order: StandingOrder = {
+        version: 1,
+        n,
+        text,
+        ts: new Date().toISOString(),
+      };
+      await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+      const line = encodeOrder(order);
+      await appendFile(path, line, { encoding: "utf8", mode: 0o600 });
+      return order;
+    },
+  };
+}
+
+/**
+ * Format standing orders as a string for injection into a Worker brief.
+ * Returns empty string if no orders exist.
+ */
+export function formatStandingOrdersBrief(orders: readonly StandingOrder[]): string {
+  if (orders.length === 0) return "";
+  const header = "## Standing Orders\n";
+  const items = orders.map((o) => `${o.n}. ${o.text}`).join("\n");
+  return `${header}${items}\n`;
+}


### PR DESCRIPTION
Implements ADR 0156 standing orders - a daemon-owned per-project append-only instruction register.

## Changes
- New store with show() and append() methods
- Wired into demandTurnForBirth() and ACP control plane
- MCP tools: standing_orders_show and standing_orders_append
- TOONL storage using encodeToonlLines

Closes #4166

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789846498&installation_model_id=20659&pr_number=4198&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4198&signature=1bb95274a5f93578339c13b3a2e9c1b21b0e4c4fc967ec381f81681c937561b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->