### PR TITLE
feat(#4169): weekly_review flags Standing orders that recur across drains

### DIFF
--- a/.changeset/weekly-review-flags-recurring-standing-orders.md
+++ b/.changeset/weekly-review-flags-recurring-standing-orders.md
@@ -1,0 +1,13 @@
+---
+"@reddb-io/dev": patch
+---
+
+`weekly_review` flags Standing orders that recur across the week's drains as
+CLAUDE.md promotion candidates. An order appended under one drain is that
+drain's correction; the same order under two drains is a pattern the repo
+should carry, and until now that signal lived only in an operator's memory of
+what they kept retyping. The weekly report now names the order, the drains it
+recurred in, and how many times it was appended — and stops there: promotion is
+a human PR, so the review writes to neither CLAUDE.md nor the register. Orders
+stamped outside the window, or carrying no usable timestamp, are counted in the
+warnings rather than attributed to a drain nobody can name.

--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -702,7 +702,7 @@ The **Label family** that declares at triage time the minimum **Countersign** cl
 _Avoid_: verification tier (tier names the model policy), risk label
 
 **Standing orders**:
-The operator's append-only per-drain register of numbered instructions, written through the daemon and injected verbatim into every Worker brief and resume. The reflex: an instruction the operator catches themselves repeating is appended before acting. Orders that stabilise are promoted into CLAUDE.md by PR; the register is drain-scoped, not a second permanent home.
+The operator's append-only per-drain register of numbered instructions, written through the daemon and injected verbatim into every Worker brief and resume. The reflex: an instruction the operator catches themselves repeating is appended before acting. Orders that stabilise are promoted into CLAUDE.md by PR; the register is drain-scoped, not a second permanent home. **Recurrence is the promotion signal**: `weekly_review` reports an order appended under more than one of the week's drains as a promotion candidate, naming the drains it recurred in — and stops there, because promotion is the human PR and a review that edited CLAUDE.md would be a second writer nobody approved.
 _Avoid_: preferences file, steering (**runner_steer** is a point-in-time nudge, not a standing register)
 
 **Harvest deadline**:

--- a/apps/plugin-dev/src/core/activity-review.ts
+++ b/apps/plugin-dev/src/core/activity-review.ts
@@ -56,6 +56,39 @@ export interface ActivityReviewTokenSummary {
   sourceRecords: number;
 }
 
+/**
+ * One **Standing order** as it was observed inside one drain of the review
+ * window. The register itself is append-only and drain-scoped (ADR 0156), so
+ * the same instruction an operator keeps repeating shows up once per drain —
+ * which is exactly the signal the weekly window reads.
+ */
+export interface ActivityReviewStandingOrder {
+  /** The drain the order was appended under. */
+  drain: string;
+  /** Its number in that drain's register. */
+  n: number;
+  /** The order verbatim, as the operator wrote it. */
+  text: string;
+  /** When it was appended, or null when the register row carries no stamp. */
+  ts: string | null;
+}
+
+/**
+ * A Standing order that recurred across drains, reported as a candidate for
+ * promotion into CLAUDE.md. **The review only surfaces the signal** — promotion
+ * is a human PR, and nothing here writes to CLAUDE.md or to the register.
+ */
+export interface ActivityReviewStandingOrderPromotion {
+  /** The order as it was first spelled in the window. */
+  text: string;
+  /** The distinct drains it recurred in, oldest first. */
+  drains: string[];
+  /** How many times it was appended across those drains. */
+  occurrences: number;
+  firstSeen: string | null;
+  lastSeen: string | null;
+}
+
 export interface ActivityReviewInput {
   kind: ActivityReviewKind;
   now: Date;
@@ -65,6 +98,8 @@ export interface ActivityReviewInput {
   history: HistoryRecord[];
   activeWorkers: ActivityReviewActiveWorker[];
   tokenSummary: ActivityReviewTokenSummary;
+  /** Standing orders observed in the window, one row per append. */
+  standingOrders?: ActivityReviewStandingOrder[];
 }
 
 export interface ActivityReviewInterval {
@@ -126,6 +161,7 @@ export interface ActivityReviewReport {
   };
   workers: ActivityReviewWorkerSummary[];
   challenges: ActivityReviewChallenge[];
+  standing_order_promotions: ActivityReviewStandingOrderPromotion[];
   issue_cycle_times: ActivityReviewCycleRow[];
   pr_cycle_times: ActivityReviewCycleRow[];
   warnings: string[];
@@ -282,6 +318,79 @@ function cycleRow(
   };
 }
 
+/**
+ * How many distinct drains an order must recur in before the weekly review
+ * calls it a promotion candidate. **Two is the smallest number that is a
+ * pattern** — an order appended once is that drain's correction, not a standing
+ * rule the repo should carry in CLAUDE.md.
+ */
+export const STANDING_ORDER_PROMOTION_MIN_DRAINS = 2;
+
+/**
+ * The same instruction, differently spelled. Case, inner spacing and trailing
+ * sentence punctuation carry no rule, so they must not split one recurring
+ * order into two singletons that nothing flags. PURE.
+ */
+function standingOrderKey(text: string): string {
+  return text.replace(/\s+/g, " ").trim().replace(/[.;!]+$/, "").toLowerCase();
+}
+
+interface DatedStandingOrder {
+  order: ActivityReviewStandingOrder;
+  at: Date;
+}
+
+/**
+ * Standing orders that recurred across drains inside the interval, oldest
+ * spelling kept and drains listed in the order they first carried the order.
+ *
+ * **Read-only by construction**: this reads rows the caller already gathered
+ * and returns a report. Promotion into CLAUDE.md is a human PR, so nothing here
+ * touches CLAUDE.md, the register, or any other file. An order stamped outside
+ * the interval, or carrying no usable stamp, is not part of "the week's drains"
+ * and is left out rather than attributed to a drain nobody can name. PURE.
+ */
+export function standingOrderPromotionCandidates(
+  orders: readonly ActivityReviewStandingOrder[],
+  interval: ActivityReviewInterval,
+): ActivityReviewStandingOrderPromotion[] {
+  const dated: DatedStandingOrder[] = [];
+  for (const order of orders) {
+    const at = parseDate(order.ts);
+    if (!inRange(at, interval) || at === null) continue;
+    dated.push({ order, at });
+  }
+  dated.sort((a, b) => a.at.getTime() - b.at.getTime());
+
+  const groups = new Map<string, ActivityReviewStandingOrderPromotion>();
+  for (const { order, at } of dated) {
+    const key = standingOrderKey(order.text);
+    if (key === "") continue;
+    const stamp = at.toISOString();
+    let group = groups.get(key);
+    if (group === undefined) {
+      group = { text: order.text.trim(), drains: [], occurrences: 0, firstSeen: stamp, lastSeen: stamp };
+      groups.set(key, group);
+    }
+    group.occurrences += 1;
+    group.lastSeen = stamp;
+    if (!group.drains.includes(order.drain)) group.drains.push(order.drain);
+  }
+
+  return [...groups.values()]
+    .filter((group) => group.drains.length >= STANDING_ORDER_PROMOTION_MIN_DRAINS)
+    .sort((a, b) => b.drains.length - a.drains.length || b.occurrences - a.occurrences || a.text.localeCompare(b.text));
+}
+
+/**
+ * How many observed orders the promotion comparison could not place in the
+ * week — a row with no usable stamp belongs to no drain the report can name.
+ * PURE.
+ */
+function undatedStandingOrders(orders: readonly ActivityReviewStandingOrder[]): number {
+  return orders.filter((order) => parseDate(order.ts) === null).length;
+}
+
 export function buildActivityReviewReport(input: ActivityReviewInput): ActivityReviewReport {
   const interval = activityReviewInterval(input.kind, input.now);
   const issuesCreated = input.issues.filter((issue) => inRange(parseDate(issue.createdAt), interval));
@@ -310,9 +419,22 @@ export function buildActivityReviewReport(input: ActivityReviewInput): ActivityR
     }))
     .sort((a, b) => a.issue - b.issue);
 
