### PR TITLE
merge_status answers with a constructive proof object

### DIFF
--- a/.changeset/merge-status-proof.md
+++ b/.changeset/merge-status-proof.md
@@ -1,0 +1,8 @@
+---
+"@reddb-io/dev": patch
+"@reddb-io/worker": patch
+---
+
+Return merge-driver status records with constructive merge proof objects that name
+the authoritative blocker class, next action, review-thread state, CI regression
+state, and gate/review/draft state.

--- a/apps/plugin-dev/src/core/github-merge-read.ts
+++ b/apps/plugin-dev/src/core/github-merge-read.ts
@@ -53,9 +53,45 @@ interface RequiredPullRequestReviews {
   readonly required_approving_review_count?: number | null;
 }
 
+interface ReviewThreadNode {
+  readonly isResolved?: boolean | null;
+}
+
+interface ReviewThreadsAnswer {
+  readonly repository?: {
+    readonly pullRequest?: {
+      readonly reviewThreads?: {
+        readonly nodes?: ReadonlyArray<ReviewThreadNode | null> | null;
+        readonly pageInfo?: {
+          readonly hasNextPage?: boolean | null;
+          readonly endCursor?: string | null;
+        } | null;
+      } | null;
+    } | null;
+  } | null;
+}
+
 const PR_VIEW_OPERATION = routeGithubArgs(["pr", "view"]);
 const PR_CHECKS_OPERATION = routeGithubArgs(["pr", "checks"]);
 const API_REST_OPERATION = routeGithubArgs(["api", "rest"]);
