### PR TITLE
fix(dev): the drain Worker prompt owns only the change

### DIFF
--- a/.changeset/child-arg-inline-form.md
+++ b/.changeset/child-arg-inline-form.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Adapter child args survive the Worker's argv parser. An adapter endpoint's
+args start with dashes (`-y`, `-p`), and the `--child-arg <value>` pair form
+read the next dash token as a flag — every adapter Worker died at its own
+front door with "--child-arg requires a value". Admission now emits the
+inline `--child-arg=<value>` form the shared parser already recognises.

--- a/.changeset/drain-prompt-owns-only-the-change.md
+++ b/.changeset/drain-prompt-owns-only-the-change.md
@@ -1,0 +1,12 @@
+---
+"@reddb-io/dev": patch
+---
+
+The drain Worker prompt owns only the change. The Worker body claims the
+Ticket through the daemon before the inner agent speaks, and the same body
+gates, publishes and lands afterwards — but the prompt still restated the v3
+whole-pipeline verbs ("claim it, open the PR, land it"). A well-behaved agent
+tried the GitHub claim mutation itself, the unattended turn refused the
+permission by design, and the agent obeyed "if you cannot claim it, stop":
+every turn ended honest and empty. The prompt now tells the truth: implement
+and commit here, never touch GitHub, signal DONE/BLOCKED.

--- a/.changeset/runner-reaches-admission-bridge.md
+++ b/.changeset/runner-reaches-admission-bridge.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The declared runner survives the unattended-turn admission bridge. The demand
+turn stated the runner on its prompt request, but admission reads the SESSION
+request — and the bridge built that one synthetically with no meta, so every
+unattended Worker still fell back to the default child. The synthetic
+`session/new` now restates the runner, through one pure, pinned builder.

