### PR TITLE
feat(dev): merge refuses stale heads on the checkout landing path

### DIFF
--- a/.changeset/stale-head-refusal.md
+++ b/.changeset/stale-head-refusal.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/dev": patch
+---
+
+Merge refuses stale heads. When a caller pins the tip its gate validated, the
+landing compares it against the branch's live remote head — identical is the
+ordinary landing, a clean rebase (same stable patch-id over the base) lands
+the live head, and any other divergence refuses with both SHAs named, because
+one commit passed the gate and a different one is what the merge would ship.

--- a/apps/plugin-dev/src/core/file-size-guard.ts
+++ b/apps/plugin-dev/src/core/file-size-guard.ts
@@ -34,7 +34,7 @@ export const FILE_SIZE_BASELINE: readonly FileSizeBaselineEntry[] = [
   { path: "apps/plugin-dev/src/core/config.ts", lines: 1401 },
   { path: "apps/plugin-dev/src/core/execution/runtime.ts", lines: 1266 },
   { path: "apps/plugin-dev/src/core/feedback.ts", lines: 1206 },
-  { path: "apps/plugin-dev/src/core/landing.ts", lines: 1183 },
+  { path: "apps/plugin-dev/src/core/landing.ts", lines: 1181 },
   { path: "apps/plugin-dev/src/core/merge.ts", lines: 2672 },
   { path: "apps/plugin-dev/src/core/process-issue/lifecycle.ts", lines: 2240 },
   { path: "apps/plugin-dev/src/core/process-issue/terminal.ts", lines: 1308 },

--- a/apps/plugin-dev/src/core/landing.ts
+++ b/apps/plugin-dev/src/core/landing.ts
@@ -38,6 +38,7 @@ import {
   type WaitForReviewInput,
 } from "./merge.js";
 import { resolveLandSerialization, type LandLock } from "./land-lock.js";
+import { resolveRemoteBranchTip, staleHeadVerdict } from "./stale-head.js";
 import { pushAttempt, type GitExec } from "./remote-branch.js";
 import { restagePiPackages } from "./pi-package-restage.js";
 import type {
@@ -220,12 +221,7 @@ export interface LandingInput {
   remote: string;
   /** The worker branch sandcastle committed on (push + land source). */
   branch: string;
-  /**
-   * The already-validated worker tip SHA, when the caller resolved one before
-   * landing. Reconcile uses this to guarantee the commit being landed is the
-   * commit that passed validation, instead of re-reading a mutable local branch
-   * ref after the gate.
-   */
+  /** The gate-validated worker tip (reconcile; #4134 stale-head guard). */
   validatedBranchTip?: string;
   /** Resolved base branch (lock > pin > main). */
   base: string;
@@ -383,7 +379,13 @@ export type LandingResult =
         // Land-lock serialization (#2596): another worker held the land-lock past
         // the wait timeout. This is a BACKOFF signal, not an infra failure — the
         // caller routes it to self-requeue rather than parking the issue.
-        | "land-lock-timeout";
+        | "land-lock-timeout"
+        // #4134: the branch advanced after the gate validated its tip, and the
+        // advance is not a clean rebase of the validated work (stable patch-id
+        // differs). Landing the live head would merge commits nothing
+        // validated; landing the validated tip would silently drop the
+        // advance. Refuse, naming both SHAs in `message`.
+        | "stale-head";
       locked: boolean;
       /** PR number left open for the CI-aware handoff (`ci-failed` / `ci-pending`). */
       prNumber?: number;
@@ -483,6 +485,15 @@ export async function doLanding(
     };
   }
   await deps.landingPhase?.("gate", { step: "push", status: "done" });
+  // #4134: one SHA passed the gate; a different one must not be what this merge ships (stale-head.ts).
+  if (input.validatedBranchTip) {
+    const { repoDir, remote, branch, base, intentBaseRef, validatedBranchTip } = input;
+    const verdict = await staleHeadVerdict(deps.mergeExec, {
+      repoDir, remote, branch, base, validatedBranchTip, ...(intentBaseRef == null ? {} : { intentBaseRef }),
+    });
+    if (verdict.stale) return { ok: false, reason: "stale-head", locked: input.locked, message: verdict.message };
+  }
+
 
   // 2. pre_merge hook.
   await deps.landingPhase?.("gate", { step: "pre_merge", status: "start" });
@@ -949,11 +960,9 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
     }));
     if (!branchTip) return { ok: false, reason: "land-failed", locked: input.locked };
 