+  // Promotion candidates are a WEEKLY judgement: one day of drains is one
+  // operator sitting down once, and calling that a standing rule of the repo
+  // would promote today's correction. `daily_review` stays the operational read.
+  const standingOrders = input.standingOrders ?? [];
+  const standingOrderPromotions = input.kind === "weekly"
+    ? standingOrderPromotionCandidates(standingOrders, interval)
+    : [];
+
   const warnings: string[] = [];
   if (!input.tokenSummary.available) {
     warnings.push("Token spend was not available in retained local worker logs; runner usage is best-effort and not guaranteed by the AFK artifact schema.");
+  }
+
+  const undated = input.kind === "weekly" ? undatedStandingOrders(standingOrders) : 0;
+  if (undated > 0) {
+    warnings.push(`${undated} standing order(s) carry no usable timestamp and were left out of the promotion comparison.`);
   }
 
   return {
@@ -339,6 +461,7 @@ export function buildActivityReviewReport(input: ActivityReviewInput): ActivityR
     },
     workers,
     challenges,
+    standing_order_promotions: standingOrderPromotions,
     issue_cycle_times: issuesClosed
       .map((issue) => cycleRow(issue, issue.closedAt, interval))
       .sort((a, b) => a.number - b.number),
@@ -370,6 +493,28 @@ function fmtTokenSummary(tokens: ActivityReviewTokenSummary): string {
   if (tokens.input !== null) parts.push(`input ${tokens.input}`);
   if (tokens.output !== null) parts.push(`output ${tokens.output}`);
   return parts.length > 0 ? parts.join(" / ") : "observed";
+}
+
+/**
+ * The promotion-candidates section: which orders recurred, and in which drains.
+ * The weekly window is the only one that carries it, and the section states its
+ * own limit — **the review surfaces the signal, a human PR promotes**. PURE.
+ */
+export function renderStandingOrderPromotions(report: ActivityReviewReport): string[] {
+  if (report.kind !== "weekly") return [];
+  const lines = ["", "Standing order promotion candidates"];
+  if (report.standing_order_promotions.length === 0) {
+    lines.push("  (no standing order recurred across drains this week)");
+    return lines;
+  }
+  for (const candidate of report.standing_order_promotions) {
+    lines.push(`  ${candidate.text}`);
+    lines.push(
+      `    recurred in ${candidate.drains.length} drains (${candidate.drains.join(", ")}), ${candidate.occurrences} appends`,
+    );
+  }
+  lines.push("  promote by PR into CLAUDE.md; this review writes nothing.");
+  return lines;
 }
 
 export function renderActivityReviewReport(report: ActivityReviewReport): string {
@@ -418,6 +563,8 @@ export function renderActivityReviewReport(report: ActivityReviewReport): string
       lines.push(`    resolution: ${challenge.resolution}`);
     }
   }
