### PR TITLE
fix(redskilled): the registered runner reaches the born Worker

### DIFF
--- a/.changeset/runner-honored-admission.md
+++ b/.changeset/runner-honored-admission.md
@@ -1,0 +1,12 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The registered runner reaches the born Worker. Admission composed every child
+from a hardcoded redcode default, so a drain registered with `--child-agent
+codex` still birthed redcode Workers. The runner now travels the declared
+route — registration argv → demand turn → session meta → admission — and an
+adapter runner (codex, claude-code, pi) is admitted through its npx-pinned
+adapter bin. A codex child runs out of a daemon-owned `CODEX_HOME` under the
+redskilled home, seeded with the operator's login and isolated from the
+operator's interactive `~/.codex/config.toml`.

--- a/apps/redskilled/src/acp-agent-catalog.ts
+++ b/apps/redskilled/src/acp-agent-catalog.ts
@@ -32,6 +32,8 @@ export interface AcpAdapterArtifact {
   readonly integrity: `sha512-${string}`;
   /** Entrypoint inside the unpacked npm artifact. */
   readonly entrypoint: string;
+  /** The package's launchable bin name, for the npx-pinned admission form. */
+  readonly bin?: string;
 }
 
 export interface NativeAcpAgentDescriptor {
@@ -66,6 +68,7 @@ export const ACP_AGENT_CATALOG: readonly AcpAgentDescriptor[] = [
       version: "0.16.2",
       integrity: "sha512-D8BJe6CCD49RtNFbZYPsfZOpQI8Z/EzhyYC9zAGMwN/HVunEtVY2sXqYl1iDSkkayzhqABfaDkDZfeqDM1T/aA==",
       entrypoint: "package/dist/index.js",
+      bin: "claude-code-acp",
     },
   },
   {
@@ -77,6 +80,7 @@ export const ACP_AGENT_CATALOG: readonly AcpAgentDescriptor[] = [
       version: "0.16.0",
       integrity: "sha512-XKzqztT5R8Wg1BVFnk6/U4JVx5GNUaZgxpf9gP2Cw6BsknvJWh3aefcAGZQljgdMivRqczjNKYL4F6H65dc5vA==",
       entrypoint: "package/bin/codex-acp.js",
+      bin: "codex-acp",
     },
   },
   {
@@ -88,6 +92,7 @@ export const ACP_AGENT_CATALOG: readonly AcpAgentDescriptor[] = [
       version: "0.0.33",
       integrity: "sha512-vX9kY1tK14E72G4dBAx+RGCk/k7XPjTHls6dLUxA8WSkBav6B6JHuSBv3eusp50LCR/GTRsR2kIKsG0Z5jANzw==",
       entrypoint: "package/dist/index.js",
+      bin: "pi-acp",
     },
   },
   { id: "opencode", label: "OpenCode", kind: "native", command: ["opencode", "acp"] },