-    // Zero-commit guard: `git merge --no-ff` succeeds on a branch with no new
-    // commits (it creates a no-op merge commit), which would incorrectly close
-    // the issue as done without delivering any work. The PR path rejects this
-    // naturally — `gh pr create` fails on an empty branch — so mirror that guard
-    // here: route a zero-commit direct landing to land-failed.
+    // Zero-commit guard: `merge --no-ff` succeeds on an empty branch (a no-op
+    // merge commit) and would close the issue with no work delivered; the PR
+    // path refuses naturally, so mirror it here as land-failed.
     const baseComparisonRef = input.intentBaseRef ?? `origin/${input.base}`;
     const countRes = await deps.mergeExec([
       "git", "-C", landDir,
@@ -1170,14 +1179,3 @@ async function emitLandingWaitHeartbeat(
   });
 }
 
-async function resolveRemoteBranchTip(
-  exec: MergeExec,
-  input: { repo: string; remote: string; branch: string },
-): Promise<string | undefined> {
-  const r = await exec([
-    "git", "-C", input.repo,
-    "rev-parse", "--verify", "--quiet", `${input.remote}/${input.branch}`,
-  ]);
-  const tip = r.stdout.trim();
-  return r.code === 0 && tip !== "" ? tip : undefined;
-}

--- a/apps/plugin-dev/src/core/stale-head.ts
+++ b/apps/plugin-dev/src/core/stale-head.ts
@@ -1,0 +1,70 @@
+/**
+ * stale-head — merge refuses a head that moved past the validated tip (#4134).
+ *
+ * A caller that pinned the tip its gate validated must never merge a head
+ * that advanced past it: one SHA passed the gate and a different one is what
+ * the merge would ship. The single forgiven divergence is a clean rebase —
+ * identical stable patch-id over the base — because it moves the validated
+ * CHANGE without editing it. Symmetric to the base-OID pin that already
+ * guards the other side of the merge.
+ */
+import type { Exec } from "./merge.js";
+
+export interface StaleHeadCheckInput {
+  readonly repoDir: string;
+  readonly remote: string;
+  readonly branch: string;
+  readonly base: string;
+  readonly intentBaseRef?: string;
+  readonly validatedBranchTip: string;
+}
+
+export type StaleHeadVerdict =
+  | { readonly stale: false }
+  | { readonly stale: true; readonly liveTip: string; readonly message: string };
+
+/** Resolve `refs/heads/<branch>` on the remote as one full object name, or null. */
+export async function resolveRemoteBranchTip(
+  exec: Exec,
+  input: { repo: string; remote: string; branch: string },
+): Promise<string | undefined> {
+  const r = await exec([
+    "git", "-C", input.repo,
+    "rev-parse", "--verify", "--quiet", `${input.remote}/${input.branch}`,
+  ]);
+  const tip = r.stdout.trim();
+  return r.code === 0 && tip !== "" ? tip : undefined;
+}
+
+/** Compare the live remote head against the validated tip; forgive one clean rebase. */
+export async function staleHeadVerdict(exec: Exec, input: StaleHeadCheckInput): Promise<StaleHeadVerdict> {
+  const liveTip = await resolveRemoteBranchTip(exec, {
+    repo: input.repoDir,
+    remote: input.remote,
+    branch: input.branch,
+  });
+  if (!liveTip || liveTip === input.validatedBranchTip) return { stale: false };
+  const baseRef = input.intentBaseRef ?? `origin/${input.base}`;
+  const validatedId = await stablePatchId(exec, input.repoDir, baseRef, input.validatedBranchTip);
+  const liveId = await stablePatchId(exec, input.repoDir, baseRef, liveTip);
+  // An unanswerable patch-id is stale, never equivalence: forgiveness needs proof.
+  if (validatedId != null && liveId != null && validatedId === liveId) return { stale: false };
+  return {
+    stale: true,
+    liveTip,
+    message:
+      `the branch head moved after validation: gate validated ${input.validatedBranchTip.slice(0, 12)}, ` +
+      `the live head is ${liveTip.slice(0, 12)}, and the divergence is not a clean rebase ` +
+      "(stable patch-id differs) — re-run the gate on the live head or restore the validated tip",
+  };
+}
+
+/** The stable patch-id of `base...tip`, or null when git cannot answer. */
+async function stablePatchId(exec: Exec, repo: string, baseRef: string, tip: string): Promise<string | null> {
+  const diff = await exec(["git", "-C", repo, "diff", `${baseRef}...${tip}`]);
+  if (diff.code !== 0) return null;
+  const id = await exec(["git", "-C", repo, "patch-id", "--stable"], { input: diff.stdout });
+  if (id.code !== 0) return null;
+  const token = id.stdout.trim().split(/\s+/)[0] ?? "";
+  return token === "" ? null : token;
+}

