### PR TITLE
fix(redskilled): the repository push reaches the canonical repository

### DIFF
--- a/.changeset/push-reaches-github.md
+++ b/.changeset/push-reaches-github.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The repository push targets the canonical GitHub URL instead of the
+mirror's `origin` — which is the human checkout, a local path — so a
+Worker's publish actually reaches the tracker, and a push failure carries
+git's own words instead of a bare internal error. Every publish on a
+mirror-cloned machine died at this line.

--- a/apps/redskilled/src/github-write.ts
+++ b/apps/redskilled/src/github-write.ts
@@ -191,8 +191,14 @@ async function pushCanonicalRepository(input: RedskilledGithubWriteUpstreamInput
   if (input.write.kind !== "repository-push") throw new Error("repository push received a non-push write");
   const write = input.write;
   const authorization = Buffer.from(`x-access-token:${input.credential.secret}`, "utf8").toString("base64");
+  // The CANONICAL repository by URL, never the mirror's `origin`: the Project
+  // mirror is cloned from the human checkout, so its `origin` is a local path —
+  // the auth header is meaningless there, the refusal wrapped into a bare
+  // "Internal error", and even a push that succeeded would have delivered the
+  // branch to the wrong place. Every publish on this machine died here.
+  const remote = `https://github.com/${input.project.projectLabel}.git`;
   await new Promise<void>((resolve, reject) => {
-    execFile("git", ["push", "origin", `${write.sha}:${write.ref}`], {
+    execFile("git", ["push", remote, `${write.sha}:${write.ref}`], {
       cwd: input.project.workspacePath,
       env: {
         ...process.env,
@@ -203,7 +209,11 @@ async function pushCanonicalRepository(input: RedskilledGithubWriteUpstreamInput
       },
       windowsHide: true,
       timeout: 60_000,
-    }, (error) => error == null ? resolve() : reject(new Error("redskilled repository push failed", { cause: error })));
+    }, (error, _stdout, stderr) => error == null
+      ? resolve()
+      : reject(new Error(
+        `redskilled repository push to ${remote} failed: ${String(stderr ?? "").trim() || error.message}`,
+      )));
   });
   return { pushed: true, ref: write.ref, sha: write.sha };
 }

--- a/apps/redskilled/tests/push-canonical-url.test.ts
+++ b/apps/redskilled/tests/push-canonical-url.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SOURCE = readFileSync(join(import.meta.dirname, "..", "src", "github-write.ts"), "utf8");
+
+/**
+ * The Project mirror's `origin` is the human checkout — a local path — so a
+ * `git push origin` from the mirror delivered nowhere: the auth header was
+ * meaningless, the refusal wrapped into a bare "Internal error", and every
+ * publish on the machine died at this line (observed: four turns across
+ * #4157/#4161, all `refused at publish: Internal error`). Source-pinned like
+ * bounded-request: the push must name the canonical URL, and its failure must
+ * carry git's own words.
+ */
+describe("the repository push reaches the canonical repository", () => {
+  it("pushes to the canonical GitHub URL derived from the project label", () => {
+    expect(SOURCE).toContain("`https://github.com/${input.project.projectLabel}.git`");
+    expect(SOURCE).toContain('execFile("git", ["push", remote,');
+    expect(SOURCE).not.toMatch(/execFile\("git", \["push", "origin"/);
+  });
+
+  it("names the remote and git's own words in the failure", () => {
+    expect(SOURCE).toContain("redskilled repository push to ${remote} failed");
+  });
+});


### PR DESCRIPTION
Every publish on this machine died at one line: `pushCanonicalRepository` ran `git push origin` in the Project mirror, whose `origin` is the human checkout — a local filesystem path. The auth header was meaningless there, the refusal wrapped into a bare "Internal error" (four turns across #4157/#4161 all ended `refused at publish: Internal error`), and even a push that succeeded would have delivered the branch to the wrong place. This was the single gate between the drain and its first `landed`.

- The push targets `https://github.com/<projectLabel>.git` — the same canonical-by-URL principle as the fork's trunk fetch (#4191); the existing `http.extraHeader` Basic auth applies to it as designed.
- A failed push rejects with git's own stderr in the message, which #4205's wire-error mapping then carries into the turn verdict.
- Source-pinned test (bounded-request precedent): the push argv names the canonical URL, never the mirror's `origin`, and the failure names the remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789857703&installation_model_id=20659&pr_number=4208&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4208&signature=d71b888266677c671a977cb934a371186ee82f1a5fd02fd80bc4cc2d9911e7f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->