### PR TITLE
A declared retry-by-failure-mode table bounds every retry

### DIFF
--- a/.changeset/worker-failure-retry-table.md
+++ b/.changeset/worker-failure-retry-table.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/worker": patch
+---
+
+Declare the ACP Worker failure retry table and bound implementer retries by failure mode.

--- a/packages/worker/src/acp/index.ts
+++ b/packages/worker/src/acp/index.ts
@@ -6,7 +6,10 @@
 // directions of drift.
 export { runAcpWorkerCommand } from "./command.js";
 export { runNativeAcpWorker } from "./native-worker.js";
-export { WorkflowChildAgent, type ChildAgentSessionOptions } from "./child-agent.js";
+export {
+  WorkflowChildAgent,
+  type ChildAgentSessionOptions,
+} from "./child-agent.js";
 export {
   createWorkerTerminalHost,
   DEFAULT_TERMINAL_OUTPUT_BYTE_LIMIT,
@@ -36,7 +39,9 @@ export {
 export {
   runTicketLoop,
   TICKET_LOOP_STAGES,
+  TICKET_LOOP_FAILURE_RETRY_CLASSES,
   reseedHandoff,
+  retryInstructionForFailureClass,
   type TicketGateRun,
   type TicketImplementOutcome,
   type TicketLoopDeps,
@@ -45,6 +50,18 @@ export {
   type TicketLoopStage,
   type TicketLoopTicket,
 } from "./ticket-loop.js";
+export {
+  classifyWorkerFailure,
+  decideWorkerFailureRetry,
+  WORKER_FAILURE_GLOBAL_RETRY_LIMIT,
+  WORKER_FAILURE_RETRY_CLASSES,
+  WORKER_FAILURE_RETRY_TABLE,
+  type WorkerFailureRetryClass,
+  type WorkerFailureRetryDecision,
+  type WorkerFailureRetryInput,
+  type WorkerFailureRetryRule,
+  type WorkerFailureRetryShape,
+} from "./retry-policy.js";
 export {
   runWorkerLocalGate,
   readWorkspace,

--- a/packages/worker/src/acp/retry-policy.test.ts
+++ b/packages/worker/src/acp/retry-policy.test.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  TICKET_LOOP_FAILURE_RETRY_CLASSES,
+  retryInstructionForFailureClass,
+} from "./ticket-loop.js";
+import {
+  classifyWorkerFailure,
+  decideWorkerFailureRetry,
+  WORKER_FAILURE_GLOBAL_RETRY_LIMIT,
+  WORKER_FAILURE_RETRY_CLASSES,
+  WORKER_FAILURE_RETRY_TABLE,
+  type WorkerFailureRetryClass,
+  type WorkerFailureRetryShape,
+} from "./retry-policy.js";
+
+const RETRY_ROWS: Array<{
+  clazz: WorkerFailureRetryClass;
+  evidence: string;
+  shape: WorkerFailureRetryShape;
+  retries: number;
+  instruction: RegExp;
+}> = [
+  {
+    clazz: "cap-hit",
+    evidence: "context limit exceeded",
+    shape: "smaller-scope",
+    retries: 2,
+    instruction: /smaller scope/i,
+  },
+  {
+    clazz: "oom",
+    evidence: "JavaScript heap out of memory",
+    shape: "smaller-scope",
+    retries: 2,
+    instruction: /working set/i,
+  },
+  {
+    clazz: "network-drop",
+    evidence: "ECONNRESET socket hang up",
+    shape: "as-is",
+    retries: 2,
+    instruction: /as-is/i,
+  },
+  {
+    clazz: "tool-error",
+    evidence: "tool call failed with MCP error",
+    shape: "different-model",
+    retries: 2,
+    instruction: /different model/i,
+  },
+  {
+    clazz: "unknown",
+    evidence: "child exited 17",
+    shape: "as-is",
+    retries: 1,
+    instruction: /once as-is/i,
+  },
+];
+
+describe("declared Worker failure retry table", () => {
+  for (const row of RETRY_ROWS) {
+    it(`${row.clazz} retries with ${row.shape}`, () => {
+      expect(classifyWorkerFailure(new Error(row.evidence))).toBe(row.clazz);
+      expect(WORKER_FAILURE_RETRY_TABLE[row.clazz]).toMatchObject({
+        shape: row.shape,
+        maxRetries: row.retries,
+      });
+
+      const decision = decideWorkerFailureRetry({
+        failureClass: row.clazz,
+        retriesUsed: 0,
+        classRetriesUsed: 0,
+        evidence: row.evidence,
+      });
+
+      expect(decision).toMatchObject({
+        action: "retry",
+        failureClass: row.clazz,
+        shape: row.shape,
+        retriesUsed: 1,
+        classRetriesUsed: 1,
+        evidence: row.evidence,
+      });
+      expect(decision.action === "retry" ? decision.instruction : "").toMatch(
+        row.instruction,
+      );
+    });
+  }
+
+  it("parks instead of allowing a third retry under the global bound", () => {
+    const decision = decideWorkerFailureRetry({
+      failureClass: "network-drop",
+      retriesUsed: WORKER_FAILURE_GLOBAL_RETRY_LIMIT,
+      classRetriesUsed: 0,
+      evidence: "ECONNRESET after two retries",
+    });
+
+    expect(decision).toEqual({
+      action: "park",
+      failureClass: "network-drop",
+      reason: "global-bound",
+      retriesUsed: 2,
+      classRetriesUsed: 0,
+      evidence: "ECONNRESET after two retries",
+    });
+  });
+
+  it("parks unknown failures after their one declared retry", () => {
+    expect(
+      decideWorkerFailureRetry({
+        failureClass: "unknown",
+        retriesUsed: 1,
+        classRetriesUsed: 1,
+        evidence: "child exited 17 again",
+      }),
+    ).toMatchObject({ action: "park", reason: "class-bound" });
+  });
+});
+
+describe("retry table to Ticket loop consumer ratchet", () => {
+  it("the live consumer declares exactly the table's failure classes", () => {
+    expect([...TICKET_LOOP_FAILURE_RETRY_CLASSES].sort()).toEqual(
+      [...WORKER_FAILURE_RETRY_CLASSES].sort(),
+    );
+  });
+
+  it("every consumed branch is backed by one declared table row", () => {
+    const branches = retryConsumerBranches();
+    expect(branches.sort()).toEqual([...WORKER_FAILURE_RETRY_CLASSES].sort());
+    for (const clazz of WORKER_FAILURE_RETRY_CLASSES) {
+      expect(retryInstructionForFailureClass(clazz)).toBe(
+        WORKER_FAILURE_RETRY_TABLE[clazz].instruction,
+      );
+    }
+  });
+});
+
+function retryConsumerBranches(): WorkerFailureRetryClass[] {
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "ticket-loop.ts"),
+    "utf8",
+  );
+  const match =
+    /function ticketLoopRetryClass[\s\S]*?switch \(clazz\) \{(?<body>[\s\S]*?)\n\}/.exec(
+      source,
+    );
+  if (match?.groups?.body == null)
+    throw new Error("ticketLoopRetryClass switch not found");
+  return [...match.groups.body.matchAll(/case "([^"]+)":/g)].map(
+    (branch) => branch[1] as WorkerFailureRetryClass,
+  );
+}

