### PR TITLE
fix(redskilled): a codex child is launched in the unattended posture

### DIFF
--- a/.changeset/codex-unattended-launch.md
+++ b/.changeset/codex-unattended-launch.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+A codex child is launched in the unattended posture. The adapter's defaults
+ask for approval on every write, nobody answers a permission dialog in an
+unattended turn, and the refusal made codex abort the whole turn as
+"interrupted" on its first apply_patch. The catalog now declares launch args
+per adapter — codex gets `approval_policy=never` and full access, the same
+trust the native redcode child already runs with, because the product's
+isolation is the disposable Worker workspace and its cgroup.

--- a/apps/redskilled/src/acp-agent-catalog.ts
+++ b/apps/redskilled/src/acp-agent-catalog.ts
@@ -49,6 +49,17 @@ export interface AdapterAcpAgentDescriptor {
   readonly label: string;
   readonly kind: "adapter";
   readonly artifact: AcpAdapterArtifact;
+  /**
+   * Arguments the adapter is LAUNCHED with, after the bin.
+   *
+   * A Worker's child runs unattended: nobody answers a permission dialog, so
+   * an adapter whose defaults ask for approval aborts its turn on the first
+   * write. The launch declares the unattended posture instead — the same
+   * trust the native redcode child already runs with, because the product's
+   * isolation is the disposable Worker workspace and its cgroup, not the
+   * adapter's own prompt-for-approval loop.
+   */
+  readonly launchArgs?: readonly string[];
 }
 
 export type AcpAgentDescriptor = NativeAcpAgentDescriptor | AdapterAcpAgentDescriptor;
@@ -82,6 +93,7 @@ export const ACP_AGENT_CATALOG: readonly AcpAgentDescriptor[] = [
       entrypoint: "package/bin/codex-acp.js",
       bin: "codex-acp",
     },
+    launchArgs: ["-c", "approval_policy=never", "-c", "sandbox_mode=danger-full-access"],
   },
   {
     id: "pi",
@@ -333,7 +345,13 @@ export function declaredChildAgentEndpoint(id: AcpAgentId): AcpEndpoint {
     agent: id,
     transport: "stdio",
     command: "npx",
-    args: ["-y", "-p", `${descriptor.artifact.package}@${descriptor.artifact.version}`, descriptor.artifact.bin],
+    args: [
+      "-y",
+      "-p",
+      `${descriptor.artifact.package}@${descriptor.artifact.version}`,
+      descriptor.artifact.bin,
+      ...(descriptor.launchArgs ?? []),
+    ],
   };
 }
 

--- a/apps/redskilled/tests/runner-honored-admission.test.ts
+++ b/apps/redskilled/tests/runner-honored-admission.test.ts
@@ -78,7 +78,13 @@ describe("the registered runner reaches the born Worker", () => {
     const endpoint = declaredChildAgentEndpoint("codex");
     expect(endpoint.agent).toBe("codex");
     expect(endpoint.command).toBe("npx");
-    expect(endpoint.args).toEqual(["-y", "-p", "@zed-industries/codex-acp@0.16.0", "codex-acp"]);
+    expect(endpoint.args).toEqual([
+      "-y", "-p", "@zed-industries/codex-acp@0.16.0", "codex-acp",
+      // Unattended posture: nobody answers a permission dialog, so an adapter
+      // left on its ask-for-approval defaults aborts its turn on the first
+      // write ("aborted by user", observed live on 4.1.15).
+      "-c", "approval_policy=never", "-c", "sandbox_mode=danger-full-access",
+    ]);
   });
 
   it("still admits the governed native default exactly as before", () => {
@@ -97,6 +103,10 @@ describe("the registered runner reaches the born Worker", () => {
       "--child-arg=-p",
       "--child-arg=@zed-industries/codex-acp@0.16.0",
       "--child-arg=codex-acp",
+      "--child-arg=-c",
+      "--child-arg=approval_policy=never",
+      "--child-arg=-c",
+      "--child-arg=sandbox_mode=danger-full-access",
     ]);
     expect(codexSpec.env?.OPENCODE_DB).toBeUndefined();
     expect(codexSpec.env?.CODEX_HOME).toBe(codexAgentHome());


### PR DESCRIPTION
Observed live on 4.1.15 with the truthful prompt (#4227): codex investigated, decided, and called `apply_patch` — and the write's permission request, refused by the unattended turn as designed, made the adapter abort the whole turn (`aborted by user after 0.1s`, `turn_aborted reason: interrupted`, stopReason `cancelled`). An adapter left on its ask-for-approval defaults can never edit unattended.

The catalog now carries per-adapter `launchArgs`, and codex declares the unattended posture at birth: `approval_policy=never`, `sandbox_mode=danger-full-access` — the same trust the native redcode child already runs with; the product's isolation is the disposable Worker workspace and its cgroup.

Refs #4221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789884220&installation_model_id=20659&pr_number=4230&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4230&signature=6d5798e29fba1ac764944f8a87c785d78e3771fb3eb7764368e4d17b2819751e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->