### PR TITLE
fix(dev): document the standing-orders tools the docs contract requires

### DIFF
--- a/.changeset/standing-orders-docs.md
+++ b/.changeset/standing-orders-docs.md
@@ -1,0 +1,7 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+MCP.md documents the standing-orders tools (`standing_orders_show` read,
+`standing_orders_append` mutating) that #4198 shipped undocumented, and the
+published-tool expectation carries them in registry order.

--- a/apps/plugin-dev/tests/mcp-tool-surface.test.ts
+++ b/apps/plugin-dev/tests/mcp-tool-surface.test.ts
@@ -401,6 +401,20 @@ const SURFACE: ReadonlyArray<{
       "MUTATING: warm the published engine bundle into the stable cache path and re-point a standing registration at it in one operation, then return the version, the bundle path, and what happened to the registration.",
     schema: ["version"],
   },
+  {
+    name: "standing_orders_show",
+    title: "Show standing orders for this project",
+    description:
+      "READ-ONLY: return all standing orders for this project. Standing orders are an append-only, numbered register injected verbatim into every Worker brief.",
+    schema: ["project_label"],
+  },
+  {
+    name: "standing_orders_append",
+    title: "Append a standing order",
+    description:
+      "MUTATING: append a new standing order to this project's register. The order is injected verbatim into every Worker brief at admission and on resume. Append is append-only — existing orders are never mutated or renumbered.",
+    schema: ["text", "project_label"],
+  },
 ];
 
 describe("aggregated rs_dev MCP tool surface", () => {

--- a/apps/plugin-dev/tests/mcp-tools.test.ts
+++ b/apps/plugin-dev/tests/mcp-tools.test.ts
@@ -251,6 +251,8 @@ describe("redskilled MCP tools", () => {
       "codex_statusline",
       "codex_monitor_agent",
       "reconcile_engine",
+      "standing_orders_show",
+      "standing_orders_append",
     ]);
   });
 

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -109,6 +109,8 @@ that block, startup preserves the explicit-only `drain`/`project_start` behavior
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |
 | `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `status {scope: project}` at `birth_latch.repair`; the structured repair supplies the exact args. |
 | `project_stop` | mutating | Give this project's registration back and stop what it still holds; pass `force: true` to hard-stop only its attributed workers. |
+| `standing_orders_show` | read | Return this project's standing orders — the append-only, numbered instruction register injected verbatim into every Worker brief (ADR 0156). |
+| `standing_orders_append` | mutating | Append one standing order to this project's register; existing orders are never mutated or renumbered, and every subsequent Worker brief carries the new order verbatim. |
 
 ### Host daemon diagnostics
 

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -109,6 +109,8 @@ that block, startup preserves the explicit-only `drain`/`project_start` behavior
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |
 | `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `status {scope: project}` at `birth_latch.repair`; the structured repair supplies the exact args. |
 | `project_stop` | mutating | Give this project's registration back and stop what it still holds; pass `force: true` to hard-stop only its attributed workers. |
+| `standing_orders_show` | read | Return this project's standing orders — the append-only, numbered instruction register injected verbatim into every Worker brief (ADR 0156). |
+| `standing_orders_append` | mutating | Append one standing order to this project's register; existing orders are never mutated or renumbered, and every subsequent Worker brief carries the new order verbatim. |
 
 ### Host daemon diagnostics
 


### PR DESCRIPTION
PR #4198 landed `standing_orders_show`/`standing_orders_append` with their docs-contract tests red — the merge went through the ambient-gh path (#4200) that honors no required checks — so main carried two undocumented `rs_dev` tools and every Worker gate and CI shard failed on the contract. Exactly the failure the gate legitimately parked #4166's own Worker for, delivered anyway.

- `MCP.md` gains both rows (`show` as read, `append` as mutating, matching their descriptions).
- `mcp-tools.test.ts`'s published-tool list gains them in the registry's own order.

Docs and test expectations only; no changeset (scope gate exempts non-shippable… if it complains, one follows). `redskilled-mcp-client-docs` and `mcp-tools` suites green (38/38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789856587&installation_model_id=20659&pr_number=4206&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4206&signature=b3f5c482a4772e2931808e054d9e59384a769664215cfe3436bc3f6090b222ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->