### PR TITLE
fix(worker): replace HOME with temp dir in credential-free env

### DIFF
--- a/.changeset/fix-4200-worker-credential-home.md
+++ b/.changeset/fix-4200-worker-credential-home.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/worker": patch
+"@reddb-io/shared": patch
+---
+Fix: Worker terminal no longer inherits the machine's ambient GitHub credentials via the gh keyring or git credential helper. The credential-free environment now replaces HOME with a temp directory so that even if a command bypasses the terminal policy, it finds no token to use.

--- a/packages/shared/credential-free-env.test.ts
+++ b/packages/shared/credential-free-env.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { credentialFreeEnv, isCredentialEnvironmentName } from "./credential-free-env.js";
+import {
+  _credentialFreeEnvWithHome,
+  credentialFreeEnv,
+  isCredentialEnvironmentName,
+} from "./credential-free-env.js";
 
 describe("the environment a disposable process may inherit", () => {
   it("refuses every GitHub and Git credential name", () => {
@@ -43,5 +47,22 @@ describe("the environment a disposable process may inherit", () => {
       RED_MODE: "spec-driven",
       UNSET: undefined,
     })).toEqual({ PATH: "/usr/bin", RED_MODE: "spec-driven" });
+  });
+
+  it("replaces HOME with the ghost home so gh keyring and git credential helper are unreachable", () => {
+    const result = _credentialFreeEnvWithHome({
+      PATH: "/usr/bin",
+      HOME: "/home/user",
+      GITHUB_TOKEN: "secret",
+      RED_MODE: "spec-driven",
+    });
+    expect(result.HOME).toBe(process.env.TMPDIR ?? process.env.TEMP ?? "/tmp");
+    expect(result.GITHUB_TOKEN).toBeUndefined();
+    expect(result.RED_MODE).toBe("spec-driven");
+  });
+
+  it("leaves HOME absent when it was absent in the input", () => {
+    const result = _credentialFreeEnvWithHome({ PATH: "/usr/bin" });
+    expect(result.HOME).toBeUndefined();
   });
 });

--- a/packages/shared/credential-free-env.ts
+++ b/packages/shared/credential-free-env.ts
@@ -41,3 +41,32 @@ export function credentialFreeEnv(env: NodeJS.ProcessEnv): Record<string, string
   }
   return kept;
 }
+
+/**
+ * ADR 0144 §3: a disposable process holds no credential anywhere, including not
+ * in files the process can reach through its own home directory.
+ *
+ * `credentialFreeEnv` strips credential env vars, but gh stores tokens in
+ * `~/.cache/gh/` and git reads `~/.gitconfig` — both reachable through `HOME`.
+ * This function replaces `HOME` with a temp directory that has no credential
+ * store, so even if a command somehow bypasses the terminal policy, it finds no
+ * token to use.
+ *
+ * The replacement is only applied when `HOME` is present (a missing `HOME` is
+ * left alone — most processes handle that gracefully, and the Worktree's own
+ * files are the working directory, not the home directory).
+ */
+export function credentialFreeHomeDir(env: NodeJS.ProcessEnv): string | undefined {
+  return env.HOME ? env.HOME : undefined;
+}
+
+const GHOST_HOME = process.env.TMPDIR ?? process.env.TEMP ?? "/tmp";
+
+/** @internal */
+export function _credentialFreeEnvWithHome(env: NodeJS.ProcessEnv): Record<string, string> {
+  const credentialFree = credentialFreeEnv(env);
+  if (credentialFree.HOME !== undefined) {
+    return { ...credentialFree, HOME: GHOST_HOME };
+  }
+  return credentialFree;
+}

--- a/packages/worker/src/acp/child-agent.ts
+++ b/packages/worker/src/acp/child-agent.ts
@@ -18,7 +18,7 @@ import {
   REDSKILLS_WIRE_MAJOR,
   type AcpEndpoint,
 } from "@reddb-io/protocol-acp";
-import { credentialFreeEnv } from "@reddb-io/shared/credential-free-env.js";
+import { _credentialFreeEnvWithHome } from "@reddb-io/shared/credential-free-env.js";
 import type { SpinPattern } from "../engine/spin-evaluator.js";
 import { createChildAcpSpinEpisode, type ChildAcpSpinEpisode } from "./child-spin.js";
 import { createWorkerTerminalHost, type WorkerTerminalHost } from "./terminal-host.js";
@@ -62,7 +62,7 @@ export class WorkflowChildAgent {
     // the terminals its predecessor opened rather than orphaning them.
     this.#terminals = createWorkerTerminalHost({
       cwd: options.cwd,
-      env: credentialFreeEnv(process.env),
+      env: _credentialFreeEnvWithHome(process.env),
       onDenial: (denial) => void this.#terminalDenial(denial),
     });
   }
@@ -142,7 +142,7 @@ export class WorkflowChildAgent {
     // strips them again rather than trusting a hop it cannot see.
     const child = spawn(endpoint.command, endpoint.args, {
       cwd: this.#options.cwd,
-      env: credentialFreeEnv(process.env),
+      env: _credentialFreeEnvWithHome(process.env),
       stdio: ["pipe", "pipe", "ignore"],
     });
     if (child.stdin == null || child.stdout == null) throw new Error("child ACP Agent did not expose stdio");


### PR DESCRIPTION
## Fixes #4200

ADR 0144 §3: a disposable process holds no credential anywhere, including not in files the process can reach through its own home directory.

The credential-free env stripped credential env vars (GH_TOKEN, etc.) but kept HOME. With HOME set to the real home directory, gh can reach its keyring at ~/.cache/gh/ and git can reach its credential helper config at ~/.gitconfig. Even though the terminal policy blocks gh entirely, the ambient credentials were present as a belt-and-suspenders gap.

This change replaces HOME with a temp directory in the credential-free env so that even if a command somehow bypasses the terminal policy, it finds no token to use.

## Testing
- All credential-free-env tests pass (6 tests)
- All terminal-host tests pass (7 tests)
- Lint and typecheck pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789851862&installation_model_id=20659&pr_number=4203&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4203&signature=cdf209e91d65e63dedc2fed4c879dfa8487a6c4a1e985cb8bb4ba050960fc7c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->