### PR TITLE
fix(worker): the publication owns its branch

### DIFF
--- a/.changeset/publication-owns-its-branch.md
+++ b/.changeset/publication-owns-its-branch.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/worker": patch
+"@reddb-io/redskilled": patch
+---
+
+A Ticket turn's publication publishes as the Worker-unique branch
+(`red/<worker>/<ticket>`) regardless of the Worktree's local branch name. An
+inner agent that committed on `main` published `refs/heads/main` (rejected
+non-fast-forward at the canonical repository), and one that reused an old
+branch name collided with the merged branch's corpse — both happened on one
+Ticket in one evening.

--- a/packages/worker/src/acp/native-worker.ts
+++ b/packages/worker/src/acp/native-worker.ts
@@ -69,10 +69,14 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
     if (ticketOutcome(response) != null) return;
     const held = sessions.get(sessionId);
     if (held == null) return;
+    const heldTicket = ticketHandoffFromMeta(held.request._meta);
     held.publisher ??= createWorkerPublisher({
       cwd: held.request.cwd,
       idempotencyScope: `worker-turn:${sessionId}`,
       request: boundedRequest(parent),
+      // The publication owns its branch: Worker-unique, so it can never target
+      // the trunk and never collide with a merged branch's corpse (#4157).
+      ...(heldTicket == null ? {} : { publishRef: `red/${heldTicket.worker_id}/${heldTicket.number}` }),
     });
     const outcome = await held.publisher.publishTurn();
     if (outcome == null) return;
@@ -121,6 +125,8 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
       cwd: held.request.cwd,
       idempotencyScope: `worker-turn:${sessionId}`,
       request: boundedRequest(parent),
+      // Same Worker-unique publication branch as the budget-grace path.
+      publishRef: `red/${ticket.worker_id}/${ticket.number}`,
     });
 
     const result = await runTicketLoop({

--- a/packages/worker/src/acp/publish-request.test.ts
+++ b/packages/worker/src/acp/publish-request.test.ts
@@ -134,3 +134,29 @@ describe("reading the Worktree's publication", () => {
     expect(await readWorktreePublication(root)).toBeNull();
   });
 });
+
+describe("the publication owns its branch", () => {
+  it("publishes as the Worker-unique ref regardless of the local branch name", async () => {
+    const requests: Array<Record<string, unknown>> = [];
+    const publisher = createWorkerPublisher({
+      cwd: "/tmp/wt",
+      idempotencyScope: "worker-turn:s1",
+      request: async (_method, params) => {
+        requests.push(params as unknown as Record<string, unknown>);
+        return { ok: true };
+      },
+      readPublication: async () => ({ branch: "main", commit: "a".repeat(40) }),
+      publishRef: "red/W1/4157",
+    });
+
+    const outcome = await publisher.publishTurn();
+
+    // An agent that committed on `main` must not publish `refs/heads/main`
+    // (rejected non-fast-forward at the canonical repository), and a reused
+    // branch name must not collide with a merged branch's corpse (#4157).
+    expect(requests[0]?.branch).toBe("red/W1/4157");
+    expect(outcome?.status).toBe("requested");
+    expect(outcome && "publication" in outcome ? outcome.publication.branch : null).toBe("red/W1/4157");
+  });
+});
+

--- a/packages/worker/src/acp/publish-request.ts
+++ b/packages/worker/src/acp/publish-request.ts
@@ -34,6 +34,15 @@ export interface WorkerPublisherOptions {
   readonly idempotencyScope: string;
   /** Test seam over `git rev-parse`. Production reads the real Worktree. */
   readonly readPublication?: (cwd: string) => Promise<WorkerPublication | null>;
+  /**
+   * The branch this publication PUBLISHES AS, regardless of the Worktree's
+   * local branch name. An inner agent that commits on `main` would otherwise
+   * publish `refs/heads/main` (rejected non-fast-forward at the canonical
+   * repository), and one that names its branch after an old merged branch
+   * collides with the corpse (#4157: both happened in one evening). A Ticket
+   * turn passes the Worker-unique ref; absent keeps the local name.
+   */
+  readonly publishRef?: string;
 }
 
 export interface WorkerPublisher {
@@ -56,7 +65,10 @@ export function createWorkerPublisher(options: WorkerPublisherOptions): WorkerPu
   let published: string | undefined;
   return {
     async publishTurn() {
-      const publication = await readPublication(options.cwd).catch(() => null);
+      const local = await readPublication(options.cwd).catch(() => null);
+      const publication = local == null
+        ? null
+        : options.publishRef == null ? local : { ...local, branch: options.publishRef };
       if (publication == null || publication.commit === published) return null;
       published = publication.commit;
       const request: RedskilledPublishRequest = {


### PR DESCRIPTION
Two publish failures on #4157 in one evening, both from trusting the Worktree's local branch name:

1. An inner agent that committed on `main` published `refs/heads/main` and was **rejected non-fast-forward** at the canonical repository (`error: failed to push some refs`, named by #4208's stderr carry).
2. Another named its branch after a long-merged one (`fix/4157-demand-plan-family`) and collided with the corpse — the land 422'd opening a PR whose head had no commits against main.

The publisher now publishes as **`red/<worker_id>/<ticket>`** — Worker-unique by construction, so it can never target the trunk and never collide — with the local branch still read for the commit itself. Both publisher creation sites pass it (the Ticket turn from its handoff; the budget-grace path from the session's held ticket, staying local-named for ordinary promptless turns). The land's PR head inherits the same ref through the returned publication.

Test: the publisher's request and returned publication both carry the unique ref when the local branch is `main`. Suite green (7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789859872&installation_model_id=20659&pr_number=4212&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4212&signature=d26799cb7a459b1e985370fe77e4f33e962576659a29f5ae129d0e1959e93d90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->