### PR TITLE
fix(worker): a turn that commits nothing publishes nothing

### DIFF
--- a/.changeset/publish-skips-unchanged-head.md
+++ b/.changeset/publish-skips-unchanged-head.md
@@ -1,0 +1,8 @@
+---
+"@reddb-io/worker": patch
+---
+
+A Ticket turn that commits nothing publishes nothing: the publisher captures
+the Worktree's HEAD before the implementer runs and skips publication when
+HEAD is unchanged, so the turn answers nothing-to-publish instead of pushing
+main's own tip and dying on GitHub's "No commits between" at the land.

--- a/packages/worker/src/acp/native-worker.ts
+++ b/packages/worker/src/acp/native-worker.ts
@@ -34,7 +34,7 @@ import {
 } from "@reddb-io/protocol-acp";
 import { WorkflowChildAgent } from "./child-agent.js";
 import { runWorkerLocalGate } from "./local-gate.js";
-import { createWorkerPublisher, type WorkerPublisher } from "./publish-request.js";
+import { createWorkerPublisher, worktreeHead, type WorkerPublisher } from "./publish-request.js";
 import { runTicketLoop, type TicketLoopRecord, type TicketLoopResult } from "./ticket-loop.js";
 
 /** One public session this Worker holds, and what it retains across its turns. */
@@ -127,6 +127,11 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
       request: boundedRequest(parent),
       // Same Worker-unique publication branch as the budget-grace path.
       publishRef: `red/${ticket.worker_id}/${ticket.number}`,
+      // Captured BEFORE the implementer runs: a turn that commits nothing must
+      // answer nothing-to-publish, not publish main's own tip (#4157).
+      ...(await worktreeHead(held.request.cwd).then(
+        (commit) => (commit == null ? {} : { baselineCommit: commit }),
+      )),
     });
 
     const result = await runTicketLoop({

--- a/packages/worker/src/acp/publish-request.test.ts
+++ b/packages/worker/src/acp/publish-request.test.ts
@@ -165,3 +165,23 @@ describe("the publication owns its branch", () => {
   });
 });
 
+describe("a turn that commits nothing publishes nothing", () => {
+  it("skips the publish when HEAD still equals the baseline", async () => {
+    const requests: unknown[] = [];
+    const publisher = createWorkerPublisher({
+      cwd: "/tmp/wt",
+      idempotencyScope: "worker-turn:s1",
+      request: async (_method, params) => void requests.push(params),
+      readPublication: async () => ({ branch: "main", commit: "b".repeat(40) }),
+      baselineCommit: "b".repeat(40),
+      publishRef: "red/W1/9",
+      updateRef: async () => {},
+    });
+
+    // The branch equalled main and GitHub answered "No commits between" — a
+    // doomed land the Worker itself can refuse for free (#4157).
+    expect(await publisher.publishTurn()).toBeNull();
+    expect(requests).toEqual([]);
+  });
+});
+

--- a/packages/worker/src/acp/publish-request.ts
+++ b/packages/worker/src/acp/publish-request.ts
@@ -37,6 +37,13 @@ export interface WorkerPublisherOptions {
   /** Test seam over `git update-ref`. Production writes the real Worktree. */
   readonly updateRef?: (cwd: string, ref: string, commit: string) => Promise<void>;
   /**
+   * The commit the Worktree held BEFORE the implementer ran (#4157). A turn
+   * that produced no new commit still had a HEAD, and publishing it opened a
+   * doomed land: the branch equalled main and GitHub answered "No commits
+   * between". A HEAD equal to the baseline publishes nothing.
+   */
+  readonly baselineCommit?: string;
+  /**
    * The branch this publication PUBLISHES AS, regardless of the Worktree's
    * local branch name. An inner agent that commits on `main` would otherwise
    * publish `refs/heads/main` (rejected non-fast-forward at the canonical
@@ -64,7 +71,7 @@ export type WorkerPublishOutcome =
 
 export function createWorkerPublisher(options: WorkerPublisherOptions): WorkerPublisher {
   const readPublication = options.readPublication ?? readWorktreePublication;
-  let published: string | undefined;
+  let published: string | undefined = options.baselineCommit;
   return {
     async publishTurn() {
       const local = await readPublication(options.cwd).catch(() => null);
@@ -114,6 +121,11 @@ export async function readWorktreePublication(cwd: string): Promise<WorkerPublic
   if (branch == null || branch === "HEAD") return null;
   const commit = await git(cwd, ["rev-parse", "HEAD"]);
   return commit == null ? null : { branch, commit };
+}
+
+/** The Worktree's HEAD commit, or null when it has none. */
+export async function worktreeHead(cwd: string): Promise<string | null> {
+  return await git(cwd, ["rev-parse", "HEAD"]);
 }
 
 /** Anchor the publish-as ref at the commit, so the daemon's fetch finds it. */


### PR DESCRIPTION
Three agent turns on #4157 examined the code, concluded nothing was needed, committed nothing — and each still published: the publisher's only skip was "same commit as last publish", so the fork's own tip went out as the publication, the daemon pushed a branch equal to main, and the land died on GitHub's named `No commits between main and red/<worker>/<ticket>` (words delivered by the #4210 pipeline — this diagnosis was one journal line).

The publisher now takes a `baselineCommit` — the Worktree HEAD captured before the implementer runs (the ticket turn passes it at publisher creation) — and a HEAD still equal to it publishes nothing, so the ticket loop answers its honest `nothing-to-publish` verdict instead of a doomed publish-and-land.

Test: baseline-equal HEAD → `publishTurn()` null, zero requests (suite 8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789872320&installation_model_id=20659&pr_number=4218&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4218&signature=1c075e81aaa90d57508bd397b14b26ef06de0c5e705bb94bd9d08672bed6bbd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->