--- a/packages/worker/src/acp/retry-policy.ts
+++ b/packages/worker/src/acp/retry-policy.ts
@@ -1,0 +1,156 @@
+/** Worker failure retry policy, declared once and consumed by the Ticket loop. */
+
+export const WORKER_FAILURE_RETRY_CLASSES = [
+  "cap-hit",
+  "oom",
+  "network-drop",
+  "tool-error",
+  "unknown",
+] as const;
+
+export type WorkerFailureRetryClass =
+  (typeof WORKER_FAILURE_RETRY_CLASSES)[number];
+
+export type WorkerFailureRetryShape =
+  "smaller-scope" | "as-is" | "different-model";
+
+export interface WorkerFailureRetryRule {
+  readonly shape: WorkerFailureRetryShape;
+  /** Per-class retry ceiling. The global ceiling still applies first. */
+  readonly maxRetries: number;
+  readonly instruction: string;
+}
+
+export const WORKER_FAILURE_GLOBAL_RETRY_LIMIT = 2;
+
+export const WORKER_FAILURE_RETRY_TABLE = {
+  "cap-hit": {
+    shape: "smaller-scope",
+    maxRetries: 2,
+    instruction:
+      "Retry with smaller scope: narrow the implementation to the smallest independently shippable slice.",
+  },
+  oom: {
+    shape: "smaller-scope",
+    maxRetries: 2,
+    instruction:
+      "Retry with smaller scope: reduce the working set and avoid broad scans before continuing.",
+  },
+  "network-drop": {
+    shape: "as-is",
+    maxRetries: 2,
+    instruction:
+      "Retry as-is: the failure was a transient network drop, so keep the same scope.",
+  },
+  "tool-error": {
+    shape: "different-model",
+    maxRetries: 2,
+    instruction:
+      "Retry on a different model: keep the task scope, but route the next implementation round away from the failed tool/model.",
+  },
+  unknown: {
+    shape: "as-is",
+    maxRetries: 1,
+    instruction:
+      "Retry once as-is: the failure mode was unknown, so do not loop without new evidence.",
+  },
+} as const satisfies Record<WorkerFailureRetryClass, WorkerFailureRetryRule>;
+
+export interface WorkerFailureRetryInput {
+  readonly failureClass: WorkerFailureRetryClass;
+  /** How many retries have already been spent across all failure classes. */
+  readonly retriesUsed: number;
+  /** How many retries have already been spent for this class. */
+  readonly classRetriesUsed: number;
+  readonly evidence: string;
+}
+
+export type WorkerFailureRetryDecision =
+  | {
+      readonly action: "retry";
+      readonly failureClass: WorkerFailureRetryClass;
+      readonly shape: WorkerFailureRetryShape;
+      readonly retriesUsed: number;
+      readonly classRetriesUsed: number;
+      readonly instruction: string;
+      readonly evidence: string;
+    }
+  | {
+      readonly action: "park";
+      readonly failureClass: WorkerFailureRetryClass;
+      readonly reason: "global-bound" | "class-bound";
+      readonly retriesUsed: number;
+      readonly classRetriesUsed: number;
+      readonly evidence: string;
+    };
+
+export function decideWorkerFailureRetry(
+  input: WorkerFailureRetryInput,
+): WorkerFailureRetryDecision {
+  const rule = WORKER_FAILURE_RETRY_TABLE[input.failureClass];
+  if (input.retriesUsed >= WORKER_FAILURE_GLOBAL_RETRY_LIMIT) {
+    return {
+      action: "park",
+      failureClass: input.failureClass,
+      reason: "global-bound",
+      retriesUsed: input.retriesUsed,
+      classRetriesUsed: input.classRetriesUsed,
+      evidence: input.evidence,
+    };
+  }
+  if (input.classRetriesUsed >= rule.maxRetries) {
+    return {
+      action: "park",
+      failureClass: input.failureClass,
+      reason: "class-bound",
+      retriesUsed: input.retriesUsed,
+      classRetriesUsed: input.classRetriesUsed,
+      evidence: input.evidence,
+    };
+  }
+  return {
+    action: "retry",
+    failureClass: input.failureClass,
+    shape: rule.shape,
+    retriesUsed: input.retriesUsed + 1,
+    classRetriesUsed: input.classRetriesUsed + 1,
+    instruction: rule.instruction,
+    evidence: input.evidence,
+  };
+}
+
+export function classifyWorkerFailure(error: unknown): WorkerFailureRetryClass {
+  const text =
+    error instanceof Error
+      ? `${error.name}\n${error.message}\n${error.stack ?? ""}`
+      : String(error);
+  if (
+    /\b(?:context|token|usage|budget|time|wall[- ]?clock)\s*(?:limit|cap|capped|exceeded)\b/i.test(
+      text,
+    )
+  ) {
+    return "cap-hit";
+  }
+  if (
+    /\b(?:oom|out of memory|heap out of memory|memory budget|memorymax|systemd-oomd)\b/i.test(
+      text,
+    )
+  ) {
+    return "oom";
+  }
+  if (
+    /\b(?:econnreset|econnrefused|etimedout|socket hang up|network|websocket|502|503|504)\b/i.test(
+      text,
+    )
+  ) {
+    return "network-drop";
+  }
+  if (
+    /\b(?:tool error|tool_call|tool call|mcp|rate_limit_error|429|overloaded|529)\b/i.test(
+      text,
+    )
+  ) {
+    return "tool-error";
+  }
+  return "unknown";
+}