@@ -306,6 +311,30 @@ export class AcpAgentCatalog {
 /** Canonical host-owned catalog location; no repository path participates. */
 export function redskilledAcpAgentCatalogRoot(homeDir: string = homedir()): string {
   return join(redskilledHomeDir(homeDir), "acp-agents");
+}
+
+/**
+ * The launch a Worker's child Agent is admitted WITH, before any provisioning.
+ *
+ * A native Agent launches from the host PATH. A pinned adapter launches through
+ * the npx-pinned form every shipped binary already rides (ADR 0091): exact
+ * version, no floating range, resolved by npm at spawn. The staged, SRI-checked
+ * activation under the catalog root remains the provisioning upgrade path; this
+ * is the admission-time answer, and it never substitutes another Agent.
+ */
+export function declaredChildAgentEndpoint(id: AcpAgentId): AcpEndpoint {
+  const descriptor = ACP_AGENT_CATALOG.find((candidate) => candidate.id === id);
+  if (descriptor == null) throw new AcpAgentUnavailableError(id, "it is not configured in the host catalog");
+  if (descriptor.kind === "native") return nativeEndpoint(descriptor);
+  if (descriptor.artifact.bin == null) {
+    throw new AcpAgentUnavailableError(id, "its pinned adapter declares no launchable bin");
+  }
+  return {
+    agent: id,
+    transport: "stdio",
+    command: "npx",
+    args: ["-y", "-p", `${descriptor.artifact.package}@${descriptor.artifact.version}`, descriptor.artifact.bin],
+  };
 }
 
 function nativeEndpoint(descriptor: NativeAcpAgentDescriptor): AcpEndpoint {

--- a/apps/redskilled/src/acp-agent-home.ts
+++ b/apps/redskilled/src/acp-agent-home.ts
@@ -1,0 +1,68 @@
+/**
+ * acp-agent-home — the host-side home a child Agent runs OUT OF.
+ *
+ * A Worker's child Agent must not inherit the operator's interactive dotfiles:
+ * the first codex Worker on this host died on the operator's own
+ * `~/.codex/config.toml` naming a model the pinned adapter cannot run. So an
+ * adapter child gets a daemon-owned home under the redskilled home, seeded with
+ * exactly one operator fact — the credential the child cannot mint for itself.
+ */
+import { chmod, copyFile, mkdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AcpAgentId } from "@reddb-io/protocol-acp";
+import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
+
+/** The env one child Agent needs to stand apart from its siblings and the operator. PURE. */
+export function childAgentWorkspaceEnv(
+  agent: AcpAgentId,
+  workspacePath: string,
+  homeDirPath: string = homedir(),
+): Record<string, string> {
+  // redcode#58: concurrent redcode instances sharing one opencode.db die on
+  // "database is locked" mid-turn, so each Worker's child gets its own DB in
+  // the Worker's disposable workspace — it dies with the workspace.
+  if (agent === "redcode") return { OPENCODE_DB: join(workspacePath, "redcode.db") };
+  if (agent === "codex") return { CODEX_HOME: codexAgentHome(homeDirPath) };
+  return {};
+}
+
+/** The daemon-owned codex home; the operator's `~/.codex` is never a Worker's. */
+export function codexAgentHome(homeDirPath: string = homedir()): string {
+  return join(redskilledHomeDir(homeDirPath), "agent-homes", "codex");
+}
+
+/**
+ * Create the daemon-owned home and seed the operator credential into it.
+ *
+ * The seed re-copies when the operator's login is NEWER than the seeded copy
+ * (a re-login must reach Workers), and never overwrites a seed the child has
+ * since refreshed itself. A host where the operator never logged in is refused
+ * loudly here, before a Worker is born to fail on it.
+ */
+export async function ensureChildAgentHome(agent: AcpAgentId, homeDirPath: string = homedir()): Promise<void> {
+  if (agent !== "codex") return;
+  const home = codexAgentHome(homeDirPath);
+  await mkdir(home, { recursive: true, mode: 0o700 });
+  const seeded = join(home, "auth.json");
+  const operator = join(homeDirPath, ".codex", "auth.json");
+  const [seededAt, operatorAt] = await Promise.all([mtimeOf(seeded), mtimeOf(operator)]);
+  if (operatorAt == null) {
+    if (seededAt != null) return;
+    throw new Error(
+      "codex has no host login: ~/.codex/auth.json is absent. Run `codex login` as the operator first.",
+    );
+  }
+  if (seededAt == null || operatorAt > seededAt) {
+    await copyFile(operator, seeded);
+    await chmod(seeded, 0o600);
+  }
+}
+
+async function mtimeOf(path: string): Promise<number | null> {
+  try {
+    return (await stat(path)).mtimeMs;
+  } catch {
+    return null;
+  }
+}

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -24,6 +24,8 @@ import {
 import { formatStandingOrdersBrief, type StandingOrdersStore } from "./standing-orders.js";
 import * as acpV2 from "@agentclientprotocol/sdk/experimental/v2";
 import {
+  ACP_AGENT_IDS,
+  type AcpAgentId,
   ACP_PROTOCOL_VERSION,
   ACP_V2_DRAFT_REVISION,
   REDSKILLS_WIRE_MAJOR,
@@ -60,6 +62,8 @@ export interface DemandBirthTurn {
   readonly workspacePath: string;
   readonly prompt: string;
   readonly workItem?: string;
+  /** The runner the registration's launch declared (its `--child-agent` token). */
+  readonly runner?: string;
   /** The Ticket handoff that puts the Worker in its Ticket loop (#4118). */
   readonly ticket?: Readonly<Record<string, unknown>>;
 }
@@ -211,6 +215,9 @@ export async function startRedskillsAcpControlPlane(
     project: await workspaceFor(await resolveAcpProjectIdentity(request.workspacePath)),
     prompt: request.prompt,
     ...(request.workItem == null ? {} : { workItem: request.workItem }),
+    ...(request.runner == null || !(ACP_AGENT_IDS as readonly string[]).includes(request.runner)
+      ? {}
+      : { runner: request.runner as AcpAgentId }),
     ...(request.ticket == null ? {} : { ticket: request.ticket }),
   });  let closed = false;
   return {

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -28,6 +28,7 @@ import { randomBytes } from "node:crypto";
 
 import { parkGateBlockedTurn } from "./demand-park.js";
 import { admitNativeAcpWorker } from "./acp-worker-admission.js";
+import { ACP_AGENT_IDS, type AcpAgentId } from "@reddb-io/protocol-acp";
 import { expandLaunchTemplate } from "./launch-template.js";
 import {
   cleanupWorkflowWorker,
@@ -149,6 +150,7 @@ export function demandTurnForBirth(
     readonly prompt?: string;
     readonly trunk?: { readonly branch: string };
     readonly validation_commands?: readonly string[];
+    readonly argv?: readonly string[];
   } | undefined,
   birth: { readonly workspace_path: string; readonly index: number; readonly work_item?: string },
   workerId: string,
@@ -158,9 +160,11 @@ export function demandTurnForBirth(
   readonly workspacePath: string;
   readonly prompt: string;
   readonly workItem?: string;
+  readonly runner?: AcpAgentId;
   readonly ticket?: Readonly<Record<string, unknown>>;
 } | null {
   if (registration?.prompt == null) return null;
+  const runner = runnerFromLaunchArgv(registration.argv);
   const expanded = expandLaunchTemplate({ argv: [registration.prompt] }, {
     worker_id: workerId,
     slot: birth.index,
@@ -182,6 +186,7 @@ export function demandTurnForBirth(
     workspacePath: birth.workspace_path,
     prompt: withOrders,
     ...(birth.work_item == null ? {} : { workItem: birth.work_item }),
+    ...(runner == null ? {} : { runner }),
     ...(briefed
       ? {
         ticket: {
@@ -198,6 +203,22 @@ export function demandTurnForBirth(
       }
       : {}),
   };
+}
+
+/**
+ * The runner a registration's launch argv declares; null when it declares none.
+ *
+ * The argv is the registration's stated launch (Amendment 5), and `--child-agent`
+ * is the one token in it that names a runner. Reading the pair here keeps the
+ * daemon shape-checking: an unknown name is no declaration, never an error.
+ */
+export function runnerFromLaunchArgv(argv: readonly string[] | undefined): AcpAgentId | null {
+  if (argv == null) return null;
+  const at = argv.indexOf("--child-agent");
+  const candidate = at >= 0 ? argv[at + 1] : undefined;
+  return candidate != null && (ACP_AGENT_IDS as readonly string[]).includes(candidate)
+    ? (candidate as AcpAgentId)
+    : null;
 }
 
 /** What one admission needs, whoever performs it. */
@@ -238,6 +259,8 @@ export interface DemandTurnRequest {
   readonly prompt: string;
   /** The queue identifier this turn is for, when the birth had one. */
   readonly workItem?: string;
+  /** The runner the registration's launch declared; admission's default when absent. */
+  readonly runner?: AcpAgentId;
   /**
    * The Ticket this Worker is briefed with (#4118's first drain).
    *
@@ -391,6 +414,7 @@ export function createDemandTurnRunner(
             redskills: {
               unattended: true,
               ...(request.workItem == null ? {} : { workItem: request.workItem }),
+              ...(request.runner == null ? {} : { runner: request.runner }),
               ...(request.ticket == null ? {} : { ticket: request.ticket }),
             },
           },

--- a/apps/redskilled/src/acp-worker-admission.ts
+++ b/apps/redskilled/src/acp-worker-admission.ts
@@ -21,10 +21,12 @@ import {
   type RequestPermissionResponse,
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
-import { ACP_AGENT_CATALOG, type AcpEndpoint } from "./acp-agent-catalog.js";
+import { declaredChildAgentEndpoint, type AcpAgentId, type AcpEndpoint } from "./acp-agent-catalog.js";
+import { childAgentWorkspaceEnv, ensureChildAgentHome } from "./acp-agent-home.js";
 import { githubMethodDomain } from "./acp-github.js";
 import { publicationMethodDomain } from "./acp-publication.js";
 import {
+  ACP_AGENT_IDS,
   ACP_PROTOCOL_VERSION,
   REDSKILLS_WIRE_MAJOR,
   bindWorkerRendezvous,
@@ -128,10 +130,15 @@ export async function admitNativeAcpWorker(
     await releaseWorkerWorkspace(workspace).catch(() => undefined);
     throw error;
   };
+  // The runner the registration declared travels on the session meta; a session
+  // that names none gets the governed default. The choice is admission's, never
+  // the Worker's (ADR 0148) — the Worker receives only the resolved endpoint.
+  const runner = runnerFromSessionMeta(session.request._meta) ?? "redcode";
   let launched: LaunchedWorker;
   try {
+    await ensureChildAgentHome(runner);
     launched = options.startWorker(
-      nativeWorkerSpec(session.project, workspace, endpoint, options.paths.runtimeDir, dispatch?.workerKind),
+      nativeWorkerSpec(session.project, workspace, endpoint, options.paths.runtimeDir, dispatch?.workerKind, runner),
     );
   } catch (error) {
     return await abandon(error);
@@ -281,10 +288,11 @@ export function nativeWorkerSpec(
   endpoint: string,
   runtimeDir: string,
   workerKind: "afk" | "go" | "scout" | undefined,
+  runner: AcpAgentId = "redcode",
 ): RedskilledWorkerSpec {
   const entry = process.argv[1];
   if (entry == null || entry === "") throw new Error("redskilled cannot resolve its Worker entry");
-  const childAgent = pinChildAgentExecutable(defaultChildAgentEndpoint());
+  const childAgent = pinChildAgentExecutable(declaredChildAgentEndpoint(runner));
   return {
     worker_id: workspace.workerId,
     // The registration store, the demand loop's live count, and queue discovery
@@ -299,12 +307,9 @@ export function nativeWorkerSpec(
     workspace_path: workspace.worktreePath,
     // ADR 0150 §2: the run declares its Working mode, so a skill written for a
     // human's checkout refuses inside a Worker instead of running there.
-    // redcode#58: concurrent redcode instances sharing one opencode.db die on
-    // "database is locked" mid-turn, so each Worker's child gets its own DB in
-    // the Worker's disposable workspace — it dies with the workspace.
     env: {
       ...workerModeEnv(workerKind),
-      ...(childAgent.agent === "redcode" ? { OPENCODE_DB: join(workspace.workspacePath, "redcode.db") } : {}),
+      ...childAgentWorkspaceEnv(childAgent.agent, workspace.workspacePath),
     },
     command: process.execPath,
     args: [
@@ -342,15 +347,10 @@ function pinChildAgentExecutable(endpoint: AcpEndpoint): AcpEndpoint {
   return endpoint;
 }
 
-function defaultChildAgentEndpoint(): AcpEndpoint {
-  const descriptor = ACP_AGENT_CATALOG.find(({ id }) => id === "redcode");
-  if (descriptor == null || descriptor.kind !== "native") {
-    throw new Error("the governed Redcode child ACP endpoint is not configured");
-  }
-  return {
-    agent: descriptor.id,
-    transport: "stdio",
-    command: descriptor.command[0],
-    args: descriptor.command.slice(1),
-  };
+/** The runner the session's daemon-side composer declared; null when it declared none. */
+export function runnerFromSessionMeta(meta: unknown): AcpAgentId | null {
+  const candidate = (meta as { redskills?: { runner?: unknown } } | undefined)?.redskills?.runner;
+  return typeof candidate === "string" && (ACP_AGENT_IDS as readonly string[]).includes(candidate)
+    ? (candidate as AcpAgentId)
+    : null;
 }

--- a/apps/redskilled/tests/runner-honored-admission.test.ts
+++ b/apps/redskilled/tests/runner-honored-admission.test.ts
@@ -1,0 +1,132 @@
+import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { declaredChildAgentEndpoint } from "../src/acp-agent-catalog.js";
+import { childAgentWorkspaceEnv, codexAgentHome, ensureChildAgentHome } from "../src/acp-agent-home.js";
+import { nativeWorkerSpec, runnerFromSessionMeta } from "../src/acp-worker-admission.js";
+import { demandTurnForBirth, runnerFromLaunchArgv } from "../src/acp-demand-turn.js";
+import type { AcpProjectWorkspace } from "../src/project-workspace.js";
+import type { MaterializedWorkerWorkspace } from "../src/worker-workspace.js";
+
+// The drain registered `--child-agent codex` and every Worker was still born
+// redcode: admission composed its child from a hardcoded default and never read
+// the registration. This suite pins the whole declared-runner route — argv →
+// demand turn → session meta → admission — so a registered runner is the one a
+// Worker actually runs, and an unknown one is refused by name.
+
+const roots: string[] = [];
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+const project: AcpProjectWorkspace = {
+  projectId: "remote:reddb-io/red-skills",
+  projectLabel: "reddb-io/red-skills",
+  checkoutRoot: "/tmp/checkout",
+  workspacePath: "/tmp/project-workspace",
+};
+const workspace: MaterializedWorkerWorkspace = {
+  workerId: "VStest03",
+  root: "/tmp/workers",
+  workspacePath: "/tmp/workers/VStest03",
+  worktreePath: "/tmp/workers/VStest03/worktree",
+} as MaterializedWorkerWorkspace;
+
+describe("the registered runner reaches the born Worker", () => {
+  it("reads the runner from a registration's launch argv, and an unknown name is no declaration", () => {
+    expect(runnerFromLaunchArgv(["npx", "-y", "acp-worker", "--child-agent", "codex"])).toBe("codex");
+    expect(runnerFromLaunchArgv(["acp-worker", "--child-agent", "redcode"])).toBe("redcode");
+    expect(runnerFromLaunchArgv(["acp-worker", "--child-agent", "gpt-magic"])).toBeNull();
+    expect(runnerFromLaunchArgv(["acp-worker", "--child-agent"])).toBeNull();
+    expect(runnerFromLaunchArgv(["acp-worker"])).toBeNull();
+    expect(runnerFromLaunchArgv(undefined)).toBeNull();
+  });
+
+  it("carries the declared runner on the demand turn it briefs", () => {
+    const turn = demandTurnForBirth(
+      {
+        prompt: "Work issue #{{work_item}}",
+        trunk: { branch: "main" },
+        argv: ["npx", "acp-worker", "--child-agent", "codex"],
+      },
+      { workspace_path: "/tmp/w", index: 0, work_item: "4153" },
+      "VStest04",
+      { id: "4153", title: "a ticket", labels: [] },
+    );
+    expect(turn?.runner).toBe("codex");
+  });
+
+  it("accepts only catalog runner ids from session meta", () => {
+    expect(runnerFromSessionMeta({ redskills: { runner: "codex" } })).toBe("codex");
+    expect(runnerFromSessionMeta({ redskills: { runner: "opencode" } })).toBe("opencode");
+    expect(runnerFromSessionMeta({ redskills: { runner: "sh -c rm" } })).toBeNull();
+    expect(runnerFromSessionMeta({ redskills: {} })).toBeNull();
+    expect(runnerFromSessionMeta(undefined)).toBeNull();
+  });
+
+  it("admits a codex Worker through the npx-pinned adapter, never through a bare guess", () => {
+    const endpoint = declaredChildAgentEndpoint("codex");
+    expect(endpoint.agent).toBe("codex");
+    expect(endpoint.command).toBe("npx");
+    expect(endpoint.args).toEqual(["-y", "-p", "@zed-industries/codex-acp@0.16.0", "codex-acp"]);
+  });
+
+  it("still admits the governed native default exactly as before", () => {
+    const endpoint = declaredChildAgentEndpoint("redcode");
+    expect([endpoint.command, ...endpoint.args]).toEqual(["redcode", "acp"]);
+  });
+
+  it("hands the runner through nativeWorkerSpec argv and keeps redcode's workspace DB", () => {
+    const codexSpec = nativeWorkerSpec(project, workspace, "/tmp/sock/x.sock", "/tmp/runtime", "afk", "codex");
+    const agentAt = codexSpec.args.indexOf("--child-agent");
+    expect(codexSpec.args[agentAt + 1]).toBe("codex");
+    expect(codexSpec.env?.OPENCODE_DB).toBeUndefined();
+    expect(codexSpec.env?.CODEX_HOME).toBe(codexAgentHome());
+
+    const redcodeSpec = nativeWorkerSpec(project, workspace, "/tmp/sock/x.sock", "/tmp/runtime", "afk");
+    const redcodeAt = redcodeSpec.args.indexOf("--child-agent");
+    expect(redcodeSpec.args[redcodeAt + 1]).toBe("redcode");
+    expect(redcodeSpec.env?.OPENCODE_DB).toBe(join(workspace.workspacePath, "redcode.db"));
+  });
+});
+
+describe("the daemon-owned codex home", () => {
+  it("is refused loudly when the operator never logged in", async () => {
+    const home = await mkdtemp(join(tmpdir(), "redskilled-agent-home-"));
+    roots.push(home);
+    await expect(ensureChildAgentHome("codex", home)).rejects.toThrow(/codex login/);
+  });
+
+  it("seeds the operator credential once, re-seeds on re-login, and keeps the child's own refresh", async () => {
+    const home = await mkdtemp(join(tmpdir(), "redskilled-agent-home-"));
+    roots.push(home);
+    await mkdir(join(home, ".codex"), { recursive: true });
+    await writeFile(join(home, ".codex", "auth.json"), '{"t":"operator-1"}');
+
+    await ensureChildAgentHome("codex", home);
+    const seeded = join(codexAgentHome(home), "auth.json");
+    expect(await readFile(seeded, "utf8")).toBe('{"t":"operator-1"}');
+    expect(((await stat(seeded)).mode & 0o777)).toBe(0o600);
+    expect(childAgentWorkspaceEnv("codex", "/tmp/w", home).CODEX_HOME).toBe(codexAgentHome(home));
+
+    // The child refreshed its own token: a NEWER seed is never clobbered by an older login.
+    await writeFile(seeded, '{"t":"child-refreshed"}');
+    const past = new Date(Date.now() - 60_000);
+    await utimes(join(home, ".codex", "auth.json"), past, past);
+    await ensureChildAgentHome("codex", home);
+    expect(await readFile(seeded, "utf8")).toBe('{"t":"child-refreshed"}');
+
+    // The operator re-logged in afterwards: the newer login reaches Workers.
+    await writeFile(join(home, ".codex", "auth.json"), '{"t":"operator-2"}');
+    await ensureChildAgentHome("codex", home);
+    expect(await readFile(seeded, "utf8")).toBe('{"t":"operator-2"}');
+  });
+
+  it("does nothing for agents that keep no daemon-owned home", async () => {
+    const home = await mkdtemp(join(tmpdir(), "redskilled-agent-home-"));
+    roots.push(home);
+    await ensureChildAgentHome("redcode", home);
+    expect(childAgentWorkspaceEnv("opencode", "/tmp/w", home)).toEqual({});
+  });
+});

--- a/apps/redskilled/tests/runner-honored-admission.test.ts
+++ b/apps/redskilled/tests/runner-honored-admission.test.ts
@@ -79,14 +79,14 @@ describe("the registered runner reaches the born Worker", () => {
 
   it("hands the runner through nativeWorkerSpec argv and keeps redcode's workspace DB", () => {
     const codexSpec = nativeWorkerSpec(project, workspace, "/tmp/sock/x.sock", "/tmp/runtime", "afk", "codex");
-    const agentAt = codexSpec.args.indexOf("--child-agent");
-    expect(codexSpec.args[agentAt + 1]).toBe("codex");
+    const codexArgs = codexSpec.args ?? [];
+    expect(codexArgs[codexArgs.indexOf("--child-agent") + 1]).toBe("codex");
     expect(codexSpec.env?.OPENCODE_DB).toBeUndefined();
     expect(codexSpec.env?.CODEX_HOME).toBe(codexAgentHome());
 
     const redcodeSpec = nativeWorkerSpec(project, workspace, "/tmp/sock/x.sock", "/tmp/runtime", "afk");
-    const redcodeAt = redcodeSpec.args.indexOf("--child-agent");
-    expect(redcodeSpec.args[redcodeAt + 1]).toBe("redcode");
+    const redcodeArgs = redcodeSpec.args ?? [];
+    expect(redcodeArgs[redcodeArgs.indexOf("--child-agent") + 1]).toBe("redcode");
     expect(redcodeSpec.env?.OPENCODE_DB).toBe(join(workspace.workspacePath, "redcode.db"));
   });
 });


### PR DESCRIPTION
## The defect

The drain registered `--child-agent codex` and every Worker was still born redcode. `admitNativeAcpWorker` composed its child from a hardcoded `defaultChildAgentEndpoint()` (always redcode), and the ACP agent catalog — `resolveForWorker`, the adapter pins, the SRI machinery — had **no runtime consumer at all**. The registered runner was fiction, observed live on 4.1.11: registration argv carried codex, worker `VStrGPA` ran redcode.

## The fix

The runner rides the declared route end to end:

1. **Registration argv → demand turn**: `runnerFromLaunchArgv` reads the `--child-agent` token from the registration's stated launch (Amendment 5); `demandTurnForBirth` carries it on the brief.
2. **Demand turn → session**: the unattended turn states it in `_meta.redskills.runner`.
3. **Session → admission**: `runnerFromSessionMeta` accepts only catalog ids; admission resolves via `declaredChildAgentEndpoint`:
   - native (redcode, opencode) → host PATH, exactly as before;
   - adapter (codex, claude-code, pi) → the npx-pinned adapter bin (`npx -y -p @zed-industries/codex-acp@0.16.0 codex-acp`), ADR 0091's canonical exact-version form. The staged SRI activation under the catalog root remains the provisioning upgrade path.
4. An unknown name is no declaration — the governed default stands.

## The codex home

The first live codex probe died on the operator's interactive `~/.codex/config.toml` naming a model (`gpt-5.6-sol`) the pinned adapter cannot run. A codex child now runs out of a daemon-owned `CODEX_HOME` (`~/.red/redskilled/agent-homes/codex`), seeded with exactly one operator fact — the `auth.json` credential. The seed re-copies when the operator re-logs in, never clobbers a token the child refreshed itself, and a host with no codex login is refused loudly at admission (verified live: the adapter completes a full ACP session/prompt turn under an isolated `CODEX_HOME`).

## Tests

`tests/runner-honored-admission.test.ts` pins the whole route (argv extraction, brief carry, meta validation, npx-pinned endpoint, spec env split, codex home seeding/refresh semantics). Pre-existing failures on `acp-control-plane.test.ts` / `acp-ticket-loop.test.ts` / the 726>700 layout cap reproduce identically on clean origin/main and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789877594&installation_model_id=20659&pr_number=4220&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4220&signature=2bf7791988c4a4a7056d691911867687ef2c83f7d18f6c92ab935071ea1c2395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->