### PR TITLE
fix(redskilled): the demand brief carries the Ticket's own words

### DIFF
--- a/.changeset/brief-carries-ticket-body.md
+++ b/.changeset/brief-carries-ticket-body.md
@@ -1,0 +1,12 @@
+---
+"@reddb-io/redskilled": patch
+"@reddb-io/dev": patch
+---
+
+The demand brief carries the Ticket's own words. The unattended posture
+forbids the inner agent GitHub access, and the brief named only number, title
+and labels — so the agent implemented blind, and the first autonomous landed
+shipped a guess. The daemon now reads the Ticket body through the Project
+gateway and appends it (bounded, cut stated) to the prompt and the handoff;
+the drain prompt also states the repo's changeset rule, which the first
+autonomous PR died on.

--- a/apps/plugin-dev/src/core/drain-registration.ts
+++ b/apps/plugin-dev/src/core/drain-registration.ts
@@ -91,6 +91,10 @@ export const DRAIN_WORKER_PROMPT =
   "You are already standing in your own dedicated worktree on the Ticket's base branch: work and " +
   "commit right here, and never create another worktree — the repository's worktree lanes govern " +
   "interactive sessions, not Workers. " +
+  // The repo's scope gate refuses a PR that changes apps/ or packages/ without
+  // a changeset, and the first autonomous PR died exactly there (#4243).
+  "If your change touches apps/ or packages/, also write a .changeset/<slug>.md entry naming each " +
+  "touched package by its package.json name with a patch bump, and commit it with the change. " +
   "When the change is committed, say <promise>DONE</promise>. If the work is genuinely blocked, " +
   "say what blocks it and <promise>BLOCKED</promise>.";
 

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -28,6 +28,7 @@ import type {
 import { randomBytes } from "node:crypto";
 
 import { parkGateBlockedTurn } from "./demand-park.js";
+import { readProjectTicketBody } from "./acp-github.js";
 import { admitNativeAcpWorker } from "./acp-worker-admission.js";
 import { ACP_AGENT_IDS, type AcpAgentId } from "@reddb-io/protocol-acp";
 import { expandLaunchTemplate } from "./launch-template.js";
@@ -49,6 +50,8 @@ export interface DemandTurnDeps {
   readonly startWorker: (spec: RedskilledWorkerSpec) => LaunchedWorker;
   readonly hostState: () => { readonly workers: readonly { readonly worker_id: string }[] };
   readonly sessionJournal: AcpSessionJournal;
+  /** Test seam over the Ticket-body read; production reads the gateway. */
+  readonly ticketBody?: (project: AcpProjectWorkspace, issue: number) => Promise<string | null>;
   readonly githubGateway?: RedskilledGithubGatewayRegistration;
   readonly evidenceRoot?: string;
   readonly evidenceTtlMs?: number;
@@ -222,6 +225,18 @@ export function runnerFromLaunchArgv(argv: readonly string[] | undefined): AcpAg
     : null;
 }
 
+/**
+ * The Ticket's own words, appended to the brief the inner agent works from.
+ *
+ * Bounded, because a brief is a prompt and a 60KB issue would drown it: the
+ * cut is stated out loud so the agent knows there is more it cannot see. PURE.
+ */
+export function ticketBodyBrief(issue: number, title: string, body: string): string {
+  const cap = 6_000;
+  const trimmed = body.length > cap ? `${body.slice(0, cap)}\n\n[… Ticket body truncated at ${cap} characters]` : body;
+  return `## Ticket #${issue}${title === "" ? "" : `: ${title}`}\n\n${trimmed}`;
+}
+
 /** What one admission needs, whoever performs it. */
 export interface DemandTurnAdmission {
   readonly project: AcpProjectWorkspace;
@@ -370,6 +385,8 @@ export function createDemandTurnRunner(
   // same idempotency scope — a publish that "succeeded" without pushing, and a
   // land that 422'd on a head no push had created.
   const runnerNonce = randomBytes(4).toString("hex");
+  const readTicketBody = deps.ticketBody
+    ?? ((project: AcpProjectWorkspace, issue: number) => readProjectTicketBody(deps.githubGateway, project, issue));
   const admit = deps.admit ?? ((input: DemandTurnAdmission) => admitNativeAcpWorker(
     {
       paths: deps.paths,
@@ -425,18 +442,38 @@ export function createDemandTurnRunner(
       // durable RedSkills ACP session", which is a birth nobody can explain
       // from the outside (observed on 4.0.2, issue #4118's first drain).
       await deps.sessionJournal.create(sessionId, request.project);
+      // #4243: the unattended posture forbids the inner agent GitHub access,
+      // so the daemon reads the Ticket's body and writes it into the brief —
+      // number+title alone made the agent implement blind.
+      let briefedPrompt = request.prompt;
+      let briefedTicket = request.ticket;
+      const ticketNumber = briefedTicket?.number;
+      if (briefedTicket != null && typeof ticketNumber === "number") {
+        const body = await readTicketBody(request.project, ticketNumber);
+        if (body != null) {
+          const brief = ticketBodyBrief(
+            ticketNumber,
+            typeof briefedTicket.title === "string" ? briefedTicket.title : "",
+            body,
+          );
+          briefedPrompt = `${briefedPrompt}\n\n${brief}`;
+          briefedTicket = typeof briefedTicket.handoff === "string"
+            ? { ...briefedTicket, handoff: `${briefedTicket.handoff}\n\n${brief}` }
+            : briefedTicket;
+        }
+      }
       const { worker, response } = await requestWorkflowTurn(
         sessionId,
         active,
         {
           sessionId,
-          prompt: [{ type: "text", text: request.prompt }],
+          prompt: [{ type: "text", text: briefedPrompt }],
           _meta: {
             redskills: {
               unattended: true,
               ...(request.workItem == null ? {} : { workItem: request.workItem }),
               ...(request.runner == null ? {} : { runner: request.runner }),
-              ...(request.ticket == null ? {} : { ticket: request.ticket }),
+              ...(briefedTicket == null ? {} : { ticket: briefedTicket }),
             },
           },
         },

--- a/apps/redskilled/src/acp-github.ts
+++ b/apps/redskilled/src/acp-github.ts
@@ -153,6 +153,30 @@ async function servedByProjectReader<T>(
   }
 }
 
+/**
+ * One Ticket's body, read through the Project gateway for the demand brief.
+ *
+ * The unattended posture forbids the inner agent GitHub access (#4227), so a
+ * brief that named only number+title made the agent implement blind — the
+ * first autonomous landed shipped a guess (#4243). The daemon holds the
+ * credential; it reads the body and hands it over. `null` on any failure:
+ * a brief without a body is degraded, never fatal.
+ */
+export async function readProjectTicketBody(
+  gateway: RedskilledGithubGatewayRegistration | undefined,
+  project: AcpProjectWorkspace,
+  issue: number,
+): Promise<string | null> {
+  try {
+    const answer = await servedByProjectReader(gateway, project, undefined, (reader) =>
+      reader.read({ kind: "rest", path: `repos/${project.projectLabel}/issues/${issue}` }));
+    const body = (answer as { value?: { body?: unknown } } | null)?.value?.body;
+    return typeof body === "string" && body.trim() !== "" ? body : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Bind one ACP connection's Project authority to the daemon-owned gateway. */
 export function bindAcpProjectGithubRead(
   gateway: RedskilledGithubGatewayRegistration | undefined,

--- a/apps/redskilled/tests/demand-turn.test.ts
+++ b/apps/redskilled/tests/demand-turn.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createDemandTurnRunner,
+  ticketBodyBrief,
   demandTurnForBirth,
   describeTurnOutcome,
   queueBriefing,
@@ -44,12 +45,14 @@ function runner(
   admit: (input: DemandTurnAdmission) => Promise<ActiveWorkflowWorker>,
   records: DemandTurnRecord[] = [],
   opened: Array<{ sessionId: string }> = [],
+  ticketBody?: (project: unknown, issue: number) => Promise<string | null>,
 ) {
   return {
     records,
     opened,
     run: createDemandTurnRunner({
       paths: {} as never,
+      ...(ticketBody == null ? {} : { ticketBody: ticketBody as never }),
       startWorker: (() => {
         throw new Error("an injected admission owns the birth in this test");
       }) as never,
@@ -173,6 +176,50 @@ describe("the daemon's unattended turn", () => {
       _meta: { redskills: { permissionResolution: "unattended-refused", reason: DEMAND_TURN_PERMISSION_REFUSAL } },
     });
     expect(DEMAND_TURN_PERMISSION_REFUSAL).toMatch(/hitl/i);
+  });
+});
+
+describe("the brief carries the Ticket's own words (#4243)", () => {
+  const ticket = {
+    number: 4171,
+    title: "The Attention audit",
+    labels: ["ready-for-agent"],
+    base: "main",
+    handoff: "Implement issue #4171",
+    worker_id: "W7",
+  };
+
+  it("appends the body the daemon read to the prompt and the handoff", async () => {
+    const worker = workerStub({ stopReason: "end_turn" });
+    const { run } = runner(async () => worker, [], [], async (_project, issue) =>
+      issue === 4171 ? "The audit runs at drain end." : null);
+
+    await run({ project, prompt: "Implement issue #4171", workItem: "4171", ticket });
+
+    const sent = worker.prompted.mock.calls[0]?.[1] as {
+      prompt: { text: string }[];
+      _meta: { redskills: { ticket: { handoff: string } } };
+    };
+    expect(sent.prompt[0]!.text).toContain("## Ticket #4171: The Attention audit");
+    expect(sent.prompt[0]!.text).toContain("The audit runs at drain end.");
+    expect(sent._meta.redskills.ticket.handoff).toContain("The audit runs at drain end.");
+  });
+
+  it("a body the gateway cannot serve degrades the brief, never the turn", async () => {
+    const worker = workerStub({ stopReason: "end_turn" });
+    const { run } = runner(async () => worker, [], [], async () => null);
+
+    const result = await run({ project, prompt: "Implement issue #4171", workItem: "4171", ticket });
+
+    expect(result.workerId).toBe("W1");
+    const sent = worker.prompted.mock.calls[0]?.[1] as { prompt: { text: string }[] };
+    expect(sent.prompt[0]!.text).toBe("Implement issue #4171");
+  });
+
+  it("states the cut when a Ticket body exceeds the brief's bound", () => {
+    const brief = ticketBodyBrief(9, "t", "x".repeat(7_000));
+    expect(brief).toContain("truncated at 6000 characters");
+    expect(brief.length).toBeLessThan(6_300);
   });
 });
 

--- a/apps/worker-container/src/registration.mjs
+++ b/apps/worker-container/src/registration.mjs
@@ -41,6 +41,8 @@ export const CONTAINER_WORKER_PROMPT =
   "You are already standing in your own dedicated worktree on the Ticket's base branch: work and " +
   "commit right here, and never create another worktree — the repository's worktree lanes govern " +
   "interactive sessions, not Workers. " +
+  "If your change touches apps/ or packages/, also write a .changeset/<slug>.md entry naming each " +
+  "touched package by its package.json name with a patch bump, and commit it with the change. " +
   "When the change is committed, say <promise>DONE</promise>. If the work is genuinely blocked, " +
   "say what blocks it and <promise>BLOCKED</promise>.";
 


### PR DESCRIPTION
The first autonomous landed (PR #4240 on #4171) shipped a change unrelated to its Ticket: the unattended posture forbids the inner agent GitHub access (#4227, by design), and the brief named only number+title+labels — the agent implemented blind.

- `readProjectTicketBody` (acp-github): the daemon reads the issue body through the Project gateway; `null` on any failure — a brief without a body is degraded, never fatal.
- The unattended turn appends the body — bounded at 6000 chars, cut stated — to the prompt AND the Ticket handoff via one pure composer (`ticketBodyBrief`), pinned by tests (enriched round-trip, degraded path, truncation).
- `DRAIN_WORKER_PROMPT` states the changeset rule the first autonomous PR died on (scope gate).

Fixes #4243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789886760&installation_model_id=20659&pr_number=4244&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4244&signature=506ed91a2c4bbff184ea766cd5246a7437dafb5e8aa3673c2ef5dd56ca611bcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->