### PR TITLE
fix(rsp): the bundled resident resolves the reddb binary instead of a path relative to the bundle

### DIFF
--- a/.changeset/rsp-bundled-resident-finds-reddb.md
+++ b/.changeset/rsp-bundled-resident-finds-reddb.md
@@ -1,0 +1,12 @@
+---
+"@reddb-io/rsp": patch
+---
+
+The bundled rsp resident finds the `red` engine binary again. esbuild inlines
+`@reddb-io/sdk`, so the SDK's `<package>/bin/red` probe — derived from its own
+module URL — resolved against the BUNDLE's directory and looked for
+`<repo>/bin/red`, a path that never existed. rsp now looks the SDK package up at
+runtime by walking the `node_modules` trees above the running module and the
+cwd, and states the whole cascade in one ordered place: `REDDB_BIN` verbatim,
+then the SDK package's `bin/red`, then the red-skills warm cache newest-first,
+then `red` on `PATH` as a last resort.

--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -1,5 +1,6 @@
 export { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_EPHEMERAL_TTL_HOURS, DEFAULT_RSP_TTL_DAYS, RSP_ELISION_COLLECTION } from "./elision-store/public.js";
 export type { RspElisionRecord, RspElisionStoreOptions, RspExpiredHandle, RspLossLevel, RspLossMeta, RspMintMeta, RspRecoveryHandle, RspStorageClass, RspStorageClassStats, RspStoreStats } from "./elision-store/public.js";
-export { ensureReddbBinaryFromWarmCache, storageClassForCommand } from "./elision-store/helpers.js";
+export { storageClassForCommand } from "./elision-store/helpers.js";
 export { contentHandle } from "./elision-store/helpers.js";
 export { provisionElisionStore, RspElisionStore } from "./elision-store/store.js";
+export { ensureReddbBinary, reddbBinaryFileName, resolveReddbBinary, type ReddbBinaryLookup, type ReddbBinarySource, type ResolvedReddbBinary } from "./reddb-binary.js";

