### PR TITLE
A declared retry-by-failure-mode table bounds every retry

### DIFF
--- a/.changeset/worker-failure-retry-table.md
+++ b/.changeset/worker-failure-retry-table.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Declare and enforce Worker failure retry policy by failure class, with exhausted retries parking the Ticket with evidence.

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -27,7 +27,7 @@ import type {
 
 import { randomBytes } from "node:crypto";
 
-import { parkGateBlockedTurn } from "./demand-park.js";
+import { parkGateBlockedTurn, parkWorkerFailureTurn } from "./demand-park.js";
 import { readProjectTicketBody } from "./acp-github.js";
 import { admitNativeAcpWorker } from "./acp-worker-admission.js";
 import { ACP_AGENT_IDS, type AcpAgentId } from "@reddb-io/protocol-acp";
@@ -43,6 +43,12 @@ import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
 import type { RedskilledPaths } from "./paths.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
+import {
+  classifyWorkerFailure,
+  decideWorkerFailureRetry,
+  retryRunnerForShape,
+  type WorkerFailureRetryShape,
+} from "./worker-failure-retry.js";
 
 /** What one unattended turn needs to exist. The daemon's own facts, no client's. */
 export interface DemandTurnDeps {
@@ -85,6 +91,17 @@ export interface DemandTurnDeps {
     ticket: Readonly<Record<string, unknown>>,
     response: PromptResponse,
     workerId: string,
+  ) => Promise<string | null>;
+  /**
+   * What happens to the Ticket when Worker failure retries are exhausted.
+   *
+   * The runner supplies the failure class and evidence from the declared retry
+   * table; the callback owns the tracker write, if this turn has a Ticket.
+   */
+  readonly parkFailure?: (
+    project: AcpProjectWorkspace,
+    ticket: Readonly<Record<string, unknown>>,
+    failure: { readonly workerId?: string; readonly failureClass: string; readonly evidence: string },
   ) => Promise<string | null>;
   /**
    * Where a turn's session updates land as Worker liveness (#4181).
@@ -246,6 +263,12 @@ export interface DemandTurnAdmission {
   readonly notify: AgentConnection["client"]["notify"];
   readonly permission: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>;
   readonly replacement: boolean;
+  readonly retry?: {
+    readonly number: number;
+    readonly failureClass: string;
+    readonly shape: WorkerFailureRetryShape;
+    readonly evidence: string;
+  };
 }
 
 export interface DemandTurnRecord {
@@ -255,6 +278,14 @@ export interface DemandTurnRecord {
   readonly work_item?: string;
   readonly detail?: string;
 }
+
+export const WORKER_FAILURE_RETRY_CONSUMER_CLASSES = [
+  "cap-hit",
+  "oom",
+  "network-drop",
+  "tool-error",
+  "unknown",
+] as const;
 
 /**
  * One unattended turn's outcome as a line an operator reads. PURE.
@@ -346,6 +377,7 @@ export function demandTurnRunnerFor(
     ...(options.recordDemandTurn == null ? {} : { record: options.recordDemandTurn }),
     ...(options.workerPulse == null ? {} : { pulse: options.workerPulse }),
     park: parkGateBlockedTurn(options.githubGateway),
+    parkFailure: parkWorkerFailureTurn(options.githubGateway),
   });
 }
 
@@ -358,12 +390,16 @@ export function demandTurnRunnerFor(
  * (the first live codex drain was born redcode exactly this way).
  */
 export function demandAdmissionSessionRequest(
-  input: Pick<DemandTurnAdmission, "project" | "runner">,
+  input: Pick<DemandTurnAdmission, "project" | "runner" | "retry">,
 ): NewSessionRequest {
+  const redskills = {
+    ...(input.runner == null ? {} : { runner: input.runner }),
+    ...(input.retry == null ? {} : { retry: input.retry }),
+  };
   return {
     cwd: input.project.workspacePath,
     mcpServers: [],
-    ...(input.runner == null ? {} : { _meta: { redskills: { runner: input.runner } } }),
+    ...(Object.keys(redskills).length === 0 ? {} : { _meta: { redskills } }),
   };
 }
 
@@ -423,6 +459,10 @@ export function createDemandTurnRunner(
     // Nobody is listening, so a notification is a record — and a pulse (#4181):
     // the turn's own updates are the only liveness a native Worker ever emits.
     let born: ActiveWorkflowWorker | null = null;
+    let lastWorker: ActiveWorkflowWorker | undefined;
+    let retriesUsed = 0;
+    let retryShape: WorkerFailureRetryShape | undefined;
+    let retryMeta: DemandTurnAdmission["retry"] | undefined;
     const notify: AgentConnection["client"]["notify"] = async (_method: string, params?: unknown) => {
       if (born == null || deps.pulse == null) return;
       const line = sessionUpdateLine(params);
@@ -462,52 +502,95 @@ export function createDemandTurnRunner(
             : briefedTicket;
         }
       }
-      const { worker, response } = await requestWorkflowTurn(
-        sessionId,
-        active,
-        {
-          sessionId,
-          prompt: [{ type: "text", text: briefedPrompt }],
-          _meta: {
-            redskills: {
-              unattended: true,
-              ...(request.workItem == null ? {} : { workItem: request.workItem }),
-              ...(request.runner == null ? {} : { runner: request.runner }),
-              ...(briefedTicket == null ? {} : { ticket: briefedTicket }),
-            },
-          },
-        },
-        (replacement) => admit({
-          project: request.project,
-          sessionId,
-          ...(request.runner == null ? {} : { runner: request.runner }),
-          notify,
-          permission: async (permission) => refusePermission(permission),
-          replacement,
-        }).then((worker) => {
-          born = worker;
-          deps.pulse?.({ workerId: worker.workerId, ...(request.workItem == null ? {} : { issue: `#${request.workItem}` }) });
-          return worker;
-        }),
-      );
-      const outcome = describeTurnOutcome(response);
-      record("demand-turn-completed", worker, outcome);
-      if (deps.park != null && request.ticket != null) {
+      for (;;) {
         try {
-          const parked = await deps.park(request.project, request.ticket, response, worker.workerId);
-          if (parked != null) record("demand-park", worker, parked);
+          const retryRunner = retryRunnerForShape(request.runner, retryShape);
+          const { worker, response } = await requestWorkflowTurn(
+            sessionId,
+            active,
+            {
+              sessionId,
+              prompt: [{ type: "text", text: briefedPrompt }],
+              _meta: {
+                redskills: {
+                  unattended: true,
+                  ...(request.workItem == null ? {} : { workItem: request.workItem }),
+                  ...(retryRunner == null ? {} : { runner: retryRunner }),
+                  ...(retryMeta == null ? {} : { retry: retryMeta }),
+                  ...(briefedTicket == null ? {} : { ticket: briefedTicket }),
+                },
+              },
+            },
+            (replacement) => admit({
+              project: request.project,
+              sessionId,
+              ...(retryRunner == null ? {} : { runner: retryRunner }),
+              notify,
+              permission: async (permission) => refusePermission(permission),
+              replacement: replacement || retriesUsed > 0,
+              ...(retryMeta == null ? {} : { retry: retryMeta }),
+            }).then((worker) => {
+              born = worker;
+              lastWorker = worker;
+              deps.pulse?.({ workerId: worker.workerId, ...(request.workItem == null ? {} : { issue: `#${request.workItem}` }) });
+              return worker;
+            }),
+            { replaceClosedTransport: false },
+          );
+          const outcome = describeTurnOutcome(response);
+          record("demand-turn-completed", worker, outcome);
+          if (deps.park != null && request.ticket != null) {
+            try {
+              const parked = await deps.park(request.project, request.ticket, response, worker.workerId);
+              if (parked != null) record("demand-park", worker, parked);
+            } catch (error) {
+              record("demand-park-failed", worker, error instanceof Error ? error.message : String(error));
+            }
+          }
+          // The turn is the Worker's whole life: it was admitted for one work item
+          // and has now finished it, so it is reaped here rather than left on an
+          // idle timer nobody will come back to.
+          cleanupWorkflowWorker(sessionId, worker, active, outcome);
+          return { workerId: worker.workerId, outcome };
         } catch (error) {
-          record("demand-park-failed", worker, error instanceof Error ? error.message : String(error));
+          const held = active.get(sessionId);
+          if (held == null && lastWorker == null) throw error;
+          const failureClass = classifyWorkerFailure(error);
+          const decision = decideWorkerFailureRetry({ failureClass, retriesUsed });
+          if (decision.decision === "retry") {
+            if (held != null) cleanupWorkflowWorker(sessionId, held, active, `retry:${decision.failureClass}`);
+            retriesUsed = decision.retryNumber;
+            retryShape = decision.shape;
+            retryMeta = {
+              number: decision.retryNumber,
+              failureClass: decision.failureClass,
+              shape: decision.shape,
+              evidence: decision.evidence,
+            };
+            record("demand-turn-retry", held ?? lastWorker, `${decision.failureClass}: ${decision.shape.kind}`);
+            continue;
+          }
+          if (held != null) cleanupWorkflowWorker(sessionId, held, active, `park:${decision.failureClass}`);
+          if (deps.parkFailure != null && request.ticket != null) {
+            try {
+              const workerId = held?.workerId ?? lastWorker?.workerId;
+              const parked = await deps.parkFailure(request.project, request.ticket, {
+                ...(workerId == null ? {} : { workerId }),
+                failureClass: decision.failureClass,
+                evidence: decision.evidence,
+              });
+              if (parked != null) record("demand-retry-park", held ?? lastWorker, parked);
+            } catch (parkError) {
+              record("demand-retry-park-failed", held ?? lastWorker, parkError instanceof Error ? parkError.message : String(parkError));
+            }
+          }
+          record("demand-turn-refused", held ?? lastWorker, `${decision.failureClass}: ${decision.evidence}`);
+          throw error;
         }
       }
-      // The turn is the Worker's whole life: it was admitted for one work item
-      // and has now finished it, so it is reaped here rather than left on an
-      // idle timer nobody will come back to.
-      cleanupWorkflowWorker(sessionId, worker, active, outcome);
-      return { workerId: worker.workerId, outcome };
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
-      record("demand-turn-refused", active.get(sessionId), detail);
+      if (retriesUsed === 0) record("demand-turn-refused", active.get(sessionId), detail);
       const held = active.get(sessionId);
       if (held != null) cleanupWorkflowWorker(sessionId, held, active, "demand-turn-refused");
       throw error;

--- a/apps/redskilled/src/acp-worker-lifecycle.ts
+++ b/apps/redskilled/src/acp-worker-lifecycle.ts
@@ -174,7 +174,9 @@ export async function requestWorkflowTurn(
   active: Map<string, ActiveWorkflowWorker>,
   params: PromptRequest,
   admit: (replacement: boolean) => Promise<ActiveWorkflowWorker>,
+  options: { readonly replaceClosedTransport?: boolean } = {},
 ): Promise<{ readonly worker: ActiveWorkflowWorker; readonly response: PromptResponse }> {
+  const replaceClosedTransport = options.replaceClosedTransport ?? true;
   let worker = active.get(publicSessionId);
   if (worker == null) {
     worker = await admit(false);
@@ -200,7 +202,7 @@ export async function requestWorkflowTurn(
     redskilledMetrics().observeTurn("completed");
     return { worker, response };
   } catch (error) {
-    if (!workerTransportIsClosed(worker)) {
+    if (!replaceClosedTransport || !workerTransportIsClosed(worker)) {
       scheduleIdleCleanup(publicSessionId, worker, active);
       redskilledMetrics().observeTurn("refused");
       throw error;

--- a/apps/redskilled/src/demand-park.ts
+++ b/apps/redskilled/src/demand-park.ts
@@ -89,6 +89,42 @@ export function gateBlockedParkWrite(input: {
   };
 }
 
+export function workerFailureParkWrite(input: {
+  readonly workspacePath: string;
+  readonly ticket: { readonly number: number; readonly labels: readonly string[] };
+  readonly workerId?: string;
+  readonly failureClass: string;
+  readonly evidence: string;
+}): { readonly request: RedskilledGithubWriteRequest; readonly summary: string } | { readonly refusal: string } {
+  const vocabulary = readEngineLabelVocabulary(
+    loadEngineConfig(resolve(input.workspacePath, ".red"), { warn: () => undefined }),
+  );
+  const plan = planTransition(
+    input.ticket.labels,
+    { kind: "park", reason: `${vocabulary.blockedPrefix}infra` },
+    vocabulary,
+  );
+  if (isRefused(plan)) return { refusal: plan.reason };
+  const actor = input.workerId == null ? "unknown worker" : `worker \`${input.workerId}\``;
+  return {
+    summary: `parked #${input.ticket.number}: exhausted ${input.failureClass} retry policy`,
+    request: {
+      idempotency_key: `worker-failure-park:${input.ticket.number}:${input.failureClass}:${input.workerId ?? "unknown"}`,
+      write: {
+        kind: "issue-transition",
+        issue: input.ticket.number,
+        add: plan.add,
+        remove: plan.remove,
+        comment:
+          `🤖 AFK park by ${actor}: Worker failure retry policy exhausted for ` +
+          `\`${input.failureClass}\`.\n\n` +
+          `**Evidence:** ${input.evidence}\n\n` +
+          `Requeue with \`/retake ${input.ticket.number}\` once the blocker is repaired.`,
+      },
+    },
+  };
+}
+
 /**
  * The executor the demand-turn runner calls after a completed Ticket turn.
  *
@@ -122,6 +158,33 @@ export function parkGateBlockedTurn(
       ticket: { number, labels },
       workerId,
       verdict,
+    });
+    if ("refusal" in composed) return `park refused for #${number}: ${composed.refusal}`;
+    const write = bindAcpProjectGithubWrite(gateway, () => project);
+    await write({ params: composed.request });
+    return composed.summary;
+  };
+}
+
+export function parkWorkerFailureTurn(
+  gateway: RedskilledGithubGatewayRegistration | undefined,
+): (
+  project: AcpProjectWorkspace,
+  ticket: Readonly<Record<string, unknown>>,
+  failure: { readonly workerId?: string; readonly failureClass: string; readonly evidence: string },
+) => Promise<string | null> {
+  return async (project, ticket, failure) => {
+    const number = Number(ticket.number);
+    const labels = Array.isArray(ticket.labels)
+      ? ticket.labels.filter((label): label is string => typeof label === "string")
+      : [];
+    if (!Number.isInteger(number) || number <= 0) {
+      return `park refused: the turn's ticket names no issue number`;
+    }
+    const composed = workerFailureParkWrite({
+      workspacePath: project.workspacePath,
+      ticket: { number, labels },
+      ...failure,
     });
     if ("refusal" in composed) return `park refused for #${number}: ${composed.refusal}`;
     const write = bindAcpProjectGithubWrite(gateway, () => project);

--- a/apps/redskilled/src/worker-failure-retry.ts
+++ b/apps/redskilled/src/worker-failure-retry.ts
@@ -1,0 +1,134 @@
+import type { AcpAgentId } from "./acp-agent-catalog.js";
+
+export type WorkerFailureRetryClass = "cap-hit" | "oom" | "network-drop" | "tool-error" | "unknown";
+
+export type WorkerFailureRetryShape =
+  | { readonly kind: "as-is" }
+  | { readonly kind: "smaller-scope" }
+  | { readonly kind: "different-model" };
+
+export interface WorkerFailureRetrySpec {
+  readonly class: WorkerFailureRetryClass;
+  readonly shape: WorkerFailureRetryShape;
+  /** Per-class bound; the global bound is enforced on top of this. */
+  readonly maxRetries: number;
+  readonly evidence: string;
+}
+
+export type WorkerFailureRetryDecision =
+  | {
+    readonly decision: "retry";
+    readonly failureClass: WorkerFailureRetryClass;
+    readonly retryNumber: number;
+    readonly shape: WorkerFailureRetryShape;
+    readonly evidence: string;
+  }
+  | {
+    readonly decision: "park";
+    readonly failureClass: WorkerFailureRetryClass;
+    readonly retryNumber: number;
+    readonly evidence: string;
+  };
+
+export const WORKER_FAILURE_GLOBAL_RETRY_BOUND = 2;
+
+export const WORKER_FAILURE_RETRY_TABLE = [
+  {
+    class: "cap-hit",
+    shape: { kind: "smaller-scope" },
+    maxRetries: WORKER_FAILURE_GLOBAL_RETRY_BOUND,
+    evidence: "resource cap hit; retry with a smaller task scope",
+  },
+  {
+    class: "oom",
+    shape: { kind: "smaller-scope" },
+    maxRetries: WORKER_FAILURE_GLOBAL_RETRY_BOUND,
+    evidence: "worker was killed by memory pressure; retry with a smaller task scope",
+  },
+  {
+    class: "network-drop",
+    shape: { kind: "as-is" },
+    maxRetries: WORKER_FAILURE_GLOBAL_RETRY_BOUND,
+    evidence: "transport dropped; retry the same turn unchanged",
+  },
+  {
+    class: "tool-error",
+    shape: { kind: "different-model" },
+    maxRetries: WORKER_FAILURE_GLOBAL_RETRY_BOUND,
+    evidence: "agent tool invocation failed; retry on a different model path",
+  },
+  {
+    class: "unknown",
+    shape: { kind: "as-is" },
+    maxRetries: 1,
+    evidence: "unclassified worker failure; retry once, then park with evidence",
+  },
+] as const satisfies readonly WorkerFailureRetrySpec[];
+
+export const WORKER_FAILURE_RETRY_CLASSES = WORKER_FAILURE_RETRY_TABLE.map((row) => row.class);
+
+const TABLE_BY_CLASS = new Map<WorkerFailureRetryClass, WorkerFailureRetrySpec>(
+  WORKER_FAILURE_RETRY_TABLE.map((row) => [row.class, row]),
+);
+
+export function classifyWorkerFailure(error: unknown): WorkerFailureRetryClass {
+  const text = failureText(error).toLowerCase();
+  if (/\b(oom|out of memory|memorymax|memory max|memory budget|sigkill)\b/.test(text)) return "oom";
+  if (/\b(cap hit|cap-hit|context cap|token cap|budget cap|wall-clock|wall clock|resource cap)\b/.test(text)) {
+    return "cap-hit";
+  }
+  if (/\b(econnreset|econnrefused|etimedout|epipe|socket hang up|network|transport closed|connection lost)\b/.test(text)) {
+    return "network-drop";
+  }
+  if (/\b(tool error|tool-call|tool call|tool invocation|method not found|requestpermission)\b/.test(text)) {
+    return "tool-error";
+  }
+  return "unknown";
+}
+
+export function decideWorkerFailureRetry(input: {
+  readonly failureClass: WorkerFailureRetryClass;
+  /** Retries already consumed before this failure. */
+  readonly retriesUsed: number;
+}): WorkerFailureRetryDecision {
+  const spec = TABLE_BY_CLASS.get(input.failureClass);
+  if (spec == null) {
+    return {
+      decision: "park",
+      failureClass: "unknown",
+      retryNumber: input.retriesUsed + 1,
+      evidence: `retry policy drift: no declared retry spec for ${input.failureClass}`,
+    };
+  }
+  const retryNumber = input.retriesUsed + 1;
+  const bounded = Math.min(spec.maxRetries, WORKER_FAILURE_GLOBAL_RETRY_BOUND);
+  if (input.retriesUsed >= bounded) {
+    return {
+      decision: "park",
+      failureClass: spec.class,
+      retryNumber,
+      evidence: `${spec.evidence}; retry bound exhausted (${input.retriesUsed}/${bounded})`,
+    };
+  }
+  return {
+    decision: "retry",
+    failureClass: spec.class,
+    retryNumber,
+    shape: spec.shape,
+    evidence: spec.evidence,
+  };
+}
+
+export function retryRunnerForShape(
+  declared: AcpAgentId | undefined,
+  shape: WorkerFailureRetryShape | undefined,
+): AcpAgentId | undefined {
+  if (shape?.kind !== "different-model") return declared;
+  if (declared == null || declared === "codex") return "redcode";
+  return "codex";
+}
+
+function failureText(error: unknown): string {
+  if (error instanceof Error) return `${error.name}: ${error.message}\n${error.stack ?? ""}`;
+  return String(error);
+}

--- a/apps/redskilled/tests/demand-park.test.ts
+++ b/apps/redskilled/tests/demand-park.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { gateBlockedParkWrite, gateBlockedVerdictOf } from "../src/demand-park.js";
+import { gateBlockedParkWrite, gateBlockedVerdictOf, workerFailureParkWrite } from "../src/demand-park.js";
 import { createDemandTurnRunner, type DemandTurnAdmission, type DemandTurnRecord } from "../src/acp-demand-turn.js";
 import type { ActiveWorkflowWorker } from "../src/acp-worker-lifecycle.js";
 import { validateWriteRequest } from "../src/github-outbox.js";
@@ -68,6 +68,30 @@ describe("the park write moves the Ticket out of the executable queue", () => {
       comment: expect.stringContaining("post_done"),
     });
     expect((composed.request.write as { comment?: string }).comment).toContain("assert red");
+  });
+
+  it("parks an exhausted Worker failure retry with evidence", () => {
+    const composed = workerFailureParkWrite({
+      workspacePath: workspace,
+      ticket: { number: 4175, labels: ["ready-for-agent"] },
+      workerId: "W3",
+      failureClass: "network-drop",
+      evidence: "transport dropped; retry bound exhausted (2/2)",
+    });
+
+    expect(composed).toMatchObject({
+      summary: "parked #4175: exhausted network-drop retry policy",
+      request: {
+        idempotency_key: "worker-failure-park:4175:network-drop:W3",
+        write: {
+          kind: "issue-transition",
+          issue: 4175,
+          add: expect.arrayContaining(["ready-for-human", "blocked:infra"]),
+          remove: ["ready-for-agent"],
+          comment: expect.stringContaining("transport dropped; retry bound exhausted"),
+        },
+      },
+    });
   });
 });
 

--- a/apps/redskilled/tests/demand-turn.test.ts
+++ b/apps/redskilled/tests/demand-turn.test.ts
@@ -26,7 +26,10 @@ const project = {
 } as never;
 
 function workerStub(response: unknown, workerId = "W1"): ActiveWorkflowWorker & { prompted: ReturnType<typeof vi.fn> } {
-  const prompted = vi.fn(async () => response);
+  const prompted = vi.fn(async () => {
+    if (response instanceof Error) throw response;
+    return response;
+  });
   return {
     workerId,
     downstreamSessionId: `down-${workerId}`,
@@ -176,6 +179,129 @@ describe("the daemon's unattended turn", () => {
       _meta: { redskills: { permissionResolution: "unattended-refused", reason: DEMAND_TURN_PERMISSION_REFUSAL } },
     });
     expect(DEMAND_TURN_PERMISSION_REFUSAL).toMatch(/hitl/i);
+  });
+});
+
+describe("the daemon's unattended turn retry policy", () => {
+  it("retries a cap-hit with smaller-scope metadata", async () => {
+    const admissions: DemandTurnAdmission[] = [];
+    const workers = [
+      workerStub(new Error("context cap hit"), "W1"),
+      workerStub({ stopReason: "end_turn" }, "W2"),
+    ];
+    const { run, records } = runner(async (input) => {
+      admissions.push(input);
+      return workers.shift()!;
+    });
+
+    const result = await run({ project, prompt: "go", workItem: "4175", runner: "codex" });
+
+    expect(result.workerId).toBe("W2");
+    expect(records).toContainEqual(expect.objectContaining({
+      event: "demand-turn-retry",
+      detail: "cap-hit: smaller-scope",
+    }));
+    expect(admissions[1]).toMatchObject({
+      replacement: true,
+      runner: "codex",
+      retry: {
+        number: 1,
+        failureClass: "cap-hit",
+        shape: { kind: "smaller-scope" },
+      },
+    });
+    expect(workers).toHaveLength(0);
+  });
+
+  it("retries a network-drop as-is", async () => {
+    const admissions: DemandTurnAdmission[] = [];
+    const first = workerStub(new Error("ECONNRESET socket hang up"), "W1");
+    (first.socket as { destroyed: boolean }).destroyed = true;
+    const workers = [
+      first,
+      workerStub({ stopReason: "end_turn" }, "W2"),
+    ];
+    const { run } = runner(async (input) => {
+      admissions.push(input);
+      return workers.shift()!;
+    });
+
+    await run({ project, prompt: "go", runner: "redcode" });
+
+    expect(admissions[1]).toMatchObject({
+      runner: "redcode",
+      retry: { failureClass: "network-drop", shape: { kind: "as-is" } },
+    });
+    expect(admissions).toHaveLength(2);
+  });
+
+  it("retries a tool-error on a different model path", async () => {
+    const admissions: DemandTurnAdmission[] = [];
+    const workers = [
+      workerStub(new Error("tool invocation failed"), "W1"),
+      workerStub({ stopReason: "end_turn" }, "W2"),
+    ];
+    const { run } = runner(async (input) => {
+      admissions.push(input);
+      return workers.shift()!;
+    });
+
+    await run({ project, prompt: "go", runner: "codex" });
+
+    expect(admissions[1]).toMatchObject({
+      runner: "redcode",
+      retry: { failureClass: "tool-error", shape: { kind: "different-model" } },
+    });
+  });
+
+  it("parks with evidence instead of taking a third retry", async () => {
+    const admissions: DemandTurnAdmission[] = [];
+    const parked: unknown[] = [];
+    const workers = [
+      workerStub(new Error("ECONNRESET socket hang up"), "W1"),
+      workerStub(new Error("ECONNRESET socket hang up"), "W2"),
+      workerStub(new Error("ECONNRESET socket hang up"), "W3"),
+      workerStub({ stopReason: "end_turn" }, "W4"),
+    ];
+    const records: DemandTurnRecord[] = [];
+    const run = createDemandTurnRunner({
+      paths: {} as never,
+      startWorker: (() => {
+        throw new Error("an injected admission owns the birth in this test");
+      }) as never,
+      hostState: () => ({ workers: [] }),
+      sessionJournal: { create: async () => {} } as never,
+      admit: async (input) => {
+        admissions.push(input);
+        return workers.shift()!;
+      },
+      record: (line) => records.push(line),
+      parkFailure: async (_project, _ticket, failure) => {
+        parked.push(failure);
+        return `parked for ${failure.failureClass}`;
+      },
+    });
+
+    await expect(run({
+      project,
+      prompt: "go",
+      workItem: "4175",
+      ticket: { number: 4175, labels: ["ready-for-agent"] },
+    })).rejects.toThrow(/ECONNRESET/);
+
+    expect(admissions).toHaveLength(3);
+    expect(workers.map((worker) => worker.workerId)).toEqual(["W4"]);
+    expect(parked).toEqual([
+      expect.objectContaining({
+        workerId: "W3",
+        failureClass: "network-drop",
+        evidence: expect.stringContaining("retry bound exhausted"),
+      }),
+    ]);
+    expect(records).toContainEqual(expect.objectContaining({
+      event: "demand-retry-park",
+      detail: "parked for network-drop",
+    }));
   });
 });
 

--- a/apps/redskilled/tests/worker-failure-retry.test.ts
+++ b/apps/redskilled/tests/worker-failure-retry.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { WORKER_FAILURE_RETRY_CONSUMER_CLASSES } from "../src/acp-demand-turn.js";
+import {
+  classifyWorkerFailure,
+  decideWorkerFailureRetry,
+  retryRunnerForShape,
+  WORKER_FAILURE_GLOBAL_RETRY_BOUND,
+  WORKER_FAILURE_RETRY_CLASSES,
+  WORKER_FAILURE_RETRY_TABLE,
+  type WorkerFailureRetryClass,
+} from "../src/worker-failure-retry.js";
+
+describe("declared Worker failure retry table", () => {
+  it("covers every declared failure class with the required retry shape", () => {
+    expect(WORKER_FAILURE_RETRY_TABLE).toEqual([
+      expect.objectContaining({ class: "cap-hit", shape: { kind: "smaller-scope" }, maxRetries: 2 }),
+      expect.objectContaining({ class: "oom", shape: { kind: "smaller-scope" }, maxRetries: 2 }),
+      expect.objectContaining({ class: "network-drop", shape: { kind: "as-is" }, maxRetries: 2 }),
+      expect.objectContaining({ class: "tool-error", shape: { kind: "different-model" }, maxRetries: 2 }),
+      expect.objectContaining({ class: "unknown", shape: { kind: "as-is" }, maxRetries: 1 }),
+    ]);
+    expect(WORKER_FAILURE_GLOBAL_RETRY_BOUND).toBe(2);
+  });
+
+  it("is consumed in both directions: no declared class lacks a branch and no branch lacks a class", () => {
+    expect([...WORKER_FAILURE_RETRY_CONSUMER_CLASSES].sort()).toEqual([...WORKER_FAILURE_RETRY_CLASSES].sort());
+  });
+
+  it("decides each declared retry shape from the table", () => {
+    const expected: Record<WorkerFailureRetryClass, string> = {
+      "cap-hit": "smaller-scope",
+      oom: "smaller-scope",
+      "network-drop": "as-is",
+      "tool-error": "different-model",
+      unknown: "as-is",
+    };
+    for (const row of WORKER_FAILURE_RETRY_TABLE) {
+      const decision = decideWorkerFailureRetry({ failureClass: row.class, retriesUsed: 0 });
+      expect(decision).toMatchObject({
+        decision: "retry",
+        failureClass: row.class,
+        retryNumber: 1,
+        shape: { kind: expected[row.class] },
+      });
+    }
+  });
+
+  it("proves a third retry never happens under the global two-retry bound", () => {
+    expect(decideWorkerFailureRetry({ failureClass: "network-drop", retriesUsed: 0 }).decision).toBe("retry");
+    expect(decideWorkerFailureRetry({ failureClass: "network-drop", retriesUsed: 1 }).decision).toBe("retry");
+    expect(decideWorkerFailureRetry({ failureClass: "network-drop", retriesUsed: 2 })).toMatchObject({
+      decision: "park",
+      failureClass: "network-drop",
+      retryNumber: 3,
+    });
+  });
+
+  it("keeps unknown failures to one retry even though the global bound is two", () => {
+    expect(decideWorkerFailureRetry({ failureClass: "unknown", retriesUsed: 0 }).decision).toBe("retry");
+    expect(decideWorkerFailureRetry({ failureClass: "unknown", retriesUsed: 1 })).toMatchObject({
+      decision: "park",
+      failureClass: "unknown",
+      retryNumber: 2,
+    });
+  });
+});
+
+describe("Worker failure classification", () => {
+  it("recognizes every declared class from ordinary failure text", () => {
+    expect(classifyWorkerFailure(new Error("context cap hit"))).toBe("cap-hit");
+    expect(classifyWorkerFailure(new Error("OOM: out of memory"))).toBe("oom");
+    expect(classifyWorkerFailure(new Error("ECONNRESET socket hang up"))).toBe("network-drop");
+    expect(classifyWorkerFailure(new Error("tool invocation failed"))).toBe("tool-error");
+    expect(classifyWorkerFailure(new Error("mystery"))).toBe("unknown");
+  });
+
+  it("tool-error retries on a different model path", () => {
+    expect(retryRunnerForShape("codex", { kind: "different-model" })).toBe("redcode");
+    expect(retryRunnerForShape("redcode", { kind: "different-model" })).toBe("codex");
+    expect(retryRunnerForShape("codex", { kind: "as-is" })).toBe("codex");
+  });
+});


### PR DESCRIPTION
Refs #4175

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:d345738b-720f-4ac5-b1a3-3616e0b65d82:land:ecf37f12bee9a3c369cf215501f96fd12df16160 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789893187&installation_model_id=20659&pr_number=4261&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4261&signature=c6087d01dc2f4790a4cc74e0d7feef40a2e67b2611613730c3405447ee43c576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->