### PR TITLE
The Attention audit runs at drain end and daily_review consumes it

### DIFF
--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -197,6 +197,7 @@ export function demandTurnForBirth(
           base: base!,
           handoff: withOrders,
           worker_id: workerId,
+          ...(runner == null ? {} : { runner }),
           ...(registration.validation_commands == null || registration.validation_commands.length === 0
             ? {}
             : { validation_commands: [...registration.validation_commands] }),

--- a/apps/redskilled/tests/demand-turn.test.ts
+++ b/apps/redskilled/tests/demand-turn.test.ts
@@ -209,7 +209,12 @@ describe("the birth briefs its Worker with a Ticket", () => {
   const birth = { workspace_path: "/tmp/w", index: 0, work_item: "4118" };
 
   it("states the handoff the Worker's Ticket loop is entered through", () => {
-    const turn = demandTurnForBirth(registration, birth, "W7", briefing);
+    const turn = demandTurnForBirth(
+      { ...registration, argv: ["redskilled", "acp-worker", "--child-agent", "codex"] },
+      birth,
+      "W7",
+      briefing,
+    );
 
     expect(turn?.ticket).toEqual({
       number: 4118,
@@ -219,6 +224,7 @@ describe("the birth briefs its Worker with a Ticket", () => {
       // The prompt IS the briefing: one sentence, with the daemon's fact in it.
       handoff: "Work issue #4118 to a merged PR",
       worker_id: "W7",
+      runner: "codex",
     });
   });
 


### PR DESCRIPTION
Refs #4171

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:f5a971e8-9147-46b9-94ab-b7d554e3eb3d:land:eb2e5c2ce9b086d269703d4639de1ea3a3bc197f -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789886092&installation_model_id=20659&pr_number=4240&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4240&signature=b1c5b040c9311a41dd9f61c36917ccf8b660e29ca9d145061073e6c2683db74b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->