### PR TITLE
fix(worker): one declared Validation execution at a time per host

### DIFF
--- a/.changeset/host-gate-slot.md
+++ b/.changeset/host-gate-slot.md
@@ -1,0 +1,12 @@
+---
+"@reddb-io/worker": patch
+"@reddb-io/dev": patch
+---
+
+One declared Validation execution at a time per host. Two Workers running
+their gates simultaneously poisoned each other — the second collapsed with six
+unrelated packages red in 15s, contention's signature — and the Verdict read
+it as branch fault. The gate now runs behind a host-wide lock file: a dead
+holder is broken immediately, a blocked Worker narrates its wait, and a
+deadline (15 min) proceeds unlocked rather than parking every Worker on a
+wedged lock.

--- a/apps/plugin-dev/src/core/declared-wait-guard.ts
+++ b/apps/plugin-dev/src/core/declared-wait-guard.ts
@@ -556,6 +556,15 @@ export function blankCommentsAndStrings(source: string): string {
  */
 export const DECLARED_WAITS: readonly DeclaredWait[] = [
   {
+    path: "packages/worker/src/acp/gate-lock.ts",
+    fn: "acquireHostGateLock",
+    subject: "the host-wide gate slot — one declared Validation execution at a time per machine (#4161)",
+    deadline: "`deadlineMs`, default 15 minutes of waiting",
+    escalation:
+      "proceeds WITHOUT the lock and says so — a wedged lock must not park every Worker on the host; a dead holder is broken immediately",
+    heartbeat: { sink: "onWait" },
+  },
+  {
     path: "apps/plugin-dev/src/core/mcp-lane-canary.ts",
     fn: "awaitHost",
     subject: "the daemon's own answer for a project reaching the shape this step requires",

--- a/packages/worker/src/acp/gate-lock.test.ts
+++ b/packages/worker/src/acp/gate-lock.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { acquireHostGateLock, hostGateLockPath } from "./gate-lock.js";
+
+// #4161: two Workers running their gates simultaneously on one host poisoned
+// each other, and the Verdict read the contention as branch fault. The gate
+// slot is one host-wide lock; this suite pins its whole contract.
+
+const roots: string[] = [];
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function lockDir(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "red-gate-lock-"));
+  roots.push(root);
+  return root;
+}
+
+describe("the host-wide gate slot (#4161)", () => {
+  it("acquires a free slot immediately and releases it", async () => {
+    const lockPath = join(await lockDir(), "gate.lock");
+    const slot = await acquireHostGateLock({ lockPath, pid: 4242 });
+    expect(slot.unlocked).toBe(false);
+    expect((await readFile(lockPath, "utf8")).trim()).toBe("4242");
+    await slot.release();
+    await expect(readFile(lockPath, "utf8")).rejects.toThrow();
+  });
+
+  it("waits for a live holder and takes the slot when it releases", async () => {
+    const lockPath = join(await lockDir(), "gate.lock");
+    const first = await acquireHostGateLock({ lockPath, pid: 1 });
+    const waits: Array<number | null> = [];
+    let clock = 0;
+    const second = acquireHostGateLock({
+      lockPath,
+      pid: 2,
+      pollMs: 10,
+      deadlineMs: 10_000,
+      now: () => clock,
+      sleep: async () => { clock += 10; await first.release(); },
+      pidAlive: () => true,
+      onWait: (holder) => { waits.push(holder); },
+    });
+    const slot = await second;
+    expect(slot.unlocked).toBe(false);
+    expect(waits).toEqual([1]);
+    expect((await readFile(lockPath, "utf8")).trim()).toBe("2");
+    await slot.release();
+  });
+
+  it("breaks a dead holder's lock immediately", async () => {
+    const lockPath = join(await lockDir(), "gate.lock");
+    await writeFile(lockPath, "999999\n");
+    const slot = await acquireHostGateLock({ lockPath, pid: 7, pidAlive: () => false });
+    expect(slot.unlocked).toBe(false);
+    expect((await readFile(lockPath, "utf8")).trim()).toBe("7");
+    await slot.release();
+  });
+
+  it("proceeds unlocked past the deadline instead of parking the Worker forever", async () => {
+    const lockPath = join(await lockDir(), "gate.lock");
+    await writeFile(lockPath, "1\n");
+    let clock = 0;
+    const slot = await acquireHostGateLock({
+      lockPath,
+      pid: 7,
+      pollMs: 10,
+      deadlineMs: 25,
+      now: () => clock,
+      sleep: async () => { clock += 10; },
+      pidAlive: () => true,
+    });
+    expect(slot.unlocked).toBe(true);
+    // The holder's lock is not ours to delete: release must not clobber it.
+    await slot.release();
+    expect((await readFile(lockPath, "utf8")).trim()).toBe("1");
+  });
+
+  it("names one lock per user per machine", () => {
+    expect(hostGateLockPath("/tmp", 1000)).toBe("/tmp/red-skills-1000/gate.lock");
+    expect(hostGateLockPath("/tmp", "Some User")).toBe("/tmp/red-skills-some-user/gate.lock");
+  });
+});

--- a/packages/worker/src/acp/gate-lock.ts
+++ b/packages/worker/src/acp/gate-lock.ts
@@ -1,0 +1,106 @@
+/**
+ * gate-lock — one declared Validation execution at a time per host (#4161).
+ *
+ * Two Workers running their gates simultaneously on one machine poisoned each
+ * other: the second collapsed in 15s with six unrelated packages red at once —
+ * contention's signature, not the branch's — and the Verdict read it as branch
+ * fault. The gate is serialized behind a host-wide lock file instead: atomic
+ * `wx` create with the holder's pid inside, a dead holder broken immediately,
+ * and a bounded wait that PROCEEDS unlocked past its deadline — a wedged lock
+ * must not park every Worker on the host, and an unlocked run risks a flake,
+ * never corruption.
+ */
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir, userInfo } from "node:os";
+import { dirname, join } from "node:path";
+
+export interface HostGateLockOptions {
+  /** The lock file every Worker on this host agrees on. */
+  readonly lockPath?: string;
+  /** How often a blocked Worker re-reads the lock. */
+  readonly pollMs?: number;
+  /** How long a blocked Worker waits before proceeding unlocked. */
+  readonly deadlineMs?: number;
+  /** Heartbeat: who holds the lock and how long this Worker has waited. */
+  readonly onWait?: (holder: number | null, waitedMs: number) => void;
+  /** Test seams. Production uses the real clock, timer, and process table. */
+  readonly now?: () => number;
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly pidAlive?: (pid: number) => boolean;
+  readonly pid?: number;
+}
+
+export interface HostGateLock {
+  /** True when the deadline passed and the gate runs WITHOUT the lock. */
+  readonly unlocked: boolean;
+  readonly waitedMs: number;
+  release(): Promise<void>;
+}
+
+/** The lock every Worker of one user on one machine agrees on. */
+export function hostGateLockPath(tmpRoot: string = tmpdir(), uid: string | number = defaultUid()): string {
+  const segment = String(uid).trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return join(tmpRoot, `red-skills-${segment}`, "gate.lock");
+}
+
+const DEFAULT_GATE_LOCK_POLL_MS = 2_000;
+const DEFAULT_GATE_LOCK_DEADLINE_MS = 15 * 60_000;
+
+export async function acquireHostGateLock(options: HostGateLockOptions = {}): Promise<HostGateLock> {
+  const lockPath = options.lockPath ?? hostGateLockPath();
+  const pollMs = options.pollMs ?? DEFAULT_GATE_LOCK_POLL_MS;
+  const deadlineMs = options.deadlineMs ?? DEFAULT_GATE_LOCK_DEADLINE_MS;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const alive = options.pidAlive ?? processAlive;
+  const pid = options.pid ?? process.pid;
+  await mkdir(dirname(lockPath), { recursive: true });
+  const startedAt = now();
+  for (;;) {
+    try {
+      await writeFile(lockPath, `${pid}\n`, { encoding: "utf8", flag: "wx" });
+      return {
+        unlocked: false,
+        waitedMs: now() - startedAt,
+        async release() {
+          await rm(lockPath, { force: true });
+        },
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    const holder = await holderOf(lockPath);
+    if (holder != null && !alive(holder)) {
+      // A dead holder is a Worker that never reached its release; breaking the
+      // lock immediately is the stale-claim sweep this file needs.
+      await rm(lockPath, { force: true });
+      continue;
+    }
+    const waitedMs = now() - startedAt;
+    if (waitedMs >= deadlineMs) {
+      return { unlocked: true, waitedMs, async release() {} };
+    }
+    options.onWait?.(holder, waitedMs);
+    await sleep(pollMs);
+  }
+}
+
+async function holderOf(lockPath: string): Promise<number | null> {
+  const text = await readFile(lockPath, "utf8").catch(() => null);
+  if (text == null) return null;
+  const pid = Number.parseInt(text.trim(), 10);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function defaultUid(): string | number {
+  return process.getuid?.() ?? userInfo().username;
+}

--- a/packages/worker/src/acp/native-worker.ts
+++ b/packages/worker/src/acp/native-worker.ts
@@ -33,6 +33,7 @@ import {
   type RedskillsTicketHandoff,
 } from "@reddb-io/protocol-acp";
 import { WorkflowChildAgent } from "./child-agent.js";
+import { acquireHostGateLock } from "./gate-lock.js";
 import { runWorkerLocalGate } from "./local-gate.js";
 import { createWorkerPublisher, worktreeHead, type WorkerPublisher } from "./publish-request.js";
 import { runTicketLoop, type TicketLoopRecord, type TicketLoopResult } from "./ticket-loop.js";
@@ -156,16 +157,32 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
         });
         return { stopReason: response.stopReason };
       },
