### PR TITLE
feat(dev): the Attention audit reads the Decision trail at drain end

### DIFF
--- a/.changeset/attention-audit-at-drain-end.md
+++ b/.changeset/attention-audit-at-drain-end.md
@@ -1,0 +1,23 @@
+---
+"@reddb-io/dev": patch
+---
+
+The drain-end **Attention audit** reads the **Decision trail** and `daily_review`
+opens with it. Decision rows existed but nothing read them, so a trail was
+narration with a schema: the night still had to be re-read in the morning. The
+audit takes the drain's rows and the drain's outcomes and computes the three
+findings that need no model — weak evidence (an `evidence` field holding prose
+where the trail promised a pointer), unproven claims (a `verified-unit` row for
+an issue the drain never landed), and unlogged pivots (more re-entries than the
+trail has pivot/revert rows to explain them). The judgment step is a declared
+seam, so nothing here makes a model call and every finding is reproducible from
+fixed inputs.
+
+The auditing identity is a configuration fact with an assertion on it: the first
+supported runner whose configured model sits on a different model family than the
+drain's Workers, because an agent grading its own night re-accepts the evidence it
+already accepted. Repoint the drain and the audit moves to the other side on its
+own; configure every runner onto one family and the audit refuses to pin an
+identity and says so, rather than performing a same-family "cross-model" read.
+`daily_review` prints the section first — before the big numbers, or the numbers
+frame the audit — and states its own emptiness when a window holds no drain end.

