### PR TITLE
chore(release): 4.1.13

### DIFF
--- a/.changeset/runner-reaches-admission-bridge.md
+++ b/.changeset/runner-reaches-admission-bridge.md
@@ -1,9 +1,0 @@
----
-"@reddb-io/redskilled": patch
----
-
-The declared runner survives the unattended-turn admission bridge. The demand
-turn stated the runner on its prompt request, but admission reads the SESSION
-request — and the bridge built that one synthetically with no meta, so every
-unattended Worker still fell back to the default child. The synthetic
-`session/new` now restates the runner, through one pure, pinned builder.

--- a/apps/herdr-plugin-redskilled/bin/red-skills-herdr.mjs
+++ b/apps/herdr-plugin-redskilled/bin/red-skills-herdr.mjs
@@ -27,7 +27,7 @@ const BINARY = "red-skills-herdr";
  * as a broken install rather than as an unbundled one. `scripts/check-manifest.py`
  * asserts this constant still equals the manifest's version.
  */
-const CHECKOUT_VERSION = "4.1.12";
+const CHECKOUT_VERSION = "4.1.13";
 
 const USAGE = `Usage: red-skills-herdr <command> [options]
 

--- a/apps/herdr-plugin-redskilled/herdr-plugin.toml
+++ b/apps/herdr-plugin-redskilled/herdr-plugin.toml
@@ -19,7 +19,7 @@
 
 id = "reddb-io.red-skills"
 name = "RedSkills"
-version = "4.1.12"
+version = "4.1.13"
 # `herdr plugin pane open --env KEY=VALUE` and `--placement` are the two flags
 # the panes here depend on, and 0.7.5 is the oldest herdr this plugin has been
 # run against. Declaring an older floor would be a claim nobody verified.

--- a/apps/herdr-plugin-redskilled/package.json
+++ b/apps/herdr-plugin-redskilled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/herdr-plugin-red-skills",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "description": "A herdr plugin that reads the redskilled host daemon: live Workers, worker logs, the host event lane, open pull requests, and notifications when any of it changes.",

--- a/apps/host-opencode/package.json
+++ b/apps/host-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "RedSkills opencode-host — the adapter layer that emits opencode.json (provider, model, mcp, plugins) from the canonical .red/config.yaml + ADR 0059 env-precedence rule. Slice 1: provider block only.",
   "license": "Apache-2.0",

--- a/apps/mcp-browser/package.json
+++ b/apps/mcp-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-browser",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "description": "Red Browser CLI surface — opens a local annotation bridge for HTML artifacts, long-polls human feedback, and enforces the layout-audit gate.",

--- a/apps/mcp-navigator/package.json
+++ b/apps/mcp-navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/code-nav-mcp",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "LSP-backed code navigation as an MCP server: symbol-level goto-definition, find-references, document/workspace symbols and hover for code agents.",
   "license": "Apache-2.0",

--- a/apps/plugin-brain/package.json
+++ b/apps/plugin-brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/brain",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "reddb.io brain plugin — project-local RedDB knowledge repository for freeform captures and graph connections.",
   "license": "Apache-2.0",

--- a/apps/plugin-dev/package.json
+++ b/apps/plugin-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/dev",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "RedSkills dev plugin implementation — the AFK TypeScript runtime (typed CLI, state-machine modules, sandcastle execution) under apps/plugin-dev. Ships the `rs_dev` Plugin MCP bundle (ADR 0034, relocated by ADR 0060; the CLI bundle was deleted by ADR 0147).",
   "license": "Apache-2.0",

--- a/apps/plugin-memory/package.json
+++ b/apps/plugin-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/memory",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "reddb.io memory plugin — governed operational memory for code agents: markdown notes, RedDB graph memory, governed recall, lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "license": "Apache-2.0",

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/redskilled",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/release/package.json
+++ b/apps/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/release",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "RedSkills release engine — changeset-compatible version computation and release orchestration.",
   "license": "Apache-2.0",

--- a/apps/rsp/package.json
+++ b/apps/rsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/rsp",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "RedSkills neutral rsp binary: reversible elision retrieval over the repo-local RedDB store.",
   "license": "Apache-2.0",

--- a/apps/vscode-extension-redskilled/package.json
+++ b/apps/vscode-extension-redskilled/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-extension-red-skills",
   "displayName": "RedSkills — redskilled",
   "description": "Surfaces the redskilled host daemon inside VSCode: live Workers with vitals, per-Worker logs, the host event lane, open pull requests, and a notification whenever any of it changes.",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "publisher": "reddb-io",
   "license": "Apache-2.0",

--- a/apps/worker-container/package.json
+++ b/apps/worker-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/afk-container",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "AFK-in-a-box — a self-sufficient Docker image that drains ready-for-agent issues from GitHub repos through the existing AFK engine (red-skills-dev), one ephemeral run at a time. Stateless by construction: the issue and the run branch are the only state.",
   "license": "Apache-2.0",

--- a/benchmarks/code-understanding/package.json
+++ b/benchmarks/code-understanding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/benchmark-code-understanding",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "Internal A/B benchmark for RedSkills code understanding against CodeGraph and native agent search.",
   "license": "Apache-2.0",

--- a/benchmarks/memory/package.json
+++ b/benchmarks/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/benchmark-memory",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "Internal benchmark and reference-eval app for RedSkills Memory.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-skills",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.5.0",

--- a/packages/brain-store/package.json
+++ b/packages/brain-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/brain-store",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "description": "The brain store engine (ADR 0152): the RedDB-backed artifact graph, its host-scoped root resolution, and the outbound channel bridge. Shared by the `brain` CLI and by redskilled, which holds the one handle per host.",

--- a/packages/brand-tokens/package.json
+++ b/packages/brand-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/brand-tokens",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "description": "Vendored RedDB brand color tokens with ANSI and CSS derivation helpers (ADR 0137).",

--- a/packages/browser-bridge/package.json
+++ b/packages/browser-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/browser-bridge",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "description": "CLI<->browser annotation bridge plus a layout-audit gate for HTML artifacts. Opens a generated artifact, injects a portable feedback SDK, long-polls for human annotations (element + character range), and blocks 'done' on a visually broken render. No cloud; state lives under .red/browser-bridge/.",

--- a/packages/build-info/package.json
+++ b/packages/build-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/build-info",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "description": "Shared runtime build metadata helpers for RedSkills bundled apps.",

--- a/packages/cdp-driver/package.json
+++ b/packages/cdp-driver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/cdp-driver",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "description": "CDP-based live-app driver for red-browser: connects to Chrome via DevTools Protocol, captures a11y-tree snapshots with numbered refs, validates stale refs, and streams console/network events.",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/github",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "description": "The one budget-aware GitHub client (ADR 0132 decision 4 as superseded by Amendment 2): which API answers a call decided by cardinality, the REST realization of a single-object read, the token's balance asked rather than counted, and a cache that carries its own age.",

--- a/packages/protocol-acp/package.json
+++ b/packages/protocol-acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/protocol-acp",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "description": "The shared RedSkills ACP wire (ADR 0148, ADR 0145 §2-3, ADR 0153): ACP v1/v2 compat and draft-revision gating, the RedSkills wire major, the Unix-socket / Named Pipe local transport, and the `_redskills/*` method schemas. Depended on by the daemon, the Worker and the stateless adapters.",

--- a/packages/redskilled-render/package.json
+++ b/packages/redskilled-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/redskilled-render",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "description": "One render implementation outside the daemon (ADR 0132 decision 1): a stateless, transport-free function from one decoded redskilled payload to one drawn surface, at parameterized densities — statusline line, host panel, full dashboard.",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/shared",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "type": "module",
   "description": "Code shared across RedSkills runtime apps (ADR 0034): CLI arg parsing over cli-args-parser, and the dynamic plugin-bundle fetch.",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/worker",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "The Worker body: agent and sandbox providers, worktree materialisation, gate runner and turn loop, running inside one admitted Worker process. Vendored from sandcastle (ADR 0101) and consumed as TypeScript source.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packaging/pi/brain/.claude-plugin/plugin.json
+++ b/packaging/pi/brain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brain",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io brain plugin — project-local RedDB knowledge repository for freeform captures and graph connections.",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/claude.hooks.json",

--- a/packaging/pi/brain/.codex-plugin/plugin.json
+++ b/packaging/pi/brain/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brain",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "author": {
     "name": "reddb.io",

--- a/packaging/pi/brain/.gemini-plugin/plugin.json
+++ b/packaging/pi/brain/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brain",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "author": {
     "name": "reddb.io",

--- a/packaging/pi/brain/package.json
+++ b/packaging/pi/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-brain",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/reddb-io/red-skills",

--- a/packaging/pi/dev/.claude-plugin/plugin.json
+++ b/packaging/pi/dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io dev plugin — engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, …)",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/claude.hooks.json",

--- a/packaging/pi/dev/.codex-plugin/plugin.json
+++ b/packaging/pi/dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "author": {
     "name": "reddb.io",

--- a/packaging/pi/dev/.gemini-plugin/plugin.json
+++ b/packaging/pi/dev/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "author": {
     "name": "reddb.io",

--- a/packaging/pi/dev/package.json
+++ b/packaging/pi/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-dev",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "license": "Apache-2.0",
   "homepage": "https://github.com/reddb-io/red-skills",

--- a/packaging/pi/internal/.claude-plugin/plugin.json
+++ b/packaging/pi/internal/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "internal",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
   "skills": [
     "./skills/maintainer/bootstrap",

--- a/packaging/pi/internal/.codex-plugin/plugin.json
+++ b/packaging/pi/internal/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "internal",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
   "author": {
     "name": "reddb.io",

--- a/packaging/pi/internal/.gemini-plugin/plugin.json
+++ b/packaging/pi/internal/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "internal",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
   "author": {
     "name": "reddb.io",

--- a/packaging/pi/internal/package.json
+++ b/packaging/pi/internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-internal",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/reddb-io/red-skills",

--- a/packaging/pi/memory/.claude-plugin/plugin.json
+++ b/packaging/pi/memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memory",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io memory plugin — governed operational memory for code agents that lives on top of `dev`. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "dependencies": [
     "dev"

--- a/packaging/pi/memory/.codex-plugin/plugin.json
+++ b/packaging/pi/memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memory",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "author": {
     "name": "reddb.io",

--- a/packaging/pi/memory/.gemini-plugin/plugin.json
+++ b/packaging/pi/memory/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memory",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "author": {
     "name": "reddb.io",

--- a/packaging/pi/memory/package.json
+++ b/packaging/pi/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-memory",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/reddb-io/red-skills",

--- a/plugins/brain/.claude-plugin/plugin.json
+++ b/plugins/brain/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brain",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io brain plugin — project-local RedDB knowledge repository for freeform captures and graph connections.",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/claude.hooks.json",

--- a/plugins/brain/.codex-plugin/plugin.json
+++ b/plugins/brain/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brain",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "author": {
     "name": "reddb.io",

--- a/plugins/brain/.gemini-plugin/plugin.json
+++ b/plugins/brain/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brain",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "author": {
     "name": "reddb.io",

--- a/plugins/brain/package.json
+++ b/plugins/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-brain",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures and graph connections.",
   "license": "Apache-2.0",

--- a/plugins/dev/.claude-plugin/plugin.json
+++ b/plugins/dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io dev plugin — engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, …)",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/claude.hooks.json",

--- a/plugins/dev/.codex-plugin/plugin.json
+++ b/plugins/dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "author": {
     "name": "reddb.io",

--- a/plugins/dev/.gemini-plugin/plugin.json
+++ b/plugins/dev/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "author": {
     "name": "reddb.io",

--- a/plugins/dev/package.json
+++ b/plugins/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-dev",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, /go dispatch, triage, tdd, diagnose, graph-aware codebase understanding, ...)",
   "license": "Apache-2.0",

--- a/plugins/internal/.claude-plugin/plugin.json
+++ b/plugins/internal/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "internal",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
   "skills": [
     "./skills/maintainer/bootstrap",

--- a/plugins/internal/.codex-plugin/plugin.json
+++ b/plugins/internal/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "internal",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
   "author": {
     "name": "reddb.io",

--- a/plugins/internal/.gemini-plugin/plugin.json
+++ b/plugins/internal/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "internal",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
   "author": {
     "name": "reddb.io",

--- a/plugins/internal/package.json
+++ b/plugins/internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-internal",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
   "license": "Apache-2.0",

--- a/plugins/memory/.claude-plugin/plugin.json
+++ b/plugins/memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memory",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io memory plugin — governed operational memory for code agents that lives on top of `dev`. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "dependencies": [
     "dev"

--- a/plugins/memory/.codex-plugin/plugin.json
+++ b/plugins/memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memory",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "author": {
     "name": "reddb.io",

--- a/plugins/memory/.gemini-plugin/plugin.json
+++ b/plugins/memory/.gemini-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memory",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "author": {
     "name": "reddb.io",

--- a/plugins/memory/package.json
+++ b/plugins/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/red-skills-memory",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "description": "reddb.io memory plugin - governed operational memory for code agents that lives on top of dev. Supports markdown notes, RedDB graph memory, zero-token governed recall, context packs, claim checks, readiness, optional lifecycle hooks, MCP/HTTP read surfaces, Workbench diagnostics, and Skill telemetry for self-improvement.",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Release 4.1.13

Released 2026-08-21.

## Patch changes

- **The declared runner survives the unattended-turn admission bridge. The demand**

  turn stated the runner on its prompt request, but admission reads the SESSION
  request — and the bridge built that one synthetically with no meta, so every
  unattended Worker still fell back to the default child. The synthetic
  `session/new` now restates the runner, through one pure, pinned builder.
<!-- red-release-plan:v1 eyJ2ZXJzaW9uIjoiNC4xLjEzIiwiZGF0ZSI6IjIwMjYtMDgtMjEiLCJjaGFuZ2VzIjpbeyJmaWxlIjoicnVubmVyLXJlYWNoZXMtYWRtaXNzaW9uLWJyaWRnZS5tZCIsInN1bW1hcnkiOiJUaGUgZGVjbGFyZWQgcnVubmVyIHN1cnZpdmVzIHRoZSB1bmF0dGVuZGVkLXR1cm4gYWRtaXNzaW9uIGJyaWRnZS4gVGhlIGRlbWFuZCIsImJvZHkiOiJUaGUgZGVjbGFyZWQgcnVubmVyIHN1cnZpdmVzIHRoZSB1bmF0dGVuZGVkLXR1cm4gYWRtaXNzaW9uIGJyaWRnZS4gVGhlIGRlbWFuZFxudHVybiBzdGF0ZWQgdGhlIHJ1bm5lciBvbiBpdHMgcHJvbXB0IHJlcXVlc3QsIGJ1dCBhZG1pc3Npb24gcmVhZHMgdGhlIFNFU1NJT05cbnJlcXVlc3Qg4oCUIGFuZCB0aGUgYnJpZGdlIGJ1aWx0IHRoYXQgb25lIHN5bnRoZXRpY2FsbHkgd2l0aCBubyBtZXRhLCBzbyBldmVyeVxudW5hdHRlbmRlZCBXb3JrZXIgc3RpbGwgZmVsbCBiYWNrIHRvIHRoZSBkZWZhdWx0IGNoaWxkLiBUaGUgc3ludGhldGljXG5gc2Vzc2lvbi9uZXdgIG5vdyByZXN0YXRlcyB0aGUgcnVubmVyLCB0aHJvdWdoIG9uZSBwdXJlLCBwaW5uZWQgYnVpbGRlci4iLCJpbXBhY3QiOiJwYXRjaCIsInJlbGVhc2VzIjpbeyJwYWNrYWdlTmFtZSI6IkByZWRkYi1pby9yZWRza2lsbGVkIiwiaW1wYWN0IjoicGF0Y2gifV19XX0 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789879172&installation_model_id=20659&pr_number=4224&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4224&signature=6768197688e146eeb1f4168d9d19e91e56af505f54dd26e3ce9e7076b4ccfb19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->