### PR TITLE
fix(worker): the publish-as ref exists in the Worktree it publishes from

### DIFF
--- a/.changeset/publish-ref-exists-locally.md
+++ b/.changeset/publish-ref-exists-locally.md
@@ -1,0 +1,8 @@
+---
+"@reddb-io/worker": patch
+---
+
+The publish-as ref is anchored in the Worktree before the publish request
+goes out: the daemon delivers by fetching `refs/heads/<branch>` from the
+Worktree, and a name that existed only as a request field fetched nothing
+("couldn't find remote ref refs/heads/red/<worker>/<ticket>").

--- a/packages/worker/src/acp/publish-request.test.ts
+++ b/packages/worker/src/acp/publish-request.test.ts
@@ -138,6 +138,7 @@ describe("reading the Worktree's publication", () => {
 describe("the publication owns its branch", () => {
   it("publishes as the Worker-unique ref regardless of the local branch name", async () => {
     const requests: Array<Record<string, unknown>> = [];
+    const anchored: string[] = [];
     const publisher = createWorkerPublisher({
       cwd: "/tmp/wt",
       idempotencyScope: "worker-turn:s1",
@@ -146,6 +147,7 @@ describe("the publication owns its branch", () => {
         return { ok: true };
       },
       readPublication: async () => ({ branch: "main", commit: "a".repeat(40) }),
+      updateRef: async (_cwd, ref, commit) => void anchored.push(`${ref}@${commit.slice(0, 4)}`),
       publishRef: "red/W1/4157",
     });
 
@@ -155,6 +157,9 @@ describe("the publication owns its branch", () => {
     // (rejected non-fast-forward at the canonical repository), and a reused
     // branch name must not collide with a merged branch's corpse (#4157).
     expect(requests[0]?.branch).toBe("red/W1/4157");
+    // The daemon delivers by fetching refs/heads/<branch> FROM the Worktree,
+    // so the publish-as name must exist there before the request goes out.
+    expect(anchored).toEqual(["refs/heads/red/W1/4157@aaaa"]);
     expect(outcome?.status).toBe("requested");
     expect(outcome && "publication" in outcome ? outcome.publication.branch : null).toBe("red/W1/4157");
   });

--- a/packages/worker/src/acp/publish-request.ts
+++ b/packages/worker/src/acp/publish-request.ts
@@ -34,6 +34,8 @@ export interface WorkerPublisherOptions {
   readonly idempotencyScope: string;
   /** Test seam over `git rev-parse`. Production reads the real Worktree. */
   readonly readPublication?: (cwd: string) => Promise<WorkerPublication | null>;
+  /** Test seam over `git update-ref`. Production writes the real Worktree. */
+  readonly updateRef?: (cwd: string, ref: string, commit: string) => Promise<void>;
   /**
    * The branch this publication PUBLISHES AS, regardless of the Worktree's
    * local branch name. An inner agent that commits on `main` would otherwise
@@ -70,6 +72,21 @@ export function createWorkerPublisher(options: WorkerPublisherOptions): WorkerPu
         ? null
         : options.publishRef == null ? local : { ...local, branch: options.publishRef };
       if (publication == null || publication.commit === published) return null;
+      // The publish-as ref must EXIST in the Worktree: the daemon delivers by
+      // fetching `refs/heads/<branch>` from here, and a name that is only a
+      // request field fetches nothing ("couldn't find remote ref", #4157).
+      if (options.publishRef != null) {
+        const anchored = await (options.updateRef ?? updateWorktreeRef)(
+          options.cwd, `refs/heads/${options.publishRef}`, publication.commit,
+        ).then(() => true).catch(() => false);
+        if (!anchored) {
+          return {
+            status: "refused",
+            publication,
+            detail: `the Worktree refused to anchor ${options.publishRef} at ${publication.commit}`,
+          };
+        }
+      }
       published = publication.commit;
       const request: RedskilledPublishRequest = {
         idempotency_key: `${options.idempotencyScope}:${publication.commit}`,
@@ -97,6 +114,16 @@ export async function readWorktreePublication(cwd: string): Promise<WorkerPublic
   if (branch == null || branch === "HEAD") return null;
   const commit = await git(cwd, ["rev-parse", "HEAD"]);
   return commit == null ? null : { branch, commit };
+}
+
+/** Anchor the publish-as ref at the commit, so the daemon's fetch finds it. */
+async function updateWorktreeRef(cwd: string, ref: string, commit: string): Promise<void> {
+  const done = await git(cwd, ["update-ref", ref, commit]);
+  // `update-ref` prints nothing on success, so only an error resolves null AND
+  // leaves the ref absent; verify by reading it back.
+  void done;
+  const at = await git(cwd, ["rev-parse", ref]);
+  if (at !== commit) throw new Error(`could not anchor ${ref} at ${commit}`);
 }
 
 function git(cwd: string, args: readonly string[]): Promise<string | null> {


### PR DESCRIPTION
The Worker-unique publication branch (#4212) was only a request field: the daemon delivers a publication by fetching `refs/heads/<branch>` **from the Worktree**, so the very next turn on #4157 died with a perfectly named error — `couldn't find remote ref refs/heads/red/VSsnAfU/4157` (the name pointed at nothing anywhere). The named-errors work paying off: this diagnosis took one journal line.

The publisher now anchors the ref at the publication commit in the Worktree (`git update-ref`, read back to verify) before the request goes out; a Worktree that refuses the anchor becomes a named publish refusal instead of a daemon-side fetch error.

Test: the anchor call is pinned beside the unique-ref assertion (7/7 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789861480&installation_model_id=20659&pr_number=4214&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4214&signature=9bf017d9ef10c0bee105ec40321bbd976de9d03a3af9de7473784f11636190f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->