--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -713,6 +713,10 @@ _Avoid_: soft deadline, timeout (the drain is not killed — admission stops, la
 Decision-level rows in `worker.log.toonl` — one row per fork taken, pivot, revert, blocker, or verified unit, with the why and an evidence pointer, never prose. At drain end an **Attention audit** (a different model family than the workers) reads trails against outcomes and emits the "Attention" section the operator reads first; `daily_review` consumes it.
 _Avoid_: narration (lifecycle events already exist), audit log
 
+**Attention audit**:
+The drain-end read of the **Decision trail** against the drain's outcomes, written by an identity on a **different model family** than the drain's Workers — a mind grading its own night re-accepts the evidence it already accepted. Three findings are computed, not judged: **weak evidence** (an `evidence` field holding prose instead of a pointer), **unproven claims** (a `verified-unit` row for an issue the drain never landed), and **unlogged pivots** (more re-entries than the trail has pivot/revert rows). The model call is the judgment step alone. `daily_review` prints the result as the "Attention" section, first — before the numbers, or the numbers frame the audit.
+_Avoid_: postmortem (a postmortem follows a death; this follows every drain), lint
+
 ## Relationships
 
 - An **Issue tracker** holds many **Issues**.

--- a/apps/plugin-dev/src/core/activity-review.ts
+++ b/apps/plugin-dev/src/core/activity-review.ts
@@ -1,3 +1,4 @@
+import { renderAttentionSection, type AttentionAudit } from "./attention-audit.js";
 import type { HistoryRecord } from "./history.js";
 import { LABEL_HUMAN } from "./triage-labels.js";
 import { blockedKindOf, blockedLabelsIn } from "./state-transition.js";
@@ -100,6 +101,8 @@ export interface ActivityReviewInput {
   tokenSummary: ActivityReviewTokenSummary;
   /** Standing orders observed in the window, one row per append. */
   standingOrders?: ActivityReviewStandingOrder[];
+  /** The latest drain-end Attention audit, or absent when no drain ended here. */
+  attentionAudit?: AttentionAudit | null;
 }
 
 export interface ActivityReviewInterval {
@@ -159,6 +162,8 @@ export interface ActivityReviewReport {
     local_worker_seconds: number;
     tokens: ActivityReviewTokenSummary;
   };
+  /** The drain-end Attention audit the morning read starts from (#4171). */
+  attention: AttentionAudit | null;
   workers: ActivityReviewWorkerSummary[];
   challenges: ActivityReviewChallenge[];
   standing_order_promotions: ActivityReviewStandingOrderPromotion[];
@@ -459,6 +464,7 @@ export function buildActivityReviewReport(input: ActivityReviewInput): ActivityR
       local_worker_seconds: workers.reduce((sum, worker) => sum + worker.durationSeconds + worker.activeSeconds, 0),
       tokens: input.tokenSummary,
     },
+    attention: input.attentionAudit ?? null,
     workers,
     challenges,
     standing_order_promotions: standingOrderPromotions,
@@ -523,6 +529,9 @@ export function renderActivityReviewReport(report: ActivityReviewReport): string
     title,
     `generated: ${report.generated_at}`,
     `interval: ${report.interval.start} -> ${report.interval.end}`,
+    // Attention leads: the audit is read BEFORE the numbers, or it is read after
+    // the operator has already formed an opinion from them.
+    ...renderAttentionSection(report.attention),
     "",
     "Big numbers",
     `  issues created: ${report.big_numbers.issues_created}`,
@@ -608,6 +617,9 @@ export function renderActivityReviewReportToon(report: ActivityReviewReport): st
 function toToonSafeActivityReviewReport(report: ActivityReviewReport): ToonValue {
   const payload = {
     ...report,
+    attention: report.attention === null
+      ? null
+      : { ...report.attention, warnings: report.attention.warnings.join(" | ") },
     workers: report.workers.map((worker) => ({
       ...worker,
       issues: worker.issues.length > 0 ? worker.issues.map((issue) => `#${issue}`).join(",") : "",

--- a/apps/plugin-dev/src/core/attention-audit-identity.ts
+++ b/apps/plugin-dev/src/core/attention-audit-identity.ts
@@ -1,0 +1,143 @@
+// attention-audit-identity — who is allowed to judge a drain's Decision trail
+// (Spec #4164, Ticket #4171).
+//
+// The Attention audit is worth reading only because the identity that writes it
+// did not do the work. An agent grading its own night grades its own reasoning
+// with that reasoning still loaded: the fork it thought obvious reads obvious
+// again, and the evidence it accepted once it accepts twice. **The audit's whole
+// value is the second opinion**, so the identity is a CONFIGURATION fact with an
+// assertion on it, not a runner somebody happened to have spare.
+//
+// The rule is a property, never a hardcoded name: the audit runs on the first
+// supported runner whose CONFIGURED model sits on a different model family than
+// the drain's Workers. Point the drain at codex and the audit moves to claude on
+// its own. Point every runner in the config at one family and the audit refuses
+// to pin an identity at all — a same-family "cross-model" audit is the failure
+// this module exists to name, and naming it beats performing it.
+
+import { resolveTaskRoute, resolveTier, type AfkModelTier, type ConfigValues } from "./config.js";
+import { runners, type Runner } from "../types/runner.js";
+
+/**
+ * A model family COARSE enough to answer the only question the audit asks: is
+ * this a different mind than the one that did the work? `ModelFamily` in
+ * `model-tier-route.ts` splits Claude into haiku/sonnet/opus, which is the right
+ * grain for cost tiering and the wrong grain here — two Claude tiers share
+ * training, refusal shape and blind spots.
+ */
+export type JudgeModelFamily = "anthropic" | "openai" | "google" | "minimax" | "unknown";
+
+/** The tier the judgment runs at: reading a trail against outcomes is a
+ * validation task, not an implementation one (the model-tier-policy skill). */
+export const ATTENTION_AUDIT_TIER: AfkModelTier = "validate";
+
+/** The tier the drain's Workers run their code work at, and so the identity the
+ * audit must differ FROM. */
+export const DRAIN_WORKER_TIER: AfkModelTier = "complex";
+
+/**
+ * Preference order for the auditing runner. Order decides only WHICH qualifying
+ * runner is chosen; qualification itself is the family difference below, so this
+ * list can never smuggle a same-family judge in.
+ */
+export const ATTENTION_AUDIT_RUNNER_PREFERENCE: readonly Runner[] = [
+  "codex",
+  "claude",
+  "opencode",
+  "claude-minimax",
+];
+
+/** The identity that ran, or would run, one side of the comparison. */
+export interface AttentionAuditIdentity {
+  readonly runner: Runner;
+  readonly model: string;
+  readonly family: JudgeModelFamily;
+}
+
+const FAMILY_MARKERS: readonly (readonly [string, JudgeModelFamily])[] = [
+  ["anthropic", "anthropic"],
+  ["claude", "anthropic"],
+  ["minimax", "minimax"],
+  ["gemini", "google"],
+  ["google", "google"],
+  ["gpt", "openai"],
+  ["openai", "openai"],
+  ["codex", "openai"],
+];
+
+/**
+ * The family a configured model id belongs to. **`unknown` is never equal to
+ * anything, including itself** — an id we cannot place is not evidence of a
+ * second opinion, so the caller treats it as unusable rather than as different.
+ * PURE.
+ */
+export function judgeModelFamily(model: string): JudgeModelFamily {
+  const id = model.toLowerCase();
+  for (const [marker, family] of FAMILY_MARKERS) {
+    if (id.includes(marker)) return family;
+  }
+  return "unknown";
+}
+
+/**
+ * The identity the drain's Workers carry: whatever runner the config routes code
+ * work to, at the model that runner's table resolves for the complex tier. PURE
+ * over the values handed in — it reads no env and no filesystem.
+ */
+export function resolveDrainWorkerIdentity(values: ConfigValues): AttentionAuditIdentity {
+  const route = resolveTaskRoute(values, DRAIN_WORKER_TIER);
+  return { runner: route.runner, model: route.model, family: judgeModelFamily(route.model) };
+}
+
+function identityFor(values: ConfigValues, runner: Runner): AttentionAuditIdentity | null {
+  try {
+    const tier = resolveTier(values, runner, ATTENTION_AUDIT_TIER);
+    return { runner, model: tier.model, family: judgeModelFamily(tier.model) };
+  } catch {
+    // A runner with no model table cannot be an identity. Borrowing another
+    // runner's table to fill the gap is exactly the silent inheritance the
+    // config refuses.
+    return null;
+  }
+}
+
+/**
+ * The auditing identity: the first preferred runner on a KNOWN family that
+ * differs from the drain's. Returns `null` when the configuration offers no such
+ * runner — the audit then still assembles, and says out loud that it is unpinned.
+ * PURE.
+ */
+export function resolveAttentionAuditIdentity(
+  values: ConfigValues,
+): AttentionAuditIdentity | null {
+  const drain = resolveDrainWorkerIdentity(values);
+  if (drain.family === "unknown") return null;
+  for (const runner of ATTENTION_AUDIT_RUNNER_PREFERENCE) {
+    const candidate = identityFor(values, runner);
+    if (candidate === null || candidate.family === "unknown") continue;
+    if (candidate.family !== drain.family) return candidate;
+  }
+  return null;
+}
+
+/**
+ * The configuration assertion, as a reason string rather than a throw: `null`
+ * when the audit identity is pinned to a different family than the drain's
+ * Workers, otherwise the sentence a human needs to fix the config. A ratchet
+ * test asserts this is `null` for the shipped defaults. PURE.
+ */
+export function attentionAuditIdentityRefusal(values: ConfigValues): string | null {
+  const drain = resolveDrainWorkerIdentity(values);
+  if (drain.family === "unknown") {
+    return `drain Workers run ${drain.runner}/${drain.model}, whose model family is unrecognised — no identity can be proven different from it`;
+  }
+  const audit = resolveAttentionAuditIdentity(values);
+  if (audit === null) {
+    const spelled = runners.join(", ");
+    return `no configured runner (${spelled}) offers a model on a family other than ${drain.family}; the Attention audit would grade the drain with the drain's own mind`;
+  }
+  if (audit.family === drain.family) {
+    return `audit identity ${audit.runner}/${audit.model} shares the drain's ${drain.family} family`;
+  }
+  return null;
+}

--- a/apps/plugin-dev/src/core/attention-audit.ts
+++ b/apps/plugin-dev/src/core/attention-audit.ts
@@ -1,0 +1,259 @@
+// attention-audit — the pure assembly half of the drain-end Attention audit
+// (Spec #4164, Ticket #4171).
+//
+// A **Decision trail** (#4167) gives every Worker a place to record the forks it
+// took, the pivots, the reverts, the blockers and the units it called verified.
+// Nothing read them. A trail nobody reads is narration with a schema: the night
+// still has to be re-read in the morning, which is the cost the trail was
+// supposed to remove.
+//
+// The Attention audit is that reader. At drain end it takes the drain's decision
+// rows and the drain's OUTCOMES — what actually landed, parked or was abandoned —
+// and emits one **Attention** section the operator reads before anything else.
+//
+// ## What is computable is computed, and only the rest is judged
+//
+// Three of the section's questions need no model at all, because each is a
+// disagreement between two records the drain already holds:
+//
+//   - **weak evidence** — the trail declares `evidence` a POINTER; the writer
+//     only enforces non-empty, so prose passes validation. Prose is a claim
+//     citing itself.
+//   - **unproven claim** — a `verified-unit` row for an issue the drain never
+//     landed. The Worker said "verified"; the outcome says otherwise.
+//   - **unlogged pivot** — the drain re-entered an issue more times than the
+//     trail has `pivot`/`revert` rows for it. A course change nobody wrote down.
+//
+// Those are set differences, so they are a PURE function over fixed inputs and
+// they are testable without a model, a network or a clock. The model call is the
+// judgment step ONLY — the reading a diff cannot do — and it enters through the
+// `AttentionJudge` seam below. An audit with no judge attached is still a real
+// audit; it just carries no judgment notes.
+
+import type { DecisionTrailKind } from "@reddb-io/worker/engine";
+import type { AttentionAuditIdentity } from "./attention-audit-identity.js";
+
+/** One Decision-trail row as the audit reads it: the Worker's payload plus the
+ * attribution the lane record carries around it (which Worker, which issue). */
+export interface AttentionTrailRow {
+  /** The Worker that wrote the row. */
+  readonly worker: string;
+  /** The issue the Worker held, or `null` when the row names none. */
+  readonly issue: number | null;
+  /** The row's stamp, or `null` when the lane record carried none. */
+  readonly at: string | null;
+  readonly type: DecisionTrailKind;
+  readonly decision: string;
+  readonly why: string;
+  /** A pointer — URL, SHA, path, `#123`. Prose here is the weak-evidence finding. */
+  readonly evidence: string;
+  readonly result: string;
+}
+
+/** Terminal state the drain reached for one issue it worked. */
+export type AttentionOutcomeState = "landed" | "parked" | "abandoned" | "open";
+
+/**
+ * What the drain OBSERVED for one issue, independent of what its Workers said.
+ * This is the second record the audit reads the trail against — the trail alone
+ * can only be internally consistent, and internal consistency is what an
+ * unreviewed night already has.
+ */
+export interface AttentionDrainOutcome {
+  readonly issue: number;
+  readonly state: AttentionOutcomeState;
+  /**
+   * How many times the drain re-entered the issue — a retry, a recycle, a
+   * second Worker on the same claim. Each re-entry is a course change that
+   * either has a `pivot`/`revert` row explaining it or does not.
+   */
+  readonly reentries: number;
+}
+
+export type AttentionFindingKind = "weak-evidence" | "unproven-claim" | "unlogged-pivot";
+
+/** One thing the operator should look at, with the row or issue it came from. */
+export interface AttentionFinding {
+  readonly kind: AttentionFindingKind;
+  /** The Worker responsible, or `"-"` when the finding is issue-level. */
+  readonly worker: string;
+  readonly issue: number | null;
+  /** One line naming what disagrees with what. */
+  readonly detail: string;
+  /** The evidence string as written, so the operator judges the cite itself. */
+  readonly evidence: string;
+}
+
+/** A note the judgment step added. Empty until a judge is attached. */
+export interface AttentionJudgmentNote {
+  /** The identity that wrote it — never the drain's own model family. */
+  readonly identity: string;
+  readonly note: string;
+}
+
+export interface AttentionAuditInput {
+  /** The drain the audit is for. */
+  readonly drain: string;
+  readonly generatedAt: string;
+  /** The identity that judges, or `null` when none could be pinned. */
+  readonly identity: AttentionAuditIdentity | null;
+  readonly rows: readonly AttentionTrailRow[];
+  readonly outcomes: readonly AttentionDrainOutcome[];
+  /** Notes from the judgment seam, when it ran. Assembly never invents them. */
+  readonly judgment?: readonly AttentionJudgmentNote[];
+}
+
+export interface AttentionAudit {
+  readonly schema_version: "red.dev.attention_audit.v1";
+  readonly drain: string;
+  readonly generated_at: string;
+  /** `runner/model (family)`, or `"unpinned"` when no cross-family identity exists. */
+  readonly identity: string;
+  readonly rows_read: number;
+  readonly findings: readonly AttentionFinding[];
+  readonly judgment: readonly AttentionJudgmentNote[];
+  readonly warnings: readonly string[];
+}
+
+/**
+ * The judgment step, declared as a seam rather than called. The daemon fills it
+ * at drain end with an agent on the identity `resolveAttentionAuditIdentity`
+ * pinned; nothing in this package makes a model call, so every test here runs
+ * offline and deterministic.
+ */
+export interface AttentionJudge {
+  judge(audit: AttentionAudit): Promise<readonly AttentionJudgmentNote[]>;
+}
+
+/** Prefixes and shapes that make an evidence string a POINTER rather than prose. */
+const POINTER_PATTERNS: readonly RegExp[] = [
+  /^https?:\/\/\S+$/,
+  /^[0-9a-f]{7,40}$/i,
+  /^#\d+$/,
+  /^[\w.-]+\/[\w.-]+#\d+$/,
+  /^(?:\.\/|\/)?[\w.-]+(?:\/[\w.-]+)*\.[A-Za-z0-9]+(?::\d+(?:-\d+)?)?$/,
+];
+
+/**
+ * Whether an evidence field cites something a reader can open. **A pointer is
+ * one token.** Prose describing evidence ("the tests passed locally") is the
+ * thing this refuses, and the giveaway is whitespace: no pointer we accept
+ * contains any. PURE.
+ */
+export function isEvidencePointer(evidence: string): boolean {
+  const value = evidence.trim();
+  if (value.length === 0 || /\s/.test(value)) return false;
+  return POINTER_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+function loggedCourseChanges(rows: readonly AttentionTrailRow[], issue: number): number {
+  return rows.filter(
+    (row) => row.issue === issue && (row.type === "pivot" || row.type === "revert"),
+  ).length;
+}
+
+/**
+ * Assemble the Attention audit: the three computable findings over the drain's
+ * decision rows and outcomes, in a stable order (weak evidence, then unproven
+ * claims, then unlogged pivots) so two runs over one drain read identically.
+ *
+ * An EMPTY trail is a legal drain, not an error — it assembles to an audit with
+ * no findings and a warning naming the silence, because a drain that logged no
+ * decisions is itself something the operator should see. PURE.
+ */
+export function assembleAttentionAudit(input: AttentionAuditInput): AttentionAudit {
+  const findings: AttentionFinding[] = [];
+  const warnings: string[] = [];
+
+  for (const row of input.rows) {
+    if (!isEvidencePointer(row.evidence)) {
+      findings.push({
+        kind: "weak-evidence",
+        worker: row.worker,
+        issue: row.issue,
+        detail: `${row.type} row cites prose, not a pointer: ${row.decision}`,
+        evidence: row.evidence,
+      });
+    }
+  }
+
+  const outcomeByIssue = new Map(input.outcomes.map((outcome) => [outcome.issue, outcome]));
+  for (const row of input.rows) {
+    if (row.type !== "verified-unit") continue;
+    const outcome = row.issue === null ? undefined : outcomeByIssue.get(row.issue);
+    if (outcome !== undefined && outcome.state === "landed") continue;
+    const observed = outcome === undefined ? "no outcome recorded" : `outcome ${outcome.state}`;
+    findings.push({
+      kind: "unproven-claim",
+      worker: row.worker,
+      issue: row.issue,
+      detail: `verified unit claimed (${row.result}) but ${observed}`,
+      evidence: row.evidence,
+    });
+  }
+
+  for (const outcome of input.outcomes) {
+    const logged = loggedCourseChanges(input.rows, outcome.issue);
+    if (outcome.reentries <= logged) continue;
+    findings.push({
+      kind: "unlogged-pivot",
+      worker: "-",
+      issue: outcome.issue,
+      detail: `${outcome.reentries} re-entries against ${logged} logged pivot/revert rows`,
+      evidence: "-",
+    });
+  }
+
+  if (input.rows.length === 0) {
+    warnings.push("drain logged no decision rows — the trail cannot be audited");
+  }
+  if (input.identity === null) {
+    warnings.push("no audit identity on a different model family than the drain's Workers");
+  }
+
+  return {
+    schema_version: "red.dev.attention_audit.v1",
+    drain: input.drain,
+    generated_at: input.generatedAt,
+    identity:
+      input.identity === null
+        ? "unpinned"
+        : `${input.identity.runner}/${input.identity.model} (${input.identity.family})`,
+    rows_read: input.rows.length,
+    findings,
+    judgment: input.judgment ?? [],
+    warnings,
+  };
+}
+
+const FINDING_HEADINGS: Readonly<Record<AttentionFindingKind, string>> = {
+  "weak-evidence": "weak evidence",
+  "unproven-claim": "unproven claims",
+  "unlogged-pivot": "unlogged pivots",
+};
+
+/**
+ * The **Attention** section, grouped by finding kind. It is rendered FIRST in
+ * the review — the morning read starts here, not at the raw log — and it states
+ * its own silence, because an absent section reads as "nothing to see" whether
+ * the drain was clean or the audit never ran. PURE.
+ */
+export function renderAttentionSection(audit: AttentionAudit | null): string[] {
+  if (audit === null) return ["", "Attention", "  (no drain-end audit for this window)"];
+  const lines = ["", `Attention — ${audit.drain}`, `  audited by: ${audit.identity}`];
+  if (audit.findings.length === 0) {
+    lines.push(`  (nothing flagged across ${audit.rows_read} decision rows)`);
+  }
+  for (const kind of ["weak-evidence", "unproven-claim", "unlogged-pivot"] as const) {
+    const group = audit.findings.filter((finding) => finding.kind === kind);
+    if (group.length === 0) continue;
+    lines.push(`  ${FINDING_HEADINGS[kind]} (${group.length})`);
+    for (const finding of group) {
+      const issue = finding.issue === null ? "-" : `#${finding.issue}`;
+      lines.push(`    ${issue} ${finding.worker}: ${finding.detail}`);
+    }
+  }
+  for (const note of audit.judgment) lines.push(`  judgment (${note.identity}): ${note.note}`);
+  for (const warning of audit.warnings) lines.push(`  warning: ${warning}`);
+  return lines;
+}

--- a/apps/plugin-dev/tests/attention-audit.test.ts
+++ b/apps/plugin-dev/tests/attention-audit.test.ts
@@ -1,0 +1,347 @@
+// The drain-end Attention audit (Spec #4164, Ticket #4171).
+//
+// Every assertion here runs offline: the assembly is a pure function over fixed
+// Decision-trail fixtures, and the identity rule is a pure function over config
+// values. **No test in this file makes a model call**, which is the point — the
+// judgment step is a declared seam, and everything a diff can decide is decided
+// without it.
+
+import { describe, expect, it } from "vitest";
+import { decode } from "@reddb-io/toon";
+import {
+  assembleAttentionAudit,
+  isEvidencePointer,
+  renderAttentionSection,
+  type AttentionAuditInput,
+  type AttentionDrainOutcome,
+  type AttentionTrailRow,
+} from "../src/core/attention-audit.js";
+import {
+  attentionAuditIdentityRefusal,
+  judgeModelFamily,
+  resolveAttentionAuditIdentity,
+  resolveDrainWorkerIdentity,
+  ATTENTION_AUDIT_RUNNER_PREFERENCE,
+  ATTENTION_AUDIT_TIER,
+  DRAIN_WORKER_TIER,
+} from "../src/core/attention-audit-identity.js";
+import { CONFIG_DEFAULTS, type ConfigValues } from "../src/core/config.js";
+import {
+  buildActivityReviewReport,
+  renderActivityReviewReport,
+  renderActivityReviewReportToon,
+  type ActivityReviewInput,
+} from "../src/core/activity-review.js";
+
+const NOW = new Date("2026-08-19T12:00:00.000Z");
+const GENERATED_AT = "2026-08-19T11:59:00.000Z";
+
+/** The identity the shipped config pins, spelled once so the fixtures agree. */
+const CODEX_IDENTITY = { runner: "codex", model: "gpt-5.6-sol", family: "openai" } as const;
+
+function row(overrides: Partial<AttentionTrailRow> = {}): AttentionTrailRow {
+  return {
+    worker: "w-1",
+    issue: 4171,
+    at: "2026-08-19T02:00:00.000Z",
+    type: "fork",
+    decision: "Kept the assembly pure and injected the judge",
+    why: "the model call is the only step a diff cannot decide",
+    evidence: "https://github.com/reddb-io/red-skills/pull/4199",
+    result: "assembly landed",
+    ...overrides,
+  };
+}
+
+function outcome(overrides: Partial<AttentionDrainOutcome> = {}): AttentionDrainOutcome {
+  return { issue: 4171, state: "landed", reentries: 0, ...overrides };
+}
+
+function auditInput(overrides: Partial<AttentionAuditInput> = {}): AttentionAuditInput {
+  return {
+    drain: "drain-2026-08-19",
+    generatedAt: GENERATED_AT,
+    identity: CODEX_IDENTITY,
+    rows: [],
+    outcomes: [],
+    ...overrides,
+  };
+}
+
+function defaultConfig(): ConfigValues {
+  return { ...CONFIG_DEFAULTS };
+}
+
+describe("isEvidencePointer — a pointer is one token a reader can open", () => {
+  it("accepts URLs, SHAs, issue refs and paths", () => {
+    expect(isEvidencePointer("https://github.com/reddb-io/red-skills/pull/4199")).toBe(true);
+    expect(isEvidencePointer("03b4cf7673914ddbed9b08f93e7b81f167550e90")).toBe(true);
+    expect(isEvidencePointer("#4167")).toBe(true);
+    expect(isEvidencePointer("reddb-io/red-skills#4167")).toBe(true);
+    expect(isEvidencePointer("apps/plugin-dev/src/core/attention-audit.ts")).toBe(true);
+    expect(isEvidencePointer("apps/plugin-dev/src/core/attention-audit.ts:42")).toBe(true);
+  });
+
+  it("refuses prose, however confident — a claim citing itself is not evidence", () => {
+    expect(isEvidencePointer("the tests passed locally")).toBe(false);
+    expect(isEvidencePointer("verified by inspection")).toBe(false);
+    expect(isEvidencePointer("")).toBe(false);
+    expect(isEvidencePointer("   ")).toBe(false);
+  });
+});
+
+describe("assembleAttentionAudit — the three findings a diff can decide", () => {
+  it("flags a decision row whose evidence is prose rather than a pointer", () => {
+    const audit = assembleAttentionAudit(
+      auditInput({
+        rows: [row({ evidence: "checked it by hand, looked right" })],
+        outcomes: [outcome()],
+      }),
+    );
+
+    expect(audit.findings).toHaveLength(1);
+    expect(audit.findings[0]).toMatchObject({
+      kind: "weak-evidence",
+      worker: "w-1",
+      issue: 4171,
+      evidence: "checked it by hand, looked right",
+    });
+  });
+
+  it("flags a verified unit the drain never landed, naming the outcome that disagrees", () => {
+    const audit = assembleAttentionAudit(
+      auditInput({
+        rows: [row({ type: "verified-unit", result: "gate green", evidence: "#4171" })],
+        outcomes: [outcome({ state: "parked" })],
+      }),
+    );
+
+    expect(audit.findings.map((finding) => finding.kind)).toEqual(["unproven-claim"]);
+    expect(audit.findings[0]?.detail).toContain("outcome parked");
+  });
+
+  it("flags a verified unit for an issue with no outcome recorded at all", () => {
+    const audit = assembleAttentionAudit(
+      auditInput({ rows: [row({ type: "verified-unit", evidence: "#4171" })], outcomes: [] }),
+    );
+
+    expect(audit.findings.map((finding) => finding.kind)).toEqual(["unproven-claim"]);
+    expect(audit.findings[0]?.detail).toContain("no outcome recorded");
+  });
+
+  it("flags re-entries the trail never explains, and stops flagging once it does", () => {
+    const unlogged = assembleAttentionAudit(
+      auditInput({ rows: [row()], outcomes: [outcome({ reentries: 2 })] }),
+    );
+    expect(unlogged.findings.map((finding) => finding.kind)).toEqual(["unlogged-pivot"]);
+    expect(unlogged.findings[0]?.detail).toBe("2 re-entries against 0 logged pivot/revert rows");
+
+    const logged = assembleAttentionAudit(
+      auditInput({
+        rows: [
+          row({ type: "pivot", evidence: "#4171" }),
+          row({ type: "revert", evidence: "#4171" }),
+        ],
+        outcomes: [outcome({ reentries: 2 })],
+      }),
+    );
+    expect(logged.findings).toEqual([]);
+  });
+
+  it("finds nothing in a clean trail, and reads the row count back", () => {
+    const audit = assembleAttentionAudit(
+      auditInput({
+        rows: [row(), row({ type: "verified-unit", worker: "w-2" })],
+        outcomes: [outcome()],
+      }),
+    );
+
+    expect(audit.findings).toEqual([]);
+    expect(audit.rows_read).toBe(2);
+    expect(audit.warnings).toEqual([]);
+    expect(audit.identity).toBe("codex/gpt-5.6-sol (openai)");
+    expect(audit.judgment).toEqual([]);
+  });
+
+  it("assembles an EMPTY-trail drain into a real audit that names the silence", () => {
+    const audit = assembleAttentionAudit(auditInput());
+
+    expect(audit.rows_read).toBe(0);
+    expect(audit.findings).toEqual([]);
+    expect(audit.warnings).toEqual([
+      "drain logged no decision rows — the trail cannot be audited",
+    ]);
+    expect(audit.schema_version).toBe("red.dev.attention_audit.v1");
+    expect(audit.drain).toBe("drain-2026-08-19");
+  });
+
+  it("says out loud when no cross-family identity could be pinned", () => {
+    const audit = assembleAttentionAudit(auditInput({ identity: null, rows: [row()] }));
+
+    expect(audit.identity).toBe("unpinned");
+    expect(audit.warnings).toContain(
+      "no audit identity on a different model family than the drain's Workers",
+    );
+  });
+
+  it("carries judgment notes through without inventing any", () => {
+    const audit = assembleAttentionAudit(
+      auditInput({
+        rows: [row()],
+        judgment: [{ identity: "codex/gpt-5.6-sol", note: "the fork rationale is thin" }],
+      }),
+    );
+
+    expect(audit.judgment).toEqual([
+      { identity: "codex/gpt-5.6-sol", note: "the fork rationale is thin" },
+    ]);
+  });
+});
+
+describe("renderAttentionSection — grouped, and never silently absent", () => {
+  it("groups findings under their kind and prints the auditing identity", () => {
+    const audit = assembleAttentionAudit(
+      auditInput({
+        rows: [
+          row({ evidence: "looked fine to me" }),
+          row({ type: "verified-unit", worker: "w-2", evidence: "#4171" }),
+        ],
+        outcomes: [outcome({ state: "abandoned", reentries: 3 })],
+      }),
+    );
+    const rendered = renderAttentionSection(audit).join("\n");
+
+    expect(rendered).toContain("Attention — drain-2026-08-19");
+    expect(rendered).toContain("audited by: codex/gpt-5.6-sol (openai)");
+    expect(rendered).toContain("weak evidence (1)");
+    expect(rendered).toContain("unproven claims (1)");
+    expect(rendered).toContain("unlogged pivots (1)");
+  });
+
+  it("states its own emptiness rather than vanishing", () => {
+    expect(renderAttentionSection(null).join("\n")).toContain(
+      "(no drain-end audit for this window)",
+    );
+    expect(renderAttentionSection(assembleAttentionAudit(auditInput())).join("\n")).toContain(
+      "(nothing flagged across 0 decision rows)",
+    );
+  });
+});
+
+describe("daily_review — the morning read starts from Attention", () => {
+  function reviewInput(audit: AttentionAuditInput | null): ActivityReviewInput {
+    return {
+      kind: "daily",
+      now: NOW,
+      issues: [],
+      pullRequests: [],
+      gitStats: { commits: 0, added: 0, removed: 0 },
+      history: [],
+      activeWorkers: [],
+      tokenSummary: { available: true, total: 10, input: 6, output: 4, sourceRecords: 1 },
+      attentionAudit: audit === null ? null : assembleAttentionAudit(audit),
+    };
+  }
+
+  /** A completed drain: one Worker, one landed issue, one prose cite it should not have got away with. */
+  const COMPLETED = auditInput({
+    rows: [
+      row({ evidence: "ran it, seemed fine" }),
+      row({ type: "verified-unit", worker: "w-2", evidence: "#4171" }),
+    ],
+    outcomes: [outcome({ state: "parked", reentries: 1 })],
+  });
+
+  it("contains the Attention section for a completed fixture drain", () => {
+    const report = buildActivityReviewReport(reviewInput(COMPLETED));
+    const rendered = renderActivityReviewReport(report);
+
+    expect(report.attention?.drain).toBe("drain-2026-08-19");
+    expect(rendered).toContain("Attention — drain-2026-08-19");
+    expect(rendered).toContain("weak evidence (1)");
+    expect(rendered).toContain("unproven claims (1)");
+  });
+
+  it("prints Attention BEFORE the big numbers, so the numbers do not frame the audit", () => {
+    const rendered = renderActivityReviewReport(buildActivityReviewReport(reviewInput(COMPLETED)));
+
+    expect(rendered.indexOf("Attention —")).toBeLessThan(rendered.indexOf("Big numbers"));
+  });
+
+  it("carries the audit through the TOON render the agent surface returns", () => {
+    const decoded = decode(
+      renderActivityReviewReportToon(buildActivityReviewReport(reviewInput(COMPLETED))),
+    ) as { attention: { drain: string; rows_read: number } };
+
+    expect(decoded.attention.drain).toBe("drain-2026-08-19");
+    expect(decoded.attention.rows_read).toBe(2);
+  });
+
+  it("keeps the section present, and honest, when no drain ended in the window", () => {
+    const report = buildActivityReviewReport(reviewInput(null));
+
+    expect(report.attention).toBeNull();
+    expect(renderActivityReviewReport(report)).toContain("(no drain-end audit for this window)");
+  });
+});
+
+describe("the audit identity is pinned to a different model family than the drain's Workers", () => {
+  it("places a configured model id in a coarse family, and refuses to guess", () => {
+    expect(judgeModelFamily("claude-opus-5")).toBe("anthropic");
+    expect(judgeModelFamily("openrouter/anthropic/claude-sonnet-5")).toBe("anthropic");
+    expect(judgeModelFamily("gpt-5.6-sol")).toBe("openai");
+    expect(judgeModelFamily("MiniMax-M3")).toBe("minimax");
+    expect(judgeModelFamily("gemini-3-pro")).toBe("google");
+    expect(judgeModelFamily("some-local-thing")).toBe("unknown");
+  });
+
+  it("pins a cross-family identity on the SHIPPED configuration", () => {
+    const values = defaultConfig();
+    const drain = resolveDrainWorkerIdentity(values);
+    const audit = resolveAttentionAuditIdentity(values);
+
+    expect(drain).toMatchObject({ runner: "claude", family: "anthropic" });
+    expect(audit).toMatchObject({ runner: "codex", family: "openai" });
+    expect(audit?.family).not.toBe(drain.family);
+    expect(attentionAuditIdentityRefusal(values)).toBeNull();
+  });
+
+  it("moves the audit to the other side when the operator repoints the drain", () => {
+    const values = { ...defaultConfig(), "afk.default_runner": "codex" };
+
+    expect(resolveDrainWorkerIdentity(values)).toMatchObject({ runner: "codex", family: "openai" });
+    expect(resolveAttentionAuditIdentity(values)).toMatchObject({
+      runner: "claude",
+      family: "anthropic",
+    });
+    expect(attentionAuditIdentityRefusal(values)).toBeNull();
+  });
+
+  it("refuses to pin an identity when every runner sits on one family", () => {
+    const values = defaultConfig();
+    for (const runner of ATTENTION_AUDIT_RUNNER_PREFERENCE) {
+      values[`afk.models.${runner}.${ATTENTION_AUDIT_TIER}.model`] = "claude-opus-5";
+      values[`afk.models.${runner}.${DRAIN_WORKER_TIER}.model`] = "claude-opus-5";
+    }
+
+    expect(resolveAttentionAuditIdentity(values)).toBeNull();
+    expect(attentionAuditIdentityRefusal(values)).toContain(
+      "the drain's own mind",
+    );
+  });
+
+  it("refuses when the drain's own model family cannot be recognised", () => {
+    const values = defaultConfig();
+    values[`afk.models.claude.${DRAIN_WORKER_TIER}.model`] = "some-local-thing";
+
+    expect(resolveAttentionAuditIdentity(values)).toBeNull();
+    expect(attentionAuditIdentityRefusal(values)).toContain("unrecognised");
+  });
+
+  it("judges at the validate tier and compares against the complex tier the Workers code at", () => {
+    expect(ATTENTION_AUDIT_TIER).toBe("validate");
+    expect(DRAIN_WORKER_TIER).toBe("complex");
+    expect(ATTENTION_AUDIT_RUNNER_PREFERENCE).toContain("codex");
+    expect(ATTENTION_AUDIT_RUNNER_PREFERENCE).toContain("claude");
+  });
+});

--- a/packaging/pi/dev/skills/engineering/daily-review/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/daily-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: daily-review
 working-mode: spec-driven
-description: Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass `--period week` for a six-day window. Covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and — for the week — Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes `/daily-review`, `/weekly-review`, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL.
+description: Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass `--period week` for a six-day window. Opens with the drain-end Attention audit, then covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and — for the week — Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes `/daily-review`, `/weekly-review`, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL.
 argument-hint: "[--period day|week] [--json] [--human]"
 disable-model-invocation: true
 ---
@@ -47,6 +47,13 @@ empty tables use the definitive `key[0]:` empty state.
 
 ## Report Sections
 
+- Attention (**first, before the numbers**): the drain-end **Attention audit** —
+  the latest drain's **Decision trail** read against its outcomes by an identity
+  on a different model family than the drain's Workers. It names weak evidence
+  (an `evidence` field holding prose instead of a pointer), unproven claims (a
+  `verified-unit` row for an issue the drain never landed), and unlogged pivots
+  (more re-entries than the trail has pivot/revert rows). A window with no drain
+  end says so; a clean drain says so; the section is never silently absent.
 - Big numbers: issues created/closed, PRs created/closed/merged, commits, lines
   added/removed, local workers, local attempts, local worker time, token spend
   when retained runner logs expose usage fields.

--- a/packaging/pi/dev/skills/engineering/daily-review/agents/openai.yaml
+++ b/packaging/pi/dev/skills/engineering/daily-review/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
   display_name: "Daily Review"
-  short_description: "Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass --period week for a six-day window. Covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and - for the week - Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes /daily-review, /weekly-review, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL."
+  short_description: "Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass --period week for a six-day window. Opens with the drain-end Attention audit, then covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and - for the week - Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes /daily-review, /weekly-review, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL."
 policy:
   allow_implicit_invocation: false

--- a/plugins/dev/skills/engineering/daily-review/SKILL.md
+++ b/plugins/dev/skills/engineering/daily-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: daily-review
 working-mode: spec-driven
-description: Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass `--period week` for a six-day window. Covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and — for the week — Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes `/daily-review`, `/weekly-review`, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL.
+description: Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass `--period week` for a six-day window. Opens with the drain-end Attention audit, then covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and — for the week — Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes `/daily-review`, `/weekly-review`, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL.
 argument-hint: "[--period day|week] [--json] [--human]"
 disable-model-invocation: true
 ---
@@ -47,6 +47,13 @@ empty tables use the definitive `key[0]:` empty state.
 
 ## Report Sections
 
+- Attention (**first, before the numbers**): the drain-end **Attention audit** —
+  the latest drain's **Decision trail** read against its outcomes by an identity
+  on a different model family than the drain's Workers. It names weak evidence
+  (an `evidence` field holding prose instead of a pointer), unproven claims (a
+  `verified-unit` row for an issue the drain never landed), and unlogged pivots
+  (more re-entries than the trail has pivot/revert rows). A window with no drain
+  end says so; a clean drain says so; the section is never silently absent.
 - Big numbers: issues created/closed, PRs created/closed/merged, commits, lines
   added/removed, local workers, local attempts, local worker time, token spend
   when retained runner logs expose usage fields.

--- a/plugins/dev/skills/engineering/daily-review/agents/openai.yaml
+++ b/plugins/dev/skills/engineering/daily-review/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
   display_name: "Daily Review"
-  short_description: "Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass --period week for a six-day window. Covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and - for the week - Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes /daily-review, /weekly-review, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL."
+  short_description: "Generates a RedSkills operational review for a requested period. Default period is yesterday midnight to now (one day); pass --period week for a six-day window. Opens with the drain-end Attention audit, then covers delivered work, local AFK workers, cycle times, HITL/blocker challenges, and - for the week - Standing orders recurring across drains as CLAUDE.md promotion candidates. Use when the user invokes /daily-review, /weekly-review, asks for daily or weekly delivery numbers, issues/PRs/commits/diffstat, worker attempts, token spend, or why tasks needed HITL."
 policy:
   allow_implicit_invocation: false


### PR DESCRIPTION
## Problem

Decision rows (#4167) gave every Worker a place to record the forks it took, the pivots, the reverts, the blockers and the units it called verified — and **nothing read them**. A trail nobody reads is narration with a schema: the night still has to be re-read in the morning, which is the cost the trail was added to remove.

## What this adds

The **Attention audit** — the drain-end reader. It takes a drain's decision rows plus the drain's **outcomes** (what actually landed, parked or was abandoned) and computes the three findings that are disagreements between two records the drain already holds, so none of them needs a model:

- **weak evidence** — the trail promised `evidence` would be a pointer; the writer enforces only non-empty, so prose passes validation and a claim ends up citing itself.
- **unproven claims** — a `verified-unit` row for an issue the drain never landed. The Worker said verified; the outcome says otherwise.
- **unlogged pivots** — more re-entries into an issue than the trail has `pivot`/`revert` rows to explain them.

Assembly is a **pure function** over fixed inputs. An empty trail is a legal drain that assembles to a real audit naming its own silence, not an error.

`daily_review` prints the section **first**, before the big numbers — or the numbers frame the audit before it is read. A window with no drain end still carries the section, saying so, because an absent section reads as "nothing to see" whether the drain was clean or the audit never ran.

## The judgment step is a seam, deliberately

`AttentionJudge` is a declared interface the daemon fills later; **nothing in this PR makes a model call**, so every test is offline and deterministic. The drain-end trigger wiring on the daemon side is likewise not in this slice — the assembly and the identity rule are what the acceptance criteria pin, and they are complete and tested here.

## The identity is configuration, with an assertion on it

An agent grading its own night re-accepts the evidence it already accepted, so the auditing identity is a configuration fact, not a runner somebody had spare. The rule is a **property, never a hardcoded name**: the audit runs on the first supported runner whose configured model sits on a different model family than the drain's Workers.

- Shipped defaults: drain = `claude`/`claude-opus-5` (anthropic), audit = `codex`/`gpt-5.6-sol` (openai).
- Repoint `afk.default_runner` at codex and the audit moves to claude on its own.
- Configure every runner onto one family and it **refuses to pin an identity** and says so — a same-family "cross-model" audit is the failure being named, and naming it beats performing it.
- `unknown` is never equal to anything, including itself: an id we cannot place is not evidence of a second opinion.

The coarse `JudgeModelFamily` is deliberately not `model-tier-route`'s `ModelFamily` — haiku/sonnet/opus is the right grain for cost tiering and the wrong grain here, because two Claude tiers share training, refusal shape and blind spots.

## Acceptance criteria

- [x] Audit assembly covered by pure-function tests over fixed trail fixtures, **including an empty-trail drain** (`apps/plugin-dev/tests/attention-audit.test.ts`).
- [x] `daily_review` output for a completed fixture drain contains the Attention section (text render, TOON render, and section ordering all asserted).
- [x] A configuration assertion pins the audit identity to a different model family than the drain's Workers — asserted against the live `CONFIG_DEFAULTS`, plus the repointed-drain case and both refusal cases.

## Files

- `apps/plugin-dev/src/core/attention-audit.ts` — new; the pure assembly, the render, the judge seam.
- `apps/plugin-dev/src/core/attention-audit-identity.ts` — new; the family rule and the configuration assertion.
- `apps/plugin-dev/src/core/activity-review.ts` — +12 lines of wiring only; it renders what it is handed.
- `apps/plugin-dev/tests/attention-audit.test.ts` — new; 22 tests.
- Glossary term, `daily-review` SKILL.md and its Pi mirror, changeset.

The audit lives in its own modules rather than inside the review core because the daemon's future trigger needs the assembly without the review around it.

## Validation

- `pnpm typecheck` — 17/17 green.
- `pnpm -C apps/plugin-dev test:invariants` — **370/370 green**, including the shrink-only file-size and complexity-coverage ratchets. No baseline was raised and no baselined file grew.
- `pnpm -C apps/plugin-dev test` — 445 files, **5723 tests green**.
- `pnpm lint` (oxlint) — clean. `pnpm generate-manifests` — no drift.

Fixes #4171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789891369&installation_model_id=20659&pr_number=4255&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4255&signature=4d607602469be0e25f9dd77103314cf69803cddede5d1453493212a550975cd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->