### PR TITLE
feat(redskilled): a declared drain budget harvests instead of taking (#4170)

### DIFF
--- a/.changeset/harvest-deadline-stops-admission.md
+++ b/.changeset/harvest-deadline-stops-admission.md
@@ -1,0 +1,8 @@
+---
+"@reddb-io/redskilled": patch
+"@reddb-io/dev": patch
+---
+
+A declared drain budget stops admission at the harvest fraction and lands what is in flight.
+
+A drain that admits a Worker ten minutes before its budget dies buys a claim it cannot land, and finished-but-unlanded work counts as zero (#4170, Spec #4164). A drain registration may now state `budget_ms` — with an optional `harvest_fraction`, 0.7 by default — and past that fraction of the budget `planHostDemand` reports `harvest-deadline` and admits no new claim, while every Worker already alive keeps publishing and landing what it carries: the deadline gates births and never the landing lane. The policy lives in one pure module (`apps/redskilled/src/harvest-deadline.ts`) with the daemon shape-checking the two numbers and reading no meaning, and `project_status` — the drain summary an operator reads — gains a `harvest` block naming the deadline instants beside `harvested` against `stranded`, the second folded from the same terminal outcome class the birth breaker reads plus the work the deadline leaves behind. **No declared budget, no deadline**: the policy reports `inert`, refuses nothing, and the daemon invents no instant the operator did not ask for.

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -409,6 +409,14 @@ jobs:
         if: env.RUN_ACP == 'true'
         run: pnpm -C apps/redskilled test:acp-agent-conformance
 
+      # The harvest deadline decides whether a budgeted drain admits a claim or
+      # spends its last third landing what is in flight (#4170). Both halves are
+      # daemon answers over the socket, so they need the daemon — and the broad
+      # gate that used to carry it is gone.
+      - name: Test the harvest deadline over ACP
+        if: env.RUN_ACP == 'true'
+        run: pnpm -C apps/redskilled test:acp-harvest-deadline
+
       - name: Report narrowed scope
         if: env.RUN_ACP != 'true'
         run: echo "apps/redskilled is not in the affected cone — no local ACP transport check to run."

--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -706,7 +706,7 @@ The operator's append-only per-drain register of numbered instructions, written 
 _Avoid_: preferences file, steering (**runner_steer** is a point-in-time nudge, not a standing register)
 
 **Harvest deadline**:
-At roughly 70% of an operator-declared drain budget, the daemon stops admitting new work and lands what already carries a **Countersign** — finished-but-unlanded work counts as zero. Armed only when the operator declares a budget; no budget, no harvest.
+At roughly 70% of an operator-declared drain budget, the daemon stops admitting new work and lands what already carries a **Countersign** — finished-but-unlanded work counts as zero. Armed only when the operator declares a budget; no budget, no harvest. The budget is stated as `budget_ms` on the drain registration (with an optional `harvest_fraction`, 0.7 by default), the refusal is the demand planner's `harvest-deadline` outcome, and the drain summary reports `harvested` against `stranded` — what the drain brought back, against the Workers it lost plus the work the deadline leaves behind.
 _Avoid_: soft deadline, timeout (the drain is not killed — admission stops, landing continues)
 
 **Decision trail**:

--- a/apps/plugin-dev/src/core/drain-registration-resolve.ts
+++ b/apps/plugin-dev/src/core/drain-registration-resolve.ts
@@ -37,6 +37,11 @@ export function drainRegistrationFor(
     : DEFAULT_FLEET_WIDTH;
   const runner = typeof input.runner === "string" && input.runner.length > 0 ? input.runner : undefined;
   const declared = declaredGateCommands(root);
+  // The operator's harvest budget, carried only when they stated one: a default
+  // here would be the daemon inventing a deadline nobody asked for (#4170).
+  const budgetMs = typeof input.budget_ms === "number" && Number.isFinite(input.budget_ms) && input.budget_ms > 0
+    ? input.budget_ms
+    : undefined;
   return buildDrainRegistration({
     repo,
     workspacePath: root,
@@ -45,6 +50,7 @@ export function drainRegistrationFor(
     ...(runner == null ? {} : { runner }),
     ...(trunkBranch(root) == null ? {} : { trunkBranch: trunkBranch(root) }),
     ...(declared.length === 0 ? {} : { validationCommands: declared }),
+    ...(budgetMs == null ? {} : { budgetMs }),
   });
 }
 

--- a/apps/plugin-dev/src/core/drain-registration.ts
+++ b/apps/plugin-dev/src/core/drain-registration.ts
@@ -37,6 +37,8 @@ export interface DrainRegistrationInput {
   readonly version: string;
   /** The label that defines "queued"; the executable lane's own by default. */
   readonly readyLabel?: string | undefined;
+  /** The operator's declared wall-clock budget for this drain; absent = none. */
+  readonly budgetMs?: number | undefined;
 }
 
 export interface DrainRegistration {
@@ -62,6 +64,15 @@ export interface DrainRegistration {
    * memory ceiling, a different package red each round.
    */
   readonly validation_commands?: readonly string[];
+  /**
+   * The operator's declared drain budget, in milliseconds (#4170).
+   *
+   * **Absent is the ordinary case and means no harvest deadline at all.** The
+   * daemon arms the deadline off this number and off nothing else, so a drain
+   * that states none runs exactly as every drain ran before it — the daemon
+   * never invents a budget an operator did not ask for.
+   */
+  readonly budget_ms?: number;
   readonly target: number;
 }
 
@@ -123,6 +134,7 @@ export function buildDrainRegistration(input: DrainRegistrationInput): DrainRegi
     ...(input.validationCommands == null || input.validationCommands.length === 0
       ? {}
       : { validation_commands: [...input.validationCommands] }),
+    ...(input.budgetMs == null ? {} : { budget_ms: input.budgetMs }),
     target: input.target,
   };
 }

--- a/apps/plugin-dev/src/mcp-tools/project.ts
+++ b/apps/plugin-dev/src/mcp-tools/project.ts
@@ -136,10 +136,11 @@ export function createProjectTools(deps: ProjectDependencies): CastleMcpTool[] {
       name: "drain",
       title: "Make this project drain",
       description:
-        "MUTATING: ensure the daemon is reachable and this project is registered. Omitted runner and target resolve from this project's canonical RedSkills configuration; repeated calls report what was kept.",
+        "MUTATING: ensure the daemon is reachable and this project is registered. Omitted runner and target resolve from this project's canonical RedSkills configuration; repeated calls report what was kept. An optional budget_ms arms the harvest deadline: past 70% of it the daemon admits no new claim and spends the rest landing what is in flight. No budget_ms, no deadline.",
       inputSchema: {
         runner: z.string().min(1).optional(),
         target: z.number().int().min(0).optional(),
+        budget_ms: z.number().int().positive().optional(),
       },
       invoke: async (input) => deps.drain(input as unknown as ProjectDrainInput),
     },

--- a/apps/plugin-dev/src/project-acp-adapter.ts
+++ b/apps/plugin-dev/src/project-acp-adapter.ts
@@ -24,6 +24,11 @@ const CONTROL_ARGUMENTS = new Set([
   "runner",
   "scope",
   "registration",
+  // The drain budget the operator declared (#4170). Accepted here and carried
+  // no further: `enrich` already folded it into the registration, which is the
+  // only place the daemon reads it from — a second copy on the control request
+  // would be a second answer to "how long is this drain".
+  "budget_ms",
   // Read shaping, accepted and ignored: `status` declares them in its schema and
   // the MCP fills the defaults in, so refusing them made the tool unusable —
   // `status { scope: project }` came back refused for a field that changes

--- a/apps/plugin-dev/tests/acp-adapter-parity.test.ts
+++ b/apps/plugin-dev/tests/acp-adapter-parity.test.ts
@@ -54,6 +54,17 @@ function projectSession() {
         observed_at: "2026-08-17T15:00:00.000Z",
         items: [],
       },
+      // No budget was declared for this drain, so the harvest deadline is inert.
+      harvest: {
+        state: "inert",
+        budget_ms: null,
+        harvest_fraction: null,
+        harvest_at: null,
+        deadline_at: null,
+        harvested: 0,
+        stranded: 0,
+        detail: "no drain budget was declared, so no harvest deadline stands and admission is unchanged",
+      },
       adapter_health: {
         status: "healthy",
         checked_at: "2026-08-17T14:59:59.000Z",

--- a/apps/plugin-dev/tests/acp-ci-posture.test.ts
+++ b/apps/plugin-dev/tests/acp-ci-posture.test.ts
@@ -53,6 +53,11 @@ const FOCUSED_ACP_SUITES = [
     suite: "tests/acp-agent-conformance.test.ts",
     why: "the five supported Agents, each probed at the ACP baseline before a Worker may reach it",
   },
+  {
+    script: "test:acp-harvest-deadline",
+    suite: "tests/acp-harvest-deadline.test.ts",
+    why: "a budgeted drain refusing a new claim past the harvest fraction while a landing in flight completes",
+  },
 ] as const;
 
 /** The broad gates #3878 removed, each with the focused surface that answers it. */

--- a/apps/plugin-dev/tests/mcp-tool-surface.test.ts
+++ b/apps/plugin-dev/tests/mcp-tool-surface.test.ts
@@ -52,8 +52,8 @@ const SURFACE: ReadonlyArray<{
     name: "drain",
     title: "Make this project drain",
     description:
-      "MUTATING: ensure the daemon is reachable and this project is registered. Omitted runner and target resolve from this project's canonical RedSkills configuration; repeated calls report what was kept.",
-    schema: ["runner", "target"],
+      "MUTATING: ensure the daemon is reachable and this project is registered. Omitted runner and target resolve from this project's canonical RedSkills configuration; repeated calls report what was kept. An optional budget_ms arms the harvest deadline: past 70% of it the daemon admits no new claim and spends the rest landing what is in flight. No budget_ms, no deadline.",
+    schema: ["runner", "target", "budget_ms"],
   },
   {
     name: "project_start",

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -51,6 +51,7 @@
     "test:acp-control-plane": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/acp-control-plane.test.ts",
     "test:acp-local-transport": "vitest run tests/acp-local-transport.test.ts",
     "test:death-evidence": "vitest run tests/death-evidence.test.ts",
+    "test:acp-harvest-deadline": "vitest run tests/acp-harvest-deadline.test.ts",
     "test:placement-contract": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/placement-contract.test.ts",
     "test:github-gateway": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/github-gateway.test.ts",
     "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/redskilled.bundle.min.mjs --asset redskilled.bundle.min.mjs --minify --reddb-from-package",

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -84,6 +84,7 @@ import {
   buildRegistrationStop,
   mayRecoverRegistration,
 } from "../registration-recovery.js";
+import { foldProjectHarvest, harvestPlanFields, type RedskilledHarvestTally } from "../harvest-deadline.js";
 import {
   buildProjectRegistration,
   renewProjectRegistration,
@@ -520,6 +521,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // right now", and a fresh daemon has no business inheriting a verdict about a
   // machine it has not tried yet.
   const birthHealth: Record<string, RedskilledBirthHealth> = {};
+  // Beside it, and in memory for the same reason: what this drain brought back (#4170).
+  const harvestTallies: Record<string, RedskilledHarvestTally> = {};
   let demandTicking = false;
   let sampleTimer: NodeJS.Timeout | undefined;
   let leaseTimer: NodeJS.Timeout | undefined;
@@ -708,6 +711,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       stops,
       orphanedRegistrations: [...orphanedRegistrations.values()],
       birthLatches: describeBirthLatches(birthHealth, Date.parse(now)),
+      harvest: harvestTallies,
       // The poll each registration was last covered by, so "why is nothing
       // happening" is answerable from one read instead of from a log.
       queue: lastQueue,
@@ -996,6 +1000,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
             argv: registration.argv,
             workspace_path: registration.workspace_path,
             target: registration.target,
+            ...harvestPlanFields(registration),
             ...(queueItems.get(registration.project_label) == null
               ? {}
               : { items: queueItems.get(registration.project_label) }),
@@ -1724,10 +1729,12 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       // lifetime and an outcome class — never a cause (rule 3): a Worker dead in
       // seconds is spent whatever the reason was UNLESS it reported that it was
       // finished, which is the one thing a spent birth never does.
+      const birthOutcome = facts.birthOutcome ?? "unreported";
+      foldProjectHarvest(harvestTallies, worker.project_label, birthOutcome);
       foldProjectBirthHealth({
         health: birthHealth, projectLabel: worker.project_label, nowMs: Date.parse(ts),
         lifetimeMs: Date.parse(ts) - Date.parse(worker.started_at),
-        outcome: facts.birthOutcome ?? "unreported",
+        outcome: birthOutcome,
         announce: (line) => process.stderr.write(line),
       });
     }

--- a/apps/redskilled/src/demand-loop.ts
+++ b/apps/redskilled/src/demand-loop.ts
@@ -52,16 +52,25 @@
  * {@link RedskilledWorkerBirthOutcome} — and only a death that reached no
  * terminal outcome counts.
  *
+ * **A declared budget stops the taking before it stops the drain.** An operator
+ * who states `budget_ms` on the registration gets a harvest deadline: past the
+ * declared fraction of that budget the planner admits no NEW claim, while every
+ * Worker already alive keeps publishing and landing what it carries, because
+ * work finished and never landed counts as zero (`harvest-deadline.ts`, #4170).
+ * No declared budget, no deadline — the daemon invents none.
+ *
  * **Rule 3 survives.** A selector and an argv are carried and handed back; not
  * one branch here turns on what either of them says. The planner reads a depth,
- * a target, a count of live Workers and a streak of short-lived deaths — four
- * integers — and nothing else. The outcome class is a closed vocabulary of three
+ * a target, a count of live Workers, a streak of short-lived deaths and a
+ * budget the operator stated in milliseconds — five numbers — and nothing else. The outcome class is a closed vocabulary of three
  * words the Worker protocol already speaks, never a repository's reason: this
  * module learns THAT a Worker reached a terminal outcome, never what the work
  * was, and the daemon is owed no more than that.
  *
  * PURE.
  */
+
+import { decideHarvest, type RedskilledHarvestWatch } from "./harvest-deadline.js";
 
 /**
  * How long the loop waits after a refusal before asking again.
@@ -122,6 +131,13 @@ export interface RedskilledDemandProject {
    * host chose. Carried, never read.
    */
   readonly items?: readonly string[];
+  /**
+   * The operator's declared drain budget, dated (#4170); absent = none declared.
+   *
+   * Two numbers and an instant, exactly as opaque as the rest: the planner
+   * compares them against `nowMs` and never asks what the drain is for.
+   */
+  readonly harvest?: RedskilledHarvestWatch;
 }
 
 /** What the loop decided about one project this tick, and why. */
@@ -134,7 +150,9 @@ export type RedskilledDemandOutcome =
   /** This project's Workers keep dying in boot, so it is not asked again yet. */
   | "birth-halted"
   /** One birth is due or running after the breaker's cooldown. */
-  | "half-open-probe";
+  | "half-open-probe"
+  /** Past the harvest fraction of a declared budget: no NEW claim, landing continues. */
+  | "harvest-deadline";
 
 export interface RedskilledDemandIntent {
   readonly project_label: string;
@@ -225,6 +243,17 @@ export function planHostDemand(input: PlanHostDemandInput): RedskilledDemandPlan
     const depth = counted ? input.queue[project.project_label] ?? null : null;
     const base = { project_label: project.project_label, queue_depth: depth, target: project.target, live };
 
+    // **Checked before the host's own backoff, and deliberately.** A backoff is
+    // this tick's weather and clears itself; a harvest deadline is the standing
+    // policy the operator declared, and it is what an operator asking "why is
+    // nothing being born" needs to read. It gates BIRTHS only — the Workers
+    // already alive keep publishing and landing what they carry, which is the
+    // whole point of stopping before the budget dies (#4170).
+    const harvest = decideHarvest(project.harvest, input.nowMs);
+    if (!harvest.admits) {
+      intents.push({ ...base, outcome: "harvest-deadline", wanted: 0, detail: harvest.detail });
+      continue;
+    }
     if (holding) {
       intents.push({
         ...base,

--- a/apps/redskilled/src/harvest-deadline.ts
+++ b/apps/redskilled/src/harvest-deadline.ts
@@ -1,0 +1,297 @@
+/**
+ * harvest-deadline — a drain the operator gave a budget stops TAKING work
+ * before the budget dies, and spends what is left bringing back what it has
+ * (#4170, Spec #4164; glossary: **Harvest deadline**).
+ *
+ * **Finished-but-unlanded work counts as zero.** A drain that admits a Worker
+ * ten minutes before its budget expires buys a claim it cannot land: the Ticket
+ * is taken, the branch exists, and nothing merged. Past the harvest fraction —
+ * 0.7 of the declared budget — the daemon therefore admits no NEW claim while
+ * the Workers already alive keep publishing and landing what they carry. The
+ * deadline gates births, never the landing lane, because the whole point is to
+ * spend the last third of the budget harvesting.
+ *
+ * **No declared budget, no deadline.** The policy is armed by an operator
+ * stating `budget_ms` on the drain registration and by nothing else: absent, it
+ * reports `inert`, refuses nothing, and invents no instant (Spec #4164 —
+ * "never invent a deadline the operator did not ask for"). There is no default
+ * budget, and a daemon that picked one would be deciding how long an operator's
+ * night is.
+ *
+ * **Shape is checked; meaning never is** (ADR 0130 rule 3). The declaration is
+ * two numbers the daemon compares against its own clock — a budget in
+ * milliseconds and a fraction — never a sentence about what the drain is for. A
+ * non-positive budget and a fraction outside `(0, 1]` are refused as client
+ * bugs the daemon can see without reading anything.
+ *
+ * PURE: every input is passed in, the clock included.
+ */
+import type { RedskilledWorkerBirthOutcome } from "./demand-loop.js";
+
+/**
+ * How much of a declared budget a drain spends taking new work.
+ *
+ * 0.7 leaves the last third for the harvest, which is the shape of the cost:
+ * a claim is cheap to take and expensive to bring back — gate, publish, PR,
+ * merge — so the tail has to be long enough for work in flight to land, and
+ * short enough that most of the night is still spent working.
+ */
+export const REDSKILLED_DEFAULT_HARVEST_FRACTION = 0.7;
+
+/**
+ * What an operator declared about a drain's budget — the whole of the policy's
+ * input, and absent on every registration that declared none.
+ *
+ * Carried by the registration REQUEST and by the record the daemon hands back,
+ * so one type states the field names once and both sides spell them the same.
+ */
+export interface RedskilledHarvestDeclaration {
+  /**
+   * Wall-clock budget for this drain, running from the daemon's `registered_at`.
+   *
+   * Milliseconds, on the daemon's own clock: a client stating an absolute
+   * deadline would state it in a clock the daemon cannot check, exactly as the
+   * renewal window is stated as a window rather than an instant.
+   */
+  readonly budget_ms?: number;
+  /** Where the harvest begins, as a fraction of the budget; 0.7 when unstated. */
+  readonly harvest_fraction?: number;
+}
+
+/** Shape-check one operator declaration, or refuse it. PURE. */
+export function requireHarvestDeclaration(
+  declaration: RedskilledHarvestDeclaration,
+  projectLabel: string,
+): RedskilledHarvestDeclaration {
+  const project = JSON.stringify(projectLabel);
+  const budgetMs = declaration.budget_ms;
+  if (budgetMs !== undefined && (!Number.isFinite(budgetMs) || budgetMs <= 0)) {
+    throw new Error(
+      `redskilled needs a positive drain budget to register project ${project}, not ` +
+        `${JSON.stringify(budgetMs)}: a budget that is already spent would harvest a drain that never started`,
+    );
+  }
+  const fraction = declaration.harvest_fraction;
+  if (fraction !== undefined && (!Number.isFinite(fraction) || fraction <= 0 || fraction > 1)) {
+    throw new Error(
+      `redskilled needs a harvest fraction in (0, 1] to register project ${project}, not ` +
+        `${JSON.stringify(fraction)}`,
+    );
+  }
+  // A fraction without a budget is a policy nobody armed; refused rather than
+  // stored, because a record carrying half a declaration reads as armed.
+  if (fraction !== undefined && budgetMs === undefined) {
+    throw new Error(
+      `redskilled cannot hold a harvest fraction for project ${project} without a budget: the harvest deadline is ` +
+        `armed by a declared \`budget_ms\` and by nothing else`,
+    );
+  }
+  return {
+    ...(budgetMs === undefined ? {} : { budget_ms: budgetMs }),
+    ...(fraction === undefined ? {} : { harvest_fraction: fraction }),
+  };
+}
+
+/** One project's declaration, dated on the instant its budget started running. */
+export interface RedskilledHarvestWatch extends RedskilledHarvestDeclaration {
+  /** When the budget started — the daemon's own `registered_at`, in milliseconds. */
+  readonly startedAtMs: number;
+}
+
+/**
+ * What a budget is doing to admission right now.
+ *
+ * `inert` is a distinct state from `admitting` on purpose: both admit, and only
+ * one of them will ever stop. An operator reading "admitting" wants to know
+ * whether a deadline is coming.
+ */
+export type RedskilledHarvestState = "inert" | "admitting" | "harvesting";
+
+/** The admission answer, with the instants a reader needs to check it. */
+export interface RedskilledHarvestDecision {
+  readonly state: RedskilledHarvestState;
+  /** Whether a NEW claim may be admitted; landing is never gated by this. */
+  readonly admits: boolean;
+  readonly budgetMs: number | null;
+  readonly fraction: number | null;
+  /** When new claims stop being admitted; `null` when no budget was declared. */
+  readonly harvestAtMs: number | null;
+  /** When the declared budget runs out; `null` when none was declared. */
+  readonly deadlineAtMs: number | null;
+  readonly detail: string;
+}
+
+/** The answer for a project whose operator declared nothing. PURE. */
+const INERT: RedskilledHarvestDecision = {
+  state: "inert",
+  admits: true,
+  budgetMs: null,
+  fraction: null,
+  harvestAtMs: null,
+  deadlineAtMs: null,
+  detail: "no drain budget was declared, so no harvest deadline stands and admission is unchanged",
+};
+
+/**
+ * Decide what a declared budget does to admission at `nowMs`. PURE.
+ *
+ * An unreadable budget start is treated as no budget at all rather than as an
+ * expired one: refusing every birth on a clock the daemon could not parse would
+ * stop a drain the operator never budgeted.
+ */
+export function decideHarvest(
+  watch: RedskilledHarvestWatch | undefined,
+  nowMs: number,
+): RedskilledHarvestDecision {
+  const budgetMs = watch?.budget_ms;
+  if (watch == null || budgetMs == null || !Number.isFinite(watch.startedAtMs)) return INERT;
+  const fraction = watch.harvest_fraction ?? REDSKILLED_DEFAULT_HARVEST_FRACTION;
+  const harvestAtMs = watch.startedAtMs + budgetMs * fraction;
+  const deadlineAtMs = watch.startedAtMs + budgetMs;
+  const harvesting = nowMs >= harvestAtMs;
+  return {
+    state: harvesting ? "harvesting" : "admitting",
+    admits: !harvesting,
+    budgetMs,
+    fraction,
+    harvestAtMs,
+    deadlineAtMs,
+    detail: harvesting
+      ? `the declared ${budgetMs}ms budget passed its harvest fraction of ${fraction} at ` +
+        `${new Date(harvestAtMs).toISOString()}, so no new claim is admitted before the budget ends at ` +
+        `${new Date(deadlineAtMs).toISOString()} — work already in flight keeps landing`
+      : `the declared ${budgetMs}ms budget admits new claims until ${new Date(harvestAtMs).toISOString()}, ` +
+        `after which the drain harvests what it holds until ${new Date(deadlineAtMs).toISOString()}`,
+  };
+}
+
+/** The watch a held registration arms, or `undefined` when it declared none. PURE. */
+export function harvestWatchOf(
+  registration: RedskilledHarvestDeclaration & { readonly registered_at?: string },
+): RedskilledHarvestWatch | undefined {
+  if (registration.budget_ms == null) return undefined;
+  const startedAtMs = Date.parse(registration.registered_at ?? "");
+  if (!Number.isFinite(startedAtMs)) return undefined;
+  return {
+    budget_ms: registration.budget_ms,
+    ...(registration.harvest_fraction == null ? {} : { harvest_fraction: registration.harvest_fraction }),
+    startedAtMs,
+  };
+}
+
+/**
+ * The planner fields one held registration contributes. PURE.
+ *
+ * Spread rather than branched at the call site: the demand tick assembles one
+ * project record per registration inside the daemon's longest closure, and a
+ * policy that made that closure one condition longer would be paid for by every
+ * reader of it, for one optional field.
+ */
+export function harvestPlanFields(
+  registration: RedskilledHarvestDeclaration & { readonly registered_at?: string },
+): { readonly harvest?: RedskilledHarvestWatch } {
+  const watch = harvestWatchOf(registration);
+  return watch == null ? {} : { harvest: watch };
+}
+
+/**
+ * What a drain has brought back, and what it has lost, since the daemon began
+ * holding this project.
+ *
+ * Folded from the outcome class a dead Worker REPORTED — the same three words
+ * the birth breaker reads — and never from an account of what the work was:
+ * `work-reported` is one unit harvested, `unreported` is one unit lost, and
+ * `no-eligible-work` is neither because nothing was taken.
+ *
+ * In memory, per daemon generation, like the birth health it folds beside: a
+ * tally is what this drain has done, not a lifetime total of the machine.
+ */
+export interface RedskilledHarvestTally {
+  /** Workers that reported a terminal outcome on work they took. */
+  readonly harvested: number;
+  /** Workers that ended without reporting one — work taken and not brought back. */
+  readonly stranded: number;
+}
+
+export const EMPTY_HARVEST_TALLY: RedskilledHarvestTally = { harvested: 0, stranded: 0 };
+
+/** Fold one death's outcome class into a project's tally. PURE. */
+export function foldHarvestOutcome(
+  tally: RedskilledHarvestTally | undefined,
+  outcome: RedskilledWorkerBirthOutcome,
+): RedskilledHarvestTally {
+  const held = tally ?? EMPTY_HARVEST_TALLY;
+  if (outcome === "work-reported") return { ...held, harvested: held.harvested + 1 };
+  if (outcome === "unreported") return { ...held, stranded: held.stranded + 1 };
+  return held;
+}
+
+/** Fold one death into the daemon's live per-project record, in place. */
+export function foldProjectHarvest(
+  tallies: Record<string, RedskilledHarvestTally>,
+  projectLabel: string,
+  outcome: RedskilledWorkerBirthOutcome,
+): void {
+  tallies[projectLabel] = foldHarvestOutcome(tallies[projectLabel], outcome);
+}
+
+/** The harvest block a drain summary carries — instants as the wire spells them. */
+export interface RedskilledHarvestReport {
+  readonly state: RedskilledHarvestState;
+  readonly budget_ms: number | null;
+  readonly harvest_fraction: number | null;
+  readonly harvest_at: string | null;
+  readonly deadline_at: string | null;
+  /** Units of work this drain brought back. */
+  readonly harvested: number;
+  /** Units it did not: lost Workers, plus what the deadline leaves behind. */
+  readonly stranded: number;
+  readonly detail: string;
+}
+
+export interface HarvestReportInput {
+  /** The daemon's `registered_at` for this project; absent leaves the policy inert. */
+  readonly registeredAt?: string | undefined;
+  readonly declaration?: RedskilledHarvestDeclaration | undefined;
+  readonly tally?: RedskilledHarvestTally | undefined;
+  /** Workers alive for this project at the read. */
+  readonly live: number;
+  /** The last counted queue depth; `null` when nobody counted it. */
+  readonly queueDepth: number | null;
+  /** The instant the summary is dated at. */
+  readonly observedAt: string;
+}
+
+/**
+ * Compose the harvested-versus-stranded block for one project's drain. PURE.
+ *
+ * **Stranded grows at the deadline, not before it.** Until the harvest begins,
+ * a live Worker and a queued item are work in progress; once it has begun,
+ * neither will be finished by this drain, so both join what the budget leaves
+ * behind. Counted separately from the lost Workers already folded into the
+ * tally, and summed into one number an operator can read at a glance.
+ *
+ * The counts are reported whatever the state, including `inert`: they describe
+ * what the drain DID, not what the policy did, and a drain with no budget still
+ * brings work back. What "inert" removes is the deadline and the refusal.
+ */
+export function harvestReport(input: HarvestReportInput): RedskilledHarvestReport {
+  const watch = input.declaration == null
+    ? undefined
+    : harvestWatchOf({ ...input.declaration, ...(input.registeredAt == null ? {} : { registered_at: input.registeredAt }) });
+  const decision = decideHarvest(watch, Date.parse(input.observedAt));
+  const tally = input.tally ?? EMPTY_HARVEST_TALLY;
+  const leftBehind = decision.state === "harvesting"
+    ? Math.max(0, input.live) + Math.max(0, input.queueDepth ?? 0)
+    : 0;
+  return {
+    state: decision.state,
+    budget_ms: decision.budgetMs,
+    harvest_fraction: decision.fraction,
+    harvest_at: decision.harvestAtMs == null ? null : new Date(decision.harvestAtMs).toISOString(),
+    deadline_at: decision.deadlineAtMs == null ? null : new Date(decision.deadlineAtMs).toISOString(),
+    harvested: tally.harvested,
+    stranded: tally.stranded + leftBehind,
+    detail: decision.detail,
+  };
+}

--- a/apps/redskilled/src/host-state.ts
+++ b/apps/redskilled/src/host-state.ts
@@ -27,6 +27,7 @@ import {
 } from "./project-registration.js";
 import { REDSKILLED_PROTOCOL_VERSION } from "./protocol.js";
 import type { RedskilledBirthLatch } from "./demand-loop.js";
+import type { RedskilledHarvestTally } from "./harvest-deadline.js";
 import type { RedskilledQueueDiscovery, RedskilledQueueOutcome } from "./queue-discovery.js";
 import type { RedskilledMajorHold, RedskilledReplacementHoldReason } from "./self-replace.js";
 import type { RedskilledWorkerBudget } from "./worker-placement.js";
@@ -240,6 +241,14 @@ export interface RedskilledRegistrationView extends RedskilledProjectRegistratio
    * is a different answer from a depth of zero and sends an operator somewhere else.
    */
   readonly last_poll?: RedskilledRegistrationPoll;
+  /**
+   * What this project's drain has brought back and lost (#4170).
+   *
+   * Beside the poll rather than inside it for the same reason the poll is beside
+   * the record: a depth is what remains, and this is what already happened.
+   * Absent when this daemon generation has seen no Worker of this project end.
+   */
+  readonly harvest?: RedskilledHarvestTally;
 }
 
 /**
@@ -418,6 +427,8 @@ export interface BuildHostStateInput {
   readonly orphanedRegistrations?: readonly RedskilledOrphanedRegistration[];
   /** The daemon's in-memory birth latches, already composed for read surfaces. */
   readonly birthLatches?: readonly RedskilledBirthLatch[];
+  /** Per-project harvest tallies, keyed by label; absent is a daemon that folded none. */
+  readonly harvest?: Readonly<Record<string, RedskilledHarvestTally>>;
   /**
    * The last queue poll, as the poller left it; absent when none has run.
    *
@@ -509,9 +520,11 @@ function buildRegistrationViews(input: BuildHostStateInput): readonly Redskilled
   return [...(input.registrations ?? [])]
     .map((registration): RedskilledRegistrationView => {
       const polled = polls.get(registration.project_label);
+      const harvest = input.harvest?.[registration.project_label];
       return {
         ...registration,
         ...(judged ? { renewal: registrationRenewalStatus(registration, nowMs) } : {}),
+        ...(harvest == null ? {} : { harvest }),
         ...(queue == null || polled == null
           ? {}
           : {

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -15,6 +15,7 @@ import {
   type RedskillsAcpMethodDomain,
 } from "./acp-method-registry.js";
 import type { RedskilledDemandOutcome } from "./demand-loop.js";
+import { harvestReport, type RedskilledHarvestReport } from "./harvest-deadline.js";
 import type { RedskilledHostState } from "./host-state.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 import { REDSKILLED_QUEUE_STALENESS_MS } from "./queue-discovery.js";
@@ -66,6 +67,15 @@ export interface ProjectStatusContext {
       readonly base_commits_ahead: number | null;
     }[];
   };
+  /**
+   * The drain's harvest block: the deadline, and what it brought back (#4170).
+   *
+   * This context IS the drain summary an operator reads — the one surface that
+   * already carries the queue, the Workers and the health of a draining
+   * project — so the harvested-versus-stranded count belongs here rather than
+   * in a second document that would have to be kept in step with this one.
+   */
+  readonly harvest: RedskilledHarvestReport;
   readonly adapter_health: {
     readonly status: "healthy" | "degraded" | "unknown";
     readonly checked_at: string | null;
@@ -196,6 +206,14 @@ export function projectStatusSnapshot(
         base_commits_ahead: worker.base_commits_ahead ?? null,
       })),
     },
+    harvest: harvestReport({
+      ...(registration?.registered_at == null ? {} : { registeredAt: registration.registered_at }),
+      ...(registration == null ? {} : { declaration: registration }),
+      ...(registration?.harvest == null ? {} : { tally: registration.harvest }),
+      live: workers.length,
+      queueDepth: depth,
+      observedAt,
+    }),
     adapter_health: health == null
       ? {
           status: "unknown",

--- a/apps/redskilled/src/project-registration.ts
+++ b/apps/redskilled/src/project-registration.ts
@@ -57,6 +57,7 @@ import {
   type RedskilledPublicHostEventKind,
 } from "./event-lane.js";
 import type { RedskilledQueueOutcome } from "./queue-discovery.js";
+import { requireHarvestDeclaration, type RedskilledHarvestDeclaration } from "./harvest-deadline.js";
 import {
   isQueuePollPlanShape,
   requireQueuePollPlan,
@@ -122,7 +123,7 @@ export interface RedskilledTrunk {
  * stating it in a clock the daemon cannot check, and a few seconds of skew would
  * silently lengthen or shorten every registration on the host.
  */
-export interface RedskilledProjectRegistrationRequest {
+export interface RedskilledProjectRegistrationRequest extends RedskilledHarvestDeclaration {
   /** The repository identity, carried as the same opaque label a Worker carries. */
   readonly project_label: string;
   /** The query that names this project's work. Opaque — carried, never read. */
@@ -160,7 +161,7 @@ export interface RedskilledProjectRegistrationRequest {
 }
 
 /** One project the daemon holds, as it reports it back. */
-export interface RedskilledProjectRegistration {
+export interface RedskilledProjectRegistration extends RedskilledHarvestDeclaration {
   readonly version: 1;
   readonly project_label: string;
   readonly selector: string;
@@ -293,6 +294,9 @@ export function buildProjectRegistration(
   // Same shape check, same reason as the argv: a registration the host could
   // never start a Worker for is a client bug the daemon can see without reading
   // anything about what the path names.
+  // The operator's harvest budget, checked exactly as opaquely: two numbers
+  // compared against the daemon's own clock, never a sentence (#4170).
+  const harvest = requireHarvestDeclaration(request, projectLabel);
   const workspacePath = requireText(
     request.workspace_path,
     `a workspace path for project ${JSON.stringify(projectLabel)}`,
@@ -340,6 +344,7 @@ export function buildProjectRegistration(
     ...(hooks == null ? {} : { hooks }),
     ...(prompt == null ? {} : { prompt }),
     ...(validationCommands == null || validationCommands.length === 0 ? {} : { validation_commands: validationCommands }),
+    ...harvest,
     target: request.target,
     ...(request.standing === true ? { standing: true } : {}),
     registered_at: new Date(nowMs).toISOString(),

--- a/apps/redskilled/tests/acp-harvest-deadline.test.ts
+++ b/apps/redskilled/tests/acp-harvest-deadline.test.ts
@@ -1,0 +1,357 @@
+// The harvest deadline over ACP (#4170, Spec #4164).
+//
+// Black-box, at the two seams a client actually reaches: what the daemon
+// ANSWERS about a drain on `_redskills/project_status`, and what the landing
+// lane does while that answer says the drain has stopped admitting. Nothing
+// here reaches inside the daemon — the registration arrives over the socket as
+// a client states it, the admission plan is the daemon's own planner, and the
+// landing is the daemon's own `_redskills/land` body.
+//
+// The clock is injected, so "past 70% of the budget" costs no wall time: a
+// suite that slept through a real budget would be pinning the machine's
+// patience rather than the policy.
+import { execFileSync } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { client, methods, type ClientConnection } from "@agentclientprotocol/sdk";
+import { socketStream } from "@reddb-io/protocol-acp";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { RedskillsProjectStatusSnapshot } from "../src/acp-client.js";
+import { startRedskillsAcpControlPlane } from "../src/acp-control-plane.js";
+import { bindAcpWorkerLand, landParams } from "../src/acp-publication.js";
+import {
+  createRedskilledGithubGateway,
+  type RedskilledGithubGatewayRegistration,
+} from "../src/github-gateway.js";
+import { planHostDemand } from "../src/demand-loop.js";
+import { foldProjectHarvest, harvestPlanFields, type RedskilledHarvestTally } from "../src/harvest-deadline.js";
+import { buildHostState, type RedskilledHostState } from "../src/host-state.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+import { buildProjectRegistration, type RedskilledProjectRegistration } from "../src/project-registration.js";
+import { resolveAcpProjectIdentity } from "../src/project-workspace.js";
+
+const REGISTERED_AT = "2026-08-21T22:00:00.000Z";
+const BUDGET_MS = 3_600_000;
+/** 0.7 of the budget, to the millisecond: admission stops here. */
+const HARVEST_AT = new Date(Date.parse(REGISTERED_AT) + BUDGET_MS * 0.7).toISOString();
+const BEFORE_HARVEST = new Date(Date.parse(HARVEST_AT) - 60_000).toISOString();
+
+const roots: string[] = [];
+const gateways: { close?(): void }[] = [];
+
+/**
+ * A checkout the daemon can name `owner/name`.
+ *
+ * The landing lane refuses a Project without a canonical repository identity,
+ * and rightly so — a credential is scoped to a repository. The fixture is a git
+ * checkout with a remote, so the drain and the landing are the SAME project
+ * rather than two labels that happen to be tested together.
+ */
+async function fixtureCheckout(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  execFileSync("git", ["init", "--quiet", "--initial-branch", "main", root], { stdio: "ignore" });
+  execFileSync("git", ["-C", root, "remote", "add", "origin", "https://github.com/acme/widgets.git"], {
+    stdio: "ignore",
+  });
+  return root;
+}
+
+afterEach(async () => {
+  for (const gateway of gateways.splice(0)) gateway.close?.();
+  // Retried: the custodian's record lands asynchronously after a handoff
+  // returns, so a removal racing that write sees ENOTEMPTY once and succeeds
+  // on the next pass — a fixture that failed there would fail the assertions
+  // it already passed.
+  await Promise.all(roots.splice(0).map((root) =>
+    rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
+  ));
+});
+
+describe("a budgeted drain over ACP", () => {
+  it("refuses a new claim past the harvest fraction while a landing in flight completes", async () => {
+    const root = await fixtureCheckout("redskilled-harvest-");
+    const identity = await resolveAcpProjectIdentity(root, { env: {} });
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+
+    let now = REGISTERED_AT;
+    const registrations = new Map<string, RedskilledProjectRegistration>();
+    const tallies: Record<string, RedskilledHarvestTally> = {};
+    const control = await startRedskillsAcpControlPlane({
+      paths,
+      clock: () => now,
+      startWorker: () => {
+        throw new Error("a harvesting drain must birth no Worker");
+      },
+      // The daemon's own registration path, exactly as the lifecycle hands it in.
+      registerProject: (request) => {
+        const held = buildProjectRegistration(request, { now });
+        registrations.set(held.project_label, held);
+        return held;
+      },
+      hostState: () => hostState(identity.projectLabel, registrations, tallies, now),
+    });
+
+    let connection: ClientConnection | undefined;
+    try {
+      const connected = await connectProject(control.socketPath, root);
+      connection = connected.connection;
+
+      // The operator declares the budget on the drain registration, and on
+      // nothing else: the daemon arms the deadline off this number alone.
+      await connection.agent.request("_redskills/project_drain", {
+        registration: {
+          selector: `repo:${identity.projectLabel} label:ready-for-agent`,
+          argv: ["redskilled", "acp-worker"],
+          workspace_path: root,
+          target: 2,
+          budget_ms: BUDGET_MS,
+        },
+      });
+      expect(registrations.get(identity.projectLabel)?.budget_ms).toBe(BUDGET_MS);
+
+      now = BEFORE_HARVEST;
+      const admitting = await connection.agent.request<RedskillsProjectStatusSnapshot>(
+        "_redskills/project_status",
+        {},
+      );
+      expect(admitting.context.harvest.state).toBe("admitting");
+      expect(admitting.context.queue.posture).toBe("asking");
+      expect(admitting.context.queue.wanted).toBe(1);
+
+      // One Worker of the pair has ended, reporting a terminal outcome on its
+      // work — the drain's yield so far.
+      foldProjectHarvest(tallies, identity.projectLabel, "work-reported");
+
+      now = HARVEST_AT;
+      const harvesting = await connection.agent.request<RedskillsProjectStatusSnapshot>(
+        "_redskills/project_status",
+        {},
+      );
+
+      // No new claim: the planner admits nothing and says why.
+      expect(harvesting.context.queue.posture).toBe("harvest-deadline");
+      expect(harvesting.context.queue.wanted).toBe(0);
+      expect(harvesting.context.queue.detail).toContain("no new claim is admitted");
+      // The drain summary names both sides of the ledger: one unit brought back,
+      // and the one live Worker plus the four queued items the budget leaves.
+      expect(harvesting.context.harvest).toMatchObject({
+        state: "harvesting",
+        budget_ms: BUDGET_MS,
+        harvest_fraction: 0.7,
+        harvest_at: HARVEST_AT,
+        harvested: 1,
+        stranded: 5,
+      });
+      // The Worker in flight is untouched — it is what the harvest is for.
+      expect(harvesting.context.workers.total).toBe(1);
+
+      // …and its landing still completes, on the same daemon, at the same
+      // instant the admission is refusing.
+      const land = bindAcpWorkerLand({
+        gateway: landingGateway(root),
+        held: () => ({
+          workerId: "0000000Worker",
+          worktreePath: join(root, "worktree"),
+          project: {
+            projectId: identity.projectId,
+            projectLabel: identity.projectLabel,
+            checkoutRoot: root,
+            workspacePath: root,
+          },
+        }),
+      });
+      const landed = await land({
+        params: landParams({
+          idempotency_key: "worker-land:harvest:1",
+          branch: "afk/4170-harvest",
+          commit: "1a23b45c".repeat(5),
+          base: "main",
+          title: "The harvest lands what is in flight",
+          body: "Refs #4170",
+          owner_ticket: 4170,
+        }),
+      });
+
+      expect(landed.pull_request).toBe(73);
+      expect(landed.custody_state).toBe("active");
+    } finally {
+      connection?.close();
+      await control.close();
+    }
+  }, 30_000);
+
+  it("arms nothing at all for a drain that declared no budget", async () => {
+    const root = await fixtureCheckout("redskilled-harvest-inert-");
+    const identity = await resolveAcpProjectIdentity(root, { env: {} });
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+
+    let now = REGISTERED_AT;
+    const registrations = new Map<string, RedskilledProjectRegistration>();
+    const control = await startRedskillsAcpControlPlane({
+      paths,
+      clock: () => now,
+      startWorker: () => {
+        throw new Error("this test births no Worker");
+      },
+      registerProject: (request) => {
+        const held = buildProjectRegistration(request, { now });
+        registrations.set(held.project_label, held);
+        return held;
+      },
+      hostState: () => hostState(identity.projectLabel, registrations, {}, now),
+    });
+
+    let connection: ClientConnection | undefined;
+    try {
+      const connected = await connectProject(control.socketPath, root);
+      connection = connected.connection;
+      await connection.agent.request("_redskills/project_drain", {
+        registration: {
+          selector: `repo:${identity.projectLabel} label:ready-for-agent`,
+          argv: ["redskilled", "acp-worker"],
+          workspace_path: root,
+          target: 2,
+        },
+      });
+
+      // A whole budget's worth of time later, and then some: with nothing
+      // declared there is no deadline to pass.
+      now = new Date(Date.parse(REGISTERED_AT) + BUDGET_MS * 10).toISOString();
+      const status = await connection.agent.request<RedskillsProjectStatusSnapshot>(
+        "_redskills/project_status",
+        {},
+      );
+
+      expect(status.context.harvest).toMatchObject({
+        state: "inert",
+        budget_ms: null,
+        harvest_at: null,
+        deadline_at: null,
+      });
+      expect(status.context.queue.posture).toBe("asking");
+      expect(status.context.queue.wanted).toBe(1);
+    } finally {
+      connection?.close();
+      await control.close();
+    }
+  }, 30_000);
+});
+
+/**
+ * The host document, composed the way the daemon composes it: the held
+ * registration, one live Worker, the last poll, and the planner's own answer.
+ */
+function hostState(
+  projectLabel: string,
+  registrations: ReadonlyMap<string, RedskilledProjectRegistration>,
+  harvest: Readonly<Record<string, RedskilledHarvestTally>>,
+  now: string,
+): RedskilledHostState {
+  const held = [...registrations.values()];
+  const live = { [projectLabel]: 1 };
+  const queue = {
+    version: 1 as const,
+    fetched_at: now,
+    request_count: 1,
+    project_count: held.length,
+    batch_size: 1,
+    rate_limit: { remaining: 4_000, reset_at: null, exhausted: false },
+    projects: held.map((registration) => ({
+      project_label: registration.project_label,
+      outcome: "counted" as const,
+      depth: 4,
+      detail: "four eligible Tickets",
+    })),
+  };
+  const plan = planHostDemand({
+    projects: held.map((registration) => ({
+      project_label: registration.project_label,
+      selector: registration.selector,
+      argv: registration.argv,
+      workspace_path: registration.workspace_path,
+      target: registration.target,
+      ...harvestPlanFields(registration),
+    })),
+    queue: Object.fromEntries(held.map((registration) => [registration.project_label, 4])),
+    live,
+    nowMs: Date.parse(now),
+  });
+  return buildHostState({
+    daemonVersion: "0.0.0-test",
+    machineIdHash: "machine",
+    sessionKeyHash: "session",
+    pid: process.pid,
+    startedAt: REGISTERED_AT,
+    workers: [{
+      worker_id: "0000000Worker",
+      project_label: projectLabel,
+      pid: process.pid,
+      started_at: REGISTERED_AT,
+      workspace_path: "[DAEMON_WORKSPACE]",
+      isolated: true,
+      warnings: [],
+    }],
+    registrations: held,
+    queue,
+    harvest,
+    demand: {
+      version: 1,
+      at: now,
+      requested: plan.births.length,
+      granted: [],
+      shortfall: 0,
+      refusal: null,
+      retry_after: null,
+      projects: plan.intents,
+    },
+    now,
+  });
+}
+
+/** A gateway that opens the pull request without a network and without a credential. */
+function landingGateway(root: string): RedskilledGithubGatewayRegistration {
+  const gateway = createRedskilledGithubGateway({
+    upstream: async () => ({ value: {}, budget: null }),
+    outboxPath: join(root, "github-outbox.toon"),
+    custodyPath: join(root, "github-custody.toon"),
+    // Long enough that a landing which awaited the merge would time this out.
+    custodyTickMs: 3_600_000,
+    writeUpstream: async ({ write }) => write.kind === "pull-request" ? { number: 73 } : {},
+    custodyUpstream: {
+      observe: async () => ({ forge_state: "open-clean", native_intent: false }),
+      arm: async () => ({ forge_state: "open-pending", native_intent: true }),
+    },
+  });
+  gateways.push(gateway);
+  return {
+    gateway,
+    credentialForProject: () => ({ profile: "engineering", credential: { secret: "fixture-secret" } }),
+  };
+}
+
+async function connectProject(
+  socketPath: string,
+  cwd: string,
+): Promise<{ readonly connection: ClientConnection; readonly sessionId: string }> {
+  const socket = connect(socketPath);
+  await once(socket, "connect");
+  const connection = client({ name: "Harvest deadline contract" }).connect(socketStream(socket));
+  await connection.agent.request(methods.agent.initialize, {
+    protocolVersion: 1,
+    clientCapabilities: {},
+    clientInfo: { name: "Harvest deadline contract", version: "1" },
+  });
+  const session = await connection.agent.request(methods.agent.session.new, { cwd, mcpServers: [] });
+  return { connection, sessionId: session.sessionId };
+}

--- a/apps/redskilled/tests/acp-project-status.test.ts
+++ b/apps/redskilled/tests/acp-project-status.test.ts
@@ -55,6 +55,10 @@ describe("Project-scoped ACP status context", () => {
           age_ms: 60_000,
           freshness: "stale",
           detail: "the Project is holding its declared target",
+          // The daemon polls this Project because it holds its registration,
+          // and this poll counted without listing what it counted.
+          registered: true,
+          items: [],
         },
         workers: {
           total: 1,
@@ -68,6 +72,18 @@ describe("Project-scoped ACP status context", () => {
             warnings: [],
             base_commits_ahead: 3,
           }],
+        },
+        // No budget was declared for this drain, so the harvest deadline is
+        // inert: no instants, and only what the drain already did (#4170).
+        harvest: {
+          state: "inert",
+          budget_ms: null,
+          harvest_fraction: null,
+          harvest_at: null,
+          deadline_at: null,
+          harvested: 0,
+          stranded: 0,
+          detail: "no drain budget was declared, so no harvest deadline stands and admission is unchanged",
         },
         adapter_health: {
           status: "degraded",

--- a/apps/redskilled/tests/harvest-deadline.test.ts
+++ b/apps/redskilled/tests/harvest-deadline.test.ts
@@ -1,0 +1,285 @@
+// The harvest deadline (#4170, Spec #4164): a declared budget stops the taking
+// and spends the rest landing what is in flight.
+//
+// Every test here injects the clock and the budget, because the property under
+// test is a comparison between two numbers and nothing else — a suite that
+// waited for real time would be testing the machine's patience instead.
+import { describe, expect, it } from "vitest";
+
+import {
+  decideHarvest,
+  EMPTY_HARVEST_TALLY,
+  foldHarvestOutcome,
+  foldProjectHarvest,
+  harvestReport,
+  harvestWatchOf,
+  REDSKILLED_DEFAULT_HARVEST_FRACTION,
+  requireHarvestDeclaration,
+} from "../src/harvest-deadline.js";
+import { planHostDemand, type RedskilledDemandProject } from "../src/demand-loop.js";
+import { buildProjectRegistration } from "../src/project-registration.js";
+
+const REGISTERED_AT = "2026-08-21T00:00:00.000Z";
+const STARTED_AT_MS = Date.parse(REGISTERED_AT);
+const BUDGET_MS = 3_600_000;
+/** 0.7 of the budget: the instant admission stops and the harvest begins. */
+const HARVEST_AT_MS = STARTED_AT_MS + BUDGET_MS * REDSKILLED_DEFAULT_HARVEST_FRACTION;
+
+function project(overrides: Partial<RedskilledDemandProject> = {}): RedskilledDemandProject {
+  return {
+    project_label: "acme/widgets",
+    selector: "repo:acme/widgets label:ready-for-agent",
+    argv: ["redskilled", "acp-worker"],
+    workspace_path: "/tmp/acme",
+    target: 2,
+    ...overrides,
+  };
+}
+
+describe("decideHarvest — what a declared budget does to admission", () => {
+  it("stays completely inert when the operator declared no budget", () => {
+    const decision = decideHarvest(undefined, HARVEST_AT_MS + BUDGET_MS);
+
+    expect(decision.state).toBe("inert");
+    expect(decision.admits).toBe(true);
+    expect(decision.harvestAtMs).toBeNull();
+    expect(decision.deadlineAtMs).toBeNull();
+    expect(decision.detail).toContain("no drain budget was declared");
+  });
+
+  it("admits while the drain is below the harvest fraction", () => {
+    const decision = decideHarvest({ budget_ms: BUDGET_MS, startedAtMs: STARTED_AT_MS }, HARVEST_AT_MS - 1);
+
+    expect(decision.state).toBe("admitting");
+    expect(decision.admits).toBe(true);
+    expect(decision.harvestAtMs).toBe(HARVEST_AT_MS);
+    expect(decision.deadlineAtMs).toBe(STARTED_AT_MS + BUDGET_MS);
+  });
+
+  it("harvests from the fraction onward, the instant itself included", () => {
+    const at = decideHarvest({ budget_ms: BUDGET_MS, startedAtMs: STARTED_AT_MS }, HARVEST_AT_MS);
+    const past = decideHarvest({ budget_ms: BUDGET_MS, startedAtMs: STARTED_AT_MS }, HARVEST_AT_MS + 60_000);
+
+    expect(at.state).toBe("harvesting");
+    expect(at.admits).toBe(false);
+    expect(past.admits).toBe(false);
+    // The refusal states both instants, because "why is nothing being born" and
+    // "how long do the live Workers have" are asked in the same breath.
+    expect(past.detail).toContain(new Date(HARVEST_AT_MS).toISOString());
+    expect(past.detail).toContain(new Date(STARTED_AT_MS + BUDGET_MS).toISOString());
+  });
+
+  it("honours a stricter fraction the operator declared", () => {
+    const watch = { budget_ms: BUDGET_MS, harvest_fraction: 0.5, startedAtMs: STARTED_AT_MS };
+
+    expect(decideHarvest(watch, STARTED_AT_MS + BUDGET_MS * 0.5 - 1).admits).toBe(true);
+    expect(decideHarvest(watch, STARTED_AT_MS + BUDGET_MS * 0.5).admits).toBe(false);
+  });
+
+  it("treats an unreadable budget start as no budget rather than as an expired one", () => {
+    expect(decideHarvest({ budget_ms: BUDGET_MS, startedAtMs: Number.NaN }, HARVEST_AT_MS).state).toBe("inert");
+    expect(harvestWatchOf({ budget_ms: BUDGET_MS, registered_at: "not an instant" })).toBeUndefined();
+    expect(harvestWatchOf({ registered_at: REGISTERED_AT })).toBeUndefined();
+  });
+});
+
+describe("requireHarvestDeclaration — shape, never meaning", () => {
+  it("keeps a stated budget and defaults nothing when none is stated", () => {
+    expect(requireHarvestDeclaration({ budget_ms: BUDGET_MS }, "acme/widgets")).toEqual({ budget_ms: BUDGET_MS });
+    expect(requireHarvestDeclaration({}, "acme/widgets")).toEqual({});
+  });
+
+  it("refuses a budget that is not a positive number", () => {
+    for (const budget of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => requireHarvestDeclaration({ budget_ms: budget }, "acme/widgets")).toThrow(/positive drain budget/);
+    }
+  });
+
+  it("refuses a fraction outside (0, 1], and one stated without a budget", () => {
+    for (const fraction of [0, -0.5, 1.5, Number.NaN]) {
+      expect(() => requireHarvestDeclaration({ budget_ms: BUDGET_MS, harvest_fraction: fraction }, "acme/widgets"))
+        .toThrow(/harvest fraction/);
+    }
+    expect(() => requireHarvestDeclaration({ harvest_fraction: 0.5 }, "acme/widgets")).toThrow(/without a budget/);
+  });
+});
+
+describe("the registration carries the declaration the operator stated", () => {
+  const request = {
+    project_label: "acme/widgets",
+    selector: "repo:acme/widgets label:ready-for-agent",
+    argv: ["redskilled", "acp-worker"],
+    workspace_path: "/tmp/acme",
+    target: 2,
+  };
+
+  it("holds a declared budget and arms a watch from its own registered_at", () => {
+    const held = buildProjectRegistration({ ...request, budget_ms: BUDGET_MS }, { now: REGISTERED_AT });
+
+    expect(held.budget_ms).toBe(BUDGET_MS);
+    expect(held.registered_at).toBe(REGISTERED_AT);
+    expect(harvestWatchOf(held)).toEqual({ budget_ms: BUDGET_MS, startedAtMs: STARTED_AT_MS });
+  });
+
+  it("holds no budget field at all when none was declared", () => {
+    const held = buildProjectRegistration(request, { now: REGISTERED_AT });
+
+    expect("budget_ms" in held).toBe(false);
+    expect(harvestWatchOf(held)).toBeUndefined();
+  });
+
+  it("refuses a non-positive budget at registration", () => {
+    expect(() => buildProjectRegistration({ ...request, budget_ms: 0 }, { now: REGISTERED_AT }))
+      .toThrow(/positive drain budget/);
+  });
+});
+
+describe("planHostDemand — the deadline gates births and nothing else", () => {
+  const queue = { "acme/widgets": 9 };
+
+  it("admits normally below the harvest fraction", () => {
+    const plan = planHostDemand({
+      projects: [project({ harvest: { budget_ms: BUDGET_MS, startedAtMs: STARTED_AT_MS } })],
+      queue,
+      live: {},
+      nowMs: HARVEST_AT_MS - 1,
+    });
+
+    expect(plan.births).toHaveLength(2);
+    expect(plan.intents[0]?.outcome).toBe("asking");
+  });
+
+  it("refuses every new claim past the fraction while the live Workers stay counted", () => {
+    const plan = planHostDemand({
+      projects: [project({ harvest: { budget_ms: BUDGET_MS, startedAtMs: STARTED_AT_MS } })],
+      queue,
+      // One Worker is mid-flight; the deadline must not touch it. Its landing is
+      // exactly what the last third of the budget is being spent on.
+      live: { "acme/widgets": 1 },
+      nowMs: HARVEST_AT_MS,
+    });
+
+    expect(plan.births).toEqual([]);
+    expect(plan.intents[0]).toMatchObject({
+      outcome: "harvest-deadline",
+      wanted: 0,
+      live: 1,
+      queue_depth: 9,
+    });
+    expect(plan.intents[0]?.detail).toContain("work already in flight keeps landing");
+  });
+
+  it("stays inert for a project that declared no budget, however late it is", () => {
+    const plan = planHostDemand({
+      projects: [project()],
+      queue,
+      live: {},
+      nowMs: STARTED_AT_MS + BUDGET_MS * 100,
+    });
+
+    expect(plan.births).toHaveLength(2);
+    expect(plan.intents[0]?.outcome).toBe("asking");
+  });
+
+  it("refuses the harvesting project without refusing its neighbour", () => {
+    const plan = planHostDemand({
+      projects: [
+        project({ harvest: { budget_ms: BUDGET_MS, startedAtMs: STARTED_AT_MS } }),
+        project({ project_label: "acme/gadgets", workspace_path: "/tmp/gadgets" }),
+      ],
+      queue: { ...queue, "acme/gadgets": 4 },
+      live: {},
+      nowMs: HARVEST_AT_MS,
+    });
+
+    // Sorted by label, which is the one fact about a project the planner reads.
+    expect(plan.intents.map((intent) => intent.outcome)).toEqual(["asking", "harvest-deadline"]);
+    expect(plan.births.every((birth) => birth.project_label === "acme/gadgets")).toBe(true);
+  });
+});
+
+describe("the tally — what a drain brought back, folded from the outcome class", () => {
+  it("counts a reported terminal outcome as harvested and an unreported end as stranded", () => {
+    expect(foldHarvestOutcome(EMPTY_HARVEST_TALLY, "work-reported")).toEqual({ harvested: 1, stranded: 0 });
+    expect(foldHarvestOutcome(EMPTY_HARVEST_TALLY, "unreported")).toEqual({ harvested: 0, stranded: 1 });
+    // Nothing was taken, so nothing was lost: a Worker that found no eligible
+    // work is neither yield nor waste.
+    expect(foldHarvestOutcome(EMPTY_HARVEST_TALLY, "no-eligible-work")).toEqual(EMPTY_HARVEST_TALLY);
+  });
+
+  it("folds per project, in place, from nothing", () => {
+    const tallies: Record<string, { harvested: number; stranded: number }> = {};
+    foldProjectHarvest(tallies, "acme/widgets", "work-reported");
+    foldProjectHarvest(tallies, "acme/widgets", "work-reported");
+    foldProjectHarvest(tallies, "acme/widgets", "unreported");
+    foldProjectHarvest(tallies, "acme/gadgets", "no-eligible-work");
+
+    expect(tallies["acme/widgets"]).toEqual({ harvested: 2, stranded: 1 });
+    expect(tallies["acme/gadgets"]).toEqual(EMPTY_HARVEST_TALLY);
+  });
+});
+
+describe("harvestReport — the drain summary names harvested and stranded", () => {
+  it("adds the work the deadline leaves behind once the harvest has begun", () => {
+    const report = harvestReport({
+      registeredAt: REGISTERED_AT,
+      declaration: { budget_ms: BUDGET_MS },
+      tally: { harvested: 3, stranded: 1 },
+      live: 2,
+      queueDepth: 4,
+      observedAt: new Date(HARVEST_AT_MS).toISOString(),
+    });
+
+    expect(report.state).toBe("harvesting");
+    expect(report.harvested).toBe(3);
+    // One Worker lost earlier, two still holding work the budget will not let
+    // them finish, four items nobody will now claim.
+    expect(report.stranded).toBe(7);
+    expect(report.harvest_at).toBe(new Date(HARVEST_AT_MS).toISOString());
+    expect(report.deadline_at).toBe(new Date(STARTED_AT_MS + BUDGET_MS).toISOString());
+    expect(report.harvest_fraction).toBe(REDSKILLED_DEFAULT_HARVEST_FRACTION);
+  });
+
+  it("counts only what was already lost while the drain is still admitting", () => {
+    const report = harvestReport({
+      registeredAt: REGISTERED_AT,
+      declaration: { budget_ms: BUDGET_MS },
+      tally: { harvested: 3, stranded: 1 },
+      live: 2,
+      queueDepth: 4,
+      observedAt: new Date(HARVEST_AT_MS - 1).toISOString(),
+    });
+
+    expect(report.state).toBe("admitting");
+    expect(report.stranded).toBe(1);
+  });
+
+  it("reports an inert policy with the counts the drain still earned", () => {
+    const report = harvestReport({
+      registeredAt: REGISTERED_AT,
+      declaration: {},
+      tally: { harvested: 5, stranded: 0 },
+      live: 2,
+      queueDepth: 4,
+      observedAt: new Date(STARTED_AT_MS + BUDGET_MS * 10).toISOString(),
+    });
+
+    expect(report).toMatchObject({
+      state: "inert",
+      budget_ms: null,
+      harvest_fraction: null,
+      harvest_at: null,
+      deadline_at: null,
+      harvested: 5,
+      stranded: 0,
+    });
+  });
+
+  it("is inert for a project the daemon holds no registration for", () => {
+    const report = harvestReport({ live: 0, queueDepth: null, observedAt: REGISTERED_AT });
+
+    expect(report.state).toBe("inert");
+    expect(report.harvested).toBe(0);
+    expect(report.stranded).toBe(0);
+  });
+});

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -104,7 +104,7 @@ that block, startup preserves the explicit-only `drain`/`project_start` behavior
 | Tool | Mode | What it does |
 | --- | --- | --- |
 | `project_activation` | read | Report whether this project opted into RedSkills and the canonical runner and target that a no-argument `drain` would register. |
-| `drain` | mutating | Ensure the daemon is reachable and this project is registered at the requested runner and target. Repeated calls succeed with a four-dimension difference report; a runner change is refused with the explicit stop-then-drain repair. |
+| `drain` | mutating | Ensure the daemon is reachable and this project is registered at the requested runner and target. Repeated calls succeed with a four-dimension difference report; a runner change is refused with the explicit stop-then-drain repair. An optional `budget_ms` arms the **Harvest deadline**: past 70% of the declared budget the daemon admits no new claim and spends the rest landing what is in flight, and `project_status` reports `harvest` with the harvested and stranded counts. Declare it only when you mean it — no `budget_ms`, no deadline. |
 | `project_start` | mutating | Register this project with the host daemon — a runner, a target width, and its work policy. It registers; it launches no process of the project's own. |
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |
 | `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `status {scope: project}` at `birth_latch.repair`; the structured repair supplies the exact args. |

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -104,7 +104,7 @@ that block, startup preserves the explicit-only `drain`/`project_start` behavior
 | Tool | Mode | What it does |
 | --- | --- | --- |
 | `project_activation` | read | Report whether this project opted into RedSkills and the canonical runner and target that a no-argument `drain` would register. |
-| `drain` | mutating | Ensure the daemon is reachable and this project is registered at the requested runner and target. Repeated calls succeed with a four-dimension difference report; a runner change is refused with the explicit stop-then-drain repair. |
+| `drain` | mutating | Ensure the daemon is reachable and this project is registered at the requested runner and target. Repeated calls succeed with a four-dimension difference report; a runner change is refused with the explicit stop-then-drain repair. An optional `budget_ms` arms the **Harvest deadline**: past 70% of the declared budget the daemon admits no new claim and spends the rest landing what is in flight, and `project_status` reports `harvest` with the harvested and stranded counts. Declare it only when you mean it — no `budget_ms`, no deadline. |
 | `project_start` | mutating | Register this project with the host daemon — a runner, a target width, and its work policy. It registers; it launches no process of the project's own. |
 | `project_resize` | mutating | Change the target width, runner, or work policy; sends the live directive. |
 | `project_reset` | mutating | Clear the named `project-birth-breaker` latch. Call it from `status {scope: project}` at `birth_latch.repair`; the structured repair supplies the exact args. |


### PR DESCRIPTION
Fixes #4170

## What this builds

**A drain the operator gave a budget stops TAKING work before the budget dies, and spends what is left bringing back what it has.** A Worker admitted ten minutes before the budget ends buys a claim it cannot land, and finished-but-unlanded work counts as zero (Spec #4164, glossary: **Harvest deadline**).

- **The declared shape** — `budget_ms` on the drain registration, with an optional `harvest_fraction` (0.7 when unstated). Wall-clock milliseconds running from the daemon's own `registered_at`, because a client stating an absolute deadline would state it in a clock the daemon cannot check. Refused as client bugs: a non-positive or non-finite budget, a fraction outside `(0, 1]`, and a fraction stated without a budget (half a declaration reads as armed).
- **The refusal** — past the fraction, `planHostDemand` reports the new `harvest-deadline` outcome with `wanted: 0` and plans no birth. It is checked before the host's own backoff: a backoff is this tick's weather, a declared deadline is the standing policy an operator is asking about.
- **Landing is never gated.** The deadline touches births only, so the Workers already alive keep publishing and landing what they carry — that is what the last third of the budget is for.
- **The drain summary** — `project_status`'s context, the one surface already carrying the queue, the Workers and the health of a draining project, gains a `harvest` block: state, the two instants, and `harvested` against `stranded`.
- **No declared budget, no deadline.** The policy reports `inert`, refuses nothing, and the daemon invents no instant the operator did not ask for.

`harvested` is folded from the same three-word terminal outcome class the birth breaker already reads (`work-reported` is one unit back, `unreported` is one lost, `no-eligible-work` is neither because nothing was taken); `stranded` adds, once the harvest has begun, the live Workers and queued items the budget leaves behind.

## Where it lives

| File | Role |
| --- | --- |
| `apps/redskilled/src/harvest-deadline.ts` | the whole policy, pure: shape check, clock-injected decision, tally, report |
| `apps/redskilled/src/project-registration.ts` | the request and the record extend the declaration; one call shape-checks it |
| `apps/redskilled/src/demand-loop.ts` | one spread and one condition in `planHostDemand`, plus the outcome word |
| `apps/redskilled/src/host-state.ts` | the tally rides the registration view, beside `last_poll` |
| `apps/redskilled/src/project-control.ts` | the drain summary's `harvest` block |
| `apps/redskilled/src/daemon/lifecycle.ts` | three lines: the in-memory tally, the fold at death, the planner field |
| `apps/plugin-dev/src/...` | `drain { budget_ms }` through the tool schema, the control adapter and the registration builder |

The daemon shape-checks and never reads meaning (ADR 0130 rule 3): it compares two numbers against its own clock and carries nothing else. `lifecycle.ts` gains no net branch — the ternary and the `??` are hoisted into the policy module and a local — so the complexity ratchet stays where it was.

## Acceptance criteria

- [x] **Pure-function tests with injected clock/budget** — `apps/redskilled/tests/harvest-deadline.test.ts` (21): below the fraction admits, the fraction instant itself harvests, past it refuses, a stricter declared fraction is honoured, no budget stays inert however late it is, an unreadable budget start is no budget rather than an expired one, and a harvesting project does not refuse its neighbour.
- [x] **ACP test** — `apps/redskilled/tests/acp-harvest-deadline.test.ts`: over a real socket, the drain registers with a budget, `project_status` reads `admitting`, then past the fraction reads `harvest-deadline` with `wanted: 0` while the in-flight Worker is still held — and that Worker's `_redskills/land` completes at the same instant, opening the PR and handing off custody. A second test proves a budget-less drain arms nothing ten budgets later.
- [x] **The drain summary names harvested and stranded** — the same ACP test asserts `harvested: 1` against `stranded: 5` (one Worker lost, one live, four queued) for the budgeted fixture drain, and the pure suite pins the arithmetic on both sides of the deadline.

The ACP suite is declared as a focused, seconds-cheap suite (~0.6s): a package script, a workflow step inside the required `test` aggregate, and an entry in `FOCUSED_ACP_SUITES` — otherwise it would run nowhere.

## Validation

- `pnpm typecheck` — 17/17 green.
- `pnpm -C apps/plugin-dev test:invariants` — 31 files, 370 tests green (complexity ratchet and file-size baseline included, both untouched).
- `pnpm -C apps/plugin-dev test` — 441 files green.
- `pnpm -C apps/redskilled test` — the only red is the set already red on `origin/main`, verified by running the same files in a clean baseline worktree: `telemetry-metrics` (3), `acp-conformance` (4), `worker-birth` (1), `acp-publication` (1), `resource-incidents` (1), `registration-counter-poll` (1), `acp-control-plane-layout` (1), plus `acp-control-plane` (2) and `acp-ticket-loop` (2).
- `acp-project-status.test.ts` was in that pre-existing set and is **repaired here**: `registered` and `items` were added to the queue block without the expectation following.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789890382&installation_model_id=20659&pr_number=4253&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4253&signature=be033ccbf8f79dbe3fc5357b32a7a5cdc4f4c0888ff90233cea1bdf19b48568c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->