### PR TITLE
feat(dev): the verdicts TOONL lane, four-way registered (#4131)

### DIFF
--- a/.changeset/verdicts-lane-four-way-registered.md
+++ b/.changeset/verdicts-lane-four-way-registered.md
@@ -1,0 +1,18 @@
+---
+"@reddb-io/dev": patch
+"@reddb-io/shared": patch
+---
+
+The verdict ledger of ADR 0154 gets its own TOONL lane. A merge authorization
+cannot live in `validation.jsonl` — that sidecar is rewritten on every write,
+names no PR and no SHA, and dies with the workspace — so `verdicts` is a new
+append-only lane in the durable Castle state tier, owned by
+`core/verdict-ledger.ts`. Rows are keyed `(pr, head_sha, patch_id)`, carry a
+`verifier_identity` (`<runner>:<model>`, or `human:<login>`) and one of the five
+closed verdicts, and cite CI as evidence rather than as authorization.
+Superseding a standing verdict appends a `voided` row; nothing is ever edited or
+removed, because a ledger a writer can rewrite is a ledger an auditor cannot
+trust. The lane lands with all four registrations a new TOONL lane owes — the
+retention registry entry, a writer that reads that entry at append time, the
+writer-enforcement declaration, and the census — plus its place among the
+declared durable members of `.red/state/castle`. No consumer is wired yet.

--- a/apps/plugin-dev/src/core/lane-retention-guard.ts
+++ b/apps/plugin-dev/src/core/lane-retention-guard.ts
@@ -92,6 +92,11 @@ export const LANE_WRITER_ENFORCEMENT: readonly LaneWriterEnforcement[] = [
     why: "a Worker's TOONL narration is line-bounded at the quiescent point, after its file logger has closed",
   },
   {
+    lane: "verdicts",
+    writers: ["apps/plugin-dev/src/core/verdict-ledger.ts"],
+    why: "the append-only merge authorization is byte-bounded as each verifier appends its row, so an audit trail cannot outgrow the durable state tier",
+  },
+  {
     lane: "worker-liveness",
     writers: [
       "packages/worker/src/LivenessLane.ts",

--- a/apps/plugin-dev/src/core/operational-probes/lane-census.ts
+++ b/apps/plugin-dev/src/core/operational-probes/lane-census.ts
@@ -147,6 +147,11 @@ function staticRegistrations(projectRoot: string, hostRoot: string): LaneRegistr
       LANE_RETENTION_REGISTRY["castle-history"],
     ),
     project(
+      "verdicts",
+      join(castleStateDir(projectRoot), "verdicts.toonl"),
+      LANE_RETENTION_REGISTRY["verdicts"],
+    ),
+    project(
       "rsp-telemetry-spool",
       join(rspStateDir(projectRoot), "rsp-telemetry.spool.toonl"),
       LANE_RETENTION_REGISTRY["rsp-telemetry-spool"],

--- a/apps/plugin-dev/src/core/verdict-ledger.ts
+++ b/apps/plugin-dev/src/core/verdict-ledger.ts
@@ -1,0 +1,393 @@
+/**
+ * verdict-ledger — the durable record of who judged what, at which head.
+ *
+ * ADR 0154 makes landing conditional on a verdict written by an identity that
+ * did not implement the change, pinned to the exact head being merged. That
+ * authorization has to outlive the workspace that produced it, so it cannot be
+ * the per-command `validation.jsonl` sidecar: a gate artifact is rewritten on
+ * every write, carries no PR and no SHA, and disappears with the Worker.
+ *
+ * So the ledger is its own TOONL lane in the durable Castle state tier,
+ * `.red/state/castle/verdicts.toonl`, and it is **append-only**. A row is never
+ * edited and never removed: superseding a standing verdict means appending a
+ * `voided` row for the same key. A ledger a writer can rewrite is a ledger an
+ * auditor cannot trust, and the reader this lane exists for is the morning
+ * human asking what was judged rather than re-reading diffs.
+ *
+ * The key is `(pr, head_sha, patch_id)`. The PR alone is not enough — the head
+ * moves between gate-green and merge, which is the whole gap ADR 0154 closes —
+ * and the patch id carries the equivalence a clean rebase preserves.
+ *
+ * This lane is new and carries no ADR 0098 sidecar exemption: TOONL, period.
+ * Its ceiling lives in `LANE_RETENTION_REGISTRY["verdicts"]` rather than beside
+ * the append below, because a bound only the writer knows is one the census
+ * cannot audit (#3645).
+ */
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  LANE_RETENTION_REGISTRY,
+  laneOverCeiling,
+  trimLaneKeepLast,
+  type LaneRetentionPolicy,
+} from "@reddb-io/shared/lane-retention.js";
+import { castleStateDir } from "@reddb-io/shared/red-paths.js";
+import { encodeToonlLines, parseRecords } from "@reddb-io/toon";
+
+type ToonlRow = Record<string, string | number | boolean | null>;
+
+/** The lane's registered retention policy — one declaration, read at append. */
+const VERDICT_LANE_POLICY = LANE_RETENTION_REGISTRY["verdicts"];
+
+/** The census id and registry key for this lane. */
+export const VERDICT_LANE_ID = "verdicts";
+
+/**
+ * What a verifier can conclude. The list is closed: an outcome outside it is a
+ * judgement nobody defined, and the land precondition would have to guess.
+ *
+ * `verifier-blocked` is the fail-closed outcome — the reviewer runner was
+ * unavailable or threw — and it parks visibly rather than degrading to a silent
+ * skip. `verifier-failed` is a reviewer that ran and refused the change.
+ */
+export const VERDICT_NAMES = [
+  "live-verified",
+  "test-verified",
+  "type-check-only",
+  "verifier-blocked",
+  "verifier-failed",
+] as const;
+
+export type VerdictName = (typeof VERDICT_NAMES)[number];
+
+/** The `(pr, head_sha, patch_id)` triple every row is keyed by. */
+export interface VerdictKey {
+  readonly pr: number;
+  readonly head_sha: string;
+  readonly patch_id: string;
+}
+
+/** One appended row. Every field is present so the TOONL segment never rotates. */
+export interface VerdictRow extends VerdictKey {
+  readonly at: string;
+  readonly verdict: VerdictName;
+  /** `<runner>:<model>` for an agent verifier, or `human:<login>`. */
+  readonly verifier_identity: string;
+  /** True when this row supersedes the standing verdict for its key. */
+  readonly voided: boolean;
+  /** What the verifier cited — a CI run, a gate record. Evidence, never authorization. */
+  readonly evidence: string | null;
+  /** Why this row was written: the refusal, the block, or the reason for voiding. */
+  readonly reason: string | null;
+}
+
+export type VerdictAppendInput = VerdictKey & {
+  readonly verdict: VerdictName;
+  readonly verifier_identity: string;
+  readonly at?: string;
+  readonly voided?: boolean;
+  readonly evidence?: string | null;
+  readonly reason?: string | null;
+};
+
+/** Voiding names the verdict it supersedes, so the history stays readable. */
+export type VerdictVoidInput = VerdictKey & {
+  readonly verdict: VerdictName;
+  readonly verifier_identity: string;
+  readonly reason: string;
+  readonly at?: string;
+  readonly evidence?: string | null;
+};
+
+const VERDICT_FIELDS = [
+  "at",
+  "pr",
+  "head_sha",
+  "patch_id",
+  "verdict",
+  "verifier_identity",
+  "voided",
+  "evidence",
+  "reason",
+] as const;
+
+const HEAD_SHA_RE = /^[0-9a-f]{7,64}$/;
+
+export class VerdictLedgerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "VerdictLedgerError";
+  }
+}
+
+/** `<runner>:<model>` — the pair that makes an agent verifier distinguishable. */
+export function agentVerifierIdentity(runner: string, model: string): string {
+  if (runner.trim() === "" || model.trim() === "") {
+    throw new VerdictLedgerError("verifier identity needs both a runner and a model");
+  }
+  return `${runner.trim()}:${model.trim()}`;
+}
+
+/** `human:<login>` — a human adopting a branch verifies it under their own name. */
+export function humanVerifierIdentity(login: string): string {
+  if (login.trim() === "") {
+    throw new VerdictLedgerError("human verifier identity needs a login");
+  }
+  return `human:${login.trim()}`;
+}
+
+/** The lane file for one project checkout. PURE. */
+export function verdictLedgerPath(projectRoot: string): string {
+  return join(castleStateDir(projectRoot), `${VERDICT_LANE_ID}.toonl`);
+}
+
+/** One stable string per key, so rows can be grouped without re-comparing fields. PURE. */
+export function verdictKeyOf(key: VerdictKey): string {
+  return `${key.pr}@${key.head_sha}#${key.patch_id}`;
+}
+
+function requireText(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new VerdictLedgerError(`verdict row needs a non-empty ${field}`);
+  }
+  return value;
+}
+
+function optionalText(value: unknown, field: string): string | null {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") {
+    throw new VerdictLedgerError(`verdict row ${field} must be a string`);
+  }
+  return value;
+}
+
+function requireVerdict(value: unknown): VerdictName {
+  if (!VERDICT_NAMES.includes(value as VerdictName)) {
+    throw new VerdictLedgerError(
+      `unknown verdict ${JSON.stringify(value)}; expected one of ${VERDICT_NAMES.join(", ")}`,
+    );
+  }
+  return value as VerdictName;
+}
+
+function requirePr(value: unknown): number {
+  const pr = typeof value === "string" ? Number(value) : value;
+  if (typeof pr !== "number" || !Number.isSafeInteger(pr) || pr <= 0) {
+    throw new VerdictLedgerError("verdict row pr must be a positive integer");
+  }
+  return pr;
+}
+
+function requireHeadSha(value: unknown): string {
+  const sha = requireText(value, "head_sha");
+  if (!HEAD_SHA_RE.test(sha)) {
+    throw new VerdictLedgerError(
+      `verdict row head_sha must be a lowercase git object id, got ${JSON.stringify(sha)}`,
+    );
+  }
+  return sha;
+}
+
+/**
+ * Normalises one decoded or caller-supplied record into a complete row.
+ * Validation happens on the way IN and on the way OUT: a lane whose tail was
+ * written by an older shape must not silently authorize a merge.
+ */
+export function normalizeVerdictRow(raw: unknown): VerdictRow {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new VerdictLedgerError("verdict row must be a record");
+  }
+  const record = raw as Record<string, unknown>;
+  const voided = record.voided;
+  return {
+    at: requireText(record.at, "at"),
+    pr: requirePr(record.pr),
+    head_sha: requireHeadSha(record.head_sha),
+    patch_id: requireText(record.patch_id, "patch_id"),
+    verdict: requireVerdict(record.verdict),
+    verifier_identity: requireText(record.verifier_identity, "verifier_identity"),
+    voided: voided === true || voided === "true",
+    evidence: optionalText(record.evidence, "evidence"),
+    reason: optionalText(record.reason, "reason"),
+  };
+}
+
+function toRow(row: VerdictRow): ToonlRow {
+  const encoded: ToonlRow = {};
+  for (const field of VERDICT_FIELDS) encoded[field] = row[field];
+  return encoded;
+}
+
+function encodeRows(rows: readonly ToonlRow[]): string {
+  if (rows.length === 0) return "";
+  const writer = encodeToonlLines({ trailer: false });
+  return rows.map((row) => writer.push(row)).join("");
+}
+
+function keepLastWithin(
+  rows: readonly ToonlRow[],
+  incomingBytes: number,
+  targetBytes: number,
+): number {
+  let low = 0;
+  let high = rows.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(encodeRows(rows.slice(-middle))) + incomingBytes <= targetBytes) {
+      low = middle;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return low;
+}
+
+/**
+ * What stands for one key after every row it carries has been read.
+ *
+ * The rule is positional, not a search for the "best" row: rows are applied in
+ * append order, a verdict row sets the standing judgement, and a `voided` row
+ * clears it. Nothing is deleted — a voided key still shows every row it ever
+ * held, which is exactly what makes the ledger an audit trail rather than a
+ * cache of the current answer.
+ */
+export interface VerdictStanding {
+  readonly key: string;
+  /** The row that stands, or null when the key's last word was a void. */
+  readonly standing: VerdictRow | null;
+  /** The void that cleared the standing verdict, when one did. */
+  readonly voidedBy: VerdictRow | null;
+  /** Every row for the key, oldest first. */
+  readonly history: readonly VerdictRow[];
+}
+
+/** Fold an append-ordered row stream into one standing per key. PURE. */
+export function standingVerdicts(rows: readonly VerdictRow[]): Map<string, VerdictStanding> {
+  const byKey = new Map<string, VerdictStanding>();
+  for (const row of rows) {
+    const key = verdictKeyOf(row);
+    const current = byKey.get(key);
+    const history = [...(current?.history ?? []), row];
+    byKey.set(key, {
+      key,
+      standing: row.voided ? null : row,
+      voidedBy: row.voided ? row : null,
+      history,
+    });
+  }
+  return byKey;
+}
+
+/** The standing verdict for one key, or null when none stands. PURE. */
+export function standingVerdictFor(
+  rows: readonly VerdictRow[],
+  key: VerdictKey,
+): VerdictRow | null {
+  return standingVerdicts(rows).get(verdictKeyOf(key))?.standing ?? null;
+}
+
+export interface VerdictLedgerFs {
+  appendFile(path: string, data: string, encoding: "utf8"): Promise<unknown>;
+  mkdir(path: string, options: { recursive: true }): Promise<unknown>;
+  readFile(path: string, encoding: "utf8"): Promise<string>;
+}
+
+export interface VerdictLedgerOptions {
+  readonly fs?: VerdictLedgerFs;
+  readonly clock?: () => string;
+  /** Override the registered byte ceiling; exposed for tiny-lane tests. */
+  readonly maxBytes?: number;
+}
+
+export interface VerdictLedger {
+  readonly path: string;
+  /** Appends one row and returns exactly what was written. */
+  append(input: VerdictAppendInput): Promise<VerdictRow>;
+  /** Appends the `voided` row that supersedes a key's standing verdict. */
+  void(input: VerdictVoidInput): Promise<VerdictRow>;
+  /** Every row, oldest first. A missing lane reads as no rows, never an error. */
+  read(): Promise<VerdictRow[]>;
+  /** The standing verdict for one key after the whole lane is folded. */
+  standing(key: VerdictKey): Promise<VerdictRow | null>;
+}
+
+/**
+ * Opens the ledger for one project checkout. Nothing is created until the first
+ * append: a checkout that has never landed has no verdicts, and an empty file
+ * would claim otherwise.
+ */
+export function createVerdictLedger(
+  projectRoot: string,
+  options: VerdictLedgerOptions = {},
+): VerdictLedger {
+  const fs = options.fs ?? { appendFile, mkdir, readFile };
+  const clock = options.clock ?? (() => new Date().toISOString());
+  const path = verdictLedgerPath(projectRoot);
+  const policy: LaneRetentionPolicy = {
+    ...VERDICT_LANE_POLICY,
+    ...(options.maxBytes === undefined ? {} : { maxBytes: options.maxBytes }),
+  };
+
+  const appendRow = async (row: VerdictRow): Promise<VerdictRow> => {
+    const encoded = encodeToonlLines().push(toRow(row));
+    const incomingBytes = Buffer.byteLength(encoded);
+    await fs.mkdir(dirname(path), { recursive: true });
+    if (await laneOverCeiling(path, incomingBytes, policy)) {
+      const ceiling = policy.maxBytes!;
+      if (incomingBytes > ceiling) {
+        throw new VerdictLedgerError(`verdict row exceeds its ${ceiling}-byte lane ceiling`);
+      }
+      const existing = parseRecords(await fs.readFile(path, "utf8")) as ToonlRow[];
+      const targetBytes = Math.max(
+        incomingBytes,
+        Math.floor(ceiling * VERDICT_LANE_POLICY.targetRatio),
+      );
+      await trimLaneKeepLast(path, keepLastWithin(existing, incomingBytes, targetBytes));
+    }
+    await fs.appendFile(path, encoded, "utf8");
+    return row;
+  };
+
+  const readRows = async (): Promise<VerdictRow[]> => {
+    let text: string;
+    try {
+      text = await fs.readFile(path, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+    return parseRecords(text).map(normalizeVerdictRow);
+  };
+
+  return {
+    path,
+
+    // `async` deliberately: a malformed row must REJECT, never throw past an
+    // awaiting caller's try/catch on the synchronous side of the call.
+    async append(input) {
+      return appendRow(normalizeVerdictRow({
+        ...input,
+        at: input.at ?? clock(),
+        voided: input.voided ?? false,
+        evidence: input.evidence ?? null,
+        reason: input.reason ?? null,
+      }));
+    },
+
+    async void(input) {
+      return appendRow(normalizeVerdictRow({
+        ...input,
+        at: input.at ?? clock(),
+        voided: true,
+        evidence: input.evidence ?? null,
+        reason: requireText(input.reason, "reason"),
+      }));
+    },
+
+    read: readRows,
+
+    async standing(key) {
+      return standingVerdictFor(await readRows(), key);
+    },
+  };
+}

--- a/apps/plugin-dev/tests/verdict-ledger.test.ts
+++ b/apps/plugin-dev/tests/verdict-ledger.test.ts
@@ -1,0 +1,267 @@
+/**
+ * The verdict ledger is an append-only history, not a store of the current
+ * answer (ADR 0154). These tests pin the two halves that make it an audit
+ * trail: a void SUPERSEDES the standing verdict, and it does so without
+ * removing or editing a single earlier row.
+ */
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { LANE_RETENTION_REGISTRY } from "@reddb-io/shared/lane-retention.js";
+import { CASTLE_STATE_MEMBERS } from "@reddb-io/shared/red-paths.js";
+import {
+  agentVerifierIdentity,
+  createVerdictLedger,
+  humanVerifierIdentity,
+  standingVerdicts,
+  VERDICT_LANE_ID,
+  VERDICT_NAMES,
+  VerdictLedgerError,
+  verdictKeyOf,
+  verdictLedgerPath,
+  type VerdictLedger,
+} from "../src/core/verdict-ledger.js";
+import { laneCensusLaneIds } from "../src/core/operational-probes/lane-census.js";
+
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
+const PATCH = "9".repeat(40);
+const REVIEWER = agentVerifierIdentity("codex", "gpt-5");
+
+const roots: string[] = [];
+
+async function ledger(): Promise<VerdictLedger> {
+  const root = await mkdtemp(join(tmpdir(), "verdict-ledger-"));
+  roots.push(root);
+  let tick = 0;
+  return createVerdictLedger(root, {
+    clock: () => new Date(Date.UTC(2026, 7, 21, 0, 0, tick++)).toISOString(),
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("verdict ledger round trip", () => {
+  it("appends, reads back, and stands the row it wrote", async () => {
+    const lane = await ledger();
+    const written = await lane.append({
+      pr: 4131,
+      head_sha: HEAD_A,
+      patch_id: PATCH,
+      verdict: "test-verified",
+      verifier_identity: REVIEWER,
+      evidence: "ci-run:1234",
+    });
+
+    expect(written).toMatchObject({
+      pr: 4131,
+      head_sha: HEAD_A,
+      verdict: "test-verified",
+      verifier_identity: REVIEWER,
+      voided: false,
+      evidence: "ci-run:1234",
+      reason: null,
+    });
+    await expect(lane.read()).resolves.toEqual([written]);
+    await expect(lane.standing({ pr: 4131, head_sha: HEAD_A, patch_id: PATCH }))
+      .resolves.toEqual(written);
+  });
+
+  it("reads a lane that was never written as no verdicts", async () => {
+    await expect((await ledger()).read()).resolves.toEqual([]);
+  });
+
+  it("supersedes by appending a voided row, never by mutating history", async () => {
+    const lane = await ledger();
+    const key = { pr: 4131, head_sha: HEAD_A, patch_id: PATCH };
+    const passed = await lane.append({ ...key, verdict: "test-verified", verifier_identity: REVIEWER });
+    const beforeVoid = await readFile(lane.path, "utf8");
+
+    const voided = await lane.void({
+      ...key,
+      verdict: "test-verified",
+      verifier_identity: REVIEWER,
+      reason: "head moved after validation",
+    });
+
+    const after = await readFile(lane.path, "utf8");
+    // The earlier bytes are a PREFIX of the later ones: nothing was rewritten.
+    expect(after.startsWith(beforeVoid)).toBe(true);
+    expect(voided.voided).toBe(true);
+
+    const rows = await lane.read();
+    expect(rows).toEqual([passed, voided]);
+    await expect(lane.standing(key)).resolves.toBeNull();
+
+    const standing = standingVerdicts(rows).get(verdictKeyOf(key));
+    expect(standing?.standing).toBeNull();
+    expect(standing?.voidedBy?.reason).toBe("head moved after validation");
+    expect(standing?.history).toEqual([passed, voided]);
+  });
+
+  it("keys by head, so voiding one head leaves another head standing", async () => {
+    const lane = await ledger();
+    const stale = { pr: 4131, head_sha: HEAD_A, patch_id: PATCH };
+    const fresh = { pr: 4131, head_sha: HEAD_B, patch_id: PATCH };
+    await lane.append({ ...stale, verdict: "test-verified", verifier_identity: REVIEWER });
+    const reviewed = await lane.append({
+      ...fresh,
+      verdict: "live-verified",
+      verifier_identity: humanVerifierIdentity("filipeforattini"),
+    });
+    await lane.void({
+      ...stale,
+      verdict: "test-verified",
+      verifier_identity: REVIEWER,
+      reason: "superseded by the re-review at the fresh head",
+    });
+
+    await expect(lane.standing(stale)).resolves.toBeNull();
+    await expect(lane.standing(fresh)).resolves.toEqual(reviewed);
+    expect(reviewed.verifier_identity).toBe("human:filipeforattini");
+    expect((await lane.read()).length).toBe(3);
+  });
+
+  it("re-verification after a void stands again without erasing the void", async () => {
+    const lane = await ledger();
+    const key = { pr: 4131, head_sha: HEAD_A, patch_id: PATCH };
+    await lane.append({ ...key, verdict: "verifier-failed", verifier_identity: REVIEWER });
+    await lane.void({
+      ...key,
+      verdict: "verifier-failed",
+      verifier_identity: REVIEWER,
+      reason: "re-reviewed after the fix",
+    });
+    const reVerified = await lane.append({
+      ...key,
+      verdict: "test-verified",
+      verifier_identity: REVIEWER,
+    });
+
+    const rows = await lane.read();
+    expect(rows.map((row) => row.verdict)).toEqual([
+      "verifier-failed",
+      "verifier-failed",
+      "test-verified",
+    ]);
+    expect(rows.map((row) => row.voided)).toEqual([false, true, false]);
+    await expect(lane.standing(key)).resolves.toEqual(reVerified);
+  });
+});
+
+describe("verdict ledger refusals", () => {
+  it("refuses a verdict outside the closed enum", async () => {
+    const lane = await ledger();
+    await expect(lane.append({
+      pr: 1,
+      head_sha: HEAD_A,
+      patch_id: PATCH,
+      verdict: "looks-fine" as never,
+      verifier_identity: REVIEWER,
+    })).rejects.toThrow(VerdictLedgerError);
+  });
+
+  it("refuses a head that is not a git object id", async () => {
+    const lane = await ledger();
+    await expect(lane.append({
+      pr: 1,
+      head_sha: "HEAD",
+      patch_id: PATCH,
+      verdict: "test-verified",
+      verifier_identity: REVIEWER,
+    })).rejects.toThrow(/head_sha/);
+  });
+
+  it("refuses a row with no verifier identity", async () => {
+    const lane = await ledger();
+    await expect(lane.append({
+      pr: 1,
+      head_sha: HEAD_A,
+      patch_id: PATCH,
+      verdict: "test-verified",
+      verifier_identity: "  ",
+    })).rejects.toThrow(/verifier_identity/);
+  });
+
+  it("refuses a void with no reason, because an unexplained void is a mutation", async () => {
+    const lane = await ledger();
+    await expect(lane.void({
+      pr: 1,
+      head_sha: HEAD_A,
+      patch_id: PATCH,
+      verdict: "test-verified",
+      verifier_identity: REVIEWER,
+      reason: "",
+    })).rejects.toThrow(/reason/);
+  });
+
+  it("names both halves of an agent identity", () => {
+    expect(agentVerifierIdentity("claude", "opus")).toBe("claude:opus");
+    expect(() => agentVerifierIdentity("claude", " ")).toThrow(VerdictLedgerError);
+    expect(() => humanVerifierIdentity("")).toThrow(VerdictLedgerError);
+  });
+});
+
+describe("verdict lane registration", () => {
+  it("writes TOONL into the durable castle state tier", async () => {
+    const lane = await ledger();
+    expect(lane.path.endsWith(join(".red", "state", "castle", "verdicts.toonl"))).toBe(true);
+    expect(verdictLedgerPath("/project")).toBe(
+      join("/project", ".red", "state", "castle", "verdicts.toonl"),
+    );
+
+    await lane.append({
+      pr: 4131,
+      head_sha: HEAD_A,
+      patch_id: PATCH,
+      verdict: "test-verified",
+      verifier_identity: REVIEWER,
+    });
+    const text = await readFile(lane.path, "utf8");
+    expect(text.split("\n")[0]).toMatch(
+      /^\[\d*\]\{at,pr,head_sha,patch_id,verdict,verifier_identity,voided,evidence,reason\}:$/,
+    );
+    expect(text.trimStart().startsWith("{")).toBe(false);
+  });
+
+  it("is registered, censused, and bounded by its registry entry", () => {
+    expect(Object.keys(LANE_RETENTION_REGISTRY)).toContain(VERDICT_LANE_ID);
+    expect(LANE_RETENTION_REGISTRY[VERDICT_LANE_ID].maxBytes).toBeGreaterThan(0);
+    expect(laneCensusLaneIds()).toContain(VERDICT_LANE_ID);
+    expect(Object.keys(CASTLE_STATE_MEMBERS)).toContain("verdicts.toonl");
+  });
+
+  it("trims to the registered ceiling instead of growing past it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "verdict-ledger-ceiling-"));
+    roots.push(root);
+    const lane = createVerdictLedger(root, { maxBytes: 900 });
+    for (let index = 0; index < 40; index += 1) {
+      await lane.append({
+        pr: 4131,
+        head_sha: HEAD_A,
+        patch_id: PATCH,
+        verdict: "test-verified",
+        verifier_identity: REVIEWER,
+        reason: `pass ${index}`,
+      });
+    }
+    const text = await readFile(lane.path, "utf8");
+    expect(Buffer.byteLength(text)).toBeLessThanOrEqual(900);
+    const rows = await lane.read();
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.at(-1)?.reason).toBe("pass 39");
+  });
+
+  it("closes the verdict vocabulary at exactly the five ADR 0154 outcomes", () => {
+    expect([...VERDICT_NAMES]).toEqual([
+      "live-verified",
+      "test-verified",
+      "type-check-only",
+      "verifier-blocked",
+      "verifier-failed",
+    ]);
+  });
+});

--- a/packages/shared/lane-retention.ts
+++ b/packages/shared/lane-retention.ts
@@ -108,6 +108,13 @@ export const LANE_RETENTION_REGISTRY = {
     maxLines: 10_000,
     targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
   },
+  "verdicts": {
+    // ADR 0154's merge authorization: one row per judged head, so the lane is
+    // low-rate and worth keeping long. Bounded by BYTES because a merge can be
+    // blocked on this append, and a byte ceiling costs one stat.
+    maxBytes: 4 * MIB,
+    targetRatio: DEFAULT_LANE_RETENTION_TARGET_RATIO,
+  },
 } as const satisfies Readonly<Record<string, RegisteredLaneRetentionPolicy>>;
 
 export type LaneRetentionPolicyName = keyof typeof LANE_RETENTION_REGISTRY;

--- a/packages/shared/red-paths.ts
+++ b/packages/shared/red-paths.ts
@@ -178,6 +178,7 @@ export function castleStateDir(root: string): string {
 export const CASTLE_STATE_MEMBERS: Readonly<Record<string, string>> = {
   "history.toonl": "the engine's durable event history",
   "validation.toonl": "the durable gate-verdict record",
+  "verdicts.toonl": "ADR 0154's append-only verdict ledger; it authorizes every merge",
   "phase-durations.toonl": "measured per-phase cost; every ETA is derived from it",
   "singleton-events.toonl": "the ordered resident event lane supervisors, waits and views all read",
   "heal-ledger.toon": "the per-issue 24h heal budget; it bounds repeated healing across time",


### PR DESCRIPTION
Fixes #4131

## What

The verdict ledger of ADR 0154 — a new TOONL lane `verdicts` in the durable Castle state tier (`.red/state/castle/verdicts.toonl`), owned by `apps/plugin-dev/src/core/verdict-ledger.ts`. This slice is the lane, its module, and its registrations. **No consumer is wired**: the review stage, the land precondition, and the entry points that will read this lane are later slices of Spec #4129.

## Why a lane and not the gate sidecar

A merge authorization has to outlive the workspace that produced it. `validation.jsonl` is a per-command gate artifact — rewritten on every write, naming no PR and no SHA, gone with the Worker — so it can attest that commands passed, never that an independent identity judged *this head*.

## Shape

- Rows are keyed `(pr, head_sha, patch_id)`. The PR alone is not a key: the head moves between gate-green and merge, which is the whole gap ADR 0154 closes, and the patch id carries the equivalence a clean rebase preserves.
- Each row names a `verifier_identity` — `<runner>:<model>` for an agent, `human:<login>` for a maintainer adopting a branch — and one of the five closed verdicts: `live-verified | test-verified | type-check-only | verifier-blocked | verifier-failed`. A row may cite a CI run as `evidence`; the run authorizes nothing.
- **Supersession appends a `voided` row.** Nothing is edited and nothing is removed, because a ledger a writer can rewrite is a ledger an auditor cannot trust. The standing verdict is a fold over rows in append order: a verdict row sets the standing judgement, a `voided` row clears it, and a voided key still shows every row it ever held.
- Malformed rows are refused on the way IN *and* on the way OUT — a lane whose tail was written by an older shape must not silently authorize a merge.

## The four registrations

A new TOONL lane owes four or the lane-retention ratchet fails the whole gate:

1. **Retention registry** — `"verdicts"` in `LANE_RETENTION_REGISTRY` (`packages/shared/lane-retention.ts`), byte-bounded at 4 MiB. Bytes rather than lines because a merge can be blocked on this append and a byte ceiling costs one stat.
2. **A writer that reads that entry at append time** — `verdict-ledger.ts` reads `LANE_RETENTION_REGISTRY["verdicts"]`, never a private constant the census cannot audit.
3. **`LANE_WRITER_ENFORCEMENT`** — the lane paired with its writer and the reason it is bounded.
4. **The lane census** — a project-tier registration in `lane-census.ts`, so an operator can observe the policy holding and the lane never appears as `unregisteredToonl`.

A fifth touch was needed and is deliberate: `CASTLE_STATE_MEMBERS` in `packages/shared/red-paths.ts`. A durable file absent from that list reads as dirt to the castle-state doctor.

## Validation

- `apps/plugin-dev/tests/verdict-ledger.test.ts` — 14 tests: append/read/void round trip, void supersedes without mutating history (asserted byte-wise: the pre-void file is a **prefix** of the post-void file), re-verification after a void, per-head keying, the six refusals, TOONL header shape, and trimming to the registered ceiling.
- `pnpm -C apps/plugin-dev exec vitest run tests/lane-retention-guard.test.ts tests/lane-census.test.ts tests/toon-json-guard.test.ts tests/castle-engine-toon-uniformity.test.ts tests/file-size-guard.test.ts` — 37 passed.
- `pnpm -C apps/plugin-dev test:invariants` — 29 files, 343 passed.
- `pnpm typecheck` (root) — 17/17 successful.
- `pnpm exec oxlint --import-plugin` on the changed files — clean.
- `packages/shared/lane-retention.test.ts` and `apps/plugin-dev/tests/castle-state-doctor.test.ts` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789885875&installation_model_id=20659&pr_number=4238&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4238&signature=14db9dcd74709fba6b3e3bcdeb52850d3599eb57d44bd6211c6cf677b22c2d6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->