### PR TITLE
fix(redskilled): an error that crosses the wire keeps its words

### DIFF
--- a/.changeset/acp-errors-carry-words.md
+++ b/.changeset/acp-errors-carry-words.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+An error that crosses the ACP wire keeps its words: a handler that threw a
+plain Error reached the Worker as bare "Internal error" with the message
+swallowed, so every carefully-worded refusal in the publish path died on the
+wire. The method registry now re-throws non-RequestError exceptions as a
+RequestError carrying the original sentence.

--- a/apps/redskilled/src/acp-method-registry.ts
+++ b/apps/redskilled/src/acp-method-registry.ts
@@ -11,6 +11,7 @@
 // A domain also declares the `_meta.redskills` fragment it contributes to
 // `initialize`, because advertising a method the endpoint does not bind (and
 // binding one it never advertises) are the same drift in the other direction.
+import { RequestError } from "@agentclientprotocol/sdk";
 import { REDSKILLS_ACP_METHODS, type RedskillsAcpMethod } from "@reddb-io/protocol-acp";
 
 /** The context an extension handler is given. Params are already validated. */
@@ -62,10 +63,26 @@ export function redskillsAcpMethod<Params, Result>(
   params: (value: unknown) => Params,
   handle: (context: RedskillsAcpMethodContext<Params>) => Result,
 ): RedskillsAcpMethodBinding {
+  // **An error that crosses the wire keeps its words.** A handler that threw a
+  // plain Error reached the Worker as bare "Internal error" (-32603, message
+  // swallowed by the SDK), so every carefully-worded refusal in the publish
+  // path — delivery failures, authority checks — died on the wire and two
+  // Workers ground one Ticket on a cause nobody could read. A RequestError
+  // passes through untouched; anything else is re-thrown as one carrying the
+  // original sentence.
+  const named = async (context: RedskillsAcpMethodContext<Params>): Promise<unknown> => {
+    try {
+      return await handle(context);
+    } catch (error) {
+      if (error instanceof RequestError) throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new RequestError(-32603, `${method} failed: ${message}`);
+    }
+  };
   return {
     method,
     params,
-    handle: handle as (context: RedskillsAcpMethodContext) => unknown,
+    handle: named as (context: RedskillsAcpMethodContext) => unknown,
   };
 }
 

--- a/apps/redskilled/tests/acp-error-words.test.ts
+++ b/apps/redskilled/tests/acp-error-words.test.ts
@@ -1,0 +1,46 @@
+import { RequestError } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+
+import { redskillsAcpMethod } from "../src/acp-method-registry.js";
+import { REDSKILLS_ACP_METHODS } from "@reddb-io/protocol-acp";
+
+/**
+ * An error that crosses the wire keeps its words. A handler that threw a plain
+ * Error reached the Worker as bare "Internal error" — two Workers ground one
+ * Ticket on `refused at publish: Internal error` while the daemon held the
+ * real sentence and swallowed it.
+ */
+describe("wire errors carry their words", () => {
+  it("re-throws a plain Error as a RequestError carrying the original sentence", async () => {
+    const binding = redskillsAcpMethod(
+      REDSKILLS_ACP_METHODS.publish,
+      (value) => value,
+      () => {
+        throw new Error("redskilled could not deliver the Worker's publication: fetch refused");
+      },
+    );
+
+    await expect(binding.handle({ params: {} } as never)).rejects.toMatchObject({
+      code: -32603,
+      message: expect.stringContaining("fetch refused"),
+    });
+  });
+
+  it("passes a RequestError through untouched", async () => {
+    const authRequired = RequestError.authRequired({ version: 1 }, "no credential profile");
+    const binding = redskillsAcpMethod(
+      REDSKILLS_ACP_METHODS.publish,
+      (value) => value,
+      () => {
+        throw authRequired;
+      },
+    );
+
+    await expect(binding.handle({ params: {} } as never)).rejects.toBe(authRequired);
+  });
+
+  it("answers a healthy handler exactly as before", async () => {
+    const binding = redskillsAcpMethod(REDSKILLS_ACP_METHODS.publish, (value) => value, () => ({ ok: true }));
+    await expect(binding.handle({ params: {} } as never)).resolves.toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
Two Workers ground Ticket #4161 on `refused at publish: Internal error` — the daemon held the real sentence (the publication delivery and authority paths throw carefully-worded `RedskilledGithubAuthorityError` messages) and swallowed it: the ACP SDK answers any non-`RequestError` exception as bare `-32603` with no message, so every named refusal died on the wire and the verdict blamed nothing anyone could read.

`redskillsAcpMethod` — the one place every domain's handler passes through — now re-throws non-`RequestError` exceptions as a `RequestError` carrying `<method> failed: <original message>`. A `RequestError` passes untouched; a healthy handler answers exactly as before.

Tests: `acp-error-words.test.ts` (3) — plain Error → -32603 with the original sentence; RequestError passthrough by identity; healthy handler unchanged. Guards green.

The next `refused at publish` will carry its cause; that named cause is how #4161's actual publish blocker gets diagnosed instead of reproduced by guesswork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789856253&installation_model_id=20659&pr_number=4205&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4205&signature=53c6587475ae5e854e51a7152afe3296a853076c8e97c790b10d4d66a4dbed98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->