### PR TITLE
feat(redskilled): land carries the validated commit; custody remembers the armed head

### DIFF
--- a/.changeset/land-carries-validated-commit.md
+++ b/.changeset/land-carries-validated-commit.md
@@ -1,0 +1,14 @@
+---
+"@reddb-io/protocol-acp": patch
+"@reddb-io/worker": patch
+"@reddb-io/redskilled": patch
+---
+
+The land request names the validated commit and the merge driver remembers the
+head it armed. Publish carried a commit and land dropped it, so the daemon
+landed a mutable branch ref and the driver, keyed by PR number alone, was
+blind to a head that moved between arming and merging. The Worker's land now
+sends the same commit its publish named, the daemon refuses a landing without
+it, custody records round-trip the armed head through their TOON snapshot, and
+a driver pass against a moved head reports the mismatch instead of arming a
+commit nobody validated.

--- a/apps/redskilled/src/acp-publication.ts
+++ b/apps/redskilled/src/acp-publication.ts
@@ -155,6 +155,7 @@ export function bindAcpWorkerLand(deps: AcpPublicationDeps) {
       owner_ticket: params.owner_ticket,
       branch: params.branch,
       base: params.base,
+      armed_head: params.commit,
     });
     return {
       version: 1,
@@ -186,16 +187,21 @@ export function publishParams(value: unknown): RedskilledPublishRequest {
 export function landParams(value: unknown): RedskilledLandRequest {
   const params = exactly(
     value,
-    ["idempotency_key", "branch", "base", "title", "body", "owner_ticket"],
+    ["idempotency_key", "branch", "commit", "base", "title", "body", "owner_ticket"],
     "a Worker landing",
   );
   const ticket = params.owner_ticket;
   if (typeof ticket !== "number" || !Number.isSafeInteger(ticket) || ticket <= 0) {
     throw new RedskilledGithubAuthorityError("a Worker landing names the Ticket that inherits the merge");
   }
+  const commit = params.commit;
+  if (typeof commit !== "string" || !OBJECT_NAME.test(commit)) {
+    throw new RedskilledGithubAuthorityError("a Worker landing names the full commit object name its publish carried");
+  }
   return {
     idempotency_key: text(params.idempotency_key, "idempotency key"),
     branch: branchName(params.branch),
+    commit,
     base: branchName(params.base),
     title: text(params.title, "title"),
     body: text(params.body, "body"),

--- a/apps/redskilled/src/github-custody-upstream.ts
+++ b/apps/redskilled/src/github-custody-upstream.ts
@@ -42,7 +42,7 @@ export function createRedskilledGithubCustodyUpstream(
       if (!pull.ok) throw new Error(`GitHub custody arm lookup failed with HTTP ${pull.status}`);
       const body = await pull.json() as Record<string, unknown>;
       if (body.merged === true || body.merged_at != null) {
-        return { forge_state: "merged", native_intent: false };
+        return { forge_state: "merged", native_intent: false, ...headShaOf(body) };
       }
       const nodeId = typeof body.node_id === "string" ? body.node_id : "";
       if (nodeId === "") throw new Error("GitHub custody cannot arm a pull request without a node identity");
@@ -71,10 +71,11 @@ function pullRequestView(value: unknown): RedskilledGithubCustodyForgeView {
     throw new Error("GitHub custody received an invalid pull request");
   }
   const pull = value as Record<string, unknown>;
+  const headSha = headShaOf(pull);
   if (pull.merged === true || pull.merged_at != null) {
-    return { forge_state: "merged", native_intent: false };
+    return { forge_state: "merged", native_intent: false, ...headSha };
   }
-  if (pull.state === "closed") return { forge_state: "closed", native_intent: false };
+  if (pull.state === "closed") return { forge_state: "closed", native_intent: false, ...headSha };
   if (pull.state !== "open") throw new Error("GitHub custody received an unknown pull request state");
   const nativeIntent = pull.auto_merge != null;
   const mergeableState = typeof pull.mergeable_state === "string" ? pull.mergeable_state.toLowerCase() : "unknown";
@@ -83,5 +84,11 @@ function pullRequestView(value: unknown): RedskilledGithubCustodyForgeView {
     : pull.mergeable === true && ["clean", "has_hooks", "unstable"].includes(mergeableState)
       ? "open-clean" as const
       : "open-pending" as const;
-  return { forge_state: forgeState, native_intent: nativeIntent };
+  return { forge_state: forgeState, native_intent: nativeIntent, ...headSha };
+}
+
+/** The PR's current head, for the armed-head comparison (#4130). */
+function headShaOf(pull: Record<string, unknown>): { head_sha?: string } {
+  const sha = (pull.head as Record<string, unknown> | undefined)?.sha;
+  return typeof sha === "string" && /^[0-9a-f]{40}$/.test(sha) ? { head_sha: sha } : {};
 }

--- a/apps/redskilled/src/github-custody.ts
+++ b/apps/redskilled/src/github-custody.ts
@@ -22,11 +22,20 @@ export interface RedskilledGithubCustodyHandoff {
   readonly owner_ticket: number;
   readonly branch: string;
   readonly base: string;
+  /**
+   * The head SHA the landing validated and armed (#4130). Optional only for
+   * records written before it existed; every new handoff carries it, and a
+   * driver pass whose observed head differs reports the mismatch instead of
+   * arming a commit nobody validated.
+   */
+  readonly armed_head?: string;
 }
 
 export interface RedskilledGithubCustodyForgeView {
   readonly forge_state: Exclude<RedskilledGithubForgeState, "unknown" | "unavailable">;
   readonly native_intent: boolean;
+  /** The pull request's CURRENT head, for the armed-head comparison (#4130). */
+  readonly head_sha?: string;
 }
 
 export interface RedskilledGithubCustodyUpstreamInput {
@@ -59,7 +68,13 @@ export interface RedskilledGithubCustodyRecord extends RedskilledGithubCustodyHa
   readonly state: "active" | "terminal";
   readonly last_tick_at: string | null;
   readonly last_forge_state: RedskilledGithubForgeState;
-  readonly next_action: "observe-forge" | "await-forge" | "retry-forge" | "repair-custodian" | "none";
+  readonly next_action:
+    | "observe-forge"
+    | "await-forge"
+    | "retry-forge"
+    | "repair-custodian"
+    | "report-moved-head"
+    | "none";
   readonly terminal_outcome: "merged" | "closed" | null;
   readonly fault?: RedskilledGithubCustodyFault;
 }
@@ -188,7 +203,14 @@ export function createGithubCustodian(options: CreateGithubCustodianOptions): Gi
         pullRequest: ticking.pull_request,
       };
       let view = validateForgeView(await options.upstream.observe(input));
-      if (view.forge_state !== "merged" && view.forge_state !== "closed" && !view.native_intent) {
+      const open = view.forge_state !== "merged" && view.forge_state !== "closed";
+      // #4130: an armed head that moved is a commit nobody validated. The pass
+      // reports the mismatch instead of proceeding — it neither arms nor
+      // pretends the obligation is on track — and keeps watching, because the
+      // head may be forced back or a new landing may restate it.
+      const movedHead = open && ticking.armed_head != null && view.head_sha != null &&
+        view.head_sha !== ticking.armed_head;
+      if (open && !movedHead && !view.native_intent) {
         view = validateForgeView(await options.upstream.arm(input));
       }
       const terminal = view.forge_state === "merged" || view.forge_state === "closed";
@@ -196,7 +218,7 @@ export function createGithubCustodian(options: CreateGithubCustodianOptions): Gi
         ...record,
         state: terminal ? "terminal" : "active",
         last_forge_state: view.forge_state,
-        next_action: terminal ? "none" : "await-forge",
+        next_action: terminal ? "none" : movedHead ? "report-moved-head" : "await-forge",
         terminal_outcome: view.forge_state === "merged"
           ? "merged"
           : view.forge_state === "closed" ? "closed" : null,
@@ -243,6 +265,17 @@ export function createGithubCustodian(options: CreateGithubCustodianOptions): Gi
             existing.base !== valid.base || existing.credential_profile !== project.credentialProfile
           ) {
             throw new Error("one pull request cannot have two merge custody owners");
+          }
+          // #4130: a re-landing after a re-publish restates the validated
+          // head; the newest validated commit is the one custody defends.
+          if (valid.armed_head != null && valid.armed_head !== existing.armed_head) {
+            const index = current.records.indexOf(existing);
+            const restated = { ...existing, armed_head: valid.armed_head };
+            const records = [...current.records];
+            records[index] = restated;
+            snapshot = { version: 1, records };
+            await persist(snapshot);
+            return restated;
           }
           return existing;
         }
@@ -316,6 +349,7 @@ function publicRecord(
           owner_ticket: record.owner_ticket,
           branch: record.branch,
           base: record.base,
+          ...(record.armed_head == null ? {} : { armed_head: record.armed_head }),
         },
       },
     },
@@ -341,11 +375,16 @@ function validateHandoff(value: RedskilledGithubCustodyHandoff): RedskilledGithu
   if (!Number.isSafeInteger(value.owner_ticket) || value.owner_ticket <= 0) {
     throw new Error("merge custody needs one positive owner Ticket number");
   }
+  const armedHead = value.armed_head;
+  if (armedHead != null && (typeof armedHead !== "string" || !/^[0-9a-f]{40}$/.test(armedHead))) {
+    throw new Error("merge custody needs the armed head as one full commit object name");
+  }
   return {
     pull_request: value.pull_request,
     owner_ticket: value.owner_ticket,
     branch: branch(value.branch, "branch"),
     base: branch(value.base, "base"),
+    ...(armedHead == null ? {} : { armed_head: armedHead }),
   };
 }
 
