### PR TITLE
feat(dev): the checkout sweeps hard Worker deaths in one tick (#4136)

### DIFF
--- a/.changeset/checkout-death-sweep.md
+++ b/.changeset/checkout-death-sweep.md
@@ -1,0 +1,15 @@
+---
+"@reddb-io/dev": patch
+---
+
+The checkout sweeps hard Worker deaths instead of waiting for the next boot.
+A classified death the daemon published — `sender_class`, `confidence`,
+`exit_code`, `signal`, `memory_peak_bytes`, keyed by `worker_id` alone — is
+joined to the claim marker that carries this host's prefix, and from there to
+the Ticket only the checkout can name. The claim is conceded eagerly, the
+terminal history row the requeue ordinal counts is appended, and the existing
+`recoveryDecision` caps decide: a memory kill requeues with the ceiling raised
+above the measured peak, or at the next model tier when no headroom is left; a
+requested stop or a host teardown requeues plainly; an unattributed SIGKILL is
+left to the staleness sweep, which stays as the backstop. Exhaustion parks with
+the receipt quoted.

--- a/apps/plugin-dev/src/core/boot.ts
+++ b/apps/plugin-dev/src/core/boot.ts
@@ -57,6 +57,7 @@ import {
   type ClaimedIssue,
 } from "./claim-staleness.js";
 import { planClaimRecovery } from "./claim-recovery.js";
+import { runDeathSweep, type DeathSweepPort, type DeathSweepResult } from "./death-sweep.js";
 import { renderConcedeOnBehalf } from "./claim.js";
 import {
   planDocsSweep,
@@ -422,6 +423,15 @@ export interface BootDeps {
   reconcileRunner?: ReconcileBootRunner;
   /** Landing lane for the Docs Sweep. Absent is valid only when the plan is clean. */
   docsSweepLander?: DocsSweepLander;
+  /**
+   * Everything the checkout death sweep reads and writes (ADR 0155 §2).
+   *
+   * Absent → the step is a no-op and a hard death waits for the staleness sweep
+   * below it, which is exactly the behaviour this port improves on rather than
+   * replaces. Present → each classified death releases its claim eagerly, in
+   * the same tick that observed it.
+   */
+  deathSweep?: DeathSweepPort;
 }
 function shortSha(sha: string | undefined): string {
   return sha ? sha.slice(0, 12) : "unknown";
@@ -864,6 +874,7 @@ export interface BootResult {
   unblockSweep?: UnblockSweepResult;
   mixedBlockedNormalize?: MixedBlockedNormalizeResult;
   specSubIssueReconcile?: SpecSubIssueReconcileBootResult;
+  deathSweep?: DeathSweepResult;
   staleClaimSweep?: StaleClaimSweepResult;
   reconcileSweep?: ReconcileSweepResult;
   straggler?: StragglerResult;
@@ -891,6 +902,10 @@ export interface BootResult {
  *   7a. mixed-blocked normalizer — shed stale blocked:* from queued/active issues.
  *   7b. Spec sub-issue reconcile — attach missing native sub-issue edges and
  *                                  strip stale needs-slicing on sliced Specs.
+ *   7b'. death sweep        — planDeathSweep; join each classified Worker death to
+ *                             the claim it left behind, release it eagerly and
+ *                             requeue or park under the existing caps (ADR 0155).
+ *                             No-op when `deathSweep` is absent.
  *   7c. stale-claim sweep   — planStaleClaimSweep; release each issue held only by
  *                             a cross-host claim that stopped refreshing (#627).
  *                             No-op when `claimedIssues` is absent.
@@ -1017,6 +1032,12 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
   // ---- 7b. Spec sub-issue reconciler (#1739) ----
   const specSubIssueReconcile = await runSpecSubIssueReconcile(deps, options);
 
+  // ---- 7b'. checkout death sweep (ADR 0155, #4136) ----
+  // Sequenced BEFORE the staleness sweep on purpose: a death the daemon
+  // explained is released with its evidence and its remedy, and only what the
+  // evidence could not name is left for the clock below to concede blind.
+  const deathSweep = await runBootDeathSweep(deps);
+
   // ---- 7c. cross-host stale-claim sweep (#627) ----
   const staleClaimSweep = await runStaleClaimSweep(deps);
 
@@ -1038,6 +1059,7 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
     unblockSweep,
     mixedBlockedNormalize,
     specSubIssueReconcile,
+    ...(deathSweep === undefined ? {} : { deathSweep }),
     staleClaimSweep,
     reconcileSweep,
     straggler,
@@ -1073,6 +1095,16 @@ async function runDocsSweep(deps: BootDeps, options: BootOptions): Promise<DocsS
  * releases an issue with no live claim. Sequenced AFTER the unblock sweep and
  * BEFORE the reconcile sweep so a freshly-released issue rejoins the executable
  * pool for the next drain. */
+/** Step 7b': one death-sweep tick, when the port is wired. */
+async function runBootDeathSweep(deps: BootDeps): Promise<DeathSweepResult | undefined> {
+  if (!deps.deathSweep) return undefined;
+  return await runDeathSweep(deps.deathSweep, {
+    env: deps.env ?? process.env,
+    clock: { ts: new Date(deps.nowS * 1000).toISOString(), epoch: deps.nowS },
+    log: deps.log,
+  });
+}
+
 async function runStaleClaimSweep(deps: BootDeps): Promise<StaleClaimSweepResult> {
   if (!deps.lookups.claimedIssues) return { released: [] };
   let claimed: ClaimedIssue[];

--- a/apps/plugin-dev/src/core/death-sweep.ts
+++ b/apps/plugin-dev/src/core/death-sweep.ts
@@ -1,0 +1,701 @@
+// death-sweep — the checkout half of ADR 0155: the daemon classifies, the
+// checkout joins and decides (Spec #4129, ticket #4136).
+//
+// **A Worker that dies HARD leaves a Ticket that nothing releases.** A graceful
+// exit routes through the terminal path: the claim is conceded, a history row
+// lands, and `recoveryDecision()` bounds the retry. A SIGKILL or a cgroup OOM
+// runs none of that — the issue keeps `running` and a live claim until the NEXT
+// Worker's boot sweep happens to concede it on a staleness clock, which makes
+// queue latency after a hard death a function of when somebody else boots.
+//
+// The evidence to do better already crosses the boundary. #4133 put the unit
+// receipt onto the daemon's worker-death record as FACTS — `sender_class`,
+// `confidence`, `exit_code`, `signal`, `memory_peak_bytes` — keyed by
+// `worker_id` and nothing else, because ADR 0130/0144 keep the daemon ignorant
+// of what an issue, a label or a tracker is. What the daemon cannot do is say
+// which Ticket that Worker held. This module does exactly that:
+//
+//   worker_id → claim marker (`<host>:<worker_id>`) → issue
+//
+// and then spends the evidence on the decision the checkout already owns.
+//
+// ## What it decides, in vocabularies that already exist
+//
+// **No sixth vocabulary.** A hard death becomes the existing `signal-killed`
+// {@link WorkerOutcome}, which `recoveryReasonFor` already maps to the `crashed`
+// policy key, which `recovery.ts` already caps and `requeueOrdinal()` already
+// counts. `dispose()` composes the label sets and the exhaustion comment exactly
+// as it does for a graceful failure. The ONLY thing this module adds is the
+// REMEDY — the answer to "retry how?" that the receipt makes possible:
+//
+//   - `oomd`                      → requeue with a memory bump, or, when no
+//                                   bump is available, a model-tier escalation
+//   - `user-signal` / `teardown` /
+//     `parent-death` / `boot-refused` → plain requeue
+//   - `unknown`, or any verdict below `medium` confidence
+//                                 → DEFER: leave it to the boot sweep's
+//                                   staleness clock, unchanged
+//
+// The deferral is deliberate and is the reason the boot sweep stays. An
+// unattributed SIGKILL is reported as `unknown`/`low` precisely because the
+// receipt could not name a sender, and releasing a claim on a guess is worse
+// than releasing it a staleness window late.
+//
+// ## Order of operations, and why
+//
+// The executor concedes FIRST, then appends the history row, then edits the
+// labels, then comments — the same order the boot claim sweep uses, so no reader
+// ever sees an issue that is unclaimed and still `running`. Each step is
+// per-issue best-effort: a failure leaves the issue exactly where the boot sweep
+// would have found it anyway.
+//
+// The sweep is idempotent by construction rather than by a ledger: once the
+// claim is conceded and `running` is stripped, the join finds no claimed issue
+// for that worker and the next tick plans nothing for it.
+//
+// PURE planner, thin executor. Every clock, every read and every mutation is
+// injected, so a simulated OOM flows through one tick in a unit test.
+
+import { AFK_MODEL_TIERS, type AfkModelTier } from "./config.js";
+import { dispose, type Disposition } from "./disposition.js";
+import type { HistoryClock, HistoryEvent, HistoryRecord } from "./history.js";
+import { requeueOrdinal } from "./history.js";
+import type { RecoveryEnv } from "./recovery.js";
+import type { ClaimedIssue } from "./claim-staleness.js";
+import { classifyIssueClaims } from "./claim-staleness.js";
+import { LABEL_RUNNING } from "./triage-labels.js";
+import type { WorkerOutcome } from "./worker-outcome.js";
+import type {
+  AttributionConfidence,
+  DeathSenderClass,
+} from "@reddb-io/shared/death-attribution.js";
+
+/**
+ * The daemon event kinds that carry a death receipt.
+ *
+ * `worker-budget-kill` rides beside `worker-death` because the daemon ends a
+ * Worker over budget the same way the host ends one over memory — the receipt
+ * shape is identical and the checkout's join does not care which authority
+ * pulled the trigger.
+ */
+export const DEATH_SWEEP_EVENT_KINDS: readonly string[] = ["worker-death", "worker-budget-kill"];
+
+/** The daemon event kind that un-does a death: the same worker id born again. */
+const BIRTH_EVENT_KIND = "worker-birth";
+
+/**
+ * One classified death, as the checkout reads it off the daemon's event lane.
+ *
+ * Declared structurally rather than imported from the daemon package so the
+ * planner stays a value function: a test poses a death by writing one down, and
+ * the transport (`drainEvents`, `events_since`, a lane read) is the caller's.
+ * Every field but `worker_id` may be absent — a receipt the host could not
+ * retain is a fact about the host, never a reason to throw.
+ */
+export interface WorkerDeathEvidence {
+  readonly worker_id: string;
+  /** The daemon's event discriminator; either spelling of the field is read. */
+  readonly kind?: string | null;
+  readonly event?: string | null;
+  readonly ts?: string | null;
+  readonly sender_class?: DeathSenderClass | null;
+  readonly confidence?: AttributionConfidence | null;
+  readonly exit_code?: number | null;
+  readonly signal?: string | null;
+  readonly memory_peak_bytes?: number | null;
+  /** The unit's memory ceiling at the time it died, when the daemon stamped one. */
+  readonly memory_max?: number | string | null;
+  readonly detail?: string | null;
+}
+
+/**
+ * The latest death per worker id, with re-births cancelling earlier deaths.
+ *
+ * A lane is a history, not an inbox: the same worker id can appear dead, then
+ * born again after a `worker_recycle`, and sweeping the stale death would rob a
+ * living Worker of its claim. Reading the lane in order and letting a birth
+ * DELETE the pending death is the whole rule.
+ */
+export function deathEvidenceIn(
+  events: readonly WorkerDeathEvidence[],
+): WorkerDeathEvidence[] {
+  const pending = new Map<string, WorkerDeathEvidence>();
+  for (const event of events) {
+    const kind = event.kind ?? event.event ?? "";
+    if (event.worker_id === "") continue;
+    if (kind === BIRTH_EVENT_KIND) {
+      pending.delete(event.worker_id);
+      continue;
+    }
+    if (!DEATH_SWEEP_EVENT_KINDS.includes(kind)) continue;
+    pending.set(event.worker_id, event);
+  }
+  return [...pending.values()];
+}
+
+/** Why the sweep declined to act on one death. */
+export type DeathDeferralReason =
+  | "no-named-sender"
+  | "low-confidence"
+  | "no-claim";
+
+/**
+ * Does this receipt name a sender well enough to spend a claim on it? PURE.
+ *
+ * `high` and `medium` are the confidences a source earns by NAMING the process
+ * or its scope (`death-attribution.ts`). `low` and `none` are a chain of
+ * inference and an honest ignorance respectively, and ADR 0155 routes both to
+ * the boot sweep's staleness clock rather than to a decision.
+ */
+export function deathVerdictIsActionable(
+  evidence: WorkerDeathEvidence,
+): DeathDeferralReason | null {
+  const sender = evidence.sender_class ?? null;
+  if (sender === null || sender === "unknown") return "no-named-sender";
+  const confidence = evidence.confidence ?? null;
+  if (confidence !== "high" && confidence !== "medium") return "low-confidence";
+  return null;
+}
+
+/**
+ * The terminal outcome a hard death IS, in the outcome vocabulary that already
+ * exists. PURE.
+ *
+ * Every named sender resolves to `signal-killed` — the outcome whose own comment
+ * already says "an OOM or watchdog kill may be transient, so a bounded fresh
+ * worker run is warranted". Inventing a per-sender outcome would fork the retry
+ * policy at the exact place ADR 0155 says not to.
+ */
+export function hardDeathOutcome(_senderClass: DeathSenderClass): WorkerOutcome {
+  return "signal-killed";
+}
+
+/** How a requeue after a hard death differs from repeating the run that died. */
+export type HardDeathRemedy = "memory-bump" | "tier-escalation" | "plain";
+
+/** Multiple of the observed peak the next placement asks for. */
+export const MEMORY_BUMP_FACTOR = 1.5;
+
+/** Bumps round up to this, so a ceiling reads as a number a human chose. */
+export const MEMORY_BUMP_GRANULARITY_BYTES = 256 * 1024 * 1024;
+
+export interface MemoryBumpInput {
+  /** Peak charged to the unit before it died, from the receipt. */
+  readonly peakBytes?: number | null;
+  /** The ceiling the dead placement ran under, when one was stamped. */
+  readonly ceilingBytes?: number | null;
+  /** The most this host will ever hand one Worker. Absent → no host ceiling. */
+  readonly hostCeilingBytes?: number | null;
+}
+
+/**
+ * The memory ceiling an OOM retry should ask for, or `null` when no bump is
+ * available. PURE.
+ *
+ * Anchored on the higher of the PEAK and the old ceiling, because the peak is
+ * what the kernel measured and the ceiling is only what somebody guessed —
+ * taking the maximum means the answer always clears the placement that died. A
+ * bump a host ceiling refuses, or one with nothing to anchor on, is `null`, and
+ * a `null` is what sends the remedy to a tier escalation instead of repeating
+ * the same placement with a rounder number.
+ */
+export function planMemoryBump(input: MemoryBumpInput): number | null {
+  const peak = positiveOrZero(input.peakBytes);
+  const ceiling = positiveOrZero(input.ceilingBytes);
+  const anchor = Math.max(peak, ceiling);
+  if (anchor <= 0) return null;
+  const wanted =
+    Math.ceil((anchor * MEMORY_BUMP_FACTOR) / MEMORY_BUMP_GRANULARITY_BYTES) *
+    MEMORY_BUMP_GRANULARITY_BYTES;
+  const hostCeiling = positiveOrZero(input.hostCeilingBytes);
+  if (hostCeiling > 0 && wanted > hostCeiling) return null;
+  return wanted;
+}
+
+/**
+ * One step UP the model-tier ladder, or `null` at the top. PURE.
+ *
+ * The sibling of `downgradeAfkModelTier`, and deliberately not in `config.ts`
+ * beside it: a tier that cannot rise any further must answer `null` rather than
+ * silently returning itself, because "escalated" and "already at the ceiling"
+ * are different facts and the remedy turns on which one it is.
+ */
+export function escalateAfkModelTier(tier: AfkModelTier): AfkModelTier | null {
+  const index = AFK_MODEL_TIERS.indexOf(tier);
+  if (index < 0 || index >= AFK_MODEL_TIERS.length - 1) return null;
+  return AFK_MODEL_TIERS[index + 1]!;
+}
+
+/** What a requeue should change about the placement that died. */
+export interface HardDeathRemedyPlan {
+  readonly remedy: HardDeathRemedy;
+  /** The ceiling the next placement should ask for, when the remedy is a bump. */
+  readonly memoryBumpBytes: number | null;
+  /** The tier the next run should use, when the remedy is an escalation. */
+  readonly escalatedTier: AfkModelTier | null;
+  /** One clause naming the remedy, for the audit comment. */
+  readonly note: string;
+}
+
+export interface HardDeathRemedyInput extends MemoryBumpInput {
+  readonly senderClass: DeathSenderClass;
+  /** The tier the dead run used, when the caller knows it. */
+  readonly tier?: AfkModelTier | null;
+}
+
+/**
+ * Decide how the retry should differ from the run that died. PURE.
+ *
+ * Only a memory kill earns a different placement — a requested stop and a host
+ * teardown say nothing about the resources the work needs, and bumping on them
+ * would inflate every ceiling on the machine for a reason nobody observed.
+ */
+export function planHardDeathRemedy(input: HardDeathRemedyInput): HardDeathRemedyPlan {
+  if (input.senderClass !== "oomd") {
+    return {
+      remedy: "plain",
+      memoryBumpBytes: null,
+      escalatedTier: null,
+      note: "requeued unchanged: the receipt names who stopped the Worker, not what it needed",
+    };
+  }
+  const bump = planMemoryBump(input);
+  if (bump !== null) {
+    return {
+      remedy: "memory-bump",
+      memoryBumpBytes: bump,
+      escalatedTier: null,
+      note: `requeued with the memory ceiling raised to ${formatGib(bump)}`,
+    };
+  }
+  const escalated = input.tier == null ? null : escalateAfkModelTier(input.tier);
+  if (escalated !== null) {
+    return {
+      remedy: "tier-escalation",
+      memoryBumpBytes: null,
+      escalatedTier: escalated,
+      note: `requeued at the \`${escalated}\` tier: no memory headroom is left to give it`,
+    };
+  }
+  return {
+    remedy: "plain",
+    memoryBumpBytes: null,
+    escalatedTier: null,
+    note: "requeued unchanged: neither a memory bump nor a tier escalation is available",
+  };
+}
+
+/** systemd's size suffixes, in the spelling `systemd.resource-control` accepts. */
+const BYTE_SUFFIXES: ReadonlyMap<string, number> = new Map([
+  ["", 1],
+  ["b", 1],
+  ["k", 1024],
+  ["kb", 1024],
+  ["ki", 1024],
+  ["m", 1024 ** 2],
+  ["mb", 1024 ** 2],
+  ["mi", 1024 ** 2],
+  ["g", 1024 ** 3],
+  ["gb", 1024 ** 3],
+  ["gi", 1024 ** 3],
+  ["t", 1024 ** 4],
+  ["tb", 1024 ** 4],
+  ["ti", 1024 ** 4],
+]);
+
+/**
+ * Read a memory ceiling the daemon stamped as systemd writes it. PURE.
+ *
+ * The receipt's `memory_max` is a STRING — `8G`, `70%`, `infinity` — because
+ * that is what the unit carried, and `Number("8G")` is `NaN`. Silently reading
+ * NaN as "no ceiling" is the bug this closes: a 4 GiB peak under a 16 GiB
+ * ceiling would then plan a 6 GiB "bump", which is a REDUCTION dressed as a
+ * remedy. A percentage and an `infinity` answer `null` honestly — neither names
+ * a number of bytes this module can compare against.
+ */
+export function parseByteQuantity(value: number | string | null | undefined): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "string") return null;
+  const match = /^\s*([0-9]+(?:\.[0-9]+)?)\s*([A-Za-z]*)\s*$/.exec(value);
+  if (match === null) return null;
+  const unit = BYTE_SUFFIXES.get(match[2]!.toLowerCase());
+  if (unit === undefined) return null;
+  const bytes = Number(match[1]) * unit;
+  return Number.isFinite(bytes) ? bytes : null;
+}
+
+/**
+ * Render the receipt as one line a human can read on the issue. PURE.
+ *
+ * Every escalation quotes this, because the whole value of a hard-death page is
+ * the evidence: "we do not know" and "the kernel reclaimed 4.00 GiB" send a
+ * maintainer to two different places.
+ */
+export function renderDeathEvidence(evidence: WorkerDeathEvidence): string {
+  const parts: string[] = [
+    `sender=${evidence.sender_class ?? "unknown"}/${evidence.confidence ?? "none"}`,
+  ];
+  if (evidence.signal != null) parts.push(`signal=${evidence.signal}`);
+  else if (evidence.exit_code != null) parts.push(`exit code=${evidence.exit_code}`);
+  if (evidence.memory_peak_bytes != null) {
+    parts.push(`memory peak=${formatGib(evidence.memory_peak_bytes)}`);
+  }
+  if (evidence.detail != null && evidence.detail !== "") parts.push(evidence.detail);
+  return parts.join("; ");
+}
+
+/** One issue the sweep will act on, with everything the executor needs. */
+export interface DeathSweepStep {
+  readonly issue: number;
+  /** The claim marker identity, `<host>:<worker_id>` — what the concede names. */
+  readonly claimOwner: string;
+  /** The daemon's key for the dead Worker. */
+  readonly workerId: string;
+  readonly evidence: WorkerDeathEvidence;
+  readonly senderClass: DeathSenderClass;
+  readonly outcome: WorkerOutcome;
+  /** The 1-based requeue ordinal the caps count (ADR 0103). */
+  readonly ordinal: number;
+  readonly disposition: Disposition;
+  readonly remedy: HardDeathRemedyPlan;
+  /** The ledger event this death appends. Non-`done`, so the ordinal advances. */
+  readonly historyEvent: HistoryEvent;
+  /** The `reason` field carried on the history row. */
+  readonly historyReason: string;
+  /** The audit comment, evidence quoted. */
+  readonly comment: string;
+  /** The ISO timestamp of the dead worker's last claim marker, when known. */
+  readonly lastHeartbeatAt?: string;
+}
+
+/** One death the sweep declined, and why — a deferral is a finding, not silence. */
+export interface DeferredDeath {
+  readonly workerId: string;
+  readonly reason: DeathDeferralReason;
+  readonly evidence: WorkerDeathEvidence;
+}
+
+export interface DeathSweepPlan {
+  readonly steps: readonly DeathSweepStep[];
+  readonly deferred: readonly DeferredDeath[];
+}
+
+export interface DeathSweepFacts {
+  /** Death receipts off the daemon's event lane, oldest first. */
+  readonly deaths: readonly WorkerDeathEvidence[];
+  /** Every currently-claimed issue with its parsed claim markers. */
+  readonly claimed: readonly ClaimedIssue[];
+  /** The castle history ledger, for the requeue ordinal. */
+  readonly history: readonly HistoryRecord[];
+  /** `<host>:` — the prefix this checkout's claim markers carry. */
+  readonly hostPrefix: string;
+  /** Env for the recovery caps. */
+  readonly env: RecoveryEnv;
+  /** The tier the drain runs at, when the caller knows it. */
+  readonly tier?: AfkModelTier | null;
+  /** The most memory this host will hand one Worker, when a ceiling is set. */
+  readonly hostCeilingBytes?: number | null;
+}
+
+/**
+ * Plan one sweep tick. PURE — no clock, no IO, no tracker.
+ *
+ * The join is the point: a claim marker's `worker` is `<host>:<worker_id>`, and
+ * only the checkout holds both halves. A marker whose latest record CONCEDED is
+ * skipped — the Worker withdrew before it died, so the claim is already free and
+ * a second release would post a second audit comment for nothing.
+ */
+export function planDeathSweep(facts: DeathSweepFacts): DeathSweepPlan {
+  const steps: DeathSweepStep[] = [];
+  const deferred: DeferredDeath[] = [];
+
+  for (const evidence of deathEvidenceIn(facts.deaths)) {
+    const deferral = deathVerdictIsActionable(evidence);
+    if (deferral !== null) {
+      deferred.push({ workerId: evidence.worker_id, reason: deferral, evidence });
+      continue;
+    }
+    const held = findHeldClaim(evidence.worker_id, facts.claimed, facts.hostPrefix);
+    if (held === null) {
+      deferred.push({ workerId: evidence.worker_id, reason: "no-claim", evidence });
+      continue;
+    }
+
+    const senderClass = evidence.sender_class as DeathSenderClass;
+    const outcome = hardDeathOutcome(senderClass);
+    const ordinal = requeueOrdinal(facts.history, held.issue);
+    const disposition = dispose(outcome, ordinal, facts.env, { stalledRecoverable: false });
+    const remedy = planHardDeathRemedy({
+      senderClass,
+      peakBytes: evidence.memory_peak_bytes ?? null,
+      ceilingBytes: parseByteQuantity(evidence.memory_max),
+      hostCeilingBytes: facts.hostCeilingBytes ?? null,
+      tier: facts.tier ?? null,
+    });
+
+    steps.push({
+      issue: held.issue,
+      claimOwner: held.owner,
+      workerId: evidence.worker_id,
+      evidence,
+      senderClass,
+      outcome,
+      ordinal,
+      disposition,
+      remedy,
+      historyEvent: "blocked",
+      historyReason: `hard-death:${senderClass}`,
+      comment: renderDeathSweepAudit({ evidence, disposition, remedy, ordinal, owner: held.owner }),
+      ...(held.lastHeartbeatAt === undefined ? {} : { lastHeartbeatAt: held.lastHeartbeatAt }),
+    });
+  }
+
+  return { steps, deferred };
+}
+
+export interface DeathSweepAuditInput {
+  readonly evidence: WorkerDeathEvidence;
+  readonly disposition: Disposition;
+  readonly remedy: HardDeathRemedyPlan;
+  readonly ordinal: number;
+  readonly owner: string;
+}
+
+/**
+ * The one comment the sweep posts per issue. PURE.
+ *
+ * A retry says what it changed; a park says what ran out AND quotes the receipt,
+ * because after the caps a human is the next reader and the evidence is the
+ * entire reason they were called.
+ */
+export function renderDeathSweepAudit(input: DeathSweepAuditInput): string {
+  const evidence = renderDeathEvidence(input.evidence);
+  const head =
+    `🤖 AFK death sweep: the Worker \`${input.owner}\` died without saying goodbye — ` +
+    `${evidence}. Its claim was released eagerly rather than left for the next boot sweep.`;
+  if (input.disposition.decision === "retry") {
+    return `${head}\n\nThis is requeue ${input.ordinal}${capSuffix(input.disposition)}; ${input.remedy.note}.`;
+  }
+  return (
+    `${head}\n\n${input.disposition.escalationComment ??
+      `Parked for a human: \`${input.disposition.typedLabel ?? "blocked"}\` carries no automatic requeue budget.`}` +
+    `\n\nDeath evidence: ${evidence}.`
+  );
+}
+
+/** The mutations one sweep tick performs. Narrow on purpose. */
+export interface DeathSweepIO {
+  /** Post the concede marker that withdraws the dead Worker's claim. */
+  concede(issue: number, owner: string, lastHeartbeatAt?: string): Promise<void>;
+  /** Append the terminal ledger row the requeue ordinal counts. */
+  appendHistory(step: DeathSweepStep, clock: HistoryClock): Promise<void>;
+  editLabels(issue: number, remove: readonly string[], add: readonly string[]): Promise<void>;
+  comment(issue: number, body: string): Promise<void>;
+  /** Current labels, re-read so a parallel edit is never clobbered. */
+  viewLabels?(issue: number): Promise<readonly string[]>;
+}
+
+/** What one issue's sweep did. */
+export interface DeathSweepOutcome {
+  readonly issue: number;
+  readonly workerId: string;
+  readonly decision: "retry" | "escalate" | "skipped" | "failed";
+  readonly remedy: HardDeathRemedy;
+}
+
+export interface DeathSweepResult {
+  readonly released: readonly number[];
+  readonly requeued: readonly number[];
+  readonly parked: readonly number[];
+  readonly deferred: readonly DeferredDeath[];
+  readonly outcomes: readonly DeathSweepOutcome[];
+}
+
+/**
+ * Apply one planned tick. THIN — every decision was already made.
+ *
+ * Concede first, ledger second, labels third, comment last: the withdrawal
+ * marker must land before the label projection changes so no reader ever sees an
+ * unclaimed-but-still-`running` issue, and the ledger row must land before the
+ * labels so a crash between them leaves the ordinal counted rather than lost.
+ * Each issue is independent — a failure is recorded and the tick continues.
+ */
+export async function executeDeathSweep(
+  plan: DeathSweepPlan,
+  io: DeathSweepIO,
+  clock: HistoryClock,
+  log?: (line: string) => void,
+): Promise<DeathSweepResult> {
+  const released: number[] = [];
+  const requeued: number[] = [];
+  const parked: number[] = [];
+  const outcomes: DeathSweepOutcome[] = [];
+
+  for (const step of plan.steps) {
+    try {
+      if (io.viewLabels) {
+        const labels = await io.viewLabels(step.issue);
+        if (!labels.includes(LABEL_RUNNING)) {
+          outcomes.push({
+            issue: step.issue,
+            workerId: step.workerId,
+            decision: "skipped",
+            remedy: step.remedy.remedy,
+          });
+          continue;
+        }
+      }
+      await io.concede(step.issue, step.claimOwner, step.lastHeartbeatAt);
+      await io.appendHistory(step, clock);
+      await io.editLabels(step.issue, step.disposition.removeLabels, step.disposition.addLabels);
+      await io.comment(step.issue, step.comment);
+      released.push(step.issue);
+      (step.disposition.decision === "retry" ? requeued : parked).push(step.issue);
+      outcomes.push({
+        issue: step.issue,
+        workerId: step.workerId,
+        decision: step.disposition.decision,
+        remedy: step.remedy.remedy,
+      });
+      log?.(
+        `death sweep #${step.issue}: ${step.senderClass} → ${step.disposition.decision}` +
+          ` (requeue ${step.ordinal}, remedy ${step.remedy.remedy})`,
+      );
+    } catch {
+      // Best effort by contract: an issue this tick could not release is exactly
+      // the issue the boot sweep's staleness clock still covers.
+      outcomes.push({
+        issue: step.issue,
+        workerId: step.workerId,
+        decision: "failed",
+        remedy: step.remedy.remedy,
+      });
+    }
+  }
+
+  return { released, requeued, parked, deferred: plan.deferred, outcomes };
+}
+
+/** The claim this dead worker still holds, or `null`. */
+interface HeldClaim {
+  readonly issue: number;
+  readonly owner: string;
+  readonly lastHeartbeatAt?: string;
+}
+
+function findHeldClaim(
+  workerId: string,
+  claimed: readonly ClaimedIssue[],
+  hostPrefix: string,
+): HeldClaim | null {
+  const exact = `${hostPrefix}${workerId}`;
+  for (const issue of claimed) {
+    const owner = issue.records
+      .map((record) => record.worker)
+      .find((worker) => worker === exact || worker === workerId);
+    if (owner === undefined) continue;
+    // A worker that CONCEDED before it died already freed the claim; releasing it
+    // again would post a second audit comment for a claim nobody holds.
+    const state = classifyIssueClaims(issue.records, () => false);
+    if (state.concededOwners.includes(owner)) continue;
+    const latest = issue.records
+      .filter((record) => record.worker === owner)
+      .sort((a, b) => b.commentId - a.commentId)[0];
+    return {
+      issue: issue.issue,
+      owner,
+      ...(latest?.createdAt === undefined ? {} : { lastHeartbeatAt: latest.createdAt }),
+    };
+  }
+  return null;
+}
+
+function capSuffix(disposition: Disposition): string {
+  return disposition.cap === null ? "" : ` of ${disposition.cap}`;
+}
+
+function positiveOrZero(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+
+
+function formatGib(bytes: number): string {
+  return `${(bytes / 1024 ** 3).toFixed(2)} GiB`;
+}
+
+// ---------------------------------------------------------------------------
+// The tick
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything one tick reads and everything it writes, in one port.
+ *
+ * A port rather than four loose callbacks because the tick has exactly one
+ * caller shape — read the lane, read the claims, read the ledger, then mutate —
+ * and a caller that wires three of the four has a sweep that silently does
+ * nothing.
+ */
+export interface DeathSweepPort extends DeathSweepIO {
+  /** Death receipts from the daemon's event lane, oldest first. */
+  deaths(): Promise<readonly WorkerDeathEvidence[]>;
+  /** Every issue currently projected `running`, with its claim markers. */
+  claimedIssues(): Promise<readonly ClaimedIssue[]>;
+  /** The castle history ledger, for the requeue ordinal. */
+  history(): Promise<readonly HistoryRecord[]>;
+  /** `<host>:` — the prefix this checkout's claim markers carry. */
+  readonly hostPrefix: string;
+}
+
+export interface DeathSweepTickContext {
+  readonly env: RecoveryEnv;
+  readonly clock: HistoryClock;
+  readonly tier?: AfkModelTier | null;
+  readonly hostCeilingBytes?: number | null;
+  readonly log?: (line: string) => void;
+}
+
+/**
+ * Read, plan and apply ONE sweep tick.
+ *
+ * This is the verb a manager tick and a reap call, and the verb the boot
+ * sequence calls before its staleness sweep — one entrance, so a new caller
+ * inherits the ordering rules rather than restating them. A read that fails
+ * yields an empty tick rather than an exception: a sweep that cannot see the
+ * lane is exactly the case the staleness clock still covers.
+ */
+export async function runDeathSweep(
+  port: DeathSweepPort,
+  context: DeathSweepTickContext,
+): Promise<DeathSweepResult> {
+  let deaths: readonly WorkerDeathEvidence[];
+  let claimed: readonly ClaimedIssue[];
+  let history: readonly HistoryRecord[];
+  try {
+    deaths = await port.deaths();
+    if (deaths.length === 0) return EMPTY_DEATH_SWEEP;
+    claimed = await port.claimedIssues();
+    history = await port.history();
+  } catch {
+    return EMPTY_DEATH_SWEEP;
+  }
+
+  const plan = planDeathSweep({
+    deaths,
+    claimed,
+    history,
+    hostPrefix: port.hostPrefix,
+    env: context.env,
+    tier: context.tier ?? null,
+    hostCeilingBytes: context.hostCeilingBytes ?? null,
+  });
+  return await executeDeathSweep(plan, port, context.clock, context.log);
+}
+
+const EMPTY_DEATH_SWEEP: DeathSweepResult = {
+  released: [],
+  requeued: [],
+  parked: [],
+  deferred: [],
+  outcomes: [],
+};

--- a/apps/plugin-dev/src/runtime/wire/boot.ts
+++ b/apps/plugin-dev/src/runtime/wire/boot.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { readBuildInfo } from "@reddb-io/build-info";
+import { readRedskilledEvents } from "@reddb-io/redskilled/event-lane";
+import { resolveRedskilledPaths } from "@reddb-io/redskilled/paths";
 import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
 import { createEnginePaths, createFileHealLedgerStore } from "@reddb-io/worker/engine";
 import { hostFingerprintPrefix } from "../../core/host-identity.js";
@@ -14,7 +16,8 @@ import type { PrecheckFacts, BootOptions, BootDeps, BootstrapInput, OrphanDir } 
 import type { AttemptDir } from "../../core/reclaim.js";
 import { LABEL_HUMAN, LABEL_READY, LABEL_RUNNING } from "../../core/triage-labels.js";
 import { allWorkersRoots, parseReapableWorkerPath } from "../../core/worker-paths.js";
-import { parseClaimRecords } from "../../core/claim.js";
+import { parseClaimRecords, renderConcedeOnBehalf } from "../../core/claim.js";
+import type { WorkerDeathEvidence } from "../../core/death-sweep.js";
 import { workerStatePath } from "../../core/state.js";
 import {
   collectFleetTruthProbeInput,
@@ -25,7 +28,7 @@ import {
   type ClaimHygieneIssueInput,
   type HostPrerequisiteProbeInput,
 } from "../../core/operational-probes.js";
-import { historyTrim } from "../../core/history.js";
+import { historyAppend, historyTrim, readHistoryRecords } from "../../core/history.js";
 import { evaluateFastForwardLocalTarget, fastForwardLocalTarget } from "../../core/merge.js";
 import { liveIssueFromBranch, type IssueMeta } from "../../core/branch-cleanup.js";
 import { readWorkerState } from "../../core/worker-state-reader.js";
@@ -504,7 +507,7 @@ export async function buildBootDeps(
     const previous = liveBranchCommitByIssue.get(issue);
     if (previous === undefined || ref.commitS! > previous) liveBranchCommitByIssue.set(issue, ref.commitS!);
   }
-  return {
+  const deps: BootDeps = {
     fs: {
       ensureDir: fsx.ensureDir,
       writeWorkerPid: fsx.writeWorkerPid,
@@ -650,6 +653,58 @@ export async function buildBootDeps(
     nowS,
     config: cfg,
     docsSweepLander: (plan) => landDocsSweep(ctx, plan),
+  };
+  attachDeathSweepPort(deps, ctx, paths.historyPath, nowS);
+  return deps;
+}
+
+/**
+ * Wire the checkout death sweep to the two lanes it joins (ADR 0155 §2).
+ *
+ * The daemon's event lane is read WHOLE and unfiltered by project: the claim
+ * join already restricts the tick to issues this checkout holds, so a worker id
+ * belonging to another project matches no claim here and costs one map lookup.
+ * The claimed-issue listing is the boot deps' own — one batched read serves both
+ * this sweep and the staleness sweep beneath it.
+ */
+function attachDeathSweepPort(
+  deps: BootDeps,
+  ctx: RepoContext,
+  historyPath: string,
+  nowS: number,
+): void {
+  const claimedIssues = deps.lookups.claimedIssues;
+  const concedeClaim = deps.concedeClaim;
+  const evictor = deps.claimEvictor;
+  if (!ctx.repo || !claimedIssues || !concedeClaim || !evictor) return;
+  deps.deathSweep = {
+    hostPrefix: hostFingerprintPrefix(),
+    deaths: async () =>
+      (await readRedskilledEvents(resolveRedskilledPaths().eventLanePath)) as readonly WorkerDeathEvidence[],
+    claimedIssues,
+    history: () => readHistoryRecords(historyPath),
+    concede: async (issue, owner, lastHeartbeatAt) => {
+      const heartbeatS = lastHeartbeatAt ? Math.floor(Date.parse(lastHeartbeatAt) / 1000) : Number.NaN;
+      await concedeClaim(
+        issue,
+        renderConcedeOnBehalf(
+          owner,
+          evictor,
+          lastHeartbeatAt,
+          Number.isFinite(heartbeatS) ? Math.max(0, nowS - heartbeatS) : undefined,
+        ),
+      );
+    },
+    appendHistory: async (step, clock) => {
+      await historyAppend(historyPath, clock, step.historyEvent, {
+        worker: step.claimOwner,
+        issue: step.issue,
+        reason: step.historyReason,
+      });
+    },
+    editLabels: (issue, remove, add) => deps.gh.editLabels(issue, [...remove], [...add]),
+    comment: (issue, body) => deps.gh.comment(issue, body),
+    viewLabels: (issue) => deps.gh.viewLabels(issue),
   };
 }
 

--- a/apps/plugin-dev/tests/death-sweep.test.ts
+++ b/apps/plugin-dev/tests/death-sweep.test.ts
@@ -1,0 +1,528 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEATH_SWEEP_EVENT_KINDS,
+  MEMORY_BUMP_FACTOR,
+  MEMORY_BUMP_GRANULARITY_BYTES,
+  deathEvidenceIn,
+  deathVerdictIsActionable,
+  escalateAfkModelTier,
+  executeDeathSweep,
+  hardDeathOutcome,
+  planDeathSweep,
+  planHardDeathRemedy,
+  parseByteQuantity,
+  planMemoryBump,
+  renderDeathEvidence,
+  renderDeathSweepAudit,
+  runDeathSweep,
+  type DeathSweepIO,
+  type DeathSweepPort,
+  type DeathSweepStep,
+  type WorkerDeathEvidence,
+} from "../src/core/death-sweep.js";
+import type { ClaimedIssue } from "../src/core/claim-staleness.js";
+import type { HistoryClock, HistoryRecord } from "../src/core/history.js";
+
+const HOST = "host-abc:";
+const WORKER_ID = "w-4136";
+const OWNER = `${HOST}${WORKER_ID}`;
+const CLOCK: HistoryClock = { ts: "2026-08-21T10:00:00.000Z", epoch: 1_787_048_400 };
+
+const GIB = 1024 ** 3;
+
+function oomDeath(overrides: Partial<WorkerDeathEvidence> = {}): WorkerDeathEvidence {
+  return {
+    worker_id: WORKER_ID,
+    kind: "worker-death",
+    ts: CLOCK.ts,
+    sender_class: "oomd",
+    confidence: "high",
+    exit_code: null,
+    signal: "SIGKILL",
+    memory_peak_bytes: 4 * GIB,
+    detail: "systemd result=oom-kill; memory peak=4.00 GiB",
+    ...overrides,
+  };
+}
+
+function claimedBy(worker: string, issue = 4136, kind: "claim" | "concede" = "claim"): ClaimedIssue {
+  return {
+    issue,
+    records: [{ commentId: 10, worker, kind, createdAt: "2026-08-21T09:30:00.000Z" }],
+  };
+}
+
+function terminalRows(issue: number, count: number): HistoryRecord[] {
+  return Array.from({ length: count }, (_row, index) => ({
+    ts: CLOCK.ts,
+    epoch: CLOCK.epoch - index,
+    worker: OWNER,
+    issue,
+    event: "blocked",
+    duration_s: 0,
+    runner: "claude",
+  }));
+}
+
+interface RecordedIO extends DeathSweepIO {
+  readonly calls: string[];
+  readonly history: DeathSweepStep[];
+}
+
+function recordingIO(overrides: Partial<DeathSweepIO> = {}): RecordedIO {
+  const calls: string[] = [];
+  const history: DeathSweepStep[] = [];
+  return {
+    calls,
+    history,
+    async concede(issue, owner) {
+      calls.push(`concede:${issue}:${owner}`);
+    },
+    async appendHistory(step) {
+      calls.push(`history:${step.issue}:${step.historyEvent}:${step.historyReason}`);
+      history.push(step);
+    },
+    async editLabels(issue, remove, add) {
+      calls.push(`labels:${issue}:-${[...remove].join("+")}:+${[...add].join("+")}`);
+    },
+    async comment(issue) {
+      calls.push(`comment:${issue}`);
+    },
+    ...overrides,
+  };
+}
+
+describe("deathEvidenceIn — the lane is a history, not an inbox", () => {
+  it("keeps the latest death per worker id", () => {
+    const first = oomDeath({ detail: "first" });
+    const second = oomDeath({ detail: "second" });
+
+    expect(deathEvidenceIn([first, second]).map((death) => death.detail)).toEqual(["second"]);
+  });
+
+  it("lets a re-birth cancel a pending death, so a living Worker is never robbed", () => {
+    const events: WorkerDeathEvidence[] = [
+      oomDeath(),
+      { worker_id: WORKER_ID, kind: "worker-birth" },
+    ];
+
+    expect(deathEvidenceIn(events)).toEqual([]);
+  });
+
+  it("reads both the `kind` and the `event` spelling, and ignores every other kind", () => {
+    const events: WorkerDeathEvidence[] = [
+      { worker_id: "w-1", event: "worker-budget-kill", sender_class: "teardown" },
+      { worker_id: "w-2", kind: "worker-heartbeat" },
+      { worker_id: "", kind: "worker-death" },
+    ];
+
+    expect(deathEvidenceIn(events).map((death) => death.worker_id)).toEqual(["w-1"]);
+    expect(DEATH_SWEEP_EVENT_KINDS).toContain("worker-budget-kill");
+  });
+});
+
+describe("deathVerdictIsActionable — a claim is never spent on a guess", () => {
+  it("acts on a named sender the receipt proved", () => {
+    expect(deathVerdictIsActionable(oomDeath())).toBeNull();
+    expect(
+      deathVerdictIsActionable(oomDeath({ sender_class: "user-signal", confidence: "medium" })),
+    ).toBeNull();
+  });
+
+  it("defers an unattributed SIGKILL to the staleness clock", () => {
+    expect(
+      deathVerdictIsActionable(oomDeath({ sender_class: "unknown", confidence: "low" })),
+    ).toBe("no-named-sender");
+    expect(deathVerdictIsActionable(oomDeath({ sender_class: null, confidence: null }))).toBe(
+      "no-named-sender",
+    );
+  });
+
+  it("defers a named sender the evidence could only infer", () => {
+    expect(deathVerdictIsActionable(oomDeath({ confidence: "low" }))).toBe("low-confidence");
+    expect(deathVerdictIsActionable(oomDeath({ confidence: null }))).toBe("low-confidence");
+  });
+});
+
+describe("the vocabulary is the one that already exists", () => {
+  it("reads every hard death as the `signal-killed` outcome, inventing no sixth class", () => {
+    expect(hardDeathOutcome("oomd")).toBe("signal-killed");
+    expect(hardDeathOutcome("teardown")).toBe("signal-killed");
+  });
+});
+
+describe("planMemoryBump — anchored on what the kernel measured", () => {
+  it("raises the ceiling above the observed peak, rounded to the granularity", () => {
+    const bump = planMemoryBump({ peakBytes: 4 * GIB, ceilingBytes: 4 * GIB });
+
+    expect(bump).toBe(
+      Math.ceil((4 * GIB * MEMORY_BUMP_FACTOR) / MEMORY_BUMP_GRANULARITY_BYTES) *
+        MEMORY_BUMP_GRANULARITY_BYTES,
+    );
+    expect(bump! % MEMORY_BUMP_GRANULARITY_BYTES).toBe(0);
+    expect(bump!).toBeGreaterThan(4 * GIB);
+  });
+
+  it("answers null when the receipt measured nothing to anchor on", () => {
+    expect(planMemoryBump({ peakBytes: null, ceilingBytes: null })).toBeNull();
+    expect(planMemoryBump({ peakBytes: 0, ceilingBytes: 0 })).toBeNull();
+  });
+
+  it("answers null when the host ceiling refuses the bump", () => {
+    expect(planMemoryBump({ peakBytes: 4 * GIB, hostCeilingBytes: 5 * GIB })).toBeNull();
+  });
+
+  it("anchors on the higher of the peak and the ceiling, so the bump always clears the placement that died", () => {
+    const bump = planMemoryBump({ peakBytes: GIB, ceilingBytes: 64 * GIB });
+
+    expect(bump).toBeGreaterThan(64 * GIB);
+  });
+});
+
+describe("parseByteQuantity — the ceiling is a systemd string, not a number", () => {
+  it("reads the suffixes systemd writes", () => {
+    expect(parseByteQuantity("8G")).toBe(8 * GIB);
+    expect(parseByteQuantity("16Gi")).toBe(16 * GIB);
+    expect(parseByteQuantity("512M")).toBe(512 * 1024 ** 2);
+    expect(parseByteQuantity("1024")).toBe(1024);
+    expect(parseByteQuantity(4 * GIB)).toBe(4 * GIB);
+  });
+
+  it("refuses a ceiling that names no number of bytes", () => {
+    for (const value of ["70%", "infinity", "", "  ", "8Q", null, undefined]) {
+      expect(parseByteQuantity(value)).toBeNull();
+    }
+  });
+
+  it("keeps a suffixed ceiling from planning a bump that is really a reduction", () => {
+    const plan = planDeathSweep({
+      deaths: [oomDeath({ memory_max: "16G", memory_peak_bytes: 4 * GIB })],
+      claimed: [claimedBy(OWNER)],
+      history: [],
+      hostPrefix: HOST,
+      env: { RED_AFK_RETRY_CRASH: "3" },
+    });
+
+    expect(plan.steps[0]!.remedy.memoryBumpBytes).toBeGreaterThan(16 * GIB);
+  });
+});
+
+describe("escalateAfkModelTier — one step up, and null at the ceiling", () => {
+  it("climbs the declared ladder", () => {
+    expect(escalateAfkModelTier("validate")).toBe("simple");
+    expect(escalateAfkModelTier("simple")).toBe("complex");
+    expect(escalateAfkModelTier("complex")).toBe("think");
+  });
+
+  it("says null rather than returning itself at the top", () => {
+    expect(escalateAfkModelTier("think")).toBeNull();
+  });
+});
+
+describe("planHardDeathRemedy — only a memory kill earns a different placement", () => {
+  it("bumps the ceiling for an OOM the receipt measured", () => {
+    const remedy = planHardDeathRemedy({ senderClass: "oomd", peakBytes: 4 * GIB });
+
+    expect(remedy.remedy).toBe("memory-bump");
+    expect(remedy.memoryBumpBytes).toBeGreaterThan(4 * GIB);
+    expect(remedy.note).toContain("memory ceiling raised");
+  });
+
+  it("escalates the tier for an OOM with no memory headroom left", () => {
+    const remedy = planHardDeathRemedy({
+      senderClass: "oomd",
+      peakBytes: 4 * GIB,
+      hostCeilingBytes: 5 * GIB,
+      tier: "simple",
+    });
+
+    expect(remedy.remedy).toBe("tier-escalation");
+    expect(remedy.escalatedTier).toBe("complex");
+    expect(remedy.memoryBumpBytes).toBeNull();
+  });
+
+  it("falls back to a plain requeue when neither remedy is available", () => {
+    const remedy = planHardDeathRemedy({
+      senderClass: "oomd",
+      peakBytes: 4 * GIB,
+      hostCeilingBytes: 5 * GIB,
+      tier: "think",
+    });
+
+    expect(remedy.remedy).toBe("plain");
+  });
+
+  it("never bumps on a requested stop or a host teardown", () => {
+    for (const sender of ["user-signal", "teardown", "parent-death", "boot-refused"] as const) {
+      const remedy = planHardDeathRemedy({ senderClass: sender, peakBytes: 4 * GIB });
+      expect(remedy.remedy).toBe("plain");
+      expect(remedy.memoryBumpBytes).toBeNull();
+    }
+  });
+});
+
+describe("renderDeathEvidence — the receipt, in one line", () => {
+  it("names the sender, the confidence, the signal and the peak", () => {
+    const line = renderDeathEvidence(oomDeath());
+
+    expect(line).toContain("sender=oomd/high");
+    expect(line).toContain("signal=SIGKILL");
+    expect(line).toContain("memory peak=4.00 GiB");
+  });
+
+  it("falls back to the exit code when no signal ended it", () => {
+    const line = renderDeathEvidence(
+      oomDeath({ signal: null, exit_code: 78, memory_peak_bytes: null, detail: null }),
+    );
+
+    expect(line).toContain("exit code=78");
+    expect(line).not.toContain("memory peak");
+  });
+});
+
+describe("planDeathSweep — the join only the checkout can perform", () => {
+  it("joins worker id to the claim marker that carries the host prefix", () => {
+    const plan = planDeathSweep({
+      deaths: [oomDeath()],
+      claimed: [claimedBy(OWNER)],
+      history: [],
+      hostPrefix: HOST,
+      env: {},
+    });
+
+    expect(plan.steps).toHaveLength(1);
+    expect(plan.steps[0]!.issue).toBe(4136);
+    expect(plan.steps[0]!.claimOwner).toBe(OWNER);
+    expect(plan.steps[0]!.workerId).toBe(WORKER_ID);
+  });
+
+  it("defers a death whose Worker holds no claim here", () => {
+    const plan = planDeathSweep({
+      deaths: [oomDeath()],
+      claimed: [claimedBy("other-host:w-999")],
+      history: [],
+      hostPrefix: HOST,
+      env: {},
+    });
+
+    expect(plan.steps).toEqual([]);
+    expect(plan.deferred).toEqual([
+      { workerId: WORKER_ID, reason: "no-claim", evidence: oomDeath() },
+    ]);
+  });
+
+  it("leaves a claim the Worker already conceded alone", () => {
+    const plan = planDeathSweep({
+      deaths: [oomDeath()],
+      claimed: [claimedBy(OWNER, 4136, "concede")],
+      history: [],
+      hostPrefix: HOST,
+      env: {},
+    });
+
+    expect(plan.steps).toEqual([]);
+    expect(plan.deferred[0]!.reason).toBe("no-claim");
+  });
+
+  it("defers a low-confidence unknown to today's lazy boot-sweep behaviour", () => {
+    const plan = planDeathSweep({
+      deaths: [oomDeath({ sender_class: "unknown", confidence: "low" })],
+      claimed: [claimedBy(OWNER)],
+      history: [],
+      hostPrefix: HOST,
+      env: {},
+    });
+
+    expect(plan.steps).toEqual([]);
+    expect(plan.deferred[0]!.reason).toBe("no-named-sender");
+  });
+
+  it("counts the requeue ordinal off the history ledger", () => {
+    const plan = planDeathSweep({
+      deaths: [oomDeath()],
+      claimed: [claimedBy(OWNER)],
+      history: terminalRows(4136, 2),
+      hostPrefix: HOST,
+      env: { RED_AFK_RETRY_CRASH: "9" },
+    });
+
+    expect(plan.steps[0]!.ordinal).toBe(3);
+  });
+});
+
+describe("one sweep tick, end to end", () => {
+  const facts = {
+    deaths: [oomDeath()],
+    claimed: [claimedBy(OWNER)],
+    history: [] as HistoryRecord[],
+    hostPrefix: HOST,
+  };
+
+  it("releases the claim, appends the history row and requeues with an escalation", async () => {
+    const plan = planDeathSweep({ ...facts, env: { RED_AFK_RETRY_CRASH: "3" } });
+    const io = recordingIO();
+
+    const result = await executeDeathSweep(plan, io, CLOCK);
+
+    // Every step of the acceptance criterion, in the order the executor owes.
+    expect(io.calls).toEqual([
+      `concede:4136:${OWNER}`,
+      "history:4136:blocked:hard-death:oomd",
+      "labels:4136:-running:+ready-for-agent",
+      "comment:4136",
+    ]);
+    expect(result.released).toEqual([4136]);
+    expect(result.requeued).toEqual([4136]);
+    expect(result.parked).toEqual([]);
+    expect(result.outcomes).toEqual([
+      { issue: 4136, workerId: WORKER_ID, decision: "retry", remedy: "memory-bump" },
+    ]);
+    // The ledger row is non-`done`, so the next hard death counts one higher.
+    expect(io.history[0]!.historyEvent).not.toBe("done");
+    expect(plan.steps[0]!.comment).toContain("memory ceiling raised");
+    expect(plan.steps[0]!.comment).toContain("sender=oomd/high");
+  });
+
+  it("parks with the death evidence quoted once the recoverable cap is spent", async () => {
+    const plan = planDeathSweep({
+      ...facts,
+      history: terminalRows(4136, 1),
+      env: { RED_AFK_RETRY_CRASH: "2" },
+    });
+    const io = recordingIO();
+
+    const result = await executeDeathSweep(plan, io, CLOCK);
+
+    expect(plan.steps[0]!.ordinal).toBe(2);
+    expect(plan.steps[0]!.disposition.decision).toBe("escalate");
+    expect(io.calls[2]).toBe("labels:4136:-running:+ready-for-human+blocked:signal-killed");
+    expect(result.parked).toEqual([4136]);
+    expect(result.requeued).toEqual([]);
+    expect(plan.steps[0]!.comment).toContain("retry budget exhausted (attempt 2/2)");
+    expect(plan.steps[0]!.comment).toContain("Death evidence: sender=oomd/high");
+    expect(plan.steps[0]!.comment).toContain("memory peak=4.00 GiB");
+  });
+
+  it("parks the very first hard death under the shipped `crashed` cap of one", () => {
+    const plan = planDeathSweep({ ...facts, env: {} });
+
+    expect(plan.steps[0]!.ordinal).toBe(1);
+    expect(plan.steps[0]!.disposition.decision).toBe("escalate");
+    expect(plan.steps[0]!.disposition.cap).toBe(1);
+  });
+
+  it("skips an issue another writer already released", async () => {
+    const plan = planDeathSweep({ ...facts, env: { RED_AFK_RETRY_CRASH: "3" } });
+    const io = recordingIO({ viewLabels: async () => ["ready-for-agent"] });
+
+    const result = await executeDeathSweep(plan, io, CLOCK);
+
+    expect(io.calls).toEqual([]);
+    expect(result.outcomes[0]!.decision).toBe("skipped");
+    expect(result.released).toEqual([]);
+  });
+
+  it("records a failure and leaves the issue for the staleness sweep", async () => {
+    const plan = planDeathSweep({ ...facts, env: { RED_AFK_RETRY_CRASH: "3" } });
+    const io = recordingIO({
+      editLabels: async () => {
+        throw new Error("gh refused");
+      },
+    });
+
+    const result = await executeDeathSweep(plan, io, CLOCK);
+
+    expect(result.outcomes[0]!.decision).toBe("failed");
+    expect(result.released).toEqual([]);
+  });
+});
+
+describe("renderDeathSweepAudit — a retry says what changed, a park says what ran out", () => {
+  it("names the requeue ordinal, the cap and the remedy on a retry", () => {
+    const plan = planDeathSweep({
+      deaths: [oomDeath()],
+      claimed: [claimedBy(OWNER)],
+      history: [],
+      hostPrefix: HOST,
+      env: { RED_AFK_RETRY_CRASH: "3" },
+    });
+    const step = plan.steps[0]!;
+
+    const body = renderDeathSweepAudit({
+      evidence: step.evidence,
+      disposition: step.disposition,
+      remedy: step.remedy,
+      ordinal: step.ordinal,
+      owner: step.claimOwner,
+    });
+
+    expect(body).toContain("died without saying goodbye");
+    expect(body).toContain("released eagerly");
+    expect(body).toContain("This is requeue 1 of 3");
+  });
+});
+
+describe("runDeathSweep — one verb for the tick and the reap", () => {
+  function port(overrides: Partial<DeathSweepPort> = {}): DeathSweepPort {
+    const io = recordingIO();
+    return {
+      ...io,
+      hostPrefix: HOST,
+      deaths: async () => [oomDeath()],
+      claimedIssues: async () => [claimedBy(OWNER)],
+      history: async () => [],
+      ...overrides,
+    };
+  }
+
+  it("reads, plans and applies in one call", async () => {
+    const lines: string[] = [];
+
+    const result = await runDeathSweep(port(), {
+      env: { RED_AFK_RETRY_CRASH: "3" },
+      clock: CLOCK,
+      log: (line) => lines.push(line),
+    });
+
+    expect(result.released).toEqual([4136]);
+    expect(lines[0]).toContain("death sweep #4136: oomd → retry");
+  });
+
+  it("costs nothing when the lane holds no death", async () => {
+    let claimReads = 0;
+
+    const result = await runDeathSweep(
+      port({
+        deaths: async () => [],
+        claimedIssues: async () => {
+          claimReads += 1;
+          return [];
+        },
+      }),
+      { env: {}, clock: CLOCK },
+    );
+
+    expect(claimReads).toBe(0);
+    expect(result.released).toEqual([]);
+  });
+
+  it("yields an empty tick when a read fails, leaving the staleness sweep to cover it", async () => {
+    const result = await runDeathSweep(
+      port({
+        deaths: async () => {
+          throw new Error("lane unreadable");
+        },
+      }),
+      { env: {}, clock: CLOCK },
+    );
+
+    expect(result).toEqual({
+      released: [],
+      requeued: [],
+      parked: [],
+      deferred: [],
+      outcomes: [],
+    });
+  });
+});


### PR DESCRIPTION
## What

ADR 0155's checkout half, on top of the daemon-side evidence #4133 delivered in #4248.

**A Worker that dies hard leaves a Ticket that nothing releases.** A graceful exit routes through the terminal path — claim conceded, history row appended, `recoveryDecision()` bounding the retry. A SIGKILL or a cgroup OOM ran none of that: the issue kept `running` with a live claim until the *next* Worker's boot sweep happened to concede it on a staleness clock, which made queue latency after a hard death a function of when somebody else booted.

The evidence to do better already crossed the boundary and nothing consumed it. `resolveUnitDeath` puts `sender_class`, `confidence`, `exit_code`, `signal` and `memory_peak_bytes` onto the worker-death record, keyed by `worker_id` and nothing else, because ADR 0130/0144 keep the daemon ignorant of what an issue, a label or a tracker is.

## How

New `apps/plugin-dev/src/core/death-sweep.ts` — pure planner, thin executor — performs the one join only the checkout can:

```
worker_id → claim marker (`<host>:<worker_id>`) → issue
```

then releases the claim **eagerly**, appends the terminal history row `requeueOrdinal()` counts, and feeds the existing `recoveryDecision()` caps.

**No sixth vocabulary.** A hard death *is* the existing `signal-killed` `WorkerOutcome`, which `recoveryReasonFor` already maps to the `crashed` policy key, which `recovery.ts` already caps. `dispose()` composes the label sets and the exhaustion comment exactly as for a graceful failure. What the receipt adds is the **remedy**:

| sender class | remedy |
| --- | --- |
| `oomd` | requeue with the memory ceiling raised above the measured peak; at the next model tier when no headroom is left |
| `user-signal`, `teardown`, `parent-death`, `boot-refused` | plain requeue |
| `unknown`, or any verdict below `medium` confidence | **defer** — today's lazy boot-sweep behaviour, unchanged |

The deferral is deliberate and is why the boot sweep stays: an unattributed SIGKILL is reported `unknown`/`low` precisely because the receipt could not name a sender, and releasing a claim on a guess is worse than releasing it a staleness window late.

**Ordering.** Concede first, ledger second, labels third, comment last — the withdrawal marker lands before the label projection changes so no reader sees an unclaimed-but-still-`running` issue, and the ledger row lands before the labels so a crash between them leaves the ordinal counted rather than lost. Idempotent by construction rather than by a ledger: once the claim is conceded and `running` is stripped, the join finds nothing next tick.

**Wiring.** `runDeathSweep` is the single verb a tick calls; the boot sequence calls it at step 7b', ahead of the staleness sweep, so a death the daemon explained is released with its evidence and only what the evidence could not name is conceded blind. `buildBootDeps` attaches the port; absent it the step is a no-op.

**One bug closed on the way in.** `memory_max` is a systemd *string* (`8G`, `70%`, `infinity`), and `Number("8G")` is `NaN`. Reading that as "no ceiling" would have planned a 6 GiB "bump" off a 4 GiB peak under a 16 GiB ceiling — a reduction dressed as a remedy. `parseByteQuantity` reads the suffixes and answers `null` honestly for a percentage or an infinity.

## Acceptance criteria

- [x] **A simulated OOM death flows through one sweep tick: claim released, history row appended, issue requeued with escalation; a planner test pins each step.** `tests/death-sweep.test.ts` asserts the executor's exact call sequence (`concede → history → labels → comment`), the non-`done` ledger event, the `memory-bump` remedy, and the evidence in the comment.
- [x] **The recoverable caps still bound hard deaths: after the cap, the issue parks with the death evidence quoted.** Pinned at `RED_AFK_RETRY_CRASH=2` with ordinal 2 → `ready-for-human` + `blocked:signal-killed`, `retry budget exhausted (attempt 2/2)`, and `Death evidence: sender=oomd/high … memory peak=4.00 GiB`. A second test pins the *shipped* default: `crashed` caps at 1, so the very first hard death parks — the existing bound, unchanged, as ADR 0155 requires.
- [x] **Extinct-source, domain-vocabulary and declared-wait guards green.** Full invariants suite: 31 files, 370 tests. The sweep introduces no poll, so it declares no wait.

## Validation

| check | result |
| --- | --- |
| `pnpm typecheck` (root) | 17/17 successful |
| `pnpm -C apps/plugin-dev test:invariants` | 31 files, 370 tests passed |
| `tests/death-sweep.test.ts` | 36 tests passed |
| `boot`, `boot-sweep`, `boot-runtime`, `wire-boot`, `claim-staleness`, `history`, `recovery`, `worker-outcome` | 275 tests passed |
| `oxlint` on the touched files | clean |

Baselines respected: no `FILE_SIZE_BASELINE` entry added or raised (`boot.ts` 1447/1606, `wire/boot.ts` 758/800, `death-sweep.ts` 701/800), and `buildBootDeps`'s `COMPLEXITY_COVERAGE_BASELINE` entry is unchanged at 812 — the wiring branch lives in a private helper rather than in the measured function.

Boundary: no daemon source is touched, so `daemon-death-evidence-guard` stays green; the join lives in plugin-dev, as ADR 0155 §2 requires.

Fixes #4136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789891703&installation_model_id=20659&pr_number=4257&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4257&signature=5a81bc55c918b072192a08398f00824307cfa37f4c7dde051c651ee7dd17f023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->