--- a/apps/rsp/src/elision-store/helpers.ts
+++ b/apps/rsp/src/elision-store/helpers.ts
@@ -1,8 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gunzipSync, gzipSync } from "node:zlib";
@@ -525,32 +523,6 @@ export async function writableStorePath(path: string): Promise<string> {
 
 export function usesEmbeddedRedDb(path: string): boolean {
   return basename(path) === "red-skills.rdb";
-}
-
-export async function ensureReddbBinaryFromWarmCache(): Promise<void> {
-  if (process.env.REDDB_BIN) return;
-  // Same default cascade as the launcher fetch: an unset RED_SKILLS_CACHE_DIR
-  // means the standard cache location, not "no cache".
-  const cacheDir =
-    process.env.RED_SKILLS_CACHE_DIR ??
-    (process.env.XDG_CACHE_HOME
-      ? join(process.env.XDG_CACHE_HOME, "red-skills", "bundles")
-      : join(homedir(), ".cache", "red-skills", "bundles"));
-  const root = join(cacheDir, "reddb");
-  let versions: string[];
-  try {
-    versions = await readdir(root);
-  } catch {
-    return;
-  }
-  versions.sort().reverse();
-  for (const version of versions) {
-    const candidate = join(root, version, process.platform === "win32" ? "red.exe" : "red");
-    if (existsSync(candidate)) {
-      process.env.REDDB_BIN = candidate;
-      return;
-    }
-  }
 }
 
 export async function writeStoreDocument(path: string, document: StoreDocument): Promise<void> {

--- a/apps/rsp/src/elision-store/store.ts
+++ b/apps/rsp/src/elision-store/store.ts
@@ -5,7 +5,8 @@ import { basename, dirname } from "node:path";
 import { connect, type RedDB } from "@reddb-io/sdk";
 import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_EPHEMERAL_TTL_HOURS, DEFAULT_RSP_TTL_DAYS, RSP_ELISION_COLLECTION, type RspElisionRecord, type RspElisionStoreOptions, type RspExpiredHandle, type RspMintMeta, type RspRecoveryHandle, type RspStoreStats } from "./public.js";
 import type { IndexDocument, IndexEntry, RedDbKvCollectionSnapshot, ResidentRecallHit, StoreDocument, StoredRecord } from "./model.js";
-import { collectMemoryFiles, compressedBlob, contentHandle, contentHash, deriveGitBlobRecipe, deriveReexecutionRecipe, ensureReddbBinaryFromWarmCache, expiresAtFor, fileStorePath, indexKey, isExpiredHandle, isHandle, isIndexDocument, isStoredBlob, isStoredRecord, parseMemoryIngestPayload, parseMemoryRecallPayload, positiveNumber, readCompressedBlob, readGitBlobRecipe, readReexecutionRecipe, readStoreDocument, recoveryHandlesForIndex, recordKey, redDbIdentifier, residentRowToRecallHit, storageClassForCommand, storageClassForRecord, storageStatsForIndex, storedBytesFor, storedBytesForIndex, storedBytesForRecord, tombstoneKey, usesEmbeddedRedDb, writableStorePath, writeStoreDocument } from "./helpers.js";
+import { ensureReddbBinary } from "../reddb-binary.js";
+import { collectMemoryFiles, compressedBlob, contentHandle, contentHash, deriveGitBlobRecipe, deriveReexecutionRecipe, expiresAtFor, fileStorePath, indexKey, isExpiredHandle, isHandle, isIndexDocument, isStoredBlob, isStoredRecord, parseMemoryIngestPayload, parseMemoryRecallPayload, positiveNumber, readCompressedBlob, readGitBlobRecipe, readReexecutionRecipe, readStoreDocument, recoveryHandlesForIndex, recordKey, redDbIdentifier, residentRowToRecallHit, storageClassForCommand, storageClassForRecord, storageStatsForIndex, storedBytesFor, storedBytesForIndex, storedBytesForRecord, tombstoneKey, usesEmbeddedRedDb, writableStorePath, writeStoreDocument } from "./helpers.js";
 
 export class RspElisionStore {
   private document!: StoreDocument;
@@ -37,7 +38,7 @@ export class RspElisionStore {
       now: opts.now ?? (() => new Date()),
     });
     if (usesEmbeddedRedDb(path)) {
-      await ensureReddbBinaryFromWarmCache();
+      ensureReddbBinary();
       // The SDK creates the .rdb file but not its parent directory; the store now
       // lives in the state tier (.red/state), which may not exist yet.
       await mkdir(dirname(path), { recursive: true });

--- a/apps/rsp/src/reddb-binary.ts
+++ b/apps/rsp/src/reddb-binary.ts
@@ -1,0 +1,176 @@
+/**
+ * reddb-binary.ts — where the `red` engine binary is, resolved from a BUNDLE.
+ *
+ * The SDK locates its own binary at `<sdk package>/bin/red`, derived from the
+ * SDK module's `import.meta.url`. That is correct while the SDK is a package on
+ * disk and WRONG the moment esbuild inlines it: the compiled file's URL is the
+ * bundle's, so `<package root>` becomes the bundle's parent directory and the
+ * probe lands on `<repo>/bin/red`, a path that has never existed (#4196). The
+ * bundled resident therefore could not open its store on any machine where
+ * neither `REDDB_BIN` nor the warm cache was populated.
+ *
+ * The fix is to stop deriving the package from the compiled file and to LOOK the
+ * package up at runtime instead, walking the `node_modules` trees above the
+ * running module and the cwd. `createRequire(...).resolve()` cannot do that job
+ * here: the SDK's `exports` map declares only `"."` with an `import` condition,
+ * so a CJS resolver is refused (`ERR_PACKAGE_PATH_NOT_EXPORTED`) and `bin/red`
+ * is not an exported subpath under any condition. The walk below is the same
+ * lookup Node itself performs, run for a path the `exports` map hides.
+ *
+ * The order is explicit-before-inferred, and the test pins it:
+ *
+ *   1. `REDDB_BIN` — the canonical operator override. Returned verbatim, never
+ *      probed: an override that points at nothing must surface the SDK's own
+ *      "binary not found" error, not be silently replaced by a guess.
+ *   2. The SDK package's `bin/red` — what the unbundled SDK would have found,
+ *      located by package lookup rather than by compiled-file arithmetic.
+ *   3. The red-skills warm cache, newest version first — where the launcher
+ *      drops the binary for a bundle that ships without a `node_modules`.
+ *   4. `red` on `PATH` — the last resort. The SDK refuses PATH outright because
+ *      the wire coupling between SDK and engine is tight, and that refusal is
+ *      right for a FIRST choice; as a fourth one the alternative is not a safer
+ *      binary, it is no store at all. A provisioned machine has the engine on
+ *      PATH, and rsp's contract is to fail open, so a version-mismatched engine
+ *      degrades the command it fronts instead of killing every command.
+ */
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Which step of the cascade produced the path — carried for diagnosis, never for logic. */
+export type ReddbBinarySource = "env" | "sdk-package" | "warm-cache" | "path";
+
+export interface ResolvedReddbBinary {
+  path: string;
+  source: ReddbBinarySource;
+}
+
+/** Injected environment. Every field defaults to this process, so a test can pose as another host. */
+export interface ReddbBinaryLookup {
+  env?: NodeJS.ProcessEnv;
+  /** Directory of the running module — the bundle's own directory in a bundled host. */
+  fromDir?: string;
+  cwd?: string;
+  platform?: NodeJS.Platform;
+  home?: string;
+  exists?: (path: string) => boolean;
+  listDir?: (path: string) => string[];
+}
+
+const SDK_PACKAGE_SEGMENTS = ["@reddb-io", "sdk"] as const;
+/** pnpm's hoist directory: the fallback lookup dir Node never walks to on its own. */
+const PNPM_HOIST_SEGMENTS = [".pnpm", "node_modules"] as const;
+
+export function reddbBinaryFileName(platform: NodeJS.Platform = process.platform): string {
+  return platform === "win32" ? "red.exe" : "red";
+}
+
+/**
+ * Resolve the engine binary, or `null` when no step of the cascade answers.
+ *
+ * `null` is a legal answer: the caller leaves `REDDB_BIN` unset and the SDK
+ * raises its own actionable error, which names the override and the repair.
+ */
+export function resolveReddbBinary(lookup: ReddbBinaryLookup = {}): ResolvedReddbBinary | null {
+  const env = lookup.env ?? process.env;
+  const exists = lookup.exists ?? existsSync;
+  const listDir = lookup.listDir ?? listDirSafe;
+  const platform = lookup.platform ?? process.platform;
+  const name = reddbBinaryFileName(platform);
+
+  const override = env.REDDB_BIN;
+  if (typeof override === "string" && override !== "") return { path: override, source: "env" };
+
+  const fromDir = lookup.fromDir ?? moduleDir();
+  const cwd = lookup.cwd ?? process.cwd();
+  for (const candidate of sdkPackageBinaries(fromDir, cwd, name)) {
+    if (exists(candidate)) return { path: candidate, source: "sdk-package" };
+  }
+
+  for (const candidate of warmCacheBinaries(env, lookup.home ?? homedir(), name, listDir)) {
+    if (exists(candidate)) return { path: candidate, source: "warm-cache" };
+  }
+
+  for (const candidate of pathBinaries(env, name)) {
+    if (exists(candidate)) return { path: candidate, source: "path" };
+  }
+
+  return null;
+}
+
+/**
+ * Publish the resolved binary as `REDDB_BIN` so the SDK's own lookup finds it.
+ *
+ * A caller that already set the override keeps it: step 1 of the cascade returns
+ * it unchanged, so the assignment is a no-op rather than a re-derivation.
+ */
+export function ensureReddbBinary(lookup: ReddbBinaryLookup = {}): ResolvedReddbBinary | null {
+  const env = lookup.env ?? process.env;
+  const resolved = resolveReddbBinary({ ...lookup, env });
+  if (resolved) env.REDDB_BIN = resolved.path;
+  return resolved;
+}
+
+/** `<node_modules>/@reddb-io/sdk/bin/red` for every `node_modules` above the two starting points. */
+function* sdkPackageBinaries(fromDir: string, cwd: string, name: string): Generator<string> {
+  const seen = new Set<string>();
+  for (const start of [fromDir, cwd]) {
+    for (const nodeModules of nodeModulesChain(start)) {
+      for (const root of [nodeModules, join(nodeModules, ...PNPM_HOIST_SEGMENTS)]) {
+        const candidate = join(root, ...SDK_PACKAGE_SEGMENTS, "bin", name);
+        if (seen.has(candidate)) continue;
+        seen.add(candidate);
+        yield candidate;
+      }
+    }
+  }
+}
+
+function* nodeModulesChain(start: string): Generator<string> {
+  let dir = start;
+  for (;;) {
+    yield join(dir, "node_modules");
+    const parent = dirname(dir);
+    if (parent === dir) return;
+    dir = parent;
+  }
+}
+
+/**
+ * Cached engine binaries, newest version first.
+ *
+ * An unset `RED_SKILLS_CACHE_DIR` means the standard cache location, not "no
+ * cache" — the same default cascade the launcher fetch uses.
+ */
+function* warmCacheBinaries(
+  env: NodeJS.ProcessEnv,
+  home: string,
+  name: string,
+  listDir: (path: string) => string[],
+): Generator<string> {
+  const cacheDir = env.RED_SKILLS_CACHE_DIR
+    ?? (env.XDG_CACHE_HOME
+      ? join(env.XDG_CACHE_HOME, "red-skills", "bundles")
+      : join(home, ".cache", "red-skills", "bundles"));
+  const root = join(cacheDir, "reddb");
+  for (const version of listDir(root).sort().reverse()) yield join(root, version, name);
+}
+
+function* pathBinaries(env: NodeJS.ProcessEnv, name: string): Generator<string> {
+  for (const dir of (env.PATH ?? "").split(delimiter)) {
+    if (dir !== "") yield join(dir, name);
+  }
+}
+
+function moduleDir(): string {
+  return dirname(fileURLToPath(import.meta.url));
+}
+
+function listDirSafe(path: string): string[] {
+  try {
+    return readdirSync(path);
+  } catch {
+    return [];
+  }
+}

--- a/apps/rsp/tests/reddb-binary.test.ts
+++ b/apps/rsp/tests/reddb-binary.test.ts
@@ -1,0 +1,99 @@
+// #4196: the bundled resident could not find the `red` engine binary.
+//
+// esbuild inlines `@reddb-io/sdk`, so the SDK's own `<package>/bin/red` probe —
+// derived from its module URL — resolved against the BUNDLE's directory and
+// landed on `<repo>/bin/red`. These specs pin the replacement cascade in both
+// directions: which step answers, and that an earlier step always wins.
+import { describe, expect, it } from "vitest";
+import { reddbBinaryFileName, resolveReddbBinary, type ReddbBinaryLookup } from "../src/reddb-binary.js";
+
+const REPO = "/repo";
+const BUNDLE_DIR = `${REPO}/dist`;
+const SDK_BIN = `${REPO}/node_modules/@reddb-io/sdk/bin/red`;
+const PNPM_SDK_BIN = `${REPO}/node_modules/.pnpm/node_modules/@reddb-io/sdk/bin/red`;
+const CACHE = "/cache/red-skills/bundles";
+const PATH_BIN = "/usr/local/bin/red";
+
+function lookup(present: string[], env: NodeJS.ProcessEnv = {}, over: Partial<ReddbBinaryLookup> = {}): ReddbBinaryLookup {
+  const set = new Set(present);
+  return {
+    env: { PATH: "/usr/local/bin:/usr/bin", RED_SKILLS_CACHE_DIR: CACHE, ...env },
+    fromDir: BUNDLE_DIR,
+    cwd: "/somewhere/else",
+    platform: "linux",
+    home: "/home/nobody",
+    exists: (path) => set.has(path),
+    listDir: (path) => path === `${CACHE}/reddb` ? ["1.20.0", "1.23.2", "1.9.0"] : [],
+    ...over,
+  };
+}
+
+describe("reddb binary resolution (#4196)", () => {
+  it("takes REDDB_BIN verbatim, without probing it", () => {
+    // An override that points at nothing must reach the SDK so its own
+    // "binary not found" error names the bad path — never a silent substitute.
+    const resolved = resolveReddbBinary(lookup([SDK_BIN, PATH_BIN], { REDDB_BIN: "/opt/handpicked/red" }));
+    expect(resolved).toEqual({ path: "/opt/handpicked/red", source: "env" });
+  });
+
+  it("ignores an empty REDDB_BIN and continues down the cascade", () => {
+    const resolved = resolveReddbBinary(lookup([SDK_BIN], { REDDB_BIN: "" }));
+    expect(resolved).toEqual({ path: SDK_BIN, source: "sdk-package" });
+  });
+
+  it("finds the SDK package from a bundle that sits above the node_modules tree", () => {
+    // The regression: `fromDir` is the bundle's dir, not the SDK package's.
+    const resolved = resolveReddbBinary(lookup([SDK_BIN]));
+    expect(resolved).toEqual({ path: SDK_BIN, source: "sdk-package" });
+  });
+
+  it("finds the SDK package in the pnpm hoist directory Node never walks to", () => {
+    const resolved = resolveReddbBinary(lookup([PNPM_SDK_BIN]));
+    expect(resolved).toEqual({ path: PNPM_SDK_BIN, source: "sdk-package" });
+  });
+
+  it("falls to the warm cache, newest version first, when no package is installed", () => {
+    const resolved = resolveReddbBinary(lookup([`${CACHE}/reddb/1.20.0/red`, `${CACHE}/reddb/1.23.2/red`]));
+    expect(resolved).toEqual({ path: `${CACHE}/reddb/1.23.2/red`, source: "warm-cache" });
+  });
+
+  it("defaults an unset RED_SKILLS_CACHE_DIR to the standard cache, not to 'no cache'", () => {
+    const home = "/home/nobody";
+    const cached = `${home}/.cache/red-skills/bundles/reddb/1.23.2/red`;
+    const resolved = resolveReddbBinary(lookup([cached], { RED_SKILLS_CACHE_DIR: undefined }, {
+      listDir: (path) => path === `${home}/.cache/red-skills/bundles/reddb` ? ["1.23.2"] : [],
+    }));
+    expect(resolved).toEqual({ path: cached, source: "warm-cache" });
+  });
+
+  it("probes PATH only as the last resort", () => {
+    const resolved = resolveReddbBinary(lookup([PATH_BIN]));
+    expect(resolved).toEqual({ path: PATH_BIN, source: "path" });
+  });
+
+  it("orders the whole cascade env > sdk-package > warm-cache > path", () => {
+    const everything = [SDK_BIN, PNPM_SDK_BIN, `${CACHE}/reddb/1.23.2/red`, PATH_BIN];
+    const order: Array<[string[], NodeJS.ProcessEnv, unknown]> = [
+      [everything, { REDDB_BIN: "/opt/handpicked/red" }, { path: "/opt/handpicked/red", source: "env" }],
+      [everything, {}, { path: SDK_BIN, source: "sdk-package" }],
+      [everything.slice(2), {}, { path: `${CACHE}/reddb/1.23.2/red`, source: "warm-cache" }],
+      [everything.slice(3), {}, { path: PATH_BIN, source: "path" }],
+    ];
+    for (const [present, env, expected] of order) {
+      expect(resolveReddbBinary(lookup(present, env)), JSON.stringify(expected)).toEqual(expected);
+    }
+  });
+
+  it("answers null when no step of the cascade finds a binary", () => {
+    // Legal: the caller leaves REDDB_BIN unset and the SDK raises its own
+    // actionable error rather than rsp guessing a path that does not exist.
+    expect(resolveReddbBinary(lookup([]))).toBeNull();
+  });
+
+  it("asks for red.exe on Windows", () => {
+    expect(reddbBinaryFileName("win32")).toBe("red.exe");
+    expect(reddbBinaryFileName("linux")).toBe("red");
+    const win = `${REPO}/node_modules/@reddb-io/sdk/bin/red.exe`;
+    expect(resolveReddbBinary(lookup([win], {}, { platform: "win32" }))).toEqual({ path: win, source: "sdk-package" });
+  });
+});


### PR DESCRIPTION
Fixes #4196.

## Root cause

`@reddb-io/sdk` locates its engine binary at `<package root>/bin/red`, where `<package root>` is derived from the SDK module's own `import.meta.url`. That is correct while the SDK is a package on disk and wrong the moment esbuild inlines it into the rsp bundle: the compiled file's URL is the bundle's, so `<package root>` collapsed to the bundle's parent directory and the probe landed on `<repo>/bin/red` — a path that has never existed.

rsp's only remaining fallback (`ensureReddbBinaryFromWarmCache`) read the red-skills warm cache, which nothing in the tree populates. So on any machine without `REDDB_BIN` set, the bundled resident could not open its store at all, and `tests/telemetry-resident.test.ts` was red — 5 of 9 failing with:

```
rsp resident store failed to open: reddb: binary "red" not found.
  expected at: <repo>/bin/red
```

## Fix

Stop deriving the SDK package from the compiled file; look it up at runtime instead. The new `apps/rsp/src/reddb-binary.ts` walks the `node_modules` trees above the running module and the cwd — including pnpm's hoist directory, which Node never walks to on its own — and states the whole cascade in one ordered, injectable place:

1. **`REDDB_BIN`** — verbatim and unprobed, so a bad override still surfaces the SDK's own actionable error instead of a silent substitute.
2. **The SDK package's `bin/red`** — what the unbundled SDK would have found, located by package lookup rather than compiled-file arithmetic.
3. **The red-skills warm cache**, newest version first — the prior behaviour, preserved.
4. **`red` on `PATH`** — last resort. The SDK's blanket refusal of PATH is right for a *first* choice; as a *fourth* one the alternative is not a safer binary, it is no store at all, and rsp fails open by contract.

`createRequire(...).resolve()` cannot do step 2 here: the SDK's `exports` map declares only `"."` with an `import` condition, so a CJS resolver is refused with `ERR_PACKAGE_PATH_NOT_EXPORTED`, and `bin/red` is not an exported subpath under any condition. The walk is the same lookup Node performs, run for a path the `exports` map hides. That reasoning is written into the module doc so the next reader does not "simplify" it back to `require.resolve`.

`tests/reddb-binary.test.ts` (10 specs) pins the order in both directions: which step answers, and that an earlier step always wins.

## Validation

| Check | Result |
| --- | --- |
| `pnpm typecheck` | 17/17 packages pass |
| `pnpm -C apps/plugin-dev test:invariants` | 29 files, 343 tests pass |
| `apps/rsp` default suite (`vitest run`) | 34 files, 492 tests pass |
| `apps/rsp` integration suite | 15 files, 249 pass / 2 skipped |
| `oxlint apps/rsp` | clean |

The reproduction, before and after, with `REDDB_BIN` unset and `RED_SKILLS_CACHE_DIR` pointed at an empty directory:

- **before** — `tests/telemetry-resident.test.ts`: 5 failed, 4 passed
- **after** — 9/9 passed

Confirmed the bundle resolves through step 2 (not the PATH last resort) in this repo: `resolveReddbBinary({ fromDir: "<repo>/dist" })` returns `<repo>/node_modules/.pnpm/node_modules/@reddb-io/sdk/bin/red` with `source: "sdk-package"`, so any machine that has run `pnpm install` is covered without needing `red` on PATH.

Not addressed here (companion change named in the issue): excluding `@reddb-io/rsp` from the root `test` aggregate to match the #3878 CI posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789885228&installation_model_id=20659&pr_number=4234&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4234&signature=8d476e9ece7aedb42d1a876862bee34400c5c719d5dd2fca35d9a63899e64a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->