### PR TITLE
fix(#4241): the Worker body owns its child Agent's process group

### DIFF
--- a/.changeset/worker-owns-its-child-agents-lifetime.md
+++ b/.changeset/worker-owns-its-child-agents-lifetime.md
@@ -1,0 +1,8 @@
+---
+"@reddb-io/worker": patch
+"@reddb-io/redskilled": patch
+---
+
+The Worker body kills the child Agent it spawned, and the process the child spawned.
+
+Every dead codex Worker on 4.1.15/4.1.16 left its `codex-acp` pair alive — the `npx` wrapper and the platform binary under it — re-parented onto the systemd user manager, six pairs in one evening, each still holding an authenticated session (#4241). The kill the body already had aimed at the pid it held, and the pid it held was the wrapper: the grandchild survived it and outlived the transient unit. The child Agent is now spawned `detached`, so it leads a process group of its own, and `child-reaper.ts` owns that group's lifetime — a confirming SIGTERM→SIGKILL group reap on teardown, replacement and failed admission, plus a synchronous group SIGKILL at the process edge, where `SIGTERM` and `exit` have no turn of the event loop left to await one. `WorkflowChildAgent.close` is awaited rather than fired, because a teardown that only asked returns before the child has left.

--- a/apps/redskilled/src/acp-body-control-cut.ts
+++ b/apps/redskilled/src/acp-body-control-cut.ts
@@ -72,6 +72,11 @@ export const WORKER_BODY_MODULES: readonly WorkerBodyModule[] = [
     runs: "spawns, prompts, steers and reaps the one governed child coding Agent",
   },
   {
+    module: "child-reaper.ts",
+    defines: ["reapChildProcessTree", "installChildAgentReaper"],
+    runs: "owns the lifetime of every child Agent process the body spawned — signals the process GROUP on teardown and again at the process edge, so no coding Agent outlives its Worker (#4241)",
+  },
+  {
     module: "child-spin.ts",
     formerDaemonModule: "acp-child-spin.ts",
     defines: ["createChildAcpSpinEpisode"],
@@ -102,6 +107,11 @@ export const WORKER_BODY_MODULES: readonly WorkerBodyModule[] = [
     module: "ticket-loop.ts",
     defines: ["runTicketLoop"],
     runs: "drives one Ticket from claim to land inside the turn: claim, implement, gate, re-seed in place, publish, land",
+  },
+  {
+    module: "gate-lock.ts",
+    defines: ["acquireHostGateLock"],
+    runs: "holds the host-wide slot that keeps two Workers from running Validation at the same time (#4161)",
   },
   {
     module: "local-gate.ts",

--- a/packages/worker/src/acp/child-agent.ts
+++ b/packages/worker/src/acp/child-agent.ts
@@ -20,6 +20,12 @@ import {
 } from "@reddb-io/protocol-acp";
 import { _credentialFreeEnvWithHome } from "@reddb-io/shared/credential-free-env.js";
 import type { SpinPattern } from "../engine/spin-evaluator.js";
+import {
+  forgetChildAgentProcess,
+  installChildAgentReaper,
+  reapChildProcessTree,
+  registerChildAgentProcess,
+} from "./child-reaper.js";
 import { createChildAcpSpinEpisode, type ChildAcpSpinEpisode } from "./child-spin.js";
 import { createWorkerTerminalHost, type WorkerTerminalHost } from "./terminal-host.js";
 import type { WorkerTerminalDenial } from "./terminal-policy.js";
@@ -55,6 +61,14 @@ export class WorkflowChildAgent {
   #active: ActiveChildAgent | undefined;
   #spinEpisode: ChildAcpSpinEpisode | undefined;
   #spinUpdates: Promise<void> = Promise.resolve();
+  /**
+   * Every reap this Agent started, so `close` can wait for all of them.
+   *
+   * A replacement reaps its predecessor from inside a turn, where there is
+   * nothing to await it — chaining the reaps here is what makes the Worker's
+   * own teardown able to promise that no child of its is left running.
+   */
+  #reaps: Promise<void> = Promise.resolve();
 
   constructor(options: ChildAgentSessionOptions) {
     this.#options = options;
@@ -130,9 +144,17 @@ export class WorkflowChildAgent {
     });
   }
 
-  close(): void {
+  /**
+   * Give up every process this Agent holds, and CONFIRM the child is gone.
+   *
+   * Awaited rather than fired: the Worker body calls this on its way out, and a
+   * teardown that only asked would return before the child had left — which is
+   * precisely how six `codex-acp` pairs outlived their Workers (#4241).
+   */
+  async close(): Promise<void> {
     this.#terminals.closeAll();
     if (this.#active != null) this.#cleanup(this.#active);
+    await this.#reaps;
   }
 
   async #admit(event: "child-admission" | "child-replacement"): Promise<ActiveChildAgent> {
@@ -140,11 +162,24 @@ export class WorkflowChildAgent {
     // The process that runs the model receives no credential (ADR 0144 §3).
     // The daemon already stripped them from the Worker's own environment; this
     // strips them again rather than trusting a hop it cannot see.
+    //
+    // `detached` buys a process GROUP, not independence: the endpoint command is
+    // usually `npx`, which spawns the real Agent binary as its own child, and a
+    // kill aimed at the pid we hold would leave that grandchild running and
+    // re-parented onto the user manager (#4241). Its own group makes the whole
+    // subtree one signal away, and `child-reaper.ts` owns sending it.
     const child = spawn(endpoint.command, endpoint.args, {
       cwd: this.#options.cwd,
       env: _credentialFreeEnvWithHome(process.env),
       stdio: ["pipe", "pipe", "ignore"],
+      detached: true,
     });
+    if (child.pid != null) {
+      installChildAgentReaper();
+      registerChildAgentProcess(child.pid);
+      const pid = child.pid;
+      child.once("exit", () => forgetChildAgentProcess(pid));
+    }
     if (child.stdin == null || child.stdout == null) throw new Error("child ACP Agent did not expose stdio");
 
     const app = client({ name: "RedSkills Workflow Worker" })
@@ -202,7 +237,7 @@ export class WorkflowChildAgent {
       return active;
     } catch (error) {
       connection.close();
-      child.kill();
+      this.#reap(child);
       throw error;
     }
   }
@@ -226,7 +261,18 @@ export class WorkflowChildAgent {
     active.cleaned = true;
     if (this.#active === active) this.#active = undefined;
     active.connection.close();
-    if (active.child.exitCode == null && active.child.signalCode == null) active.child.kill();
+    this.#reap(active.child);
+  }
+
+  /**
+   * Queue one child's group kill behind the reaps already running.
+   *
+   * Synchronous callers — a replacement mid-turn, an admission that threw — get
+   * the kill STARTED; `close` is where somebody finally waits for it.
+   */
+  #reap(child: ChildProcess): void {
+    const reap = () => reapChildProcessTree(child).then(() => undefined);
+    this.#reaps = this.#reaps.then(reap, reap);
   }
 
   /** Tell the parent what the policy refused, so the Worker log holds the lesson. */

--- a/packages/worker/src/acp/child-reaper.test.ts
+++ b/packages/worker/src/acp/child-reaper.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The child Agent dies with its Worker — and so does the process IT spawned.
+ *
+ * Issue #4241: every dead codex Worker left a live `codex-acp` pair behind, the
+ * `npx` wrapper and the platform binary under it, re-parented onto the systemd
+ * user manager. The bug was never visible in a unit test of the kill call,
+ * because the pid the Worker held was not the process that survived. So the
+ * fixture here is a WRAPPER: it spawns a grandchild that sleeps forever, and
+ * the assertion is about the grandchild.
+ */
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { AgentConnection } from "@agentclientprotocol/sdk";
+import { isLivePid } from "@reddb-io/shared/kill-tree.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { WorkflowChildAgent } from "./child-agent.js";
+import {
+  forgetChildAgentProcess,
+  liveChildAgentProcesses,
+  reapChildAgentProcesses,
+  registerChildAgentProcess,
+} from "./child-reaper.js";
+
+const orphanFixture = resolve(__dirname, "fixtures", "orphan-child.mjs");
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+/** A pid stops answering `kill -0` within `deadlineMs`, or the wait says so. */
+async function goneWithin(pid: number, deadlineMs = 5_000): Promise<boolean> {
+  const until = Date.now() + deadlineMs;
+  while (Date.now() < until) {
+    if (!isLivePid(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return !isLivePid(pid);
+}
+
+const silentParent = {
+  notify: async () => undefined,
+  request: async () => ({}),
+} as unknown as AgentConnection["client"];
+
+describe("a Worker closing its child Agent (#4241)", () => {
+  it("kills the child AND the process the child spawned", async () => {
+    const root = await mkdtemp(join(tmpdir(), "worker-orphan-reap-"));
+    roots.push(root);
+    const pidFile = join(root, "pids.json");
+    const child = new WorkflowChildAgent({
+      endpoint: {
+        agent: "redcode",
+        transport: "stdio",
+        command: process.execPath,
+        args: [orphanFixture, pidFile],
+      },
+      cwd: root,
+      mcpServers: [],
+      publicSessionId: "public-session",
+      parent: silentParent,
+    });
+
+    const response = await child.prompt({
+      sessionId: "public-session",
+      prompt: [{ type: "text", text: "delegate" }],
+    });
+    expect(response.stopReason).toBe("end_turn");
+
+    const pids = JSON.parse(await readFile(pidFile, "utf8")) as {
+      child: number;
+      grandchild: number;
+    };
+    // The premise: both are running, and the grandchild is a process the Worker
+    // never saw. A test that skipped this would pass on a fixture that died on
+    // its own.
+    expect(isLivePid(pids.child), "the child Agent never started").toBe(true);
+    expect(isLivePid(pids.grandchild), "the fixture spawned no grandchild").toBe(true);
+
+    await child.close();
+
+    expect(await goneWithin(pids.child), `child ${pids.child} outlived close()`).toBe(true);
+    expect(
+      await goneWithin(pids.grandchild),
+      `grandchild ${pids.grandchild} outlived close() — the orphan #4241 is about`,
+    ).toBe(true);
+    expect(liveChildAgentProcesses()).not.toContain(pids.child);
+  }, 30_000);
+});
+
+describe("the reap the process edge performs (#4241)", () => {
+  it("signals every registered group synchronously, which is all an exit hook may do", async () => {
+    // The same act `process.on("exit")` performs, proved without ending this
+    // process: a detached leader with a child of its own, one synchronous
+    // signal, both gone.
+    const leader = spawn(
+      process.execPath,
+      [
+        "-e",
+        "require('node:child_process').spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{stdio:'ignore'});setInterval(()=>{},1000)",
+      ],
+      { detached: true, stdio: "ignore" },
+    );
+    const pid = leader.pid;
+    expect(pid).toBeTypeOf("number");
+    registerChildAgentProcess(pid!);
+
+    try {
+      expect(liveChildAgentProcesses()).toContain(pid);
+      expect(reapChildAgentProcesses("SIGKILL")).toBeGreaterThanOrEqual(1);
+      expect(await goneWithin(pid!)).toBe(true);
+    } finally {
+      forgetChildAgentProcess(pid!);
+    }
+  }, 20_000);
+});

--- a/packages/worker/src/acp/child-reaper.ts
+++ b/packages/worker/src/acp/child-reaper.ts
@@ -1,0 +1,149 @@
+/**
+ * The lifetime of every child Agent process this Worker body spawned.
+ *
+ * **A coding Agent that outlives its Worker is an orphan holding a session.**
+ * On 4.1.15 every dead codex Worker left its `codex-acp` pair alive — the `npx`
+ * wrapper AND the platform binary it had spawned — re-parented onto the systemd
+ * user manager, six pairs in one evening, each still holding an authenticated
+ * session and its idle memory (#4241). Two layers should have caught it and
+ * neither did, so this is the one that OWNS it: the body spawned the process,
+ * and the body kills it.
+ *
+ * Two facts decide the shape:
+ *
+ * 1. **The child is a wrapper, so the pid is not the process.** `npx` execs a
+ *    launcher that spawns the real binary as its own child; killing the pid we
+ *    hold leaves the grandchild running and re-parented. So the child is spawned
+ *    `detached`, which gives it a process group of its own, and every signal
+ *    goes to the GROUP (`-pid`) — one signal reaches the whole subtree without
+ *    walking `/proc`, and the group id is a number we already have.
+ * 2. **The last exit path cannot await anything.** A `SIGTERM` from the daemon
+ *    and a plain process exit both end the loop; `process.on("exit")` may only
+ *    do synchronous work. So the registry below is synchronous by construction:
+ *    the graceful, confirming kill is `reapChildProcessTree`, and what runs at
+ *    the edge of the process is one unconfirmed group `SIGKILL` per survivor.
+ *
+ * Spawning detached has one cost, taken deliberately: the child no longer shares
+ * the Worker's process group, so a group-wide `SIGINT` from a terminal no longer
+ * reaches it incidentally. That incidental reach is exactly what was failing —
+ * it never covered the re-parented grandchild — and it is replaced here by a
+ * kill this module performs on purpose.
+ */
+import type { ChildProcess } from "node:child_process";
+import { killTreeAndWait, signalTree } from "@reddb-io/shared/kill-tree.js";
+
+/**
+ * How long a child Agent has to honour `SIGTERM` before the group is killed.
+ *
+ * The `killTreeAndWait` defaults already spell this grace — 20 polls of 100ms —
+ * and it is named here so the number a reader is looking for is in the module
+ * that owns the promise rather than in the killer's argument defaults.
+ */
+export const CHILD_AGENT_KILL_GRACE_MS = 2_000;
+
+/** Every child Agent process group this body still believes is alive. */
+const liveChildAgents = new Set<number>();
+
+let reaperInstalled = false;
+
+/** Signals whose default disposition would end the process without an `exit`. */
+const TERMINAL_SIGNALS: readonly NodeJS.Signals[] = ["SIGTERM", "SIGINT", "SIGHUP"];
+
+/** Conventional shell exit status for a process ended by a signal. */
+const SIGNAL_EXIT_CODES: Readonly<Record<string, number>> = {
+  SIGHUP: 129,
+  SIGINT: 130,
+  SIGTERM: 143,
+};
+
+/** Start owning `pid`'s group: the exit paths below will kill it if nothing else does. */
+export function registerChildAgentProcess(pid: number): void {
+  liveChildAgents.add(pid);
+}
+
+/** Stop owning `pid`'s group — it exited, or its reap already confirmed it gone. */
+export function forgetChildAgentProcess(pid: number): void {
+  liveChildAgents.delete(pid);
+}
+
+/** The child Agent process groups still owned. Reading order is registration order. */
+export function liveChildAgentProcesses(): readonly number[] {
+  return [...liveChildAgents];
+}
+
+/**
+ * Signal every owned group, synchronously, and say how many were reached.
+ *
+ * This is the body of the `exit` hook, which is why it confirms nothing: at
+ * that point there is no turn of the event loop left to confirm in. It is
+ * exported so the same act is testable without ending the test process.
+ */
+export function reapChildAgentProcesses(signal: NodeJS.Signals): number {
+  const pids = [...liveChildAgents];
+  for (const pid of pids) signalTree(pid, signal);
+  return pids.length;
+}
+
+/**
+ * Kill one child Agent's whole process group and CONFIRM it is gone.
+ *
+ * `killTreeAndWait` is the repo's one wait-and-escalate killer: SIGTERM the
+ * group, poll for a graceful exit through the grace above, escalate to SIGKILL,
+ * and confirm. A child that was already reaped costs one `kill -0`.
+ */
+export async function reapChildProcessTree(child: ChildProcess): Promise<boolean> {
+  const pid = child.pid;
+  if (pid == null) return true;
+  try {
+    return await killTreeAndWait(pid);
+  } finally {
+    forgetChildAgentProcess(pid);
+  }
+}
+
+/**
+ * Install the process-edge reaper once, on the first child Agent spawned.
+ *
+ * Lazy on purpose: a Worker body that never delegates installs no handler, and
+ * a handler that exists without a child would suppress the daemon's `SIGTERM`
+ * for nothing. Installing on the first spawn means the suppression and the
+ * reason for it arrive together.
+ */
+export function installChildAgentReaper(): void {
+  if (reaperInstalled) return;
+  reaperInstalled = true;
+  process.on("exit", onProcessExit);
+  for (const signal of TERMINAL_SIGNALS) process.once(signal, onTerminalSignal);
+}
+
+/** The last thing this process does: no survivor leaves with the exit code. */
+function onProcessExit(): void {
+  reapChildAgentProcesses("SIGKILL");
+}
+
+/**
+ * A terminal signal reached the Worker: pass it on, then stop waiting.
+ *
+ * Installing a listener suppresses the default disposition, so this owes the
+ * process an exit. It asks the group to leave first, then hands control to the
+ * escalation below — which force-exits whether or not the child obliged.
+ */
+function onTerminalSignal(signal: NodeJS.Signals): void {
+  reapChildAgentProcesses("SIGTERM");
+  scheduleChildAgentEscalation(signal);
+}
+
+/**
+ * End the process once the grace has passed, killing whatever is still there.
+ *
+ * Unreferenced: a Worker that finishes shutting down sooner exits sooner, and
+ * the `exit` hook kills the same survivors on the way out. The timer is what
+ * bounds the case where nothing else ends the loop.
+ */
+function scheduleChildAgentEscalation(signal: NodeJS.Signals): void {
+  const timer = setTimeout(() => {
+    reapChildAgentProcesses("SIGKILL");
+    process.exit(SIGNAL_EXIT_CODES[signal] ?? 1);
+  }, CHILD_AGENT_KILL_GRACE_MS);
+  timer.unref();
+}

--- a/packages/worker/src/acp/fixtures/orphan-child.mjs
+++ b/packages/worker/src/acp/fixtures/orphan-child.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// A stub child coding Agent shaped like the one that leaked: a WRAPPER.
+//
+// The real endpoint is `npx`, which spawns the platform Agent binary as its own
+// child, so the pid the Worker holds is never the process holding the session.
+// This fixture reproduces that shape with nothing but node: it spawns a
+// grandchild that sleeps forever, writes BOTH pids to the file named in argv so
+// the test can watch them, and only then serves ACP.
+//
+// Writing the pids before the connection is what makes the test race-free: the
+// Worker's own handshake cannot complete until this process is already past the
+// spawn, so a test that got an answer has a pid file on disk.
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { Readable, Writable } from "node:stream";
+import { agent, methods, ndJsonStream } from "@agentclientprotocol/sdk";
+
+const pidFile = process.argv[2];
+
+// Nothing to reap here on purpose: this fixture must NOT tidy up after itself,
+// because the orphan it leaves is exactly what the Worker is supposed to kill.
+const grandchild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+  stdio: "ignore",
+});
+grandchild.unref();
+
+writeFileSync(pidFile, JSON.stringify({ child: process.pid, grandchild: grandchild.pid }));
+
+const app = agent({ name: "orphan child fixture" })
+  .onRequest(methods.agent.initialize, () => ({
+    protocolVersion: 1,
+    agentCapabilities: { promptCapabilities: {} },
+    agentInfo: { name: "orphan child fixture", version: "1" },
+  }))
+  .onRequest(methods.agent.session.new, () => ({ sessionId: "orphan-child" }))
+  .onRequest(methods.agent.session.prompt, () => ({
+    stopReason: "end_turn",
+    _meta: { stub: { child: process.pid, grandchild: grandchild.pid } },
+  }));
+
+app.connect(ndJsonStream(
+  Writable.toWeb(process.stdout),
+  Readable.toWeb(process.stdin),
+));

--- a/packages/worker/src/acp/native-worker.ts
+++ b/packages/worker/src/acp/native-worker.ts
@@ -370,7 +370,10 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
   const socket = await connectWithDeadline(socketPath, 10_000);
   const connection = app.connect(socketStream(socket));
   await connection.closed;
-  for (const session of sessions.values()) session.child?.close();
+  // The transport is gone, and the child coding Agent is not: it is a process
+  // this body spawned, and this is the last moment anything in the process can
+  // wait for it to LEAVE. Awaited rather than fired (#4241).
+  await Promise.all([...sessions.values()].map((session) => session.child?.close()));
   return 0;
 }
 

--- a/packages/worker/src/acp/worker-terminal-and-publish.test.ts
+++ b/packages/worker/src/acp/worker-terminal-and-publish.test.ts
@@ -104,7 +104,7 @@ describe("a child Agent asking the Worker for terminals", () => {
       expect(ordinary?.exitCode).toBe(0);
       expect(ordinary?.output).toBe("terminal-ok");
     } finally {
-      child.close();
+      await child.close();
     }
 
     // The refusal is not only the child's problem: the parent is told what the


### PR DESCRIPTION
Fixes #4241

## The leak

Every dead codex Worker on 4.1.15/4.1.16 left its `codex-acp` pair alive — the `npx` wrapper AND the platform binary under it — re-parented onto the systemd user manager, ages 2h30+. Six pairs accumulated in one evening, each holding an authenticated ChatGPT session and idle memory.

The body already had a kill. It aimed at the pid it held, and **the pid it held was the wrapper**: `npx` execs a launcher that spawns the real Agent binary as its own child, so `child.kill()` reached the one process that was not holding the session. The grandchild survived it, survived the transient unit, and was re-parented.

## Chosen approach: process group, not a `/proc` walk

The child Agent is now spawned `detached: true`, which gives it a process group of its own (`pgid == pid`), and every teardown signal goes to the **group** (`-pid`).

Why the group over walking children:

- **One signal reaches the whole subtree**, including a great-grandchild nobody enumerated. A `/proc` walk is a race against a subtree that is still spawning, and it is the only part of this that would not be portable to a fixture.
- **The group id is a number we already have.** Nothing new has to be discovered, stored, or kept in sync with a process that is exiting.
- **`packages/shared/kill-tree.ts` already does exactly this**, group-first with a leader fallback, wait-and-escalate, and confirm — and it is already declared in `DECLARED_WAITS`, so reusing it adds no wait to declare.
- **It is the least invasive change that is testable**: one spawn option and one owner module, no supervisor, no reaper daemon, no new state on disk.

The one cost, taken deliberately: a detached child no longer shares the Worker's process group, so a terminal's group-wide `SIGINT` no longer reaches it incidentally. That incidental reach is what was failing — it never covered the re-parented grandchild — and it is replaced by a kill this code performs on purpose.

## What was added

`packages/worker/src/acp/child-reaper.ts` owns the lifetime of every child Agent process the body spawned:

- **Teardown, replacement, failed admission** → `reapChildProcessTree`: `killTreeAndWait` on the group — SIGTERM, 2s grace, SIGKILL, confirm.
- **The process edge** → a `process.on("exit")` hook and `SIGTERM`/`SIGINT`/`SIGHUP` listeners. `exit` has no turn of the event loop left, so what runs there is one synchronous group `SIGKILL` per survivor. Installing a signal listener suppresses the default disposition, so the handler owes the process an exit and takes it after the same 2s grace, unref'd so a Worker that finishes sooner exits sooner.
- The reaper installs **lazily, on the first child spawned** — a body that never delegates suppresses no signal.

`WorkflowChildAgent.close` became `async` and `runNativeAcpWorker` awaits it. A teardown that only *asked* returned before the child had left, which is the whole failure.

Daemon-side defence in depth was left out: the required fix is body-side ownership, and a reaper sweep would need a stray-attribution rule that is its own decision.

## Proof

`packages/worker/src/acp/child-reaper.test.ts`, against a fixture shaped like the leak (`fixtures/orphan-child.mjs`): an ACP agent that spawns a grandchild sleeping forever and writes both pids to a file, then serves the wire. The test asserts both are live, calls `close()`, and asserts both are gone.

Red-first, with `child-agent.ts` reverted to its `main` content:

```
AssertionError: grandchild 1974732 outlived close() — the orphan #4241 is about
```

A second test performs the exact act the `exit` hook performs — one synchronous group signal over the registry — against a real detached leader with a child of its own, without ending the test process.

## Validation

| Check | Result |
| --- | --- |
| `pnpm typecheck` (root) | 17/17 pass |
| `pnpm -C apps/plugin-dev test:invariants` | 29 files, 343 tests pass |
| `declared-wait-guard.test.ts` | 23 pass (no new wait: the escalation is one unref'd `setTimeout`, and the polling killer is already declared) |
| `acp-body-control-cut.test.ts` | 10 pass (was **red on main** — `gate-lock.ts` was undeclared; this PR declares it alongside `child-reaper.ts`) |
| `packages/worker` vitest | 1837 pass, 6 fail — `local-gate.test.ts` (4) and `validation-cone.test.ts` (2), both **red on main**, verified by stashing this branch |
| `acp-control-plane-layout` | 1 fail, `726 > 700` on the untouched `acp-control-plane.ts` — known pre-existing |

Changeset: `@reddb-io/worker` + `@reddb-io/redskilled`, patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789887081&installation_model_id=20659&pr_number=4245&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4245&signature=fd1c4785c776156edfc4c29592a69a25398ba0f4a08e067ff3357ac0acecf513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->