### PR TITLE
fix(redskilled): demand sessions survive restarts unique, and 422s speak

### DIFF
--- a/.changeset/demand-session-nonce.md
+++ b/.changeset/demand-session-nonce.md
@@ -1,0 +1,10 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Unattended demand sessions are unique across daemon lifetimes (a per-runner
+nonce joins the sequence), and a GitHub write refusal carries GitHub's own
+words. The sequence alone restarted at zero with the process, so the
+publication outbox replayed the previous boot's durable receipt for the same
+idempotency scope — a publish that "succeeded" without pushing, then a land
+422 on a head no push had created.

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -24,6 +24,8 @@ import type {
   RequestPermissionResponse,
 } from "@agentclientprotocol/sdk";
 
+import { randomBytes } from "node:crypto";
+
 import { parkGateBlockedTurn } from "./demand-park.js";
 import { admitNativeAcpWorker } from "./acp-worker-admission.js";
 import { expandLaunchTemplate } from "./launch-template.js";
@@ -318,6 +320,12 @@ export function createDemandTurnRunner(
 ): (request: DemandTurnRequest) => Promise<DemandTurnResult> {
   const active = new Map<string, ActiveWorkflowWorker>();
   let sequence = 0;
+  // Unique across daemon lifetimes: the sequence alone restarts at zero with
+  // the process, so `demand-3-<project>` recurred after every restart and the
+  // publication outbox replayed the PREVIOUS boot's durable receipt for the
+  // same idempotency scope — a publish that "succeeded" without pushing, and a
+  // land that 422'd on a head no push had created.
+  const runnerNonce = randomBytes(4).toString("hex");
   const admit = deps.admit ?? ((input: DemandTurnAdmission) => admitNativeAcpWorker(
     {
       paths: deps.paths,
@@ -341,7 +349,7 @@ export function createDemandTurnRunner(
     // Synthetic and unique per turn: the session id keys the admission map and
     // the journal, and a reused one would make two unattended turns look like
     // one session being replaced.
-    const sessionId = `demand-${sequence}-${request.project.projectId}`;
+    const sessionId = `demand-${runnerNonce}-${sequence}-${request.project.projectId}`;
     const record = (event: string, worker?: ActiveWorkflowWorker, detail?: string): void => {
       deps.record?.({
         event,

--- a/apps/redskilled/src/github-transport.ts
+++ b/apps/redskilled/src/github-transport.ts
@@ -23,6 +23,8 @@ export function githubUpstreamRefusal(
   response: Response,
   now: string,
   profile: string,
+  /** GitHub's own words, read by the caller that owns the body stream. */
+  bodyText?: string,
 ): Error {
   const observed = {
     status: response.status,
@@ -34,5 +36,6 @@ export function githubUpstreamRefusal(
     return new RedskilledGithubCredentialProfileError("invalid-credentials", profile);
   }
   if (response.status === 403) return githubCredentialScopeRefusal(profile);
-  return new Error(`redskilled GitHub ${surface} failed with status ${response.status}`);
+  const reason = bodyText == null || bodyText.trim() === "" ? "" : `: ${bodyText.trim().slice(0, 300)}`;
+  return new Error(`redskilled GitHub ${surface} failed with status ${response.status}${reason}`);
 }

--- a/apps/redskilled/src/github-write.ts
+++ b/apps/redskilled/src/github-write.ts
@@ -81,7 +81,8 @@ export function createRedskilledGithubWriteUpstream(
       body: JSON.stringify(request.body),
     });
     if (!response.ok) {
-      throw githubUpstreamRefusal("write", "rest", response, clock(), input.project.credentialProfile);
+      const body = await response.text().catch(() => "");
+      throw githubUpstreamRefusal("write", "rest", response, clock(), input.project.credentialProfile, body);
     }
     return responseValue(response);
   };

--- a/apps/redskilled/tests/demand-turn.test.ts
+++ b/apps/redskilled/tests/demand-turn.test.ts
@@ -139,6 +139,17 @@ describe("the daemon's unattended turn", () => {
 
     expect(opened).toHaveLength(1);
     expect(opened[0]?.sessionId).toContain("github:1");
+    // Unique across daemon lifetimes (#4157's land 422): the sequence restarts
+    // with the process, so the id carries a per-runner nonce and two runners
+    // never mint the same session — or the publication outbox replays the
+    // previous boot's receipt for a publish that never pushed.
+    const again: Array<{ sessionId: string }> = [];
+    const second = runner(async (input) => {
+      void input;
+      return workerStub({ result: { stopReason: "end_turn" } });
+    }, [], again);
+    await second.run({ project, prompt: "p" });
+    expect(again[0]?.sessionId).not.toBe(opened[0]?.sessionId);
   });
 
   it("refuses permission on nobody's behalf, and says why", async () => {


### PR DESCRIPTION
The last two links of the land chain, from live evidence on #4157:

1. **Session ids recurred across restarts.** The unattended session id was `demand-<sequence>-<project>` and the sequence restarts at zero with the daemon, so after every restart the same ids recurred and the publication outbox — idempotency-scoped by session id — replayed the PREVIOUS boot's durable receipt: a publish that "succeeded" without pushing anything, then a land that 422'd opening a PR for a head no push had created (observed twice on #4157 tonight; the pushed branch never appeared on GitHub while the turn verdict said publish passed). A per-runner random nonce joins the id; the new test pins that two runners never mint the same session.

2. **The 422 said nothing.** The GitHub write refusal named only the status because the sync refusal builder never had the body. The write path now reads the body and the refusal carries GitHub's own words (head invalid / no commits between / a pull request already exists — the three 422s this chain can produce), truncated to 300 chars, which #4205's wire mapping then delivers into the turn verdict.

Suites green (demand-turn 15, worker-pulse 5); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789859445&installation_model_id=20659&pr_number=4210&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4210&signature=41ff8a9dd3f5d98d978bc66c80262b0888006dc8e6268fbf68497c2c71c67fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->