-      gate: async () => await runWorkerLocalGate({
-        worktree: held.request.cwd,
-        base: ticket.base,
-        ...(ticket.backpressure_commands == null
-          ? {}
-          : { backpressureCommands: ticket.backpressure_commands }),
-        ...(ticket.validation_commands == null
-          ? {}
-          : { validationCommands: ticket.validation_commands }),
-      }),
+      gate: async () => {
+        // #4161: one Validation execution at a time per host — two concurrent
+        // gates read each other's contention as branch fault.
+        const slot = await acquireHostGateLock({
+          onWait: (holder, waitedMs) => void notifyTicketStage(parent, sessionId, {
+            stage: "gate",
+            ok: true,
+            detail: `waiting for the host gate slot (${Math.round(waitedMs / 1000)}s` +
+              `${holder == null ? "" : `, held by pid ${holder}`})`,
+          }),
+        });
+        try {
+          return await runWorkerLocalGate({
+            worktree: held.request.cwd,
+            base: ticket.base,
+            ...(ticket.backpressure_commands == null
+              ? {}
+              : { backpressureCommands: ticket.backpressure_commands }),
+            ...(ticket.validation_commands == null
+              ? {}
+              : { validationCommands: ticket.validation_commands }),
+          });
+        } finally {
+          await slot.release();
+        }
+      },
       publisher: held.publisher,
       narrate: (record) => notifyTicketStage(parent, sessionId, record),
     });


### PR DESCRIPTION
Two Workers running their gates simultaneously on one host poisoned each other (#4161): mass ELIFECYCLE across six unrelated packages in 15s — contention's signature — verdicted as branch fault. The gate stage now runs behind a host-wide lock (`gate-lock.ts`): atomic `wx` create carrying the holder's pid, dead holders broken immediately, the wait narrated via the ticket stage lane, and a 15-minute deadline that proceeds unlocked with the fact stated (a wedged lock must not park the host). The wait loop is declared in `DECLARED_WAITS` per the #3024 ratchet; the suite pins acquire/wait/steal/deadline/naming.

Fixes #4161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789884483&installation_model_id=20659&pr_number=4232&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4232&signature=338c2af29994e380dfeabf69bd13d7fecc33e77f09b7ffa16569d3cc1ce8af37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->