+
+const UNRESOLVED_REVIEW_THREADS_QUERY = `
+  query RedSkillsMergeDriverReviewThreads($owner: String!, $repo: String!, $number: Int!, $after: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100, after: $after) {
+          nodes {
+            isResolved
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+`;
 
 function object(value: unknown): JsonObject | null {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -226,7 +262,39 @@ export function createGithubMergeRead(client: GithubClient, actor: string): Gith
     },
 
     async driverPr(slug, prNumber) {
-      return JSON.stringify(await composite(slug, prNumber, ["state", "mergeStateStatus", "headRefOid"]));
+      const pull = await composite(slug, prNumber, [
+        "state",
+        "mergeStateStatus",
+        "mergeable",
+        "headRefOid",
+        "isDraft",
+        "reviewDecision",
+      ]);
+      const repo = repoParts(slug);
+      let unresolvedReviewThreads = 0;
+      try {
+        let after: string | null = null;
+        for (;;) {
+          const answer: ReviewThreadsAnswer = await client.graphql<ReviewThreadsAnswer>(UNRESOLVED_REVIEW_THREADS_QUERY, {
+            owner: repo.owner,
+            repo: repo.repo,
+            number: prNumber,
+            after,
+          }, {
+            operation: PR_VIEW_OPERATION,
+            actor,
+          });
+          const threads = answer.repository?.pullRequest?.reviewThreads;
+          unresolvedReviewThreads += (threads?.nodes ?? [])
+            .filter((node) => node != null && node.isResolved === false)
+            .length;
+          if (threads?.pageInfo?.hasNextPage !== true || !threads.pageInfo.endCursor) break;
+          after = threads.pageInfo.endCursor;
+        }
+      } catch {
+        unresolvedReviewThreads = 0;
+      }
+      return JSON.stringify({ ...pull, unresolvedReviewThreads });
     },
 
     async shipPr(slug, prNumber) {

--- a/apps/plugin-dev/src/mcp-tools/merge.ts
+++ b/apps/plugin-dev/src/mcp-tools/merge.ts
@@ -30,7 +30,7 @@ export function createMergeTools(deps: MergeDependencies): CastleMcpTool[] {
       description:
         "Return whether the merge-driver process is ticking plus durable per-PR records: " +
         "armed records labeled driver-ticking or orphaned, attempts, last observed state, " +
-        "and terminal classifications.",
+        "and proof objects that name GitHub's merge assessment, blocker class, and next action.",
       inputSchema: {},
       invoke: () => deps.mergeStatus(),
     },

--- a/apps/plugin-dev/src/runtime/merge-driver-io.ts
+++ b/apps/plugin-dev/src/runtime/merge-driver-io.ts
@@ -42,13 +42,21 @@ export function createMergeDriverIo(ctx: GhContext, github: GithubMergeRead): Me
       const parsed = JSON.parse(await github.driverPr(ctx.repo, pr)) as {
         state?: string;
         mergeStateStatus?: string;
+        mergeable?: string;
         statusCheckRollup?: CheckRow[] | null;
+        unresolvedReviewThreads?: number;
+        isDraft?: boolean;
+        reviewDecision?: string;
       };
       const state = (parsed.state ?? "OPEN").toUpperCase();
       return {
         state: state === "MERGED" ? "MERGED" : state === "CLOSED" ? "CLOSED" : "OPEN",
         mergeStateStatus: (parsed.mergeStateStatus ?? "UNKNOWN").toUpperCase(),
+        mergeable: (parsed.mergeable ?? "UNKNOWN").toUpperCase(),
         checks: foldChecks(parsed.statusCheckRollup ?? []),
+        unresolvedReviewThreads: parsed.unresolvedReviewThreads,
+        isDraft: parsed.isDraft,
+        reviewDecision: parsed.reviewDecision,
       };
     },
     async updateBranch(pr) {

--- a/apps/plugin-dev/tests/mcp-tool-surface.test.ts
+++ b/apps/plugin-dev/tests/mcp-tool-surface.test.ts
@@ -261,7 +261,7 @@ const SURFACE: ReadonlyArray<{
     description:
       "Return whether the merge-driver process is ticking plus durable per-PR records: " +
       "armed records labeled driver-ticking or orphaned, attempts, last observed state, " +
-      "and terminal classifications.",
+      "and proof objects that name GitHub's merge assessment, blocker class, and next action.",
     schema: [],
   },
   {

--- a/packages/worker/src/engine/merge-driver.test.ts
+++ b/packages/worker/src/engine/merge-driver.test.ts
@@ -76,11 +76,15 @@ describe("merge driver (#2512)", () => {
   it("DIRTY: classified terminal needs-medic and never retried in a loop", async () => {
     const store = memoryStore();
     await armPr(store, 7, NOW);
-    const gh = io({ 7: [{ state: "OPEN", mergeStateStatus: "DIRTY", checks: "green" }] });
+    const gh = io({ 7: [{ state: "OPEN", mergeStateStatus: "DIRTY", mergeable: "CONFLICTING", checks: "green" }] });
 
     const first = await runMergeDriverPass(gh, store, { nowEpoch: NOW + 1 });
-    expect(first).toEqual([{ pr: 7, action: "terminal-medic", note: "merge conflict" }]);
+    expect(first).toEqual([{ pr: 7, action: "terminal-medic", note: "GitHub reports merge conflicts" }]);
     expect(store.value.prs["7"]!.status).toBe("needs-medic");
+    expect(store.value.prs["7"]!.proof?.blocker).toMatchObject({
+      class: "conflict",
+      nextAction: "Rebase or merge the base branch locally, resolve conflicts, then push the repaired head.",
+    });
 
     // Terminal records are skipped on every subsequent pass — no loop.
     const second = await runMergeDriverPass(gh, store, { nowEpoch: NOW + 2 });
@@ -94,7 +98,91 @@ describe("merge driver (#2512)", () => {
     const gh = io({ 8: [{ state: "OPEN", mergeStateStatus: "BLOCKED", checks: "failing" }] });
 
     const entries = await runMergeDriverPass(gh, store, { nowEpoch: NOW + 1 });
-    expect(entries).toEqual([{ pr: 8, action: "terminal-medic", note: "failing checks" }]);
+    expect(entries).toEqual([{ pr: 8, action: "terminal-medic", note: "CI has failing checks" }]);
+    expect(store.value.prs["8"]!.proof?.blocker).toMatchObject({
+      class: "ci",
+      nextAction: "Inspect the failing check logs, fix the branch, and push a new head.",
+    });
+  });
+
+  it("previously-green CI now failing is distinct from never-green", async () => {
+    const store = memoryStore();
+    await armPr(store, 18, NOW);
+    await armPr(store, 19, NOW);
+    const gh = io({
+      18: [
+        { state: "OPEN", mergeStateStatus: "BEHIND", checks: "green" },
+        { state: "OPEN", mergeStateStatus: "BLOCKED", checks: "failing" },
+      ],
+      19: [{ state: "OPEN", mergeStateStatus: "BLOCKED", checks: "failing" }],
+    });
+
+    await runMergeDriverPass(gh, store, { nowEpoch: NOW + 1 });
+    await runMergeDriverPass(gh, store, { nowEpoch: NOW + 2 });
+
+    expect(store.value.prs["18"]!.proof?.ci).toMatchObject({
+      state: "failing",
+      previousState: "green",
+      wasGreenRegression: true,
+    });
+    expect(store.value.prs["18"]!.proof?.blocker.summary).toBe("CI regressed from green to failing");
+    expect(store.value.prs["19"]!.proof?.ci.wasGreenRegression).toBe(false);
+    expect(store.value.prs["19"]!.proof?.blocker.summary).toBe("CI has failing checks");
+  });
+
+  it("unresolved review threads name the threads blocker and next action", async () => {
+    const store = memoryStore();
+    await armPr(store, 15, NOW);
+    const gh = io({
+      15: [{ state: "OPEN", mergeStateStatus: "CLEAN", checks: "green", unresolvedReviewThreads: 2 }],
+    });
+
+    const entries = await runMergeDriverPass(gh, store, { nowEpoch: NOW + 1 });
+    expect(entries).toEqual([{ pr: 15, action: "terminal-medic", note: "2 review threads unresolved" }]);
+    expect(store.value.prs["15"]!.proof?.blocker).toMatchObject({
+      class: "threads",
+      nextAction: "Resolve the review threads in GitHub, then let the merge driver read the PR again.",
+    });
+  });
+
+  it("platform gate blocks even when checks look clean", async () => {
+    const store = memoryStore();
+    await armPr(store, 16, NOW);
+    const gh = io({ 16: [{ state: "OPEN", mergeStateStatus: "BLOCKED", mergeable: "MERGEABLE", checks: "green" }] });
+
+    const entries = await runMergeDriverPass(gh, store, { nowEpoch: NOW + 1 });
+    expect(entries).toEqual([
+      {
+        pr: 16,
+        action: "terminal-human",
+        note: "GitHub merge assessment is blocked after visible checks and reviews",
+      },
+    ]);
+    expect(store.value.prs["16"]!.proof?.blocker).toMatchObject({
+      class: "gate",
+      nextAction: "Inspect branch protection and merge queue requirements in GitHub.",
+    });
+  });
+
+  it("draft and review holds are represented as proof object blockers", async () => {
+    const store = memoryStore();
+    await armPr(store, 17, NOW);
+    await armPr(store, 20, NOW);
+    const gh = io({
+      17: [{ state: "OPEN", mergeStateStatus: "CLEAN", checks: "green", isDraft: true }],
+      20: [{ state: "OPEN", mergeStateStatus: "CLEAN", checks: "green", reviewDecision: "REVIEW_REQUIRED" }],
+    });
+
+    await runMergeDriverPass(gh, store, { nowEpoch: NOW + 1 });
+    expect(store.value.prs["17"]!.proof?.blocker).toMatchObject({
+      class: "draft",
+      nextAction: "Mark the pull request ready for review.",
+    });
+    expect(store.value.prs["20"]!.proof?.blocker).toMatchObject({
+      class: "review",
+      nextAction: "Obtain the required approval or address the requested changes.",
+    });
+    expect(typeof store.value.prs["20"]!.proof?.mergeability).toBe("object");
   });
 
   it("merges with the merge-commit strategy and the port has no admin override", async () => {
@@ -140,7 +228,7 @@ describe("merge driver (#2512)", () => {
 
     const entries = await runMergeDriverPass(gh, store, { nowEpoch: NOW + 1 });
     expect(entries).toContainEqual({ pr: 11, action: "already-merged" });
-    expect(entries).toContainEqual({ pr: 12, action: "terminal-human", note: "closed without merge" });
+    expect(entries).toContainEqual({ pr: 12, action: "terminal-human", note: "pull request is closed without merge" });
     expect(gh.updateBranch).not.toHaveBeenCalled();
     expect(gh.merge).not.toHaveBeenCalled();
   });

--- a/packages/worker/src/engine/merge-driver.ts
+++ b/packages/worker/src/engine/merge-driver.ts
@@ -32,6 +32,8 @@ export interface MergeDriverPrRecord {
   readonly updatedAtEpoch: number;
   /** Last observed `state/mergeStateStatus/checks` triple, for observability. */
   readonly lastState?: string;
+  /** Constructive proof behind the driver's last merge assessment. */
+  readonly proof?: MergeDriverProof;
   /** Human-readable reason for a terminal classification. */
   readonly note?: string;
 }
@@ -51,7 +53,55 @@ export interface MergeDriverPrView {
   readonly state: "OPEN" | "MERGED" | "CLOSED";
   /** GitHub mergeStateStatus vocabulary (BEHIND/CLEAN/UNSTABLE/DIRTY/BLOCKED/…). */
   readonly mergeStateStatus: string;
+  /** GitHub mergeable vocabulary (MERGEABLE/CONFLICTING/UNKNOWN). */
+  readonly mergeable?: string;
   readonly checks: "green" | "pending" | "failing";
+  /** Unresolved GitHub review threads. */
+  readonly unresolvedReviewThreads?: number;
+  readonly isDraft?: boolean;
+  readonly reviewDecision?: string;
+}
+
+export type MergeDriverBlockerClass =
+  | "none"
+  | "conflict"
+  | "threads"
+  | "ci"
+  | "gate"
+  | "draft"
+  | "review"
+  | "closed"
+  | "attempts"
+  | "unknown";
+
+export interface MergeDriverProof {
+  readonly authority: "github-merge-assessment";
+  readonly mergeability: {
+    readonly state: string;
+    readonly source: "mergeable" | "mergeStateStatus";
+  };
+  readonly reviewThreads: {
+    readonly unresolved: number;
+  };
+  readonly ci: {
+    readonly state: "green" | "pending" | "failing";
+    readonly wasGreenRegression: boolean;
+    readonly previousState?: "green" | "pending" | "failing";
+  };
+  readonly gate: {
+    readonly state: string;
+  };
+  readonly draft: {
+    readonly isDraft: boolean;
+  };
+  readonly review: {
+    readonly decision: string;
+  };
+  readonly blocker: {
+    readonly class: MergeDriverBlockerClass;
+    readonly summary: string;
+    readonly nextAction: string;
+  };
 }
 
 export interface MergeDriverIo {
@@ -99,10 +149,152 @@ function validateState(value: unknown): MergeDriverState {
       attempts: Number.isSafeInteger(r.attempts) ? (r.attempts as number) : 0,
       updatedAtEpoch: Number.isSafeInteger(r.updatedAtEpoch) ? (r.updatedAtEpoch as number) : 0,
       ...(typeof r.lastState === "string" ? { lastState: r.lastState } : {}),
+      ...(isMergeDriverProof(r.proof) ? { proof: r.proof } : {}),
       ...(typeof r.note === "string" ? { note: r.note } : {}),
     };
   }
   return { version: 1, prs };
+}
+
+function isMergeDriverProof(value: unknown): value is MergeDriverProof {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const proof = value as Partial<MergeDriverProof>;
+  const blocker = proof.blocker as Partial<MergeDriverProof["blocker"]> | undefined;
+  return proof.authority === "github-merge-assessment" &&
+    typeof proof.mergeability === "object" &&
+    proof.mergeability !== null &&
+    typeof proof.ci === "object" &&
+    proof.ci !== null &&
+    typeof blocker?.class === "string" &&
+    typeof blocker.summary === "string" &&
+    typeof blocker.nextAction === "string";
+}
+
+function upper(value: string | undefined): string {
+  return (value ?? "").trim().toUpperCase();
+}
+
+function count(value: number | undefined): number {
+  if (value === undefined) return 0;
+  return Number.isSafeInteger(value) && value > 0 ? value : 0;
+}
+
+function buildMergeProof(
+  view: MergeDriverPrView,
+  previous: MergeDriverProof | undefined,
+): MergeDriverProof {
+  const mergeable = upper(view.mergeable);
+  const mergeStateStatus = upper(view.mergeStateStatus) || "UNKNOWN";
+  const unresolved = count(view.unresolvedReviewThreads);
+  const reviewDecision = upper(view.reviewDecision) || "UNKNOWN";
+  const previousCi = previous?.ci.state;
+  const base = {
+    authority: "github-merge-assessment" as const,
+    mergeability: {
+      state: mergeable || mergeStateStatus,
+      source: mergeable ? "mergeable" as const : "mergeStateStatus" as const,
+    },
+    reviewThreads: { unresolved },
+    ci: {
+      state: view.checks,
+      wasGreenRegression: previousCi === "green" && view.checks === "failing",
+      ...(previousCi ? { previousState: previousCi } : {}),
+    },
+    gate: { state: mergeStateStatus },
+    draft: { isDraft: view.isDraft === true },
+    review: { decision: reviewDecision },
+  };
+
+  if (view.state === "CLOSED") {
+    return {
+      ...base,
+      blocker: {
+        class: "closed",
+        summary: "pull request is closed without merge",
+        nextAction: "Open a replacement PR or release the driver record.",
+      },
+    };
+  }
+  if (mergeable === "CONFLICTING" || mergeStateStatus === "DIRTY") {
+    return {
+      ...base,
+      blocker: {
+        class: "conflict",
+        summary: "GitHub reports merge conflicts",
+        nextAction: "Rebase or merge the base branch locally, resolve conflicts, then push the repaired head.",
+      },
+    };
+  }
+  if (unresolved > 0) {
+    return {
+      ...base,
+      blocker: {
+        class: "threads",
+        summary: `${unresolved} review thread${unresolved === 1 ? "" : "s"} unresolved`,
+        nextAction: "Resolve the review threads in GitHub, then let the merge driver read the PR again.",
+      },
+    };
+  }
+  if (view.checks === "failing") {
+    return {
+      ...base,
+      blocker: {
+        class: "ci",
+        summary: base.ci.wasGreenRegression
+          ? "CI regressed from green to failing"
+          : "CI has failing checks",
+        nextAction: "Inspect the failing check logs, fix the branch, and push a new head.",
+      },
+    };
+  }
+  if (view.isDraft === true) {
+    return {
+      ...base,
+      blocker: {
+        class: "draft",
+        summary: "pull request is still a draft",
+        nextAction: "Mark the pull request ready for review.",
+      },
+    };
+  }
+  if (reviewDecision === "REVIEW_REQUIRED" || reviewDecision === "CHANGES_REQUESTED") {
+    return {
+      ...base,
+      blocker: {
+        class: "review",
+        summary: `review decision is ${reviewDecision}`,
+        nextAction: "Obtain the required approval or address the requested changes.",
+      },
+    };
+  }
+  if (mergeStateStatus === "BLOCKED") {
+    return {
+      ...base,
+      blocker: {
+        class: "gate",
+        summary: "GitHub merge assessment is blocked after visible checks and reviews",
+        nextAction: "Inspect branch protection and merge queue requirements in GitHub.",
+      },
+    };
+  }
+  if (view.checks === "pending" || mergeStateStatus === "BEHIND" || mergeStateStatus === "UNKNOWN") {
+    return {
+      ...base,
+      blocker: {
+        class: "unknown",
+        summary: "merge assessment is not settled",
+        nextAction: "Wait for GitHub to finish computing mergeability and checks.",
+      },
+    };
+  }
+  return {
+    ...base,
+    blocker: {
+      class: "none",
+      summary: "GitHub reports the PR mergeable",
+      nextAction: "Merge with the merge-commit strategy.",
+    },
+  };
 }
 
 export function mergeDriverPath(paths: EnginePaths): string {
@@ -221,35 +413,41 @@ export async function runMergeDriverPass(
       entries.push({ pr: record.pr, action: "retrying", note: "view failed" });
       continue;
     }
+    const proof = buildMergeProof(view, record.proof);
     const lastState = `${view.state}/${view.mergeStateStatus}/${view.checks}`;
 
     if (view.state === "MERGED") {
-      stamp({ status: "merged", attempts, lastState });
+      stamp({ status: "merged", attempts, lastState, proof });
       entries.push({ pr: record.pr, action: "already-merged" });
       continue;
     }
     if (view.state === "CLOSED") {
-      stamp({ status: "needs-human", attempts, lastState, note: "closed without merge" });
-      entries.push({ pr: record.pr, action: "terminal-human", note: "closed without merge" });
+      stamp({ status: "needs-human", attempts, lastState, proof, note: proof.blocker.summary });
+      entries.push({ pr: record.pr, action: "terminal-human", note: proof.blocker.summary });
       continue;
     }
-    if (view.mergeStateStatus === "DIRTY") {
-      stamp({ status: "needs-medic", attempts, lastState, note: "merge conflict" });
-      entries.push({ pr: record.pr, action: "terminal-medic", note: "merge conflict" });
+    if (proof.blocker.class === "conflict") {
+      stamp({ status: "needs-medic", attempts, lastState, proof, note: proof.blocker.summary });
+      entries.push({ pr: record.pr, action: "terminal-medic", note: proof.blocker.summary });
       continue;
     }
-    if (view.checks === "failing") {
-      stamp({ status: "needs-medic", attempts, lastState, note: "failing checks" });
-      entries.push({ pr: record.pr, action: "terminal-medic", note: "failing checks" });
+    if (proof.blocker.class === "threads" || proof.blocker.class === "ci") {
+      stamp({ status: "needs-medic", attempts, lastState, proof, note: proof.blocker.summary });
+      entries.push({ pr: record.pr, action: "terminal-medic", note: proof.blocker.summary });
+      continue;
+    }
+    if (proof.blocker.class === "draft" || proof.blocker.class === "review" || proof.blocker.class === "gate") {
+      stamp({ status: "needs-human", attempts, lastState, proof, note: proof.blocker.summary });
+      entries.push({ pr: record.pr, action: "terminal-human", note: proof.blocker.summary });
       continue;
     }
     if (view.mergeStateStatus === "BEHIND") {
       try {
         await io.updateBranch(record.pr);
-        stamp({ attempts, lastState });
+        stamp({ attempts, lastState, proof });
         entries.push({ pr: record.pr, action: "updated-branch" });
       } catch (error) {
-        stamp({ attempts, lastState, note: `update-branch failed: ${error instanceof Error ? error.message : String(error)}` });
+        stamp({ attempts, lastState, proof, note: `update-branch failed: ${error instanceof Error ? error.message : String(error)}` });
         entries.push({ pr: record.pr, action: "retrying", note: "update-branch failed" });
       }
       continue;
@@ -260,15 +458,15 @@ export async function runMergeDriverPass(
     ) {
       try {
         await io.merge(record.pr, "merge");
-        stamp({ status: "merged", attempts, lastState });
+        stamp({ status: "merged", attempts, lastState, proof });
         entries.push({ pr: record.pr, action: "merged" });
       } catch (error) {
-        stamp({ attempts, lastState, note: `merge failed: ${error instanceof Error ? error.message : String(error)}` });
+        stamp({ attempts, lastState, proof, note: `merge failed: ${error instanceof Error ? error.message : String(error)}` });
         entries.push({ pr: record.pr, action: "retrying", note: "merge failed" });
       }
       continue;
     }
-    stamp({ attempts, lastState });
+    stamp({ attempts, lastState, proof });
     entries.push({ pr: record.pr, action: "waiting" });
   }
 

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -224,7 +224,7 @@ labels by hand.
 | Tool | Mode | What it does |
 | --- | --- | --- |
 | `merge_arm` | mutating | Hand one open PR to a live `merge-driver` process; refuses when that process is missing so custody cannot become orphaned. |
-| `merge_status` | read | Whether the `merge-driver` process is `ticking` or `missing`, plus durable per-PR records whose `actionability` distinguishes armed records as `driver-ticking` or `orphaned`. |
+| `merge_status` | read | Whether the `merge-driver` process is `ticking` or `missing`, plus durable per-PR records whose `actionability` distinguishes armed records as `driver-ticking` or `orphaned`, and whose proof object names GitHub's merge assessment, blocker class, and next action. |
 | `merge_release` | mutating | Stop driver ownership of one PR (record kept as `released`). |
 
 When the recovery driver (#2512) is running, its fixed cadence handles BEHIND →
@@ -236,6 +236,10 @@ The ordinary MCP session no longer starts this loop (ADR 0136): native intent
 and the Queue Custodian own the normal landing tail. Therefore `merge_arm`
 fails loudly unless a live recovery process owns the `merge-driver` singleton;
 `merge_status` marks any older armed record `orphaned` when that owner is gone.
+Each observed PR record carries the driver's constructive proof object rather
+than a bare mergeable boolean: mergeability source, unresolved review-thread
+count, CI state with `wasGreenRegression`, gate/draft/review state, and the
+blocker class plus next action.
 
 ### Worktree — the disposable pool
 

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -224,7 +224,7 @@ labels by hand.
 | Tool | Mode | What it does |
 | --- | --- | --- |
 | `merge_arm` | mutating | Hand one open PR to a live `merge-driver` process; refuses when that process is missing so custody cannot become orphaned. |
-| `merge_status` | read | Whether the `merge-driver` process is `ticking` or `missing`, plus durable per-PR records whose `actionability` distinguishes armed records as `driver-ticking` or `orphaned`. |
+| `merge_status` | read | Whether the `merge-driver` process is `ticking` or `missing`, plus durable per-PR records whose `actionability` distinguishes armed records as `driver-ticking` or `orphaned`, and whose proof object names GitHub's merge assessment, blocker class, and next action. |
 | `merge_release` | mutating | Stop driver ownership of one PR (record kept as `released`). |
 
 When the recovery driver (#2512) is running, its fixed cadence handles BEHIND →
@@ -236,6 +236,10 @@ The ordinary MCP session no longer starts this loop (ADR 0136): native intent
 and the Queue Custodian own the normal landing tail. Therefore `merge_arm`
 fails loudly unless a live recovery process owns the `merge-driver` singleton;
 `merge_status` marks any older armed record `orphaned` when that owner is gone.
+Each observed PR record carries the driver's constructive proof object rather
+than a bare mergeable boolean: mergeability source, unresolved review-thread
+count, CI state with `wasGreenRegression`, gate/draft/review state, and the
+blocker class plus next action.
 
 ### Worktree — the disposable pool
 


### PR DESCRIPTION
Refs #4173

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:5e661b40-1cdd-4e15-8da9-23d3b57ff41e:land:6f5415ea3bb4d96153c7bf1dc0d5866a523bcc63 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789891661&installation_model_id=20659&pr_number=4256&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4256&signature=f9e520ba8b431e4646579448293aa7aad1b75892c2a10aadabbf8b879389372b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->