@@ -364,7 +403,8 @@ function validateForgeView(value: RedskilledGithubCustodyForgeView): RedskilledG
   if (
     value == null || typeof value !== "object" ||
     !["open-clean", "open-pending", "open-blocked", "merged", "closed"].includes(value.forge_state) ||
-    typeof value.native_intent !== "boolean"
+    typeof value.native_intent !== "boolean" ||
+    (value.head_sha != null && (typeof value.head_sha !== "string" || !/^[0-9a-f]{40}$/.test(value.head_sha)))
   ) {
     throw new Error("the GitHub custody upstream returned an invalid forge view");
   }
@@ -392,6 +432,7 @@ function parseRecord(value: unknown): RedskilledGithubCustodyRecord {
     owner_ticket: record.owner_ticket as number,
     branch: record.branch as string,
     base: record.base as string,
+    ...(record.armed_head == null ? {} : { armed_head: record.armed_head as string }),
   });
   const state = record.state === "active" || record.state === "terminal" ? record.state : invalidState();
   const forge = typeof record.last_forge_state === "string" && [
@@ -425,7 +466,10 @@ function scalar(value: unknown): string {
 }
 
 function nextAction(value: unknown): RedskilledGithubCustodyRecord["next_action"] {
-  if (["observe-forge", "await-forge", "retry-forge", "repair-custodian", "none"].includes(String(value))) {
+  if (
+    ["observe-forge", "await-forge", "retry-forge", "repair-custodian", "report-moved-head", "none"]
+      .includes(String(value))
+  ) {
     return value as RedskilledGithubCustodyRecord["next_action"];
   }
   throw new Error("redskilled GitHub custody contains an invalid next action");

--- a/apps/redskilled/tests/acp-publication.test.ts
+++ b/apps/redskilled/tests/acp-publication.test.ts
@@ -196,6 +196,7 @@ describe("`_redskills/land` — the daemon opens the PR and hands the merge on",
       params: landParams({
         idempotency_key: "worker-land:s:1",
         branch: "afk/4019-landing",
+        commit: host.commit,
         base: "main",
         title: "The daemon publishes and lands",
         body: "Refs #4019",
@@ -218,6 +219,7 @@ describe("`_redskills/land` — the daemon opens the PR and hands the merge on",
       params: landParams({
         idempotency_key: "worker-land:s:1",
         branch: "afk/4019-unheld-landing",
+        commit: host.commit,
         base: "main",
         title: "unheld",
         body: "Refs #4019",
@@ -225,6 +227,33 @@ describe("`_redskills/land` — the daemon opens the PR and hands the merge on",
       }),
     })).rejects.toThrow(/no longer holds|does not hold/i);
   }, 30_000);
+});
+
+describe("the land decoder (#4130)", () => {
+  const valid = {
+    idempotency_key: "worker-land:s:1",
+    branch: "afk/4130-decoder",
+    commit: "a".repeat(40).replace(/a/g, "1a23b45c").slice(0, 40),
+    base: "main",
+    title: "t",
+    body: "b",
+    owner_ticket: 4130,
+  };
+
+  it("refuses a landing without the validated commit", () => {
+    const { commit: _commit, ...withoutCommit } = valid;
+    expect(() => landParams(withoutCommit)).toThrow(/cannot name|exactly/i);
+  });
+
+  it("refuses a commit that is not one full object name", () => {
+    expect(() => landParams({ ...valid, commit: "main" })).toThrow(/object name/i);
+    expect(() => landParams({ ...valid, commit: "abc123" })).toThrow(/object name/i);
+  });
+
+  it("pins the exact-keys contract", () => {
+    expect(() => landParams({ ...valid, remote: "origin" })).toThrow();
+    expect(landParams(valid).commit).toBe(valid.commit);
+  });
 });
 
 describe("the publication domain", () => {

--- a/apps/redskilled/tests/github-custody-armed-head.test.ts
+++ b/apps/redskilled/tests/github-custody-armed-head.test.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createGithubCustodian,
+  type RedskilledGithubCustodyForgeView,
+  type RedskilledGithubCustodyUpstream,
+} from "../src/github-custody.js";
+
+// #4130: land carries the validated commit, and the merge driver remembers the
+// head SHA it armed. A driver pass whose observed head differs REPORTS the
+// mismatch instead of arming a commit nobody validated.
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+const PROJECT = {
+  projectId: "github:9001",
+  projectLabel: "acme/widgets",
+  workspacePath: "/tmp/acme-widgets",
+  credentialProfile: "default",
+};
+const CREDENTIAL = { secret: "s" };
+const ARMED = "1".repeat(40);
+const MOVED = "2".repeat(40);
+
+function upstreamFixture(headSha: () => string) {
+  let armCalls = 0;
+  const view = (native: boolean): RedskilledGithubCustodyForgeView => ({
+    forge_state: "open-clean",
+    native_intent: native,
+    head_sha: headSha(),
+  });
+  const upstream: RedskilledGithubCustodyUpstream = {
+    async observe() { return view(false); },
+    async arm() { armCalls += 1; return view(true); },
+  };
+  return { upstream, armCalls: () => armCalls };
+}
+
+async function custodyPath(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-armed-head-"));
+  roots.push(root);
+  return join(root, "github-custody.toon");
+}
+
+async function tickOnce(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 30));
+}
+
+describe("the armed head on merge custody (#4130)", () => {
+  it("arms when the observed head IS the validated commit, and round-trips it through the snapshot", async () => {
+    const path = await custodyPath();
+    const { upstream, armCalls } = upstreamFixture(() => ARMED);
+    const custodian = createGithubCustodian({
+      path, upstream, clock: () => new Date().toISOString(), tickMs: 5, inertMs: 60_000,
+    });
+    const record = await custodian.handoff(PROJECT, CREDENTIAL, {
+      pull_request: 73, owner_ticket: 4130, branch: "afk/4130", base: "main", armed_head: ARMED,
+    });
+    expect(record.armed_head).toBe(ARMED);
+    await tickOnce();
+    expect(armCalls()).toBeGreaterThan(0);
+    custodian.close();
+
+    // The snapshot remembers the armed head across a daemon replacement.
+    const revived = createGithubCustodian({
+      path, upstream, clock: () => new Date().toISOString(), tickMs: 3_600_000, inertMs: 3_600_000,
+    });
+    const status = await revived.status(PROJECT, CREDENTIAL);
+    expect(status.records[0]?.armed_head).toBe(ARMED);
+    revived.close();
+  });
+
+  it("reports a moved head instead of arming a commit nobody validated", async () => {
+    const path = await custodyPath();
+    const { upstream, armCalls } = upstreamFixture(() => MOVED);
+    const custodian = createGithubCustodian({
+      path, upstream, clock: () => new Date().toISOString(), tickMs: 5, inertMs: 60_000,
+    });
+    await custodian.handoff(PROJECT, CREDENTIAL, {
+      pull_request: 74, owner_ticket: 4130, branch: "afk/4130-moved", base: "main", armed_head: ARMED,
+    });
+    await tickOnce();
+    expect(armCalls()).toBe(0);
+    const status = await custodian.status(PROJECT, CREDENTIAL);
+    expect(status.records[0]?.next_action).toBe("report-moved-head");
+    expect(status.records[0]?.state).toBe("active");
+    custodian.close();
+  });
+
+  it("a re-landing restates the validated head on the same pull request", async () => {
+    const path = await custodyPath();
+    const { upstream } = upstreamFixture(() => ARMED);
+    const custodian = createGithubCustodian({
+      path, upstream, clock: () => new Date().toISOString(), tickMs: 3_600_000, inertMs: 3_600_000,
+    });
+    const handoff = {
+      pull_request: 75, owner_ticket: 4130, branch: "afk/4130-restate", base: "main",
+    };
+    await custodian.handoff(PROJECT, CREDENTIAL, { ...handoff, armed_head: ARMED });
+    const restated = await custodian.handoff(PROJECT, CREDENTIAL, { ...handoff, armed_head: MOVED });
+    expect(restated.armed_head).toBe(MOVED);
+    custodian.close();
+  });
+
+  it("a record written before the armed head existed still parses and never reports a mismatch", async () => {
+    const path = await custodyPath();
+    const { upstream, armCalls } = upstreamFixture(() => MOVED);
+    const custodian = createGithubCustodian({
+      path, upstream, clock: () => new Date().toISOString(), tickMs: 5, inertMs: 60_000,
+    });
+    await custodian.handoff(PROJECT, CREDENTIAL, {
+      pull_request: 76, owner_ticket: 4130, branch: "afk/4130-legacy", base: "main",
+    });
+    await tickOnce();
+    expect(armCalls()).toBeGreaterThan(0);
+    custodian.close();
+  });
+});