--- a/apps/plugin-dev/src/core/drain-registration.ts
+++ b/apps/plugin-dev/src/core/drain-registration.ts
@@ -68,14 +68,21 @@ export interface DrainRegistration {
 /**
  * What a Worker born for this project is told to do.
  *
- * One sentence, because the Worker is a coder Agent carrying the dev skills:
- * the verbs it needs are already its own, and a prompt that restated them would
- * be a second copy of `/afk` maintained here. `{{work_item}}` is the daemon's
- * fact, written in at birth (#4099).
+ * The inner agent's whole job is the CHANGE: the Worker body has already
+ * claimed the Ticket through the daemon before the agent speaks, and the same
+ * body runs the gate, publishes the commits and lands the PR after it stops.
+ * The old prompt restated the v3 whole-pipeline verbs ("claim it, open the PR,
+ * land it") — so a well-behaved agent tried the GitHub claim mutation itself,
+ * the unattended turn refused the permission by design, and the agent obeyed
+ * "if you cannot claim it, stop": every turn ended honest and empty. The
+ * prompt now tells the truth about the division of labour.
+ * `{{work_item}}` is the daemon's fact, written in at birth (#4099).
  */
 export const DRAIN_WORKER_PROMPT =
-  "Work issue #{{work_item}} in this repository to a merged pull request, following the /afk skill: " +
-  "claim it, implement it in this workspace, run the gate, open the PR, and land it. " +
+  "Implement issue #{{work_item}} in this workspace. The Ticket is already claimed for you, and " +
+  "the daemon runs the gate, publishes your commits and lands the pull request after you finish — " +
+  "so never touch GitHub yourself: no label moves, no claim or status comments, no PR. Your whole " +
+  "job is the change and its commits, right here. " +
   // #4162: an inner agent reading the repository's interactive-mode rules built
   // a NESTED worktree under .red/tmp/worktrees/manual inside its own worktree.
   // The Worker's workspace was already materialised by the daemon on the
@@ -84,7 +91,8 @@ export const DRAIN_WORKER_PROMPT =
   "You are already standing in your own dedicated worktree on the Ticket's base branch: work and " +
   "commit right here, and never create another worktree — the repository's worktree lanes govern " +
   "interactive sessions, not Workers. " +
-  "If you cannot claim it or the work is blocked, say so plainly and stop.";
+  "When the change is committed, say <promise>DONE</promise>. If the work is genuinely blocked, " +
+  "say what blocks it and <promise>BLOCKED</promise>.";
 
 /** Build the registration a drain carries. PURE. */
 export function buildDrainRegistration(input: DrainRegistrationInput): DrainRegistration {

--- a/apps/plugin-dev/tests/drain-registration.test.ts
+++ b/apps/plugin-dev/tests/drain-registration.test.ts
@@ -45,7 +45,14 @@ describe("what a drain hands the daemon", () => {
       .toEqual(["pnpm typecheck"]);
     expect(buildDrainRegistration(input).validation_commands).toBeUndefined();
     expect(DRAIN_WORKER_PROMPT).toContain("{{work_item}}");
-    expect(DRAIN_WORKER_PROMPT).toContain("/afk");
+    // The Worker body claims, gates, publishes and lands; a prompt restating
+    // those verbs sent well-behaved agents into GitHub mutations the
+    // unattended turn refuses by design, and every turn ended honest and
+    // empty. The prompt owns only the change and forbids the rest.
+    expect(DRAIN_WORKER_PROMPT).toContain("already claimed");
+    expect(DRAIN_WORKER_PROMPT).toContain("never touch GitHub");
+    expect(DRAIN_WORKER_PROMPT).toContain("<promise>DONE</promise>");
+    expect(DRAIN_WORKER_PROMPT).toContain("<promise>BLOCKED</promise>");
     // #4162: the Worker's workspace is already materialised on the Ticket's
     // base; an inner agent told nothing builds a nested worktree by following
     // the repository's interactive-mode rules.

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -19,6 +19,7 @@
  */
 import type {
   AgentConnection,
+  NewSessionRequest,
   PromptResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
@@ -225,6 +226,8 @@ export function runnerFromLaunchArgv(argv: readonly string[] | undefined): AcpAg
 export interface DemandTurnAdmission {
   readonly project: AcpProjectWorkspace;
   readonly sessionId: string;
+  /** The runner the registration declared for this birth; admission defaults when absent. */
+  readonly runner?: AcpAgentId;
   readonly notify: AgentConnection["client"]["notify"];
   readonly permission: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>;
   readonly replacement: boolean;
@@ -332,6 +335,24 @@ export function demandTurnRunnerFor(
 }
 
 /**
+ * The synthetic `session/new` an unattended turn admits its Worker with. PURE.
+ *
+ * Admission reads the runner from the SESSION request's meta — the prompt
+ * request's meta never reaches it — so the declared runner must be restated
+ * here or every unattended Worker silently falls back to admission's default
+ * (the first live codex drain was born redcode exactly this way).
+ */
+export function demandAdmissionSessionRequest(
+  input: Pick<DemandTurnAdmission, "project" | "runner">,
+): NewSessionRequest {
+  return {
+    cwd: input.project.workspacePath,
+    mcpServers: [],
+    ...(input.runner == null ? {} : { _meta: { redskills: { runner: input.runner } } }),
+  };
+}
+
+/**
  * Bind the daemon's unattended turn runner.
  *
  * One `active` map per runner, held for the daemon's life: a Worker admitted
@@ -360,7 +381,7 @@ export function createDemandTurnRunner(
       ...(deps.githubGateway == null ? {} : { githubGateway: deps.githubGateway }),
     },
     deps.sessionJournal,
-    { request: { cwd: input.project.workspacePath, mcpServers: [] }, project: input.project },
+    { request: demandAdmissionSessionRequest(input), project: input.project },
     input.sessionId,
     input.notify,
     input.permission,
@@ -422,6 +443,7 @@ export function createDemandTurnRunner(
         (replacement) => admit({
           project: request.project,
           sessionId,
+          ...(request.runner == null ? {} : { runner: request.runner }),
           notify,
           permission: async (permission) => refusePermission(permission),
           replacement,

--- a/apps/redskilled/src/acp-worker-admission.ts
+++ b/apps/redskilled/src/acp-worker-admission.ts
@@ -319,7 +319,9 @@ export function nativeWorkerSpec(
       "--socket", endpoint,
       "--child-agent", childAgent.agent,
       "--child-command", childAgent.command,
-      ...childAgent.args.flatMap((arg) => ["--child-arg", arg]),
+      // Inline form, because an adapter's args start with dashes (`-y`, `-p`)
+      // and the pair form reads the next dash token as a flag, not a value.
+      ...childAgent.args.map((arg) => `--child-arg=${arg}`),
     ],
     log_path: join(runtimeDir, "acp-workers", `${randomBytes(6).toString("hex")}.toonl`),
   };

--- a/apps/redskilled/tests/runner-honored-admission.test.ts
+++ b/apps/redskilled/tests/runner-honored-admission.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { declaredChildAgentEndpoint } from "../src/acp-agent-catalog.js";
 import { childAgentWorkspaceEnv, codexAgentHome, ensureChildAgentHome } from "../src/acp-agent-home.js";
 import { nativeWorkerSpec, runnerFromSessionMeta } from "../src/acp-worker-admission.js";
-import { demandTurnForBirth, runnerFromLaunchArgv } from "../src/acp-demand-turn.js";
+import { demandAdmissionSessionRequest, demandTurnForBirth, runnerFromLaunchArgv } from "../src/acp-demand-turn.js";
 import type { AcpProjectWorkspace } from "../src/project-workspace.js";
 import type { MaterializedWorkerWorkspace } from "../src/worker-workspace.js";
 
@@ -55,6 +55,15 @@ describe("the registered runner reaches the born Worker", () => {
       { id: "4153", title: "a ticket", labels: [] },
     );
     expect(turn?.runner).toBe("codex");
+  });
+
+  it("restates the declared runner on the synthetic session request admission actually reads", () => {
+    const briefed = demandAdmissionSessionRequest({ project, runner: "codex" });
+    expect(runnerFromSessionMeta(briefed._meta)).toBe("codex");
+    expect(briefed.cwd).toBe(project.workspacePath);
+    const unbriefed = demandAdmissionSessionRequest({ project });
+    expect(unbriefed._meta).toBeUndefined();
+    expect(runnerFromSessionMeta(unbriefed._meta)).toBeNull();
   });
 
   it("accepts only catalog runner ids from session meta", () => {

--- a/apps/redskilled/tests/runner-honored-admission.test.ts
+++ b/apps/redskilled/tests/runner-honored-admission.test.ts
@@ -90,6 +90,14 @@ describe("the registered runner reaches the born Worker", () => {
     const codexSpec = nativeWorkerSpec(project, workspace, "/tmp/sock/x.sock", "/tmp/runtime", "afk", "codex");
     const codexArgs = codexSpec.args ?? [];
     expect(codexArgs[codexArgs.indexOf("--child-agent") + 1]).toBe("codex");
+    // Dash-leading adapter args must ride the inline form: the pair form reads
+    // `--child-arg -y` as a flag pair and the Worker dies at its own front door.
+    expect(codexArgs.filter((arg) => arg.startsWith("--child-arg"))).toEqual([
+      "--child-arg=-y",
+      "--child-arg=-p",
+      "--child-arg=@zed-industries/codex-acp@0.16.0",
+      "--child-arg=codex-acp",
+    ]);
     expect(codexSpec.env?.OPENCODE_DB).toBeUndefined();
     expect(codexSpec.env?.CODEX_HOME).toBe(codexAgentHome());
 


### PR DESCRIPTION
Live codex rollouts on 4.1.14 named the real reason every unattended turn ended `nothing-to-publish`: the prompt restated the v3 whole-pipeline verbs ("claim it, open the PR, land it"), the agent dutifully tried the GitHub claim mutation, the unattended turn refused the permission **by design**, and the agent obeyed the prompt's own "if you cannot claim it, stop". Every well-behaved runner loses the same way — redcode's empty turns looked like runner quality and were not.

The Worker body already claims through the daemon before the inner agent speaks (ticket-loop stage `claim`), and gates/publishes/lands after it stops. The prompt now tells the truth: implement and commit in this worktree, never touch GitHub, signal `<promise>DONE</promise>` / `<promise>BLOCKED</promise>`.

Refs #4221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789882379&installation_model_id=20659&pr_number=4227&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4227&signature=c49af2abcf7ce899652e38269861c8d402a65dea14bcfbc385514db20a662fc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->