--- a/packages/worker/src/acp/ticket-loop.test.ts
+++ b/packages/worker/src/acp/ticket-loop.test.ts
@@ -29,7 +29,11 @@ const PUBLICATION = { branch: "afk/4020-ticket-loop", commit: "a".repeat(40) };
 
 function publisher(overrides: Partial<WorkerPublisher> = {}): WorkerPublisher {
   return {
-    publishTurn: async () => ({ status: "requested", publication: PUBLICATION, receipt: {} }),
+    publishTurn: async () => ({
+      status: "requested",
+      publication: PUBLICATION,
+      receipt: {},
+    }),
     ...overrides,
   };
 }
@@ -40,9 +44,13 @@ function deps(overrides: Partial<TicketLoopDeps> = {}): TicketLoopDeps {
     workerId: "host:VSk6WPt",
     sessionId: "public-session",
     request: async (method) =>
-      method === REDSKILLS_ACP_METHODS.land ? { version: 1, pull_request: 4321 } : { version: 1 },
+      method === REDSKILLS_ACP_METHODS.land
+        ? { version: 1, pull_request: 4321 }
+        : { version: 1 },
     implement: async () => ({ stopReason: "end_turn" }),
-    gate: async (): Promise<TicketGateRun> => ({ stages: [{ stage: "feedback", ok: true }] }),
+    gate: async (): Promise<TicketGateRun> => ({
+      stages: [{ stage: "feedback", ok: true }],
+    }),
     publisher: publisher(),
     now: () => new Date("2026-08-19T12:00:00.000Z"),
     ...overrides,
@@ -55,27 +63,45 @@ function stages(records: readonly TicketLoopRecord[]): string[] {
 
 describe("the Ticket loop's declared arc", () => {
   it("names its stages in the order one Ticket travels through them", () => {
-    expect(TICKET_LOOP_STAGES).toEqual(["claim", "implement", "gate", "publish", "land"]);
+    expect(TICKET_LOOP_STAGES).toEqual([
+      "claim",
+      "implement",
+      "gate",
+      "publish",
+      "land",
+    ]);
   });
 
   it("claims through the parent, implements, gates, publishes and lands", async () => {
     const requests: { method: string; params: unknown }[] = [];
-    const result = await runTicketLoop(deps({
-      request: async (method, params) => {
-        requests.push({ method, params });
-        return method === REDSKILLS_ACP_METHODS.land ? { version: 1, pull_request: 77 } : { version: 1 };
-      },
-    }));
+    const result = await runTicketLoop(
+      deps({
+        request: async (method, params) => {
+          requests.push({ method, params });
+          return method === REDSKILLS_ACP_METHODS.land
+            ? { version: 1, pull_request: 77 }
+            : { version: 1 };
+        },
+      }),
+    );
 
     expect(result.outcome).toBe("landed");
     if (result.outcome !== "landed") return;
     expect(result.pullRequest).toBe(77);
     expect(result.rounds).toBe(1);
-    expect(stages(result.records)).toEqual(["claim", "implement", "gate", "publish", "land"]);
+    expect(stages(result.records)).toEqual([
+      "claim",
+      "implement",
+      "gate",
+      "publish",
+      "land",
+    ]);
 
     // The claim is a WRITE the parent performs; the Worker holds no credential.
     expect(requests[0]!.method).toBe(REDSKILLS_ACP_METHODS.githubWrite);
-    const claim = requests[0]!.params as { write: { issue: number; body: string } };
+    const claim = requests[0]!.params as {
+      write: { issue: number; body: string };
+    };
     expect(claim.write.issue).toBe(4020);
     expect(claim.write.body).toContain("worker=host:VSk6WPt");
 
@@ -98,11 +124,13 @@ describe("the lane-to-mode contract, enforced at the claim", () => {
   it("refuses a scout-lane Ticket a plain Worker would have pushed", async () => {
     const request = vi.fn(async () => ({ version: 1 }));
     const implement = vi.fn(async () => ({ stopReason: "end_turn" as const }));
-    const result = await runTicketLoop(deps({
-      ticket: { ...TICKET, labels: ["ready-for-agent", "lane:scout"] },
-      request,
-      implement,
-    }));
+    const result = await runTicketLoop(
+      deps({
+        ticket: { ...TICKET, labels: ["ready-for-agent", "lane:scout"] },
+        request,
+        implement,
+      }),
+    );
 
     expect(result.outcome).toBe("refused");
     if (result.outcome !== "refused") return;
@@ -115,10 +143,12 @@ describe("the lane-to-mode contract, enforced at the claim", () => {
   });
 
   it("admits the same Ticket to a Worker that holds the mode", async () => {
-    const result = await runTicketLoop(deps({
-      ticket: { ...TICKET, labels: ["lane:scout"] },
-      runMode: "scout",
-    }));
+    const result = await runTicketLoop(
+      deps({
+        ticket: { ...TICKET, labels: ["lane:scout"] },
+        runMode: "scout",
+      }),
+    );
     expect(result.outcome).toBe("landed");
   });
 });
@@ -127,19 +157,29 @@ describe("re-seeding in place, within the budget", () => {
   it("re-instructs the same implementer with what the gate refused", async () => {
     const handoffs: string[] = [];
     let round = 0;
-    const result = await runTicketLoop(deps({
-      reseedBudget: 2,
-      implement: async (handoff) => {
-        handoffs.push(handoff);
-        return { stopReason: "end_turn" };
-      },
-      gate: async (): Promise<TicketGateRun> => {
-        round += 1;
-        return round < 3
-          ? { stages: [{ stage: "feedback", ok: false }], detail: "pnpm typecheck exited 2" }
-          : { stages: [{ stage: "feedback", ok: true }, { stage: "review", ok: true }] };
-      },
-    }));
+    const result = await runTicketLoop(
+      deps({
+        reseedBudget: 2,
+        implement: async (handoff) => {
+          handoffs.push(handoff);
+          return { stopReason: "end_turn" };
+        },
+        gate: async (): Promise<TicketGateRun> => {
+          round += 1;
+          return round < 3
+            ? {
+                stages: [{ stage: "feedback", ok: false }],
+                detail: "pnpm typecheck exited 2",
+              }
+            : {
+                stages: [
+                  { stage: "feedback", ok: true },
+                  { stage: "review", ok: true },
+                ],
+              };
+        },
+      }),
+    );
 
     expect(result.outcome).toBe("landed");
     if (result.outcome !== "landed") return;
@@ -152,14 +192,19 @@ describe("re-seeding in place, within the budget", () => {
 
   it("stops at the gate's verdict when the rounds are spent, and publishes nothing", async () => {
     const publishTurn = vi.fn(async () => null);
-    const result = await runTicketLoop(deps({
-      reseedBudget: 1,
-      gate: async (): Promise<TicketGateRun> => ({
-        stages: [{ stage: "feedback", ok: true }, { stage: "backpressure", ok: false }],
-        detail: "the operator's command exited 1",
+    const result = await runTicketLoop(
+      deps({
+        reseedBudget: 1,
+        gate: async (): Promise<TicketGateRun> => ({
+          stages: [
+            { stage: "feedback", ok: true },
+            { stage: "backpressure", ok: false },
+          ],
+          detail: "the operator's command exited 1",
+        }),
+        publisher: publisher({ publishTurn }),
       }),
-      publisher: publisher({ publishTurn }),
-    }));
+    );
 
     expect(result.outcome).toBe("gate-blocked");
     if (result.outcome !== "gate-blocked") return;
@@ -169,33 +214,100 @@ describe("re-seeding in place, within the budget", () => {
   });
 
   it("names the EARLIEST blocking stage, whatever order the gate reported", async () => {
-    const result = await runTicketLoop(deps({
-      gate: async (): Promise<TicketGateRun> => ({
-        stages: [{ stage: "review", ok: false }, { stage: "feedback", ok: false }],
+    const result = await runTicketLoop(
+      deps({
+        gate: async (): Promise<TicketGateRun> => ({
+          stages: [
+            { stage: "review", ok: false },
+            { stage: "feedback", ok: false },
+          ],
+        }),
       }),
-    }));
+    );
     expect(result.outcome).toBe("gate-blocked");
     if (result.outcome !== "gate-blocked") return;
     expect(result.failedStage).toBe("feedback");
   });
 
   it("treats a skipped stage as no blocker at all", async () => {
-    const result = await runTicketLoop(deps({
-      gate: async (): Promise<TicketGateRun> => ({
-        stages: [{ stage: "feedback", ok: true }, { stage: "review", ok: false, skipped: true }],
+    const result = await runTicketLoop(
+      deps({
+        gate: async (): Promise<TicketGateRun> => ({
+          stages: [
+            { stage: "feedback", ok: true },
+            { stage: "review", ok: false, skipped: true },
+          ],
+        }),
       }),
-    }));
+    );
     expect(result.outcome).toBe("landed");
+  });
+});
+
+describe("failure-mode retry policy", () => {
+  it("retries implementer failures by declared shape, then parks with evidence instead of a third retry", async () => {
+    const implement = vi.fn(async () => {
+      throw new Error("ECONNRESET while reading the child stream");
+    });
+    const gate = vi.fn(async (): Promise<TicketGateRun> => ({
+      stages: [{ stage: "feedback", ok: true }],
+    }));
+    const publishTurn = vi.fn(async () => null);
+
+    const result = await runTicketLoop(
+      deps({
+        implement,
+        gate,
+        publisher: publisher({ publishTurn }),
+      }),
+    );
+
+    expect(result.outcome).toBe("gate-blocked");
+    if (result.outcome !== "gate-blocked") return;
+    expect(result.failedStage).toBe("feedback");
+    expect(result.rounds).toBe(3);
+    expect(result.detail).toContain("global two-retry bound exhausted");
+    expect(result.detail).toContain("ECONNRESET");
+    expect(implement).toHaveBeenCalledTimes(3);
+    expect(gate).not.toHaveBeenCalled();
+    expect(publishTurn).not.toHaveBeenCalled();
+    expect(result.records.map((record) => record.detail)).toEqual([
+      undefined,
+      expect.stringContaining("retry 1/2 as as-is"),
+      expect.stringContaining("retry 2/2 as as-is"),
+      expect.stringContaining("parking with evidence"),
+    ]);
+  });
+
+  it("unknown failures get exactly one retry even below the global bound", async () => {
+    const implement = vi.fn(async () => {
+      throw new Error("child disappeared without a classified symptom");
+    });
+
+    const result = await runTicketLoop(
+      deps({
+        implement,
+        classifyFailure: () => "unknown",
+      }),
+    );
+
+    expect(result.outcome).toBe("gate-blocked");
+    if (result.outcome !== "gate-blocked") return;
+    expect(result.rounds).toBe(2);
+    expect(result.detail).toContain("unknown retry bound exhausted");
+    expect(implement).toHaveBeenCalledTimes(2);
   });
 });
 
 describe("the outcomes that reach no remote", () => {
   it("publishes nothing for a cancelled round", async () => {
     const publishTurn = vi.fn(async () => null);
-    const result = await runTicketLoop(deps({
-      implement: async () => ({ stopReason: "cancelled" }),
-      publisher: publisher({ publishTurn }),
-    }));
+    const result = await runTicketLoop(
+      deps({
+        implement: async () => ({ stopReason: "cancelled" }),
+        publisher: publisher({ publishTurn }),
+      }),
+    );
 
     expect(result.outcome).toBe("cancelled");
     expect(publishTurn).not.toHaveBeenCalled();
@@ -203,11 +315,17 @@ describe("the outcomes that reach no remote", () => {
   });
 
   it("lands nothing when the Worktree committed nothing", async () => {
-    const request = vi.fn(async (method: string, _params: unknown) => ({ version: 1, pull_request: 1, method }));
-    const result = await runTicketLoop(deps({
-      request,
-      publisher: publisher({ publishTurn: async () => null }),
+    const request = vi.fn(async (method: string, _params: unknown) => ({
+      version: 1,
+      pull_request: 1,
+      method,
     }));
+    const result = await runTicketLoop(
+      deps({
+        request,
+        publisher: publisher({ publishTurn: async () => null }),
+      }),
+    );
 
     expect(result.outcome).toBe("nothing-to-publish");
     expect(request).toHaveBeenCalledTimes(1);
@@ -215,11 +333,17 @@ describe("the outcomes that reach no remote", () => {
   });
 
   it("returns the parent's refusal instead of throwing it", async () => {
-    const result = await runTicketLoop(deps({
-      publisher: publisher({
-        publishTurn: async () => ({ status: "refused", publication: PUBLICATION, detail: "no credential profile" }),
+    const result = await runTicketLoop(
+      deps({
+        publisher: publisher({
+          publishTurn: async () => ({
+            status: "refused",
+            publication: PUBLICATION,
+            detail: "no credential profile",
+          }),
+        }),
       }),
-    }));
+    );
 
     expect(result.outcome).toBe("refused");
     if (result.outcome !== "refused") return;
@@ -228,9 +352,11 @@ describe("the outcomes that reach no remote", () => {
   });
 
   it("refuses a landing answer that named no pull request", async () => {
-    const result = await runTicketLoop(deps({
-      request: async () => ({ version: 1 }),
-    }));
+    const result = await runTicketLoop(
+      deps({
+        request: async () => ({ version: 1 }),
+      }),
+    );
 
     expect(result.outcome).toBe("refused");
     if (result.outcome !== "refused") return;

--- a/packages/worker/src/acp/ticket-loop.ts
+++ b/packages/worker/src/acp/ticket-loop.ts
@@ -24,14 +24,43 @@
 import type { PromptResponse } from "@agentclientprotocol/sdk";
 import { REDSKILLS_ACP_METHODS } from "@reddb-io/protocol-acp";
 import { renderClaimComment } from "../engine/tracker/claim.js";
-import { gateVerdict, type GateStage, type GateStageOutcome } from "../engine/gate-stage-order.js";
+import {
+  gateVerdict,
+  type GateStage,
+  type GateStageOutcome,
+} from "../engine/gate-stage-order.js";
 import { laneRunModeRefusal } from "../engine/lane-run-mode.js";
-import type { WorkerPublication, WorkerPublisher, WorkerPublishOutcome } from "./publish-request.js";
+import type {
+  WorkerPublication,
+  WorkerPublisher,
+  WorkerPublishOutcome,
+} from "./publish-request.js";
+import {
+  classifyWorkerFailure,
+  decideWorkerFailureRetry,
+  WORKER_FAILURE_GLOBAL_RETRY_LIMIT,
+  WORKER_FAILURE_RETRY_TABLE,
+  type WorkerFailureRetryClass,
+} from "./retry-policy.js";
 
 /** The loop's stages, in the order one Ticket travels through them. */
-export const TICKET_LOOP_STAGES = ["claim", "implement", "gate", "publish", "land"] as const;
+export const TICKET_LOOP_STAGES = [
+  "claim",
+  "implement",
+  "gate",
+  "publish",
+  "land",
+] as const;
 
 export type TicketLoopStage = (typeof TICKET_LOOP_STAGES)[number];
+
+export const TICKET_LOOP_FAILURE_RETRY_CLASSES = [
+  "cap-hit",
+  "oom",
+  "network-drop",
+  "tool-error",
+  "unknown",
+] as const satisfies readonly WorkerFailureRetryClass[];
 
 /** The Ticket the daemon admitted this Worker for. */
 export interface TicketLoopTicket {
@@ -81,7 +110,12 @@ export interface TicketLoopDeps {
   /** Sends one request to the ACP parent; the parent owns every credential. */
   readonly request: (method: string, params: unknown) => Promise<unknown>;
   /** Runs one implementing round against the retained child Agent. */
-  readonly implement: (handoff: string, round: number) => Promise<TicketImplementOutcome>;
+  readonly implement: (
+    handoff: string,
+    round: number,
+  ) => Promise<TicketImplementOutcome>;
+  /** Test seam for failure classification; production classifies the thrown evidence. */
+  readonly classifyFailure?: (error: unknown) => WorkerFailureRetryClass;
   /** Runs the declared gate stages locally, in the Worktree. */
   readonly gate: (round: number) => Promise<TicketGateRun>;
   /** Asks the parent to publish what the Worktree now holds. */
@@ -146,7 +180,9 @@ export type TicketLoopResult =
  * not ask about — a dead child, a closed socket — still propagates, because
  * that is a Worker death and the daemon reaps those.
  */
-export async function runTicketLoop(deps: TicketLoopDeps): Promise<TicketLoopResult> {
+export async function runTicketLoop(
+  deps: TicketLoopDeps,
+): Promise<TicketLoopResult> {
   const records: TicketLoopRecord[] = [];
   const now = deps.now ?? (() => new Date());
   const budget = Math.max(0, Math.trunc(deps.reseedBudget ?? 0));
@@ -188,11 +224,47 @@ export async function runTicketLoop(deps: TicketLoopDeps): Promise<TicketLoopRes
   // ---- implement / gate / re-seed ---------------------------------------
   let handoff = deps.ticket.handoff;
   let rounds = 0;
+  let failureRetriesUsed = 0;
+  const failureRetriesByClass = new Map<WorkerFailureRetryClass, number>();
   let verdict = gateVerdict([]);
   let gateDetail: string | undefined;
   for (;;) {
     rounds += 1;
-    const implemented = await deps.implement(handoff, rounds);
+    let implemented: TicketImplementOutcome;
+    try {
+      implemented = await deps.implement(handoff, rounds);
+    } catch (error) {
+      const failureClass = ticketLoopRetryClass(
+        (deps.classifyFailure ?? classifyWorkerFailure)(error),
+      );
+      const classRetriesUsed = failureRetriesByClass.get(failureClass) ?? 0;
+      const evidence = messageOf(error);
+      const decision = decideWorkerFailureRetry({
+        failureClass,
+        retriesUsed: failureRetriesUsed,
+        classRetriesUsed,
+        evidence,
+      });
+      await note({
+        stage: "implement",
+        ok: false,
+        round: rounds,
+        detail: implementationFailureDetail(decision),
+      });
+      if (decision.action === "park") {
+        return {
+          outcome: "gate-blocked",
+          failedStage: "feedback",
+          rounds,
+          detail: implementationFailureDetail(decision),
+          records,
+        };
+      }
+      failureRetriesUsed = decision.retriesUsed;
+      failureRetriesByClass.set(failureClass, decision.classRetriesUsed);
+      handoff = retryHandoff(deps.ticket, decision, rounds);
+      continue;
+    }
     await note({
       stage: "implement",
       ok: implemented.stopReason !== "cancelled",
@@ -212,7 +284,9 @@ export async function runTicketLoop(deps: TicketLoopDeps): Promise<TicketLoopRes
       round: rounds,
       ...(verdict.ok
         ? {}
-        : { detail: `${verdict.failedStage} blocked${run.detail == null ? "" : `: ${run.detail}`}` }),
+        : {
+            detail: `${verdict.failedStage} blocked${run.detail == null ? "" : `: ${run.detail}`}`,
+          }),
     });
     if (verdict.ok) break;
     // Re-seed IN PLACE: same Worker, same Worktree, same branch. The budget
@@ -227,20 +301,38 @@ export async function runTicketLoop(deps: TicketLoopDeps): Promise<TicketLoopRes
         records,
       };
     }
-    handoff = reseedHandoff(deps.ticket, verdict.failedStage, run.detail, rounds);
+    handoff = reseedHandoff(
+      deps.ticket,
+      verdict.failedStage,
+      run.detail,
+      rounds,
+    );
   }
 
   // ---- publish -----------------------------------------------------------
   const published = await deps.publisher.publishTurn();
   if (published == null) {
-    await note({ stage: "publish", ok: false, detail: "the Worktree committed nothing to publish" });
+    await note({
+      stage: "publish",
+      ok: false,
+      detail: "the Worktree committed nothing to publish",
+    });
     return { outcome: "nothing-to-publish", rounds, records };
   }
   if (published.status === "refused") {
     await note({ stage: "publish", ok: false, detail: published.detail });
-    return { outcome: "refused", stage: "publish", detail: published.detail, records };
+    return {
+      outcome: "refused",
+      stage: "publish",
+      detail: published.detail,
+      records,
+    };
   }
-  await note({ stage: "publish", ok: true, detail: publicationDetail(published) });
+  await note({
+    stage: "publish",
+    ok: true,
+    detail: publicationDetail(published),
+  });
 
   // ---- land --------------------------------------------------------------
   // Landing ARMS custody; it does not await a merge. A Worker that waited for
@@ -258,8 +350,18 @@ export async function runTicketLoop(deps: TicketLoopDeps): Promise<TicketLoopRes
       owner_ticket: deps.ticket.number,
     });
     const pullRequest = pullRequestNumber(landed);
-    await note({ stage: "land", ok: true, detail: `pull request ${pullRequest}` });
-    return { outcome: "landed", publication: published.publication, pullRequest, rounds, records };
+    await note({
+      stage: "land",
+      ok: true,
+      detail: `pull request ${pullRequest}`,
+    });
+    return {
+      outcome: "landed",
+      publication: published.publication,
+      pullRequest,
+      rounds,
+      records,
+    };
   } catch (error) {
     const detail = messageOf(error);
     await note({ stage: "land", ok: false, detail });
@@ -298,13 +400,64 @@ function landingBody(ticket: TicketLoopTicket, rounds: number): string {
   ].join("\n");
 }
 
-function publicationDetail(published: Extract<WorkerPublishOutcome, { status: "requested" }>): string {
+function publicationDetail(
+  published: Extract<WorkerPublishOutcome, { status: "requested" }>,
+): string {
   return `${published.publication.branch}@${published.publication.commit.slice(0, 12)}`;
+}
+
+function retryHandoff(
+  ticket: TicketLoopTicket,
+  decision: Extract<
+    ReturnType<typeof decideWorkerFailureRetry>,
+    { action: "retry" }
+  >,
+  round: number,
+): string {
+  return [
+    `The implementer failed round ${round} of Ticket #${ticket.number} with ${decision.failureClass}.`,
+    retryInstructionForFailureClass(decision.failureClass),
+    decision.evidence,
+    "Retry inside this same Worktree and commit whatever changed.",
+  ].join("\n");
+}
+
+export function retryInstructionForFailureClass(
+  clazz: WorkerFailureRetryClass,
+): string {
+  return WORKER_FAILURE_RETRY_TABLE[clazz].instruction;
+}
+
+function ticketLoopRetryClass(
+  clazz: WorkerFailureRetryClass,
+): WorkerFailureRetryClass {
+  switch (clazz) {
+    case "cap-hit":
+    case "oom":
+    case "network-drop":
+    case "tool-error":
+    case "unknown":
+      return clazz;
+  }
+}
+
+function implementationFailureDetail(
+  decision: ReturnType<typeof decideWorkerFailureRetry>,
+): string {
+  if (decision.action === "retry") {
+    return `worker failure ${decision.failureClass}; retry ${decision.retriesUsed}/${WORKER_FAILURE_GLOBAL_RETRY_LIMIT} as ${decision.shape}: ${decision.evidence}`;
+  }
+  const bound =
+    decision.reason === "global-bound"
+      ? "global two-retry bound exhausted"
+      : `${decision.failureClass} retry bound exhausted`;
+  return `worker failure ${decision.failureClass}; ${bound}; parking with evidence: ${decision.evidence}`;
 }
 
 /** The pull request the daemon opened; anything else is a landing that lied. */
 function pullRequestNumber(answer: unknown): number {
-  const value = (answer as { pull_request?: unknown } | undefined)?.pull_request;
+  const value = (answer as { pull_request?: unknown } | undefined)
+    ?.pull_request;
   if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
     throw new Error("the parent's landing answer named no pull request");
   }


### PR DESCRIPTION
Refs #4175

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:92e409d2-de5e-4a0b-a517-1cad66fbae27:land:596ede5b6aeece02f29cd1115ad589fe3e423184 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789892098&installation_model_id=20659&pr_number=4258&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4258&signature=53d0dcc9f986b0c382fdf11d0d6468cbae040f7f21f24aac6418da0b4ca0790d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->