### PR TITLE
fix(redskilled): the Project ACP client survives a daemon restart

### DIFF
--- a/.changeset/acp-client-self-healing-dial.md
+++ b/.changeset/acp-client-self-healing-dial.md
@@ -1,0 +1,10 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The rs_dev MCP survives a daemon restart. The Project ACP client held one
+connection for its whole life, so every release install turned every later
+tool call into "ACP connection closed" until the operator restarted the MCP
+process. The session now rides a self-healing dial: a dead connection is
+re-dialled single-flight before answering the call, and only a genuinely
+unreachable daemon surfaces, with the provision repair the dial carries.

--- a/apps/redskilled/src/acp-client.ts
+++ b/apps/redskilled/src/acp-client.ts
@@ -122,6 +122,20 @@ const PROJECT_CONTROL_METHOD = {
   status: REDSKILLS_ACP_METHODS.projectStatus,
 } as const;
 
+/**
+ * One live dialled connection: socket, handshake, public session. Everything
+ * here dies with the socket; the session object above it survives by dialling
+ * a replacement (#4154).
+ */
+interface LiveProjectAcpConnection {
+  readonly connection: ReturnType<ReturnType<typeof client>["connect"]>;
+  readonly socket: Socket;
+  readonly sessionId: string;
+  readonly pendingUpdates: SessionNotification["update"][];
+  readonly dead: () => boolean;
+  readonly close: () => void;
+}
+
 /** Connect a public adapter to redskilled through ACP and no private daemon wire. */
 export async function connectRedskillsProjectAcp(
   options: ConnectRedskillsProjectAcpOptions = {},
@@ -130,42 +144,67 @@ export async function connectRedskillsProjectAcp(
   const name = options.name ?? "RedSkills Project client";
   const version = options.version ?? "1";
   const paths = options.paths ?? resolveRedskilledPaths();
-  await ensureRedskilledDaemon(paths);
-  const endpoint = (await resolveRedskilledClientEndpoint(paths)).paths;
-  const socket = await connectEndpoint(endpoint.acpSocketPath);
-  const pendingUpdates: SessionNotification["update"][] = [];
-  let publicSessionId = "";
 
-  let app = client({ name })
-    .onNotification(methods.client.session.update, async ({ params }) => {
-      if (params.sessionId !== publicSessionId) return;
-      pendingUpdates.push(params.update);
-      await options.onUpdate?.(params.update);
+  const dial = async (): Promise<LiveProjectAcpConnection> => {
+    await ensureRedskilledDaemon(paths);
+    const endpoint = (await resolveRedskilledClientEndpoint(paths)).paths;
+    const socket = await connectEndpoint(endpoint.acpSocketPath);
+    const pendingUpdates: SessionNotification["update"][] = [];
+    let sessionId = "";
+    let dead = false;
+    socket.once("close", () => { dead = true; });
+    socket.once("error", () => { dead = true; });
+
+    let app = client({ name })
+      .onNotification(methods.client.session.update, async ({ params }) => {
+        if (params.sessionId !== sessionId) return;
+        pendingUpdates.push(params.update);
+        await options.onUpdate?.(params.update);
+      });
+    if (options.requestPermission != null) {
+      app = app.onRequest(methods.client.session.requestPermission, ({ params }) =>
+        options.requestPermission!(params));
+    }
+    const connection = app.connect(ndJsonStream(
+      Writable.toWeb(socket) as WritableStream<Uint8Array>,
+      Readable.toWeb(socket) as ReadableStream<Uint8Array>,
+    ));
+    await connection.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name, version },
+      _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR } },
     });
