### PR TITLE
fix(redskilled): the declared runner survives the admission bridge

### DIFF
--- a/.changeset/runner-reaches-admission-bridge.md
+++ b/.changeset/runner-reaches-admission-bridge.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The declared runner survives the unattended-turn admission bridge. The demand
+turn stated the runner on its prompt request, but admission reads the SESSION
+request — and the bridge built that one synthetically with no meta, so every
+unattended Worker still fell back to the default child. The synthetic
+`session/new` now restates the runner, through one pure, pinned builder.

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -19,6 +19,7 @@
  */
 import type {
   AgentConnection,
+  NewSessionRequest,
   PromptResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
@@ -225,6 +226,8 @@ export function runnerFromLaunchArgv(argv: readonly string[] | undefined): AcpAg
 export interface DemandTurnAdmission {
   readonly project: AcpProjectWorkspace;
   readonly sessionId: string;
+  /** The runner the registration declared for this birth; admission defaults when absent. */
+  readonly runner?: AcpAgentId;
   readonly notify: AgentConnection["client"]["notify"];
   readonly permission: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>;
   readonly replacement: boolean;
@@ -332,6 +335,24 @@ export function demandTurnRunnerFor(
 }
 
 /**
+ * The synthetic `session/new` an unattended turn admits its Worker with. PURE.
+ *
+ * Admission reads the runner from the SESSION request's meta — the prompt
+ * request's meta never reaches it — so the declared runner must be restated
+ * here or every unattended Worker silently falls back to admission's default
+ * (the first live codex drain was born redcode exactly this way).
+ */
+export function demandAdmissionSessionRequest(
+  input: Pick<DemandTurnAdmission, "project" | "runner">,
+): NewSessionRequest {
+  return {
+    cwd: input.project.workspacePath,
+    mcpServers: [],
+    ...(input.runner == null ? {} : { _meta: { redskills: { runner: input.runner } } }),
+  };
+}
+
+/**
  * Bind the daemon's unattended turn runner.
  *
  * One `active` map per runner, held for the daemon's life: a Worker admitted
@@ -360,7 +381,7 @@ export function createDemandTurnRunner(
       ...(deps.githubGateway == null ? {} : { githubGateway: deps.githubGateway }),
     },
     deps.sessionJournal,
-    { request: { cwd: input.project.workspacePath, mcpServers: [] }, project: input.project },
+    { request: demandAdmissionSessionRequest(input), project: input.project },
     input.sessionId,
     input.notify,
     input.permission,
@@ -422,6 +443,7 @@ export function createDemandTurnRunner(
         (replacement) => admit({
           project: request.project,
           sessionId,
+          ...(request.runner == null ? {} : { runner: request.runner }),
           notify,
           permission: async (permission) => refusePermission(permission),
           replacement,

--- a/apps/redskilled/tests/runner-honored-admission.test.ts
+++ b/apps/redskilled/tests/runner-honored-admission.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { declaredChildAgentEndpoint } from "../src/acp-agent-catalog.js";
 import { childAgentWorkspaceEnv, codexAgentHome, ensureChildAgentHome } from "../src/acp-agent-home.js";
 import { nativeWorkerSpec, runnerFromSessionMeta } from "../src/acp-worker-admission.js";
-import { demandTurnForBirth, runnerFromLaunchArgv } from "../src/acp-demand-turn.js";
+import { demandAdmissionSessionRequest, demandTurnForBirth, runnerFromLaunchArgv } from "../src/acp-demand-turn.js";
 import type { AcpProjectWorkspace } from "../src/project-workspace.js";
 import type { MaterializedWorkerWorkspace } from "../src/worker-workspace.js";
 
@@ -55,6 +55,15 @@ describe("the registered runner reaches the born Worker", () => {
       { id: "4153", title: "a ticket", labels: [] },
     );
     expect(turn?.runner).toBe("codex");
+  });
+
+  it("restates the declared runner on the synthetic session request admission actually reads", () => {
+    const briefed = demandAdmissionSessionRequest({ project, runner: "codex" });
+    expect(runnerFromSessionMeta(briefed._meta)).toBe("codex");
+    expect(briefed.cwd).toBe(project.workspacePath);
+    const unbriefed = demandAdmissionSessionRequest({ project });
+    expect(unbriefed._meta).toBeUndefined();
+    expect(runnerFromSessionMeta(unbriefed._meta)).toBeNull();
   });
 
   it("accepts only catalog runner ids from session meta", () => {


### PR DESCRIPTION
Follow-up to #4220, observed live on 4.1.12: the demand turn briefed `runner=codex` on its **prompt** request, but admission reads the **session** request — and the bridge built that one synthetically (`{cwd, mcpServers}`) with no meta, so Workers were still born redcode.

The synthetic `session/new` is now built by one pure, exported builder (`demandAdmissionSessionRequest`) that restates the declared runner in `_meta.redskills.runner`; the test suite pins the builder against `runnerFromSessionMeta` so the two ends of the bridge cannot disagree silently again.

Refs #4221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789878928&installation_model_id=20659&pr_number=4223&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4223&signature=942e1ee6db7056ede5c04dc89639a53bbfca401a54504e4139ca2eedd913f377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->