### PR TITLE
feat(worker): the local gate runs the declared validation commands

### DIFF
--- a/.changeset/worker-gate-runs-declared.md
+++ b/.changeset/worker-gate-runs-declared.md
@@ -1,0 +1,14 @@
+---
+"@reddb-io/redskilled": patch
+"@reddb-io/red-skills": patch
+"@reddb-io/protocol-acp": patch
+---
+
+The Worker's local gate runs the repo's DECLARED validation commands. The
+drain registration composes them from `plugins.dev.afk.validation`
+(`post_done` then `landing`), the daemon carries them opaquely onto every
+Ticket, and the Worker runs exactly those instead of improvising a full
+workspace suite — which contradicted the "sole local validation authority"
+contract and flaked under the Worker memory ceiling, a different package red
+each round, none of them the branch's fault. A repo that declared nothing
+keeps the improvised cone.

--- a/apps/plugin-dev/src/core/drain-registration-resolve.ts
+++ b/apps/plugin-dev/src/core/drain-registration-resolve.ts
@@ -11,6 +11,8 @@ import { resolveProjectIdentityForDir } from "@reddb-io/shared/project-identity-
 import { DEFAULT_FLEET_WIDTH } from "@reddb-io/shared/default-fleet-width.js";
 
 import { buildDrainRegistration, type DrainRegistration } from "./drain-registration.js";
+import { loadConfig, readValidationMoments } from "./config.js";
+import { afkPaths } from "../runtime/wire/paths.js";
 
 /**
  * The registration this checkout's drain carries, or `undefined` when the
@@ -34,6 +36,7 @@ export function drainRegistrationFor(
     ? input.target
     : DEFAULT_FLEET_WIDTH;
   const runner = typeof input.runner === "string" && input.runner.length > 0 ? input.runner : undefined;
+  const declared = declaredGateCommands(root);
   return buildDrainRegistration({
     repo,
     workspacePath: root,
@@ -41,7 +44,26 @@ export function drainRegistrationFor(
     version,
     ...(runner == null ? {} : { runner }),
     ...(trunkBranch(root) == null ? {} : { trunkBranch: trunkBranch(root) }),
+    ...(declared.length === 0 ? {} : { validationCommands: declared }),
   });
+}
+
+/**
+ * The repo's declared local gate, in schedule order (#4166).
+ *
+ * `post_done` then `landing`: the Worker's gate sits between DONE and the
+ * publish, which is exactly those two moments back to back. `iteration` is
+ * the inner agent's while-writing loop and deliberately not repeated here.
+ * A repo that declared nothing gets an empty answer — the Worker then falls
+ * back to its improvised cone, which stays legal for undeclared repos.
+ */
+export function declaredGateCommands(root: string): string[] {
+  try {
+    const moments = readValidationMoments(loadConfig(afkPaths(root).configPath, { warn: () => undefined }));
+    return [...(moments.post_done ?? []), ...(moments.landing ?? [])];
+  } catch {
+    return [];
+  }
 }
 
 /** The branch `origin/HEAD` points at, or `undefined` when git cannot say. */

--- a/apps/plugin-dev/src/core/drain-registration.ts
+++ b/apps/plugin-dev/src/core/drain-registration.ts
@@ -23,6 +23,8 @@ import {
 export interface DrainRegistrationInput {
   /** The trunk branch this checkout lands against; `main` when unstated. */
   readonly trunkBranch?: string | undefined;
+  /** The declared local gate commands; absent means the repo declared none. */
+  readonly validationCommands?: readonly string[] | undefined;
   /** `owner/name` — the repository whose tracker holds this project's queue. */
   readonly repo: string;
   /** Where a Worker for this project runs; the project's own checkout. */
@@ -53,6 +55,13 @@ export interface DrainRegistration {
    */
   readonly trunk: { readonly remote: string; readonly branch: string };
   readonly prompt: string;
+  /**
+   * The repo's DECLARED local gate, handed to every Worker (#4166). Without
+   * it the Worker improvises a full workspace suite — contradicting the
+   * "sole local validation authority" contract and flaking under the Worker
+   * memory ceiling, a different package red each round.
+   */
+  readonly validation_commands?: readonly string[];
   readonly target: number;
 }
 
@@ -99,6 +108,9 @@ export function buildDrainRegistration(input: DrainRegistrationInput): DrainRegi
     workspace_path: input.workspacePath,
     trunk: { remote: "origin", branch: input.trunkBranch ?? "main" },
     prompt: DRAIN_WORKER_PROMPT,
+    ...(input.validationCommands == null || input.validationCommands.length === 0
+      ? {}
+      : { validation_commands: [...input.validationCommands] }),
     target: input.target,
   };
 }