--- a/packages/protocol-acp/publication.ts
+++ b/packages/protocol-acp/publication.ts
@@ -44,6 +44,13 @@ export interface RedskilledPublishAnswer {
 export interface RedskilledLandRequest {
   readonly idempotency_key: string;
   readonly branch: string;
+  /**
+   * The commit this landing is FOR — the same full object name its publish
+   * carried (#4130). Publish validated it; a land without it would hand
+   * custody a mutable branch ref, and the merge driver could not tell an
+   * armed head from one that moved after arming.
+   */
+  readonly commit: string;
   readonly base: string;
   readonly title: string;
   readonly body: string;

--- a/packages/worker/src/acp/ticket-loop.test.ts
+++ b/packages/worker/src/acp/ticket-loop.test.ts
@@ -79,11 +79,18 @@ describe("the Ticket loop's declared arc", () => {
     expect(claim.write.issue).toBe(4020);
     expect(claim.write.body).toContain("worker=host:VSk6WPt");
 
-    const land = requests[1]!.params as { owner_ticket: number; base: string; body: string };
+    const land = requests[1]!.params as {
+      owner_ticket: number;
+      base: string;
+      body: string;
+      commit: string;
+    };
     expect(requests[1]!.method).toBe(REDSKILLS_ACP_METHODS.land);
     expect(land.owner_ticket).toBe(4020);
     expect(land.base).toBe("main");
     expect(land.body).toContain("Refs #4020");
+    // #4130: the land names the exact commit its publish validated.
+    expect(land.commit).toBe(result.publication.commit);
   });
 });
 