+
+  lines.push(...renderStandingOrderPromotions(report));
 
   lines.push("", "Issue cycle times");
   if (report.issue_cycle_times.length === 0) {
@@ -470,6 +617,10 @@ function toToonSafeActivityReviewReport(report: ActivityReviewReport): ToonValue
     challenges: report.challenges.map((challenge) => ({
       ...challenge,
       labels: challenge.labels.join(","),
+    })),
+    standing_order_promotions: report.standing_order_promotions.map((candidate) => ({
+      ...candidate,
+      drains: candidate.drains.join(","),
     })),
   };
   return JSON.parse(JSON.stringify(payload)) as ToonValue;

--- a/apps/plugin-dev/src/core/complexity-coverage-guard.ts
+++ b/apps/plugin-dev/src/core/complexity-coverage-guard.ts
@@ -108,7 +108,6 @@ export interface ComplexityCoverageBaselineEntry {
  * add one — a new entry is the untested complexity this exists to refuse.
  */
 export const COMPLEXITY_COVERAGE_BASELINE: readonly ComplexityCoverageBaselineEntry[] = [
-  { path: "apps/plugin-dev/src/core/activity-review.ts", name: "renderActivityReviewReport", crap: 306 },
   { path: "apps/plugin-dev/src/core/claim-recovery.ts", name: "planClaimRecovery", crap: 462 },
   { path: "apps/plugin-dev/src/core/declared-wait-guard.ts", name: "blankCommentsAndStrings", crap: 272 },
   { path: "apps/plugin-dev/src/core/development-workflow.ts", name: "activatePrimaryBranchLockConfig", crap: 506 },

--- a/apps/plugin-dev/tests/activity-review-standing-orders.test.ts
+++ b/apps/plugin-dev/tests/activity-review-standing-orders.test.ts
@@ -1,0 +1,211 @@
+import { mkdtempSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { decode } from "@reddb-io/toon";
+import {
+  buildActivityReviewReport,
+  renderActivityReviewReport,
+  renderActivityReviewReportToon,
+  renderStandingOrderPromotions,
+  standingOrderPromotionCandidates,
+  STANDING_ORDER_PROMOTION_MIN_DRAINS,
+  activityReviewInterval,
+  type ActivityReviewInput,
+  type ActivityReviewStandingOrder,
+} from "../src/core/activity-review.js";
+
+const NOW = new Date("2026-08-19T12:00:00.000Z");
+
+/** The recurring order the fixture drains share, spelled as the operator wrote it. */
+const RECURRING = "Run the repo gate before pushing.";
+
+function order(
+  drain: string,
+  n: number,
+  text: string,
+  ts: string | null,
+): ActivityReviewStandingOrder {
+  return { drain, n, text, ts };
+}
+
+function reviewInput(
+  kind: "daily" | "weekly",
+  standingOrders: ActivityReviewStandingOrder[],
+): ActivityReviewInput {
+  return {
+    kind,
+    now: NOW,
+    issues: [],
+    pullRequests: [],
+    gitStats: { commits: 0, added: 0, removed: 0 },
+    history: [],
+    activeWorkers: [],
+    tokenSummary: { available: true, total: 10, input: 6, output: 4, sourceRecords: 1 },
+    standingOrders,
+  };
+}
+
+describe("standingOrderPromotionCandidates — recurrence across the week's drains", () => {
+  const interval = activityReviewInterval("weekly", NOW);
+
+  it("flags an order two drains share, naming the order and both drains", () => {
+    const candidates = standingOrderPromotionCandidates(
+      [
+        order("drain-mon", 1, RECURRING, "2026-08-15T09:00:00.000Z"),
+        order("drain-mon", 2, "Prefer REST over GraphQL here.", "2026-08-15T10:00:00.000Z"),
+        order("drain-thu", 1, "run the repo gate before pushing", "2026-08-18T09:00:00.000Z"),
+      ],
+      interval,
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      text: RECURRING,
+      drains: ["drain-mon", "drain-thu"],
+      occurrences: 2,
+      firstSeen: "2026-08-15T09:00:00.000Z",
+      lastSeen: "2026-08-18T09:00:00.000Z",
+    });
+  });
+
+  it("does not flag an order seen in a single drain, however often it was appended", () => {
+    const candidates = standingOrderPromotionCandidates(
+      [
+        order("drain-mon", 1, "Only this drain says so.", "2026-08-15T09:00:00.000Z"),
+        order("drain-mon", 2, "Only this drain says so.", "2026-08-15T11:00:00.000Z"),
+      ],
+      interval,
+    );
+
+    expect(candidates).toEqual([]);
+    expect(STANDING_ORDER_PROMOTION_MIN_DRAINS).toBe(2);
+  });
+
+  it("leaves an order stamped outside the week out of the comparison", () => {
+    const candidates = standingOrderPromotionCandidates(
+      [
+        order("drain-old", 1, RECURRING, "2026-06-01T09:00:00.000Z"),
+        order("drain-thu", 1, RECURRING, "2026-08-18T09:00:00.000Z"),
+      ],
+      interval,
+    );
+
+    expect(candidates).toEqual([]);
+  });
+});
+
+describe("weekly_review report — the promotion-candidates section", () => {
+  const shared = [
+    order("drain-mon", 1, RECURRING, "2026-08-15T09:00:00.000Z"),
+    order("drain-thu", 1, RECURRING, "2026-08-18T09:00:00.000Z"),
+    order("drain-thu", 2, "Only this drain says so.", "2026-08-18T09:30:00.000Z"),
+  ];
+
+  it("reports the recurring order with the drains it recurred in", () => {
+    const report = buildActivityReviewReport(reviewInput("weekly", shared));
+
+    expect(report.standing_order_promotions).toEqual([
+      {
+        text: RECURRING,
+        drains: ["drain-mon", "drain-thu"],
+        occurrences: 2,
+        firstSeen: "2026-08-15T09:00:00.000Z",
+        lastSeen: "2026-08-18T09:00:00.000Z",
+      },
+    ]);
+
+    const rendered = renderActivityReviewReport(report);
+    expect(rendered).toContain("Standing order promotion candidates");
+    expect(rendered).toContain(RECURRING);
+    expect(rendered).toContain("recurred in 2 drains (drain-mon, drain-thu), 2 appends");
+    expect(rendered).not.toContain("Only this drain says so.");
+    expect(renderStandingOrderPromotions(report).join("\n")).toContain(
+      "promote by PR into CLAUDE.md; this review writes nothing.",
+    );
+  });
+
+  it("carries the candidate through the TOON render as one flat row", () => {
+    const payload = decode(
+      renderActivityReviewReportToon(buildActivityReviewReport(reviewInput("weekly", shared))),
+    ) as { standing_order_promotions: Array<{ text: string; drains: string; occurrences: number }> };
+
+    expect(payload.standing_order_promotions).toEqual([
+      expect.objectContaining({ text: RECURRING, drains: "drain-mon,drain-thu", occurrences: 2 }),
+    ]);
+  });
+
+  it("says so plainly when no order recurred", () => {
+    const report = buildActivityReviewReport(
+      reviewInput("weekly", [order("drain-mon", 1, "Only this drain says so.", "2026-08-15T09:00:00.000Z")]),
+    );
+
+    expect(report.standing_order_promotions).toEqual([]);
+    expect(renderActivityReviewReport(report)).toContain(
+      "(no standing order recurred across drains this week)",
+    );
+  });
+
+  it("warns rather than guesses when a register row carries no stamp", () => {
+    const report = buildActivityReviewReport(
+      reviewInput("weekly", [
+        order("drain-mon", 1, RECURRING, null),
+        order("drain-thu", 1, RECURRING, "2026-08-18T09:00:00.000Z"),
+      ]),
+    );
+
+    expect(report.standing_order_promotions).toEqual([]);
+    expect(report.warnings.join("\n")).toContain(
+      "1 standing order(s) carry no usable timestamp",
+    );
+  });
+
+  it("keeps promotion candidates out of the daily window", () => {
+    const report = buildActivityReviewReport(reviewInput("daily", shared));
+
+    expect(report.standing_order_promotions).toEqual([]);
+    expect(renderActivityReviewReport(report)).not.toContain("Standing order promotion candidates");
+  });
+});
+
+describe("the review changes nothing on its own", () => {
+  it("writes to neither CLAUDE.md nor the standing-orders register", () => {
+    const dir = mkdtempSync(join(tmpdir(), "activity-review-readonly-"));
+    const claudeMd = join(dir, "CLAUDE.md");
+    const register = join(dir, "redskilled.orders.toonl");
+    writeFileSync(claudeMd, "# Project instructions\n", "utf8");
+    writeFileSync(
+      register,
+      [
+        JSON.stringify({ version: 1, n: 1, text: RECURRING, ts: "2026-08-15T09:00:00.000Z" }),
+        JSON.stringify({ version: 1, n: 1, text: RECURRING, ts: "2026-08-18T09:00:00.000Z" }),
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const snapshot = (): string =>
+      JSON.stringify(
+        readdirSync(dir).sort().map((name) => {
+          const path = join(dir, name);
+          const stats = statSync(path);
+          return [name, readFileSync(path, "utf8"), stats.size, stats.mtimeMs];
+        }),
+      );
+    const before = snapshot();
+
+    const report = buildActivityReviewReport(
+      reviewInput("weekly", [
+        order("drain-mon", 1, RECURRING, "2026-08-15T09:00:00.000Z"),
+        order("drain-thu", 1, RECURRING, "2026-08-18T09:00:00.000Z"),
+      ]),
+    );
+    renderActivityReviewReport(report);
+    renderActivityReviewReportToon(report);
+
+    // The signal is reported...
+    expect(report.standing_order_promotions).toHaveLength(1);
+    // ...and promotion stays a human PR: nothing on disk moved.
+    expect(snapshot()).toBe(before);
+  });
+});

--- a/packaging/pi/dev/skills/engineering/daily-review/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/daily-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: daily-review
 working-mode: spec-driven
-description: Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass `--period week` for a six-day window. Covers delivered work, local AFK workers, cycle times, and HITL/blocker challenges. Use when the user invokes `/daily-review`, `/weekly-review`, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL.
+description: Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass `--period week` for a six-day window. Covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and — for the week — Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes `/daily-review`, `/weekly-review`, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL.
 argument-hint: "[--period day|week] [--json] [--human]"
 disable-model-invocation: true
 ---
@@ -58,6 +58,13 @@ empty tables use the definitive `key[0]:` empty state.
   labels, issue bodies/comments, and local AFK history reasons.
 - Issue and PR cycle times: closed-in-interval rows include items opened before
   the interval, so old work closed in the review window remains visible.
+- Standing order promotion candidates (**week only**): Standing orders appended
+  under more than one of the week's drains, each naming the drains it recurred
+  in. One drain is that drain's correction; two are a pattern worth carrying in
+  the repo. **The report writes nothing** — it neither edits CLAUDE.md nor
+  touches the register, because promotion is a human PR. An order stamped
+  outside the window, or carrying no usable timestamp, is left out and counted
+  in the warnings rather than attributed to a drain nobody can name.
 
 ## Notes
 

--- a/packaging/pi/dev/skills/engineering/daily-review/agents/openai.yaml
+++ b/packaging/pi/dev/skills/engineering/daily-review/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
   display_name: "Daily Review"
-  short_description: "Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass --period week for a six-day window. Covers delivered work, local AFK workers, cycle times, and HITL/blocker challenges. Use when the user invokes /daily-review, /weekly-review, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL."
+  short_description: "Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass --period week for a six-day window. Covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and - for the week - Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes /daily-review, /weekly-review, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL."
 policy:
   allow_implicit_invocation: false

--- a/plugins/dev/skills/engineering/daily-review/SKILL.md
+++ b/plugins/dev/skills/engineering/daily-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: daily-review
 working-mode: spec-driven
-description: Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass `--period week` for a six-day window. Covers delivered work, local AFK workers, cycle times, and HITL/blocker challenges. Use when the user invokes `/daily-review`, `/weekly-review`, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL.
+description: Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass `--period week` for a six-day window. Covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and — for the week — Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes `/daily-review`, `/weekly-review`, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL.
 argument-hint: "[--period day|week] [--json] [--human]"
 disable-model-invocation: true
 ---
@@ -58,6 +58,13 @@ empty tables use the definitive `key[0]:` empty state.
   labels, issue bodies/comments, and local AFK history reasons.
 - Issue and PR cycle times: closed-in-interval rows include items opened before
   the interval, so old work closed in the review window remains visible.
+- Standing order promotion candidates (**week only**): Standing orders appended
+  under more than one of the week's drains, each naming the drains it recurred
+  in. One drain is that drain's correction; two are a pattern worth carrying in
+  the repo. **The report writes nothing** — it neither edits CLAUDE.md nor
+  touches the register, because promotion is a human PR. An order stamped
+  outside the window, or carrying no usable timestamp, is left out and counted
+  in the warnings rather than attributed to a drain nobody can name.
 
 ## Notes
 

--- a/plugins/dev/skills/engineering/daily-review/agents/openai.yaml
+++ b/plugins/dev/skills/engineering/daily-review/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
   display_name: "Daily Review"
-  short_description: "Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass --period week for a six-day window. Covers delivered work, local AFK workers, cycle times, and HITL/blocker challenges. Use when the user invokes /daily-review, /weekly-review, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL."
+  short_description: "Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass --period week for a six-day window. Covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and - for the week - Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes /daily-review, /weekly-review, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL."
 policy:
   allow_implicit_invocation: false


### PR DESCRIPTION
Fixes #4169

## What changed

`weekly_review` now compares the week's **Standing orders** across drains and reports every order appended under more than one drain as a CLAUDE.md promotion candidate — the order, the drains it recurred in, and how many appends it took. One drain is that drain's correction; two are a pattern the repo should carry.

**The review stops at the signal.** Promotion is a human PR, so the report writes to neither CLAUDE.md nor the register.

- `apps/plugin-dev/src/core/activity-review.ts` — `ActivityReviewStandingOrder` rows on the input, `standing_order_promotions` on the report, the pure `standingOrderPromotionCandidates`, and the text/TOON sections (the TOON row flattens `drains` to a joined field, like `challenges.labels`).
- Recurrence matching normalises case, inner spacing and trailing punctuation, so one instruction spelled two ways does not read as two singletons nothing flags.
- An order stamped outside the window, or carrying no usable stamp, is counted in `warnings` rather than attributed to a drain nobody can name. The daily window carries no section at all — a single day of drains is one operator sitting down once.
- `renderActivityReviewReport` leaves `COMPLEXITY_COVERAGE_BASELINE`: the new suite names it, so the untested-complexity debt is paid and the shrink-only ratchet refuses to re-authorise it.
- Docs: the dev glossary's **Standing orders** entry and the `/daily-review` skill state the new section; the generated Pi/OpenAI mirrors were rebuilt.

## Acceptance criteria

- [x] A fixture with two drains sharing an order yields a promotion-candidates section naming the order and the drains it recurred in.
- [x] An order seen in a single drain is not flagged — however many times it was appended in that drain.
- [x] The review output changes nothing on its own: the read-only test snapshots a fixture directory holding a `CLAUDE.md` and a register file (bytes, sizes, mtimes) around a full build-and-render and asserts it is byte-identical after.

## Validation

- `pnpm typecheck` — 17/17 tasks pass.
- `pnpm -C apps/plugin-dev test:invariants` — 30 files, 360 tests pass.
- `pnpm -C apps/plugin-dev test` — 442 files, 5687 tests pass (the Pi mirror check failed until `pnpm pi:packages:build` regenerated it; green after).
- `pnpm lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789888541&installation_model_id=20659&pr_number=4249&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4249&signature=ce8d74bce5d91cd3dfea73d652a4cf606d744657a31ed57245273f50acc10563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->