--- a/apps/plugin-dev/tests/drain-registration.test.ts
+++ b/apps/plugin-dev/tests/drain-registration.test.ts
@@ -39,6 +39,11 @@ describe("what a drain hands the daemon", () => {
 
   it("tells the Worker to work the item the daemon fills in, and nothing more", () => {
     expect(buildDrainRegistration(input).prompt).toBe(DRAIN_WORKER_PROMPT);
+    // #4166: the declared local gate rides the registration so the Worker
+    // never improvises a suite; a repo that declared none carries none.
+    expect(buildDrainRegistration({ ...input, validationCommands: ["pnpm typecheck"] }).validation_commands)
+      .toEqual(["pnpm typecheck"]);
+    expect(buildDrainRegistration(input).validation_commands).toBeUndefined();
     expect(DRAIN_WORKER_PROMPT).toContain("{{work_item}}");
     expect(DRAIN_WORKER_PROMPT).toContain("/afk");
     // #4162: the Worker's workspace is already materialised on the Ticket's

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -144,6 +144,7 @@ export function demandTurnForBirth(
   registration: {
     readonly prompt?: string;
     readonly trunk?: { readonly branch: string };
+    readonly validation_commands?: readonly string[];
   } | undefined,
   birth: { readonly workspace_path: string; readonly index: number; readonly work_item?: string },
   workerId: string,
@@ -181,6 +182,9 @@ export function demandTurnForBirth(
           base: base!,
           handoff: expanded,
           worker_id: workerId,
+          ...(registration.validation_commands == null || registration.validation_commands.length === 0
+            ? {}
+            : { validation_commands: [...registration.validation_commands] }),
         },
       }
       : {}),

--- a/apps/redskilled/src/project-registration.ts
+++ b/apps/redskilled/src/project-registration.ts
@@ -135,38 +135,22 @@ export interface RedskilledProjectRegistrationRequest {
   readonly workspace_path: string;
   /** Explicit git coordinates; optional only for one-release client skew. */
   readonly trunk?: RedskilledTrunk;
-  /**
-   * What to add to a Worker's environment at birth. Opaque, likewise.
-   *
-   * The slot-scoped bag that used to be composed at the spawn site — a retire
-   * file, a worker id, a slot — arrives here, with the per-birth facts written as
-   * `{{worker_id}}`-style placeholders the daemon fills in. Absent means nothing
-   * to add, which is an ordinary answer rather than a missing one.
-   */
+  /** What to add to a Worker's environment at birth; opaque, with
+   * `{{worker_id}}`-style placeholders the daemon fills in. Absent = nothing. */
   readonly env?: Readonly<Record<string, string>>;
-  /**
-   * Where a Worker born for this project writes its output. Opaque, likewise.
-   *
-   * A template, carrying the same `{{worker_id}}`-style placeholders the env
-   * does, because one registration births many Workers and two of them must never
-   * share a file. Absent means this project keeps its Worker's last line entirely
-   * on the heartbeat — legal, and the reason the daemon never refuses a
-   * registration for stating no path.
-   */
+  /** Where a Worker writes its output; a `{{worker_id}}` template so two
+   * Workers never share a file. Absent = the heartbeat carries the last line. */
   readonly log_path?: string;
   /** Project-scoped notifications keyed by the public host-event vocabulary. */
   readonly hooks?: RedskilledProjectHooks;
-  /**
-   * What to SAY to a Worker born for this project, when saying anything is the
-   * point (#4100).
-   *
-   * A registration's argv births a process; a prompt is what makes that process
-   * do the project's work. Opaque exactly as the argv is — the daemon expands
-   * its own facts (`{{work_item}}`, `{{worker_id}}`) into it and never reads a
-   * word. Absent means this project's Workers are born and not spoken to, which
-   * is the shape every registration had before this field and stays legal.
-   */
+  /** What to SAY to a born Worker (#4100); opaque like the argv, with
+   * `{{work_item}}`-style facts the daemon expands. Absent = born unspoken-to. */
   readonly prompt?: string;
+  /**
+   * The project's DECLARED local gate, run by the Worker instead of an
+   * improvised suite (#4166). Opaque command strings, exactly like the argv.
+   */
+  readonly validation_commands?: readonly string[];
   /** How many Workers this project wants; the host still decides how many it gets. */
   readonly target: number;
   /** Whether project policy declares this drain should remain recoverable. */
@@ -191,6 +175,8 @@ export interface RedskilledProjectRegistration {
   readonly hooks?: RedskilledProjectHooks;
   /** What to say to a Worker born for this project; opaque, expanded at birth. */
   readonly prompt?: string;
+  /** The project's declared local gate; opaque command strings (#4166). */
+  readonly validation_commands?: readonly string[];
   readonly target: number;
   /** True only when the project explicitly declared a standing drain policy. */
   readonly standing?: boolean;
@@ -299,6 +285,11 @@ export function buildProjectRegistration(
   // Blank, not merely empty: a prompt of spaces is a Worker told nothing.
   if (request.prompt !== undefined) requireText(request.prompt.trim(), `a prompt for ${projectLabel}`);
   const prompt = request.prompt;
+  // Same opacity as the argv: shape-checked strings the daemon never reads.
+  const validationCommands = request.validation_commands == null
+    ? undefined
+    : request.validation_commands.map((command, index) =>
+      requireText(command, `validation command ${index} for project ${JSON.stringify(projectLabel)}`));
   // Same shape check, same reason as the argv: a registration the host could
   // never start a Worker for is a client bug the daemon can see without reading
   // anything about what the path names.
@@ -348,6 +339,7 @@ export function buildProjectRegistration(
     ...(logPath == null ? {} : { log_path: logPath }),
     ...(hooks == null ? {} : { hooks }),
     ...(prompt == null ? {} : { prompt }),
+    ...(validationCommands == null || validationCommands.length === 0 ? {} : { validation_commands: validationCommands }),
     target: request.target,
     ...(request.standing === true ? { standing: true } : {}),
     registered_at: new Date(nowMs).toISOString(),

--- a/packages/protocol-acp/ticket.ts
+++ b/packages/protocol-acp/ticket.ts
@@ -41,6 +41,14 @@ export interface RedskillsTicketHandoff {
   readonly reseed_budget?: number;
   /** The operator's extra gate commands, run after feedback and only if it passed. */
   readonly backpressure_commands?: readonly string[];
+  /**
+   * The project's DECLARED local gate (#4166). When present, the Worker runs
+   * exactly these commands as its feedback stage instead of improvising a
+   * package-cone suite — the declared schedule is the sole local validation
+   * authority, and an improvised full suite both contradicts it and flakes
+   * under the Worker's memory ceiling.
+   */
+  readonly validation_commands?: readonly string[];
 }
 
 /**
@@ -78,6 +86,9 @@ export function ticketHandoffFromMeta(meta: unknown): RedskillsTicketHandoff | u
       : {}),
     ...(isStringArray(ticket.backpressure_commands)
       ? { backpressure_commands: ticket.backpressure_commands }
+      : {}),
+    ...(isStringArray(ticket.validation_commands)
+      ? { validation_commands: ticket.validation_commands }
       : {}),
   };
 }

--- a/packages/worker/src/acp/declared-gate.test.ts
+++ b/packages/worker/src/acp/declared-gate.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { runWorkerLocalGate } from "./local-gate.js";
+import { ticketHandoffFromMeta } from "@reddb-io/protocol-acp";
+
+/**
+ * The declared schedule is the sole local validation authority (#4166): a
+ * Worker handed `validation_commands` runs exactly those and never improvises
+ * the package-cone suite, which contradicted the declaration and flaked under
+ * the Worker memory ceiling — a different package red each round.
+ */
+describe("the Worker gate runs the declared commands", () => {
+  it("runs them in order as the feedback stage and stops at the first failure", async () => {
+    const ran: string[] = [];
+    const result = await runWorkerLocalGate({
+      worktree: "/tmp/wt",
+      base: "main",
+      validationCommands: ["pnpm typecheck", "pnpm -C apps/plugin-dev test:invariants", "never-reached"],
+      backpressureExec: async ({ command }) => {
+        ran.push(command);
+        return command === "pnpm -C apps/plugin-dev test:invariants"
+          ? { code: 1, stdout: "", stderr: "invariant broke: lane unregistered" }
+          : { code: 0, stdout: "ok", stderr: "" };
+      },
+    });
+
+    expect(ran).toEqual(["pnpm typecheck", "pnpm -C apps/plugin-dev test:invariants"]);
+    expect(result.stages.find((stage) => stage.stage === "feedback")?.ok).toBe(false);
+    expect(result.detail).toContain("invariant broke: lane unregistered");
+  });
+
+  it("passes clean and still runs backpressure afterwards", async () => {
+    const ran: string[] = [];
+    const result = await runWorkerLocalGate({
+      worktree: "/tmp/wt",
+      base: "main",
+      validationCommands: ["pnpm typecheck"],
+      backpressureCommands: ["pnpm extra"],
+      backpressureExec: async ({ command }) => {
+        ran.push(command);
+        return { code: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    expect(ran).toEqual(["pnpm typecheck", "pnpm extra"]);
+    expect(result.stages.find((stage) => stage.stage === "feedback")?.ok).toBe(true);
+    expect(result.stages.find((stage) => stage.stage === "backpressure")?.ok).toBe(true);
+    expect(result.sidecar.length).toBe(2);
+  });
+});
+
+describe("the ticket wire carries the declared commands", () => {
+  it("round-trips validation_commands and drops a malformed list", () => {
+    const base = {
+      number: 7, title: "t", labels: [], base: "main", handoff: "h", worker_id: "W1",
+    };
+    expect(ticketHandoffFromMeta({
+      redskills: { ticket: { ...base, validation_commands: ["pnpm typecheck"] } },
+    })?.validation_commands).toEqual(["pnpm typecheck"]);
+    expect(ticketHandoffFromMeta({
+      redskills: { ticket: { ...base, validation_commands: [7] } },
+    })?.validation_commands).toBeUndefined();
+  });
+});

--- a/packages/worker/src/acp/local-gate.ts
+++ b/packages/worker/src/acp/local-gate.ts
@@ -27,7 +27,7 @@ import {
   type ScriptLayout,
   type ValidationCheck,
 } from "../engine/gate-executor.js";
-import { KILLED_EXIT_CODE } from "../engine/gate-constants.js";
+import { CASTLE_VALIDATION_SCHEMA, KILLED_EXIT_CODE } from "../engine/gate-constants.js";
 import type { GateStageOutcome } from "../engine/gate-stage-order.js";
 import type { WorkspaceGraph, WorkspacePackage } from "../engine/validation-cone.js";
 import type { TicketGateRun } from "./ticket-loop.js";
@@ -42,6 +42,15 @@ export interface WorkerLocalGateOptions {
   readonly base: string;
   /** The operator's extra commands, run after feedback and only if it passed. */
   readonly backpressureCommands?: readonly string[];
+  /**
+   * The project's DECLARED gate (#4166). When non-empty, the feedback stage
+   * runs exactly these commands and the improvised package-cone suite never
+   * runs: the declared schedule is the sole local validation authority, and
+   * the improvised full suite both contradicted it and flaked under the
+   * Worker's memory ceiling — a different package red each round, none of
+   * them the branch's fault.
+   */
+  readonly validationCommands?: readonly string[];
   /** Test seam over the package suite. Production runs real `pnpm`. */
   readonly feedbackExec?: (args: string[]) => Promise<ExecResult>;
   /** Test seam over the operator's commands. Production runs a real shell. */
@@ -68,6 +77,9 @@ export interface WorkerLocalGateResult extends TicketGateRun {
 export async function runWorkerLocalGate(
   options: WorkerLocalGateOptions,
 ): Promise<WorkerLocalGateResult> {
+  if (options.validationCommands != null && options.validationCommands.length > 0) {
+    return await runDeclaredGate(options, options.validationCommands);
+  }
   const readChanged = options.changedFiles ?? changedFilesSince;
   const changed = await readChanged(options.worktree, options.base);
   const { layout, graph } = readWorkspace(options.worktree);
@@ -106,6 +118,84 @@ export async function runWorkerLocalGate(
     checks: result.checks,
     sidecar: result.sidecar,
   };
+}
+
+/**
+ * The declared gate: each command is one feedback check, run in order, stopped
+ * at the first failure — exactly what the operator wrote, nothing discovered.
+ */
+async function runDeclaredGate(
+  options: WorkerLocalGateOptions,
+  commands: readonly string[],
+): Promise<WorkerLocalGateResult> {
+  const exec = options.backpressureExec
+    ?? (({ command, cwd, timeoutMs }) => runShell(command, cwd, timeoutMs));
+  const now = options.now ?? Date.now;
+  const checks: ValidationCheck[] = [];
+  for (const command of commands) {
+    const startedAt = now();
+    const run = await exec({ command, cwd: options.worktree, timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS });
+    const passed = run.code === 0;
+    checks.push(declaredCheck(`declared:${command}`, command, run.code, now() - startedAt,
+      passed ? undefined : tail(run.stderr || run.stdout, 400)));
+    if (!passed) break;
+  }
+  const backpressureCommands = options.backpressureCommands ?? [];
+  const feedbackOk = checks.every((check) => check.status === "passed");
+  if (feedbackOk) {
+    for (const command of backpressureCommands) {
+      const startedAt = now();
+      const run = await exec({ command, cwd: options.worktree, timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS });
+      const passed = run.code === 0;
+      checks.push(declaredCheck(`backpressure:${command}`, command, run.code, now() - startedAt,
+        passed ? undefined : tail(run.stderr || run.stdout, 400)));
+      if (!passed) break;
+    }
+  }
+  const feedback = checks.filter((check) => check.name.startsWith("declared:"));
+  const backpressure = checks.filter((check) => check.name.startsWith("backpressure:"));
+  const stages: GateStageOutcome[] = [
+    stageOutcome("feedback", feedback),
+    stageOutcome("backpressure", backpressure),
+    { stage: "review", ok: true, skipped: true },
+  ];
+  const detail = failureDetail(checks);
+  return {
+    stages,
+    ...(detail == null ? {} : { detail }),
+    checks,
+    sidecar: checks.map((check) => JSON.stringify(check.record)),
+  };
+}
+
+/** One declared command's outcome, in the gate's own record shape. */
+function declaredCheck(
+  name: string,
+  command: string,
+  exitCode: number,
+  durationMs: number,
+  failureSummary: string | undefined,
+): ValidationCheck {
+  const status = exitCode === 0 ? "passed" as const : "failed" as const;
+  return {
+    name,
+    status,
+    record: {
+      schema: CASTLE_VALIDATION_SCHEMA,
+      name,
+      status,
+      command,
+      exitCode,
+      durationMs: Math.max(0, Math.round(durationMs)),
+      ...(status === "passed" ? {} : { summary: failureSummary || "exited non-zero" }),
+    },
+  };
+}
+
+/** The last `max` characters — the failing part of a long build log. */
+function tail(text: string, max: number): string {
+  const trimmed = text.trim();
+  return trimmed.length <= max ? trimmed : trimmed.slice(trimmed.length - max);
 }
 
 function stageOutcome(

--- a/packages/worker/src/acp/native-worker.ts
+++ b/packages/worker/src/acp/native-worker.ts
@@ -151,6 +151,9 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
         ...(ticket.backpressure_commands == null
           ? {}
           : { backpressureCommands: ticket.backpressure_commands }),
+        ...(ticket.validation_commands == null
+          ? {}
+          : { validationCommands: ticket.validation_commands }),
       }),
       publisher: held.publisher,
       narrate: (record) => notifyTicketStage(parent, sessionId, record),


### PR DESCRIPTION
The contract says `plugins.dev.afk.validation` is the **sole local validation authority** and "the engine never discovers or improvises a suite" — but the Worker's gate improvised one: the package-cone `pnpm test`, which reached the ROOT aggregate on any branch carrying a root-level file (every changeset does) and ran the full workspace under the Worker's 3.2GB memory ceiling. Live on 4.1.5 that flaked a different package each round (release, brain, memory — 55/55 green on the same commit outside the Worker), gate-blocking Tickets on failures that were never the branch's fault (#4166 repeatedly).

## The declared schedule travels the whole chain

- **plugin-dev**: `drainRegistrationFor` composes `validation_commands` from the repo's declared schedule — `post_done` then `landing`, the two moments the Worker's gate sits across (`declaredGateCommands`); `iteration` stays the inner agent's while-writing loop.
- **daemon**: the registration accepts and stores them opaquely (shape-checked strings, exactly like the argv) and `demandTurnForBirth` stamps them onto every briefed Ticket.
- **wire**: `RedskillsTicketHandoff.validation_commands`, validated like `backpressure_commands`.
- **worker**: `runWorkerLocalGate` handed `validationCommands` runs exactly those in order as its feedback stage — first failure stops, the detail carries the failing command's output **tail** (the part with the error in it) — and never touches the improvised cone. Backpressure still runs after a green feedback. A repo that declared nothing keeps the cone, so undeclared repos gate exactly as before.

For this repo that means every Worker gate becomes `pnpm typecheck && pnpm -C apps/plugin-dev test:invariants` — minutes instead of tens of minutes, no OOM roulette, and the merge queue keeps owning the full-suite verdict on the live tip, as the config comment already said.

## Tests

`declared-gate.test.ts` (worker): ordered execution, stop-at-first-failure, detail tail, backpressure-after-green, wire round-trip. `drain-registration.test.ts`: passthrough and absent-means-absent. Registration suite 18/18, demand-turn 29/29, guards green (file-size satisfied by compressing three prose comments in project-registration.ts). Pre-existing on clean main, untouched: `local-gate.test.ts`'s four fixture failures (environment), worker-package tsc warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789851090&installation_model_id=20659&pr_number=4201&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4201&signature=fc838074fe328e26b79a033120bfa375a9733d0fdbe0ca699b0b2c849db35cbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->