-  if (options.requestPermission != null) {
-    app = app.onRequest(methods.client.session.requestPermission, ({ params }) =>
-      options.requestPermission!(params));
-  }
-  const connection = app.connect(ndJsonStream(
-    Writable.toWeb(socket) as WritableStream<Uint8Array>,
-    Readable.toWeb(socket) as ReadableStream<Uint8Array>,
-  ));
-  await connection.agent.request(methods.agent.initialize, {
-    protocolVersion: 1,
-    clientCapabilities: {},
-    clientInfo: { name, version },
-    _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR } },
-  });
-  publicSessionId = (await connection.agent.request(methods.agent.session.new, {
-    cwd,
-    mcpServers: [],
-  })).sessionId;
+    sessionId = (await connection.agent.request(methods.agent.session.new, {
+      cwd,
+      mcpServers: [],
+    })).sessionId;
+    return {
+      connection,
+      socket,
+      sessionId,
+      pendingUpdates,
+      dead: () => dead,
+      close() {
+        dead = true;
+        connection.close();
+        socket.destroy();
+      },
+    };
+  };
+
+  // The first dial fails exactly as it always did: a caller that connects to a
+  // machine with no daemon deserves the fail-closed answer immediately, not a
+  // session that will fail later.
+  const healing = await createSelfHealingDial(dial);
+  const ensureLive = healing.ensure;
 
   const control = (async (
     operation: RedskillsProjectControlOperation,
     request: RedskillsProjectControlRequest = {},
   ) => {
-    const outcome = await connection.agent.request<unknown>(PROJECT_CONTROL_METHOD[operation], {
+    const held = await ensureLive();
+    const outcome = await held.connection.agent.request<unknown>(PROJECT_CONTROL_METHOD[operation], {
       ...(request.target == null ? {} : { target: request.target }),
       ...(request.runner == null ? {} : { runner: request.runner }),
       ...(request.registration == null ? {} : { registration: request.registration }),
@@ -179,38 +218,43 @@ export async function connectRedskillsProjectAcp(
 
   return {
     control,
-    github(request) {
-      return connection.agent.request<RedskilledGithubRequestAnswer>(
+    async github(request) {
+      const held = await ensureLive();
+      return await held.connection.agent.request<RedskilledGithubRequestAnswer>(
         REDSKILLS_ACP_METHODS.githubRequest,
         { request },
       );
     },
-    brain(call) {
-      return connection.agent.request<RedskilledBrainAnswer>(
+    async brain(call) {
+      const held = await ensureLive();
+      return await held.connection.agent.request<RedskilledBrainAnswer>(
         REDSKILLS_ACP_METHODS.brainCall,
         { tool: call.tool, arguments: call.arguments },
       );
     },
-    memory(call) {
-      return connection.agent.request<RedskilledMemoryAnswer>(
+    async memory(call) {
+      const held = await ensureLive();
+      return await held.connection.agent.request<RedskilledMemoryAnswer>(
         REDSKILLS_ACP_METHODS.memoryCall,
         { tool: call.tool, arguments: call.arguments, ...(call.mode == null ? {} : { mode: call.mode }) },
       );
     },
     async prompt(text) {
-      const firstUpdate = pendingUpdates.length;
-      const response = await connection.agent.request(methods.agent.session.prompt, {
-        sessionId: publicSessionId,
+      const held = await ensureLive();
+      const firstUpdate = held.pendingUpdates.length;
+      const response = await held.connection.agent.request(methods.agent.session.prompt, {
+        sessionId: held.sessionId,
         prompt: [{ type: "text", text }],
       });
       return {
         stopReason: response.stopReason,
         ...projectControlFrom(response._meta),
-        updates: pendingUpdates.slice(firstUpdate),
+        updates: held.pendingUpdates.slice(firstUpdate),
       };
     },
-    cancel() {
-      return connection.agent.notify(methods.agent.session.cancel, { sessionId: publicSessionId });
+    async cancel() {
+      const held = await ensureLive();
+      return await held.connection.agent.notify(methods.agent.session.cancel, { sessionId: held.sessionId });
     },
     async permission(request) {
       if (options.requestPermission == null) {
@@ -222,8 +266,41 @@ export async function connectRedskillsProjectAcp(
       return await options.requestPermission(request);
     },
     close() {
-      connection.close();
-      socket.destroy();
+      healing.close();
+    },
+  };
+}
+
+/**
+ * The connection every call rides, re-dialled when the held one died (#4154).
+ *
+ * A daemon restart is a routine event on a machine that installs releases, so
+ * a dead connection is an instruction to dial again — single-flight, so
+ * concurrent tool calls share one replacement instead of leaking sockets. Only
+ * a genuinely unreachable daemon surfaces, with the provision repair the dial
+ * already carries. The FIRST dial happens here and fails to the caller
+ * directly: a machine with no daemon deserves the fail-closed answer at
+ * connect time, never a session that fails later.
+ */
+export async function createSelfHealingDial<Held extends { dead(): boolean; close(): void }>(
+  dial: () => Promise<Held>,
+): Promise<{ ensure(): Promise<Held>; close(): void }> {
+  let live = await dial();
+  let closed = false;
+  let redialling: Promise<Held> | null = null;
+  return {
+    async ensure() {
+      if (closed) throw new Error("this RedSkills Project ACP client is closed");
+      if (!live.dead()) return live;
+      redialling ??= dial().then(
+        (replacement) => { live = replacement; redialling = null; return replacement; },
+        (error) => { redialling = null; throw error; },
+      );
+      return await redialling;
+    },
+    close() {
+      closed = true;
+      live.close();
     },
   };
 }

--- a/apps/redskilled/tests/acp-client-redial.test.ts
+++ b/apps/redskilled/tests/acp-client-redial.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { createSelfHealingDial } from "../src/acp-client.js";
+
+// #4154: the rs_dev MCP held one ACP connection for its whole life, so a
+// routine daemon restart (every release install) turned every later tool call
+// into "ACP connection closed" until the operator restarted the MCP process.
+// The session now rides a self-healing dial; this suite pins its contract.
+
+interface FakeHeld {
+  readonly id: number;
+  dead(): boolean;
+  close(): void;
+  kill(): void;
+}
+
+function fakeDialler(failures: number = 0) {
+  let dialled = 0;
+  let failuresLeft = failures;
+  const held: FakeHeld[] = [];
+  const dial = async (): Promise<FakeHeld> => {
+    if (failuresLeft > 0) {
+      failuresLeft -= 1;
+      throw new Error("daemon unreachable");
+    }
+    dialled += 1;
+    let dead = false;
+    const line: FakeHeld = {
+      id: dialled,
+      dead: () => dead,
+      close: () => { dead = true; },
+      kill: () => { dead = true; },
+    };
+    held.push(line);
+    return line;
+  };
+  return { dial, held, count: () => dialled };
+}
+
+describe("the self-healing ACP dial (#4154)", () => {
+  it("returns the same live connection while it lives", async () => {
+    const { dial, count } = fakeDialler();
+    const healing = await createSelfHealingDial(dial);
+    const first = await healing.ensure();
+    expect(await healing.ensure()).toBe(first);
+    expect(count()).toBe(1);
+  });
+
+  it("dials a replacement when the held connection died, once for concurrent calls", async () => {
+    const { dial, held, count } = fakeDialler();
+    const healing = await createSelfHealingDial(dial);
+    const first = await healing.ensure();
+    held[0]!.kill();
+    const [a, b, c] = await Promise.all([healing.ensure(), healing.ensure(), healing.ensure()]);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+    expect(a).not.toBe(first);
+    expect(count()).toBe(2);
+  });
+
+  it("re-dials after a failed replacement instead of caching the failure", async () => {
+    const { dial, held } = fakeDialler();
+    let failNext = false;
+    const healing = await createSelfHealingDial(async () => {
+      if (failNext) { failNext = false; throw new Error("daemon unreachable"); }
+      return await dial();
+    });
+    held[0]!.kill();
+    failNext = true;
+    await expect(healing.ensure()).rejects.toThrow("daemon unreachable");
+    const replacement = await healing.ensure();
+    expect(replacement.id).toBe(2);
+  });
+
+  it("refuses calls after an explicit close, and the first dial's failure reaches the caller", async () => {
+    const { dial } = fakeDialler();
+    const healing = await createSelfHealingDial(dial);
+    healing.close();
+    await expect(healing.ensure()).rejects.toThrow("closed");
+    await expect(createSelfHealingDial(async () => { throw new Error("no daemon"); }))
+      .rejects.toThrow("no daemon");
+  });
+});


### PR DESCRIPTION
The rs_dev MCP memoised one ACP connection for its whole process life, so a routine daemon restart (every release install) turned every later tool call into `ACP connection closed` until the operator restarted the MCP process (#4154's evidence: a READ answered the error while a raw probe against the same socket answered normally).

`connectRedskillsProjectAcp` now separates the dial (socket, handshake, session/new) from the session the adapters hold, and routes every call through a self-healing, single-flight re-dial (`createSelfHealingDial`, pinned by its own suite): dead connection → dial again before answering; concurrent calls share one replacement; a failed replacement is retried next call, not cached; explicit close stays closed; the first dial still fails closed at connect time.

Fixes #4154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789884064&installation_model_id=20659&pr_number=4229&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4229&signature=1f17ec0a6c912c146f29ae0a01a0cdc9acbd14e63e3b30dc50b513edfe57c15e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->