--- a/packages/worker/src/acp/ticket-loop.ts
+++ b/packages/worker/src/acp/ticket-loop.ts
@@ -249,6 +249,9 @@ export async function runTicketLoop(deps: TicketLoopDeps): Promise<TicketLoopRes
     const landed = await deps.request(REDSKILLS_ACP_METHODS.land, {
       idempotency_key: `${deps.sessionId}:land:${published.publication.commit}`,
       branch: published.publication.branch,
+      // #4130: the land names the exact commit its publish validated, so the
+      // merge driver can tell an armed head from one that moved after arming.
+      commit: published.publication.commit,
       base: deps.ticket.base,
       title: deps.ticket.title,
       body: landingBody(deps.ticket, rounds),


### PR DESCRIPTION
Implements #4130 (Spec #4129, Wave 1).

- **Wire** (`@reddb-io/protocol-acp`): `RedskilledLandRequest` gains `commit` — the same full object name its publish carried.
- **Daemon**: `landParams` refuses a landing without `commit` (object-name discipline identical to publish; exact-keys contract pinned by decoder tests). The land handler passes `armed_head` into merge custody; records round-trip it through the TOON snapshot (optional only for pre-#4130 records on disk); a driver pass whose observed `head.sha` differs reports `report-moved-head` and does **not** arm; a re-landing restates the newest validated head.
- **Worker**: the ticket loop's land call sends `published.publication.commit`; its suite pins the round-trip.

Validation: focused suites green (ticket-loop 12, publication decoder, custody 7 incl. 4 new), root typecheck green, invariants 343 green. Pre-existing red on clean main not touched: the publication push test that reaches the real network, and the known acp-control-plane/ticket-loop/layout failures.

Fixes #4130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789885081&installation_model_id=20659&pr_number=4233&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4233&signature=9ec273fca7c24ad516c47d046cde66f5a5b444bd236b4ca185deb0048a0838df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->