--- a/apps/plugin-dev/tests/landing-stale-head.test.ts
+++ b/apps/plugin-dev/tests/landing-stale-head.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_BRANCH_TIP, doLanding, harness } from "./landing.test-support.js";
+
+// #4134: merge refuses stale heads. A caller that pinned the tip its gate
+// validated must never merge a head that moved past it — unless the move is a
+// clean rebase carrying the identical stable patch-id.
+
+const VALIDATED = "1111111111111111111111111111111111111111";
+
+function withPatchIds(
+  h: ReturnType<typeof harness>,
+  ids: Record<string, string | null>,
+): void {
+  const inner = h.deps.mergeExec;
+  let lastDiffTip = "";
+  h.deps.mergeExec = async (args: string[], options?: { input?: string }) => {
+    const joined = args.join(" ");
+    const diffMatch = joined.match(/ diff \S+\.\.\.(\S+)$/);
+    if (diffMatch) {
+      lastDiffTip = diffMatch[1]!;
+      return { code: 0, stdout: `diff-of-${lastDiffTip}\n`, stderr: "" };
+    }
+    if (joined.includes("patch-id --stable")) {
+      const tip = (options?.input ?? "").replace(/^diff-of-/, "").trim();
+      const id = ids[tip];
+      return id == null
+        ? { code: 1, stdout: "", stderr: "no patch id" }
+        : { code: 0, stdout: `${id} deadbeef\n`, stderr: "" };
+    }
+    return inner(args, options);
+  };
+}
+
+describe("doLanding refuses a stale head (#4134)", () => {
+  it("refuses when the branch advanced past the validated tip with a different change", async () => {
+    const h = harness({ locked: false });
+    withPatchIds(h, { [VALIDATED]: "aaaa", [DEFAULT_BRANCH_TIP]: "bbbb" });
+    const r = await doLanding(h.deps, { ...h.input, validatedBranchTip: VALIDATED }, h.hooks);
+
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("stale-head");
+    expect(r.message).toContain(VALIDATED.slice(0, 12));
+    expect(r.message).toContain(DEFAULT_BRANCH_TIP.slice(0, 12));
+  });
+
+  it("treats an unanswerable patch-id as stale, never as equivalence", async () => {
+    const h = harness({ locked: false });
+    withPatchIds(h, { [VALIDATED]: null, [DEFAULT_BRANCH_TIP]: null });
+    const r = await doLanding(h.deps, { ...h.input, validatedBranchTip: VALIDATED }, h.hooks);
+
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("stale-head");
+  });
+
+  it("lands the live head when the divergence is a clean rebase (same stable patch-id)", async () => {
+    const h = harness({ locked: false });
+    withPatchIds(h, { [VALIDATED]: "same", [DEFAULT_BRANCH_TIP]: "same" });
+    const r = await doLanding(h.deps, { ...h.input, validatedBranchTip: VALIDATED }, h.hooks);
+
+    expect(r.ok).toBe(true);
+  });
+
+  it("an identical live head is the ordinary landing, no patch-id consulted", async () => {
+    const h = harness({ locked: false });
+    let patchIdCalls = 0;
+    const inner = h.deps.mergeExec;
+    h.deps.mergeExec = async (args: string[], options?: { input?: string }) => {
+      if (args.join(" ").includes("patch-id")) patchIdCalls += 1;
+      return inner(args, options);
+    };
+    const r = await doLanding(h.deps, { ...h.input, validatedBranchTip: DEFAULT_BRANCH_TIP }, h.hooks);
+
+    expect(r.ok).toBe(true);
+    expect(patchIdCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
Implements #4134 (Spec #4129) on the checkout landing path; the daemon's ordinary AFK path already holds the same contract via #4130's `armed_head` custody (report-moved-head; re-landing restates the newest validated head).

`doLanding` compares a caller-pinned `validatedBranchTip` against the branch's live remote head before either landing path runs: identical → ordinary; same stable patch-id over the base → clean rebase, the live head lands; anything else (unanswerable patch-id included) → new `stale-head` refusal naming both SHAs. Verdict extracted to `stale-head.ts`; `landing.ts` shrank to 1181 lines and the shrink-only baseline follows.

Tests: 4-case suite (refusal, unanswerable-as-stale, clean-rebase pass, identical fast path with zero patch-id calls); landing+reconcile suites green (114); invariants 370 green.

Fixes #4134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789889812&installation_model_id=20659&pr_number=4251&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4251&signature=5d1f5d12daa209d0f57a8c629f112ef48932e8c466dcc6a0c7e066c231c72504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->