### PR TITLE
fix(redskilled): an absent notification binary degrades the sink, not the breaker

### DIFF
--- a/.changeset/notification-sink-degrades.md
+++ b/.changeset/notification-sink-degrades.md
@@ -1,0 +1,10 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+An absent notification binary degrades the sink instead of crash-looping it.
+On a headless host the daemon fired notify-send through the Worker birth
+pipeline for every lifecycle event; each sink Worker died on ENOENT inside a
+second, tripped the crash-loop breaker, backed off and re-armed — forever,
+each churn holding a slot against the host ceiling. The binary is probed once
+per boot; when absent the daemon says so once and never births the sink again.

--- a/apps/redskilled/src/host-event-sink.ts
+++ b/apps/redskilled/src/host-event-sink.ts
@@ -1,4 +1,6 @@
 /** Operator-scoped programs fired from the daemon's public lifecycle vocabulary. */
+import { constants, accessSync } from "node:fs";
+import { delimiter, isAbsolute, join } from "node:path";
 import type { RedskilledAdmissionVerdict } from "./admission.js";
 import {
   REDSKILLED_PUBLIC_HOST_EVENT_KINDS,
@@ -18,6 +20,8 @@ export interface RedskilledHostEventSinks {
   readonly notifications?: readonly RedskilledPublicHostEventKind[];
   /** Test seam for native notification command selection. */
   readonly platform?: NodeJS.Platform;
+  /** Test seam over the PATH probe. Production checks the real filesystem. */
+  readonly commandAvailable?: (binary: string) => boolean;
 }
 
 export interface RedskilledHostEventSinkRuntime {
@@ -74,6 +78,13 @@ export function createRedskilledHostEventSinkRuntime(options: {
   readonly refuse: (detail: string) => void;
 }): RedskilledHostEventSinkRuntime {
   const sinkWorkers = new Set<string>();
+  // #4153: a headless host has no notification binary, and firing the sink
+  // anyway put an ENOENT death through the Worker birth pipeline every few
+  // minutes forever — crash-loop breaker, backoff, re-arm, again. An optional
+  // notification degrades: probed ONCE per boot, refused out loud ONCE, and
+  // never born again on this runtime.
+  let nativeNotificationsUnavailable = false;
+  const commandAvailable = options.declaration?.commandAvailable ?? executableOnPath;
 
   function fire(template: RedskilledLaunchTemplate, state: RedskilledHostState, kind: RedskilledPublicHostEventKind): void {
     const workerId = mintHostWorkerId(options.liveWorkerIds());
@@ -115,14 +126,47 @@ export function createRedskilledHostEventSinkRuntime(options: {
       if (hook == null && !notify) return;
       const state = options.hostState();
       if (hook != null) fire(hook, state, publicKind);
-      if (notify) {
+      if (notify && !nativeNotificationsUnavailable) {
         const template = nativeNotificationTemplate(publicKind, state, options.declaration?.platform);
         if (template == null) {
           options.refuse(`operator-scoped ${publicKind} notification has no native sink on platform ${process.platform}`);
+        } else if (!commandAvailable(template.argv[0]!)) {
+          nativeNotificationsUnavailable = true;
+          options.refuse(
+            `native notifications unavailable on this host: ${template.argv[0]} is not on PATH; ` +
+              "disabling the notification sink for this boot",
+          );
         } else {
           fire(template, state, publicKind);
         }
       }
     },
   };
+}
+
+/** Whether one binary resolves on the daemon's PATH; absolute paths are trusted as-is. */
+function executableOnPath(binary: string): boolean {
+  if (isAbsolute(binary) || binary.includes("/") || binary.includes("\\")) {
+    try {
+      accessSync(binary, constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  const extensions = process.platform === "win32"
+    ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";")
+    : [""];
+  for (const directory of (process.env.PATH ?? "").split(delimiter)) {
+    if (directory === "") continue;
+    for (const extension of extensions) {
+      try {
+        accessSync(join(directory, `${binary}${extension}`), constants.X_OK);
+        return true;
+      } catch {
+        // Keep walking the PATH; a miss in one directory proves nothing.
+      }
+    }
+  }
+  return false;
 }

--- a/apps/redskilled/tests/host-event-sink.test.ts
+++ b/apps/redskilled/tests/host-event-sink.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { createRedskilledHostEventSinkRuntime } from "../src/host-event-sink.js";
+import type { RedskilledHostState, RedskilledWorkerView } from "../src/host-state.js";
+
+// #4153: an absent optional notification binary must cost one refusal line,
+// never a crash-looping birth through the breaker. This suite drives the sink
+// runtime directly, so the probe's once-per-boot memory is pinned where it
+// lives rather than inferred from daemon-level launch counts.
+
+const state: RedskilledHostState = {
+  version: 1,
+  protocol_version: 1,
+  workers: [],
+} as unknown as RedskilledHostState;
+
+const worker = { worker_id: "source", project_label: "acme/widgets" } as RedskilledWorkerView;
+
+function sinkFixture(commandAvailable: () => boolean) {
+  const refusals: string[] = [];
+  const started: string[] = [];
+  const runtime = createRedskilledHostEventSinkRuntime({
+    declaration: {
+      workspacePath: "/tmp/sink",
+      notifications: ["worker-birth"],
+      platform: "linux",
+      commandAvailable,
+    },
+    hostState: () => state,
+    liveWorkerIds: () => [],
+    admit: () => ({ admitted: true }) as never,
+    start: (spec) => {
+      started.push(spec.command);
+      return { worker_id: spec.worker_id, project_label: spec.project_label } as RedskilledWorkerView;
+    },
+    refuse: (detail) => refusals.push(detail),
+  });
+  return { runtime, refusals, started };
+}
+
+describe("the host event sink degrades without its binary (#4153)", () => {
+  it("births the notification sink when the binary resolves", () => {
+    const { runtime, started, refusals } = sinkFixture(() => true);
+    runtime.onEvent("worker-birth", worker);
+    expect(started).toEqual(["notify-send"]);
+    expect(refusals).toEqual([]);
+  });
+
+  it("refuses once, out loud, and never births the sink again on this boot", () => {
+    const { runtime, started, refusals } = sinkFixture(() => false);
+    runtime.onEvent("worker-birth", worker);
+    runtime.onEvent("worker-birth", worker);
+    runtime.onEvent("worker-birth", worker);
+    expect(started).toEqual([]);
+    expect(refusals).toHaveLength(1);
+    expect(refusals[0]).toContain("native notifications unavailable on this host");
+    expect(refusals[0]).toContain("notify-send");
+  });
+});

--- a/apps/redskilled/tests/machine-event-sink.test.ts
+++ b/apps/redskilled/tests/machine-event-sink.test.ts
@@ -104,6 +104,7 @@ describe("operator-scoped daemon event sinks", () => {
         workspacePath: root,
         notifications: ["worker-birth"],
         platform: "linux",
+        commandAvailable: () => true,
       },
     });
     daemons.push(daemon);
@@ -126,5 +127,45 @@ describe("operator-scoped daemon event sinks", () => {
     expect(JSON.parse(launched[1]!.spec.input!)).toMatchObject({
       workers: [{ worker_id: "source" }],
     });
+  });
+
+  it("degrades once and permanently when the notification binary is absent (#4153)", async () => {
+    const root = await scratch("redskilled-machine-notification-absent-");
+    const workspace = await scratch("redskilled-machine-notification-absent-workspace-");
+    const launched: LaunchWorkerOptions[] = [];
+    const daemon = await startRedskilledDaemon({
+      paths: resolveRedskilledPaths({
+        env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+        runtimeDir: root,
+      }),
+      launch: recordingLaunch(launched),
+      unitInventory: () => [],
+      sampleMs: 0,
+      hostEventSinks: {
+        workspacePath: root,
+        notifications: ["worker-birth"],
+        platform: "linux",
+        commandAvailable: () => false,
+      },
+    });
+    daemons.push(daemon);
+
+    daemon.startWorker({
+      worker_id: "source-a",
+      project_label: "acme/widgets",
+      workspace_path: workspace,
+      command: "work",
+    });
+    daemon.startWorker({
+      worker_id: "source-b",
+      project_label: "acme/widgets",
+      workspace_path: workspace,
+      command: "work",
+    });
+    await daemon.flushEvents();
+
+    // Two eligible events, ZERO sink Workers: an absent optional binary is a
+    // one-line degradation, never a crash-looping birth in the breaker.
+    expect(launched.map((launch) => launch.spec.project_label)).toEqual(["acme/widgets", "acme/widgets"]);
   });
 });


### PR DESCRIPTION
On a headless host the daemon fired `notify-send` through the Worker birth pipeline for every lifecycle event; each sink Worker died on ENOENT inside a second, tripped the crash-loop breaker, backed off, re-armed — forever (journal evidence since 2026-08-19), each churn holding a slot against the host ceiling.

The notification binary is probed once per boot (PATH walk; absolute paths trusted as-is). Absent → one loud refusal line, sink disabled for the boot, zero sink Workers born — proven by a daemon-level test with two eligible events. Probe seam on the declaration beside the existing `platform` seam.

Fixes #4153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789887845&installation_model_id=20659&pr_number=4247&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4247&signature=96846ba594dbf5f2423fcfc5142f10b593a4353e38206552aa774f3920d47945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->