### PR TITLE
feat(dev): a zombie is reconciled and a silent death leaves a postmortem (#4176)

### DIFF
--- a/.changeset/synthetic-postmortem.md
+++ b/.changeset/synthetic-postmortem.md
@@ -1,0 +1,12 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+A silently dead Worker leaves the account it never got to write. A death whose
+receipt names no sender at an actionable confidence — the set the checkout sweep
+deliberately defers — now appends a second `worker-postmortem` row beside it on
+the daemon's registered event lane, carrying the failure mode as a structured
+`failure_mode` field (`oom`, `cap-hit`, `unattributed-kill`, `host-vanished`,
+`unknown`) and every last thing the host held about that Worker in one line: when
+it was born, what its tree had burned, the ceiling it ran under, the signal or
+receipt if either spoke, the journal tail, and the path to its own narration.

--- a/.changeset/zombie-reconciliation.md
+++ b/.changeset/zombie-reconciliation.md
@@ -1,0 +1,15 @@
+---
+"@reddb-io/dev": patch
+---
+
+A Worker that returns after the world moved lands nothing. `doLanding` gains a
+`zombie` refusal beside the `stale-head` one: when the caller states the world
+its Worker forked from, the landing compares the claim it held and the base
+generation it branched from against what the tracker and the remote say now. A
+claim that was released or taken, a closed Ticket, or a base that advanced is a
+displacement, and every displacement refuses the merge by name. Salvage travels
+through the tracker instead — a fresh reconciliation Ticket carrying the branch,
+the head SHA and the displacement when the original is no longer ours to write,
+or an evidenced park through the state-transition planner when it is still open
+and unheld. Both land nothing; the choice is only about where the salvage is
+addressed.

--- a/apps/plugin-dev/src/core/landing.ts
+++ b/apps/plugin-dev/src/core/landing.ts
@@ -41,6 +41,7 @@ import { resolveLandSerialization, type LandLock } from "./land-lock.js";
 import { landHeadPrecondition } from "./land-precondition.js";
 import { landingMergeTitle } from "./landing-merge-title.js";
 import { resolveRemoteBranchTip } from "./stale-head.js";
+import { zombieLandingRefusal, type ZombieWatch } from "./zombie-reconciliation.js";
 import type { LandCountersignGate } from "@reddb-io/shared/land-countersign.js";
 import { pushAttempt, type GitExec } from "./remote-branch.js";
 import { restagePiPackages } from "./pi-package-restage.js";
@@ -160,7 +161,6 @@ export interface LandingDeps {
    * aborts the landing and routes through the existing recovery instead of merging
    * an unvalidated or stale-main-broken result. Absent (the default) → skipped,
    * so existing callers that have not yet wired the dep are unchanged.
-   *
    * Called with the path of the already-integrated worktree:
    *   - direct path: the detached landing worktree after `integrateOrigin`
    *   - PR path: the isolated rebase worktree after `preMergeRebase`
@@ -235,6 +235,8 @@ export interface LandingInput {
   branch: string;
   /** The gate-validated worker tip (reconcile; #4134 stale-head guard). */
   validatedBranchTip?: string;
+  /** The world this Worker forked from, when the caller can state it (#4176). */
+  zombieWatch?: ZombieWatch;
   /** Resolved base branch (lock > pin > main). */
   base: string;
   /** Immutable base commit shared by the Landing integration and intent geometry. */
@@ -350,7 +352,11 @@ export type LandingResult =
         // landing would merge — no row, a voided one, a judgement of a
         // different tree, or a verifier that refused or could not conclude.
         // `message` carries the refusal and the repair it names.
-        | "unverified-head";
+        | "unverified-head"
+        // #4176: the claim was released or taken, the Ticket closed, or the base
+        // generation moved while this Worker worked. Landing would merge an
+        // account of a world that is gone; salvage is reconciled instead.
+        | "zombie";
       locked: boolean;
       /** PR number left open for the CI-aware handoff (`ci-failed` / `ci-pending`). */
       prNumber?: number;
@@ -386,22 +392,18 @@ export type LandingPostMergeValidation =
  * pre_merge hook on the `openPr` flag — NOT the lock, which only resolved `base`
  * upstream — and neither destructively touches the primary checkout's working
  * tree (issue #572, the primary branch is sacred):
- *
  *   1. pushAttempt — make the worker branch's origin state certain so
  *      landMerge/landPr have a ref to merge.
  *   2. fireHook("pre_merge") — abort → { ok:false, reason:"pre_merge-abort" }.
  *   3. SERIALIZE the land (#1337) — native merge queue when `<base>` has one, else
  *      the global land-lock when wired, so no two workers integrate-and-push into
- *      the same base concurrently. Everything after this point is the critical
- *      section; the lock is always released, on success and on failure alike.
- *
+ *      the same base concurrently. Everything after is the critical section; the
+ *      lock is always released, on success and on failure alike.
  *   openPr=true → {@link landAdminPr}. The PR is admin-merged REMOTELY into
  *   `<base>`, so there is nothing to integrate locally first; the prior pre-merge
  *   `merge --ff-only origin/<base>` is dropped (it failed the whole landing on a
- *   diverged primary, #572). After a successful non-queued merge, landPr
- *   promotes the fleet-owned `red-trunk` mirror with `update-ref`, never the
- *   primary checkout.
- *
+ *   diverged primary, #572). After a successful non-queued merge, landPr promotes
+ *   the fleet-owned `red-trunk` mirror with `update-ref`, never the primary.
  *   openPr=false → {@link landDirectInWorktree}. The merge / push / rollback run
  *   inside an ISOLATED detached worktree (makeLandingWorktree) at `<base>`, so the
  *   `reset --hard` on a push reject only rewinds that throwaway worktree — the
@@ -428,16 +430,13 @@ export async function doLanding(
   });
   if (!pushed.ok) {
     // Carry the REAL failure into the terminal record (#2576): a generic
-    // land-failed with no diagnostic was being misread as a merge conflict.
-    //
-    // #2811: route the push refusal to `infra`, NOT `land-failed`. `land-failed`
-    // funnels into the merge-conflict terminal, so the record said
-    // `kind: merge-conflict` under a summary stating the cause was the push and
-    // not a merge conflict, and told the next human to resolve a conflict that
-    // does not exist. `infra` is the honest kind for a push that never landed a
-    // byte, and its next-action ("fix the failure, then requeue") applies.
-    // `pushed.status` keeps "the git call never ran" distinct from "the remote
-    // refused it" — both were previously narrated as *the push failed*.
+    // land-failed with no diagnostic was being misread as a merge conflict, and
+    // #2811 routes the push refusal to `infra` rather than `land-failed`, which
+    // funnels into the merge-conflict terminal and told the next human to resolve
+    // a conflict that does not exist. `infra` is the honest kind for a push that
+    // never landed a byte, and its next-action ("fix the failure, then requeue")
+    // applies. `pushed.status` keeps "the git call never ran" distinct from "the
+    // remote refused it" — both were once narrated as *the push failed*.
     const detail = pushed.warn ? `: ${pushed.warn}` : "";
     return {
       ok: false,
@@ -455,6 +454,9 @@ export async function doLanding(
   // both fail for one reason: the merged tree is not the judged tree.
   const refusal = await landHeadPrecondition(deps.mergeExec, input, deps.countersignGate);
   if (refusal) return { ok: false, reason: refusal.reason, locked, message: refusal.message };
+  // #4176: a Worker that returns after the world moved lands nothing.
+  const zombie = await zombieLandingRefusal(deps.mergeExec, input);
+  if (zombie != null) return { ok: false, reason: "zombie", locked: input.locked, message: zombie };
 
 
   // 2. pre_merge hook.
@@ -468,12 +470,10 @@ export async function doLanding(
   // fresh base, revalidate the integrated tree, merge, push — is the critical
   // section two near-simultaneous workers used to race in: A pushes, B's push is
   // rejected non-fast-forward, B re-integrates, and overlapping diffs conflict.
-  //
   //   native-merge-queue → the forge serializes; take no local lock.
   //   land-lock          → only one worker at a time enters, so each rebases onto
   //                        a tip no concurrent land can move underneath it.
   //   unserialized       → no lock wired (pre-#1337 default): land as before.
-  //
   // A wait timeout ABORTS the landing as `infra` — pushing unserialized after
   // failing to serialize would reintroduce exactly the race the lock exists for.
   const serialization = resolveLandSerialization({

--- a/apps/plugin-dev/src/core/zombie-reconciliation.ts
+++ b/apps/plugin-dev/src/core/zombie-reconciliation.ts
@@ -1,0 +1,396 @@
+// zombie-reconciliation — a Worker that returns after the world moved is
+// reconciled, never believed (ADR 0155, Spec #4164, #4176).
+//
+// **The world does not pause while a Worker works.** Between the moment a
+// Worker takes a claim and the moment it announces a branch, its claim can be
+// conceded by a staleness sweep, released eagerly by the death sweep (#4136),
+// or taken by another Worker; the Ticket it holds can be closed by somebody
+// else's PR; and `origin/<base>` can advance past the generation it forked
+// from. Any one of those makes the Worker a ZOMBIE — alive, finished, and
+// holding an account of a world that no longer exists.
+//
+// Nothing in the landing path noticed. `doLanding` asked whether the branch was
+// pushable and whether its head still matched the SHA the gate validated
+// (#4134); it never asked whether the WORK was still wanted. So a zombie's push
+// landed on a Ticket that had already moved on, and the queue learned about it
+// from the merge.
+//
+// ## Two answers, and never a third
+//
+// **Nothing a zombie produced is landed.** The refusal is the whole point: the
+// gate that validated the work judged a base that is gone, and the claim that
+// authorised it belongs to somebody else. What the work is worth is a decision
+// the queue makes with the branch in front of it, which is why salvage always
+// travels through the tracker:
+//
+//   - **a reconciliation Ticket** when the original is no longer ours to write
+//     — it is closed, or another Worker holds its claim. A fresh Ticket carries
+//     the branch, the head SHA and the displacement, and enters triage like any
+//     other demand.
+//   - **an evidenced park** when the original is still open and unheld. The
+//     Ticket is where this work belongs; it goes back to a human with the
+//     evidence attached rather than to a Worker that would repeat the race.
+//
+// Both land nothing. The choice is about WHERE the salvage is addressed, never
+// about whether the merge may proceed.
+//
+// PURE planner, thin executor: every read and every mutation is injected, so a
+// simulated zombie flows through one plan in a unit test.
+
+import type { Exec } from "./merge.js";
+import { resolveRemoteBranchTip } from "./stale-head.js";
+import { transitionLabels, type StateTransition } from "./state-transition.js";
+import { LABEL_READY, LABEL_RUNNING } from "./triage-labels.js";
+
+/** Every way the world can move under a Worker that is still working. */
+export const ZOMBIE_DISPLACEMENTS = [
+  "claim-released",
+  "claim-taken",
+  "base-moved",
+  "issue-closed",
+] as const;
+
+export type ZombieDisplacement = (typeof ZOMBIE_DISPLACEMENTS)[number];
+
+/** One line per displacement, addressed to whoever the landing just refused. */
+export const ZOMBIE_DISPLACEMENT_REASONS: Readonly<Record<ZombieDisplacement, string>> = {
+  "claim-released": "the claim this Worker held was released while it was working",
+  "claim-taken": "another Worker holds the claim on this Ticket now",
+  "base-moved": "the base generation advanced past the commit this work forked from",
+  "issue-closed": "the Ticket this work targets was closed while the Worker was working",
+};
+
+/**
+ * What the Worker knew at the fork, and what the tracker says now.
+ *
+ * Declared structurally rather than read from a tracker client so the planner
+ * stays a value function: a test poses a zombie by writing one down, and the
+ * transport is the caller's.
+ */
+export interface ZombieWatch {
+  /** The daemon's key for the Worker that is returning. */
+  readonly workerId: string;
+  /** Its claim marker identity, `<host>:<worker_id>`. */
+  readonly claimOwner: string;
+  /** Claim owners the Ticket still reads as HOLDING, read now. */
+  readonly activeClaimOwners: readonly string[];
+  /** Claim owners that withdrew, read now. */
+  readonly concededClaimOwners?: readonly string[];
+  /** `origin/<base>` at the moment this Worker forked; absent → not compared. */
+  readonly baseAtStart?: string | null;
+  /** The Ticket's open state, read now; absent → assumed open. */
+  readonly issueOpen?: boolean;
+}
+
+/** Everything the planner needs: the watch, the live base, and the salvage. */
+export interface ZombieFacts extends ZombieWatch {
+  /** The Ticket the Worker claimed. */
+  readonly issue: number;
+  /** The branch the Worker pushed, which is the salvage. */
+  readonly branch: string;
+  /** The tip the Worker's gate validated, when the caller pinned one. */
+  readonly headSha?: string | null;
+  /** `origin/<base>` now; absent → the base could not be read, so not compared. */
+  readonly baseNow?: string | null;
+  /** The base branch name, for the salvage note. */
+  readonly base?: string;
+  /** The Ticket's title, echoed into a reconciliation Ticket. */
+  readonly title?: string;
+  /** The Ticket's labels as the caller read them; absent → the claim lane's pair. */
+  readonly currentLabels?: readonly string[];
+}
+
+/**
+ * Every way this Worker's world moved, in declaration order. PURE.
+ *
+ * An empty result is the ordinary case and the reason this is cheap enough to
+ * sit on the landing path: a Worker whose claim is still its own, on a base
+ * that has not moved, is not a zombie and pays one string comparison to prove
+ * it.
+ */
+export function detectZombieDisplacements(watch: ZombieWatch & {
+  readonly baseNow?: string | null;
+}): ZombieDisplacement[] {
+  const found: ZombieDisplacement[] = [];
+  const active = watch.activeClaimOwners;
+  const conceded = watch.concededClaimOwners ?? [];
+  if (conceded.includes(watch.claimOwner) || !active.includes(watch.claimOwner)) {
+    found.push("claim-released");
+  }
+  if (active.some((owner) => owner !== watch.claimOwner)) found.push("claim-taken");
+  if (
+    watch.baseAtStart != null && watch.baseNow != null &&
+    watch.baseAtStart !== watch.baseNow
+  ) {
+    found.push("base-moved");
+  }
+  if (watch.issueOpen === false) found.push("issue-closed");
+  return found;
+}
+
+export type ZombieVerdict =
+  | { readonly zombie: false }
+  | {
+      readonly zombie: true;
+      readonly displacements: readonly ZombieDisplacement[];
+      readonly message: string;
+    };
+
+/**
+ * Is this completion a zombie's? PURE.
+ *
+ * The message names every displacement rather than the first, because a Worker
+ * whose claim was released AND whose base moved is a different repair from one
+ * that only lost a race, and the reader of the refusal is the one who has to
+ * tell them apart.
+ */
+export function zombieVerdict(watch: ZombieWatch & {
+  readonly baseNow?: string | null;
+}): ZombieVerdict {
+  const displacements = detectZombieDisplacements(watch);
+  if (displacements.length === 0) return { zombie: false };
+  const reasons = displacements.map((kind) => ZOMBIE_DISPLACEMENT_REASONS[kind]).join("; ");
+  return {
+    zombie: true,
+    displacements,
+    message:
+      `the world moved while \`${watch.claimOwner}\` was working — ${reasons}. ` +
+      "Nothing is landed: the salvage is reconciled against the current queue " +
+      "and ledger state before any of it is accepted (#4176)",
+  };
+}
+
+/**
+ * The landing precondition, resolving the live base itself. Returns the refusal
+ * text, or `null` when the landing may proceed.
+ *
+ * A caller that states no watch is not judged: the check is opt-in because only
+ * a caller that knows the world at the fork can say whether it moved, and a
+ * default answer of "zombie" for every caller that cannot would refuse every
+ * landing in the repo.
+ */
+export async function zombieLandingRefusal(
+  exec: Exec,
+  input: {
+    readonly repoDir: string;
+    readonly remote: string;
+    readonly base: string;
+    readonly zombieWatch?: ZombieWatch;
+  },
+): Promise<string | null> {
+  const watch = input.zombieWatch;
+  if (watch === undefined) return null;
+  const baseNow = watch.baseAtStart == null
+    ? null
+    : await resolveRemoteBranchTip(exec, {
+        repo: input.repoDir, remote: input.remote, branch: input.base,
+      }) ?? null;
+  const verdict = zombieVerdict({ ...watch, baseNow });
+  return verdict.zombie ? verdict.message : null;
+}
+
+/** Where the salvage is addressed. Never "the merge proceeds". */
+export type ZombieSalvage = "reconciliation-ticket" | "evidenced-park";
+
+/** A fresh Ticket carrying the salvage, ready for the tracker to mint. */
+export interface ZombieReconciliationTicket {
+  readonly title: string;
+  readonly body: string;
+  readonly labels: readonly string[];
+}
+
+/** The park a still-open, unheld Ticket earns instead of a new one. */
+export interface ZombiePark {
+  readonly issue: number;
+  readonly comment: string;
+  /**
+   * The transition the planner applies — a plain human gate.
+   *
+   * The delta is never written here: ADR 0122 rule 5 has one place where a
+   * state role changes, and a module that composed its own label pair would be
+   * the second.
+   */
+  readonly transition: StateTransition;
+  /** The label set the plan is computed against. */
+  readonly currentLabels: readonly string[];
+}
+
+export interface ZombieReconciliationPlan {
+  /** Always `refused`. Stated as a field so a reader never has to infer it. */
+  readonly landing: "refused";
+  readonly issue: number;
+  readonly workerId: string;
+  readonly displacements: readonly ZombieDisplacement[];
+  readonly salvage: ZombieSalvage;
+  readonly evidence: string;
+  /** Present when `salvage` is `reconciliation-ticket`. */
+  readonly ticket?: ZombieReconciliationTicket;
+  /** Present when `salvage` is `evidenced-park`. */
+  readonly park?: ZombiePark;
+  /** The claim to withdraw first, when this Worker still holds one. */
+  readonly concede: string | null;
+}
+
+/**
+ * The evidence every salvage route quotes. PURE.
+ *
+ * The branch and the head SHA lead, because the first question a reader of
+ * either route asks is "where is the work?" and an answer they have to
+ * reconstruct from a Worker id is an answer they will not go and get.
+ */
+export function renderZombieEvidence(facts: ZombieFacts): string {
+  const parts = [`branch=\`${facts.branch}\``];
+  if (facts.headSha != null && facts.headSha !== "") parts.push(`head=${facts.headSha.slice(0, 12)}`);
+  parts.push(`worker=\`${facts.claimOwner}\``);
+  if (facts.baseAtStart != null) {
+    const base = facts.base == null ? "base" : `origin/${facts.base}`;
+    const now = facts.baseNow == null ? "unreadable" : facts.baseNow.slice(0, 12);
+    parts.push(`${base} ${facts.baseAtStart.slice(0, 12)} → ${now}`);
+  }
+  const holders = facts.activeClaimOwners.filter((owner) => owner !== facts.claimOwner);
+  if (holders.length > 0) parts.push(`claim now held by ${holders.map((o) => `\`${o}\``).join(", ")}`);
+  if (facts.issueOpen === false) parts.push("the Ticket is closed");
+  return parts.join("; ");
+}
+
+/**
+ * Which door the salvage goes through. PURE.
+ *
+ * The rule is ownership, not severity: a Ticket that is closed or claimed by
+ * another Worker is not ours to write on, and parking it would reopen somebody
+ * else's finished work or steal a live Worker's Ticket out from under it.
+ */
+export function zombieSalvageRoute(
+  displacements: readonly ZombieDisplacement[],
+): ZombieSalvage {
+  return displacements.includes("issue-closed") || displacements.includes("claim-taken")
+    ? "reconciliation-ticket"
+    : "evidenced-park";
+}
+
+/**
+ * Plan one zombie's reconciliation. PURE — no clock, no IO, no tracker.
+ *
+ * Callers reach this only after {@link zombieVerdict} said `zombie: true`; a
+ * completion whose world did not move has nothing to reconcile, and the planner
+ * says so by refusing to invent a displacement it did not observe.
+ */
+export function planZombieReconciliation(facts: ZombieFacts): ZombieReconciliationPlan | null {
+  const displacements = detectZombieDisplacements(facts);
+  if (displacements.length === 0) return null;
+  const evidence = renderZombieEvidence(facts);
+  const salvage = zombieSalvageRoute(displacements);
+  const reasons = displacements.map((kind) => `- ${ZOMBIE_DISPLACEMENT_REASONS[kind]}`).join("\n");
+  const concede = facts.activeClaimOwners.includes(facts.claimOwner) ? facts.claimOwner : null;
+  const base = {
+    landing: "refused" as const,
+    issue: facts.issue,
+    workerId: facts.workerId,
+    displacements,
+    salvage,
+    evidence,
+    concede,
+  };
+  return salvage === "reconciliation-ticket"
+    ? { ...base, ticket: buildReconciliationTicket(facts, reasons, evidence) }
+    : { ...base, park: buildZombiePark(facts, reasons, evidence) };
+}
+
+function buildReconciliationTicket(
+  facts: ZombieFacts,
+  reasons: string,
+  evidence: string,
+): ZombieReconciliationTicket {
+  const title = facts.title == null || facts.title === ""
+    ? `Reconcile salvaged work from #${facts.issue}`
+    : `Reconcile salvaged work from #${facts.issue}: ${facts.title}`;
+  return {
+    title,
+    labels: [],
+    body:
+      `A Worker finished work for #${facts.issue} after the world moved, so nothing was landed.\n\n` +
+      `**Why the landing was refused**\n${reasons}\n\n` +
+      `**Where the salvage is**\n${evidence}\n\n` +
+      "The branch is unmerged and unvalidated against the current base. Decide what of it is " +
+      "still wanted, rebase what is, and discard the rest — this Ticket exists so that decision " +
+      "is made with the branch in front of you rather than by a merge nobody reviewed (#4176).",
+  };
+}
+
+function buildZombiePark(facts: ZombieFacts, reasons: string, evidence: string): ZombiePark {
+  return {
+    issue: facts.issue,
+    transition: { kind: "human" },
+    currentLabels: facts.currentLabels ?? [LABEL_RUNNING, LABEL_READY],
+    comment:
+      "🤖 Zombie reconciliation: a Worker finished this Ticket after the world moved, " +
+      "so nothing was landed.\n\n" +
+      `**Why the landing was refused**\n${reasons}\n\n` +
+      `**Where the salvage is**\n${evidence}\n\n` +
+      "Requeue it once you have decided whether the branch is still the answer; a blind " +
+      "requeue would repeat the race that produced this park (#4176).",
+  };
+}
+
+/** The mutations one reconciliation performs. Narrow on purpose. */
+export interface ZombieReconciliationIO {
+  /** Withdraw the returning Worker's claim, when it still holds one. */
+  concede(issue: number, owner: string): Promise<void>;
+  /** Mint the reconciliation Ticket; answers its number. */
+  openTicket(ticket: ZombieReconciliationTicket): Promise<number>;
+  comment(issue: number, body: string): Promise<void>;
+  editLabels(issue: number, remove: readonly string[], add: readonly string[]): Promise<void>;
+}
+
+export interface ZombieReconciliationResult {
+  /** Always false. The type states the invariant the executor cannot break. */
+  readonly landed: false;
+  readonly salvage: ZombieSalvage;
+  /** The reconciliation Ticket that was minted, when that was the route. */
+  readonly reconciliationIssue?: number;
+  /** The Ticket that was parked, when that was the route. */
+  readonly parkedIssue?: number;
+  /** Set when a step failed; the plan is unchanged and may be replayed. */
+  readonly failure?: string;
+}
+
+/**
+ * Apply one plan. THIN — every decision was already made.
+ *
+ * Concede first, then write: the withdrawal must land before the label
+ * projection changes so no reader ever sees an unclaimed-but-still-`running`
+ * Ticket, exactly as the death sweep orders its own tick. A failure is reported
+ * rather than thrown, because a reconciliation that could not write is still a
+ * landing that correctly did not happen.
+ */
+export async function executeZombieReconciliation(
+  plan: ZombieReconciliationPlan,
+  io: ZombieReconciliationIO,
+): Promise<ZombieReconciliationResult> {
+  try {
+    if (plan.concede != null) await io.concede(plan.issue, plan.concede);
+    if (plan.ticket !== undefined) {
+      const reconciliationIssue = await io.openTicket(plan.ticket);
+      await io.comment(
+        plan.issue,
+        `🤖 Zombie reconciliation: nothing was landed for this Ticket; the salvage is tracked in #${reconciliationIssue} (${plan.evidence}).`,
+      );
+      return { landed: false, salvage: plan.salvage, reconciliationIssue };
+    }
+    const park = plan.park!;
+    const applied = await transitionLabels(
+      (remove, add) => io.editLabels(park.issue, remove, add),
+      park.currentLabels,
+      park.transition,
+    );
+    if (!applied.applied) return { landed: false, salvage: plan.salvage, failure: applied.reason };
+    await io.comment(park.issue, park.comment);
+    return { landed: false, salvage: plan.salvage, parkedIssue: park.issue };
+  } catch (error) {
+    return {
+      landed: false,
+      salvage: plan.salvage,
+      failure: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/apps/plugin-dev/tests/zombie-reconciliation.test.ts
+++ b/apps/plugin-dev/tests/zombie-reconciliation.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ZOMBIE_DISPLACEMENTS,
+  ZOMBIE_DISPLACEMENT_REASONS,
+  detectZombieDisplacements,
+  executeZombieReconciliation,
+  planZombieReconciliation,
+  renderZombieEvidence,
+  zombieLandingRefusal,
+  zombieSalvageRoute,
+  zombieVerdict,
+  type ZombieFacts,
+  type ZombieReconciliationIO,
+  type ZombieWatch,
+} from "../src/core/zombie-reconciliation.js";
+import { doLanding, harness } from "./landing.test-support.js";
+
+// #4176: a Worker that completes after its claim was released or after the base
+// generation moved is reconciled against the current queue state before any of
+// its output is accepted. Nothing it produced is landed; the salvage travels
+// through a fresh Ticket or an evidenced park.
+
+const OWNER = "host-a:wZ0MB1E";
+const OTHER = "host-a:wLIVE";
+
+function watch(overrides: Partial<ZombieWatch> = {}): ZombieWatch {
+  return {
+    workerId: "wZ0MB1E",
+    claimOwner: OWNER,
+    activeClaimOwners: [OWNER],
+    baseAtStart: "0r1g1nsha",
+    issueOpen: true,
+    ...overrides,
+  };
+}
+
+function facts(overrides: Partial<ZombieFacts> = {}): ZombieFacts {
+  return {
+    ...watch(),
+    issue: 4176,
+    title: "Zombie reconciliation",
+    branch: "afk/wZ0MB1E/4176-zombie",
+    headSha: "abcdef0123456789abcdef0123456789abcdef01",
+    base: "main",
+    baseNow: "0r1g1nsha",
+    ...overrides,
+  };
+}
+
+function recordingIo(): ZombieReconciliationIO & {
+  readonly calls: string[];
+} {
+  const calls: string[] = [];
+  return {
+    calls,
+    async concede(issue, owner) {
+      calls.push(`concede #${issue} ${owner}`);
+    },
+    async openTicket(ticket) {
+      calls.push(`openTicket ${ticket.title}`);
+      return 4999;
+    },
+    async comment(issue, body) {
+      calls.push(`comment #${issue} ${body.slice(0, 24)}`);
+    },
+    async editLabels(issue, remove, add) {
+      calls.push(`labels #${issue} -${remove.join(",")} +${add.join(",")}`);
+    },
+  };
+}
+
+describe("detecting a world that moved", () => {
+  it("names nothing when the claim is still held and the base has not moved", () => {
+    expect(detectZombieDisplacements({ ...watch(), baseNow: "0r1g1nsha" })).toEqual([]);
+    expect(zombieVerdict({ ...watch(), baseNow: "0r1g1nsha" })).toEqual({ zombie: false });
+  });
+
+  it("names every displacement, not the first", () => {
+    const verdict = zombieVerdict({
+      ...watch({ activeClaimOwners: [OTHER], concededClaimOwners: [OWNER], issueOpen: false }),
+      baseNow: "n3wb4sesha",
+    });
+
+    expect(verdict.zombie).toBe(true);
+    if (!verdict.zombie) return;
+    expect(verdict.displacements).toEqual([
+      "claim-released",
+      "claim-taken",
+      "base-moved",
+      "issue-closed",
+    ]);
+    for (const kind of ZOMBIE_DISPLACEMENTS) {
+      expect(verdict.message).toContain(ZOMBIE_DISPLACEMENT_REASONS[kind]);
+    }
+  });
+
+  it("does not compare a base the caller could not read", () => {
+    expect(detectZombieDisplacements({ ...watch(), baseNow: null })).toEqual([]);
+  });
+});
+
+describe("the landing precondition", () => {
+  it("judges nothing when the caller states no watch", async () => {
+    let calls = 0;
+    const refusal = await zombieLandingRefusal(
+      async () => {
+        calls += 1;
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      { repoDir: "/repo", remote: "origin", base: "main" },
+    );
+
+    expect(refusal).toBeNull();
+    expect(calls).toBe(0);
+  });
+
+  it("refuses a completion whose claim was released and whose base moved", async () => {
+    const refusal = await zombieLandingRefusal(
+      async () => ({ code: 0, stdout: "n3wb4sesha\n", stderr: "" }),
+      {
+        repoDir: "/repo",
+        remote: "origin",
+        base: "main",
+        zombieWatch: watch({ activeClaimOwners: [], concededClaimOwners: [OWNER] }),
+      },
+    );
+
+    expect(refusal).toContain(ZOMBIE_DISPLACEMENT_REASONS["claim-released"]);
+    expect(refusal).toContain(ZOMBIE_DISPLACEMENT_REASONS["base-moved"]);
+  });
+});
+
+describe("doLanding refuses a zombie completion (#4176)", () => {
+  it("lands nothing when the claim was released and the base generation moved", async () => {
+    const h = harness({ locked: false });
+    const r = await doLanding(
+      h.deps,
+      {
+        ...h.input,
+        zombieWatch: watch({
+          activeClaimOwners: [],
+          concededClaimOwners: [OWNER],
+          baseAtStart: "0ldb4sesha",
+        }),
+      },
+      h.hooks,
+    );
+
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("zombie");
+    expect(r.message).toContain(ZOMBIE_DISPLACEMENT_REASONS["claim-released"]);
+    expect(r.message).toContain(ZOMBIE_DISPLACEMENT_REASONS["base-moved"]);
+  });
+
+  it("is the ordinary landing when the world the Worker forked from held", async () => {
+    const h = harness({ locked: false });
+    const r = await doLanding(h.deps, { ...h.input, zombieWatch: watch() }, h.hooks);
+
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("where the salvage is addressed", () => {
+  it("parks the original Ticket with the evidence when it is still open and unheld", async () => {
+    const plan = planZombieReconciliation(
+      facts({ activeClaimOwners: [], concededClaimOwners: [OWNER], baseNow: "n3wb4sesha" }),
+    );
+
+    expect(plan).not.toBeNull();
+    if (plan == null) return;
+    expect(plan.landing).toBe("refused");
+    expect(plan.salvage).toBe("evidenced-park");
+    expect(plan.ticket).toBeUndefined();
+    expect(plan.park?.transition).toEqual({ kind: "human" });
+    expect(plan.park?.currentLabels).toEqual(["running", "ready-for-agent"]);
+    expect(plan.park?.comment).toContain("afk/wZ0MB1E/4176-zombie");
+    expect(plan.park?.comment).toContain("abcdef012345");
+    expect(plan.concede).toBeNull();
+  });
+
+  it("mints a reconciliation Ticket when the original is closed or claimed by another Worker", () => {
+    expect(zombieSalvageRoute(["claim-released"])).toBe("evidenced-park");
+    expect(zombieSalvageRoute(["issue-closed"])).toBe("reconciliation-ticket");
+    expect(zombieSalvageRoute(["claim-taken"])).toBe("reconciliation-ticket");
+
+    const plan = planZombieReconciliation(facts({ issueOpen: false }));
+
+    expect(plan?.salvage).toBe("reconciliation-ticket");
+    expect(plan?.park).toBeUndefined();
+    expect(plan?.ticket?.title).toContain("#4176");
+    expect(plan?.ticket?.body).toContain("nothing was landed");
+    expect(plan?.ticket?.body).toContain("afk/wZ0MB1E/4176-zombie");
+    // The Worker still holds its claim on a closed Ticket, so it is withdrawn.
+    expect(plan?.concede).toBe(OWNER);
+  });
+
+  it("plans nothing for a completion whose world did not move", () => {
+    expect(planZombieReconciliation(facts())).toBeNull();
+  });
+
+  it("leads the evidence with where the work is", () => {
+    const evidence = renderZombieEvidence(
+      facts({ activeClaimOwners: [OTHER], baseNow: "n3wb4sesha", issueOpen: false }),
+    );
+
+    expect(evidence.startsWith("branch=`afk/wZ0MB1E/4176-zombie`")).toBe(true);
+    expect(evidence).toContain("origin/main 0r1g1nsha → n3wb4sesha");
+    expect(evidence).toContain(OTHER);
+    expect(evidence).toContain("the Ticket is closed");
+  });
+});
+
+describe("executing one reconciliation", () => {
+  it("mints the Ticket, points the original at it, and lands nothing", async () => {
+    const plan = planZombieReconciliation(facts({ activeClaimOwners: [OWNER, OTHER] }))!;
+    const io = recordingIo();
+
+    const result = await executeZombieReconciliation(plan, io);
+
+    expect(result.landed).toBe(false);
+    expect(result.salvage).toBe("reconciliation-ticket");
+    expect(result.reconciliationIssue).toBe(4999);
+    expect(io.calls[0]).toBe(`concede #4176 ${OWNER}`);
+    expect(io.calls[1]).toContain("openTicket Reconcile salvaged work from #4176");
+    expect(io.calls[2]).toContain("comment #4176");
+  });
+
+  it("withdraws the claim before the labels move on a park", async () => {
+    const plan = planZombieReconciliation(facts({ baseNow: "n3wb4sesha" }))!;
+    const io = recordingIo();
+
+    const result = await executeZombieReconciliation(plan, io);
+
+    expect(result.landed).toBe(false);
+    expect(result.parkedIssue).toBe(4176);
+    expect(io.calls).toEqual([
+      `concede #4176 ${OWNER}`,
+      "labels #4176 -ready-for-agent,running +ready-for-human",
+      expect.stringContaining("comment #4176"),
+    ]);
+  });
+
+  it("reports a write it could not perform instead of throwing", async () => {
+    const plan = planZombieReconciliation(facts({ baseNow: "n3wb4sesha" }))!;
+    const io = recordingIo();
+    const result = await executeZombieReconciliation(plan, {
+      ...io,
+      async editLabels() {
+        throw new Error("the tracker refused");
+      },
+    });
+
+    expect(result.landed).toBe(false);
+    expect(result.failure).toBe("the tracker refused");
+  });
+});

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -219,6 +219,7 @@ import {
 import { replaceWithViableSuccessor } from "./takeover.js";
 import { createRemotePollDeadline } from "./remote-poll.js";
 import { createConfiguredRedskilledSelfPingMonitor } from "./self-ping.js";
+import { appendSyntheticPostmortem } from "./synthetic-postmortem.js";
 import { resolveUnitDeath } from "./unit-death.js";
 // Error moved to ./daemon/errors.ts — keep re-export for backward compat
 export { RedskilledAlreadyRunningError } from "../daemon/errors.js";
@@ -1574,7 +1575,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       forgetWorker(worker.worker_id);
       const pgid = worker.pgid ?? worker.pid;
       record("worker-death", worker, confirmed ? detail : `${detail}; unconfirmed-stop: the host did not confirm ` +
-        `process group ${pgid} stopped, so process group ${pgid} may still be alive`);
+        `process group ${pgid} stopped, so process group ${pgid} may still be alive`, { deliberate: true });
     });
     return true;
   }
@@ -1738,9 +1739,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         announce: (line) => process.stderr.write(line),
       });
     }
-    void eventLane
-      .recordWorker(input)
-      .catch(() => undefined);
+    void eventLane.recordWorker(input).catch(() => undefined);
+    appendSyntheticPostmortem((row) => void eventLane.recordWorker(row).catch(() => undefined), input);
     projectHooks.onEvent(kind, worker);
     hostEventSinks.onEvent(kind, worker);
   }
@@ -2461,7 +2461,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       const worker = workers.get(workerId);
       const removed = worker != null;
       if (worker != null) forgetWorker(workerId);
-      if (worker) record("worker-death", worker, "released by the daemon");
+      if (worker) record("worker-death", worker, "released by the daemon", { deliberate: true });
       return removed;
     },
     workerCount: () => workers.size,

--- a/apps/redskilled/src/daemon/synthetic-postmortem.ts
+++ b/apps/redskilled/src/daemon/synthetic-postmortem.ts
@@ -1,0 +1,179 @@
+/**
+ * synthetic-postmortem — a Worker that ends without saying goodbye still leaves
+ * a story (ADR 0155, Spec #4164, #4176).
+ *
+ * **A death nothing explains is a death nobody can act on.** #4133 put the unit
+ * receipt onto the worker-death record as facts, and #4136 taught the checkout
+ * to spend those facts on a claim. Both halves work only when the receipt NAMES
+ * a sender: an unattributed SIGKILL, a Worker the host simply stopped
+ * confirming, a unit systemd retained no exit details for — all three reach the
+ * lane as `sender_class: unknown`, which the checkout deliberately DEFERS to a
+ * staleness clock. That deferral is correct and it is also the moment the
+ * failure story evaporates: the row says a Worker died and nothing else, so the
+ * only account of what happened lives in whoever was watching.
+ *
+ * **So the daemon writes the account the Worker never got to write.** A silent
+ * death appends a SECOND row, `worker-postmortem`, beside the death it explains:
+ * the failure mode as a structured field, and every last thing the daemon held
+ * about that Worker rendered into one line — when it was born, what its tree had
+ * burned, the ceiling it ran under, the signal or receipt if either spoke, and
+ * the path to the narration it left behind. Synthetic because nobody witnessed
+ * it: the row is assembled from what the host retained, and it says so.
+ *
+ * **Facts only; the join is still the checkout's.** ADR 0130/0144 keep the
+ * daemon ignorant of what a Ticket, a label or a tracker is. This row is keyed
+ * by `worker_id` exactly as the death it accompanies, rides the daemon's own
+ * registered event lane, and decides nothing about recovery — the boundary is
+ * enforced mechanically by `daemon-death-evidence-guard`.
+ */
+import type { RecordWorkerEventInput } from "../event-lane.js";
+import type { RedskilledWorkerView } from "../host-state.js";
+
+/**
+ * What the host can tell about a death nobody explained.
+ *
+ * Three of the five are spelled exactly as the Worker failure retry classes
+ * (#4175) so a checkout routes on the word without a translation table; the
+ * other two name what only a host-scoped observer can see and no error text ever
+ * carries — a process that vanished between two liveness probes, and a kill
+ * whose signal named no sender.
+ */
+export const SILENT_DEATH_FAILURE_MODES = [
+  "oom",
+  "cap-hit",
+  "unattributed-kill",
+  "host-vanished",
+  "unknown",
+] as const;
+
+export type SilentDeathFailureMode = (typeof SILENT_DEATH_FAILURE_MODES)[number];
+
+/** The death-record fields the postmortem turns on; every one may be absent. */
+export type SilentDeathEvidence = Pick<
+  RecordWorkerEventInput,
+  | "deliberate"
+  | "senderClass"
+  | "confidence"
+  | "exitCode"
+  | "signal"
+  | "systemdResult"
+  | "memoryPeakBytes"
+  | "memorySwapPeakBytes"
+  | "journalTail"
+>;
+
+/**
+ * Did this death explain itself? PURE.
+ *
+ * The complement of the checkout's `deathVerdictIsActionable` on purpose: a
+ * death the sweep can act on already carries its own account, and a second row
+ * restating it would be noise. What is left is exactly the set the sweep defers
+ * — no exit status of its own, and no sender named at a confidence anyone would
+ * spend a claim on — which is the set whose story would otherwise be lost. A
+ * death the DAEMON decided on is excluded outright: the decider is the account.
+ */
+export function deathWasSilent(evidence: SilentDeathEvidence): boolean {
+  if (evidence.deliberate === true) return false;
+  if (evidence.exitCode != null) return false;
+  const sender = evidence.senderClass ?? null;
+  if (sender === null || sender === "unknown") return true;
+  return evidence.confidence !== "high" && evidence.confidence !== "medium";
+}
+
+/**
+ * Name the failure mode from whatever the host retained. PURE.
+ *
+ * The order is the order of authority: a memory verdict first, because it is the
+ * only one a kernel writes down; then the supervisor's own timeout, which is a
+ * cap by another name; then a signal, which names an act and no author; then the
+ * absence of every receipt at once, which is its own finding — a Worker the host
+ * stopped confirming with nothing retained about how it went.
+ */
+export function classifySilentDeath(evidence: SilentDeathEvidence): SilentDeathFailureMode {
+  const result = evidence.systemdResult ?? null;
+  const signal = evidence.signal ?? null;
+  if (result === "oom-kill" || evidence.senderClass === "oomd") return "oom";
+  if (result === "timeout" || result === "watchdog") return "cap-hit";
+  if (signal != null) return "unattributed-kill";
+  if (result === null && evidence.exitCode == null) return "host-vanished";
+  return "unknown";
+}
+
+/**
+ * Every last thing the daemon held about this Worker, in one line. PURE.
+ *
+ * The whole value of a postmortem is that a reader who was not watching can
+ * still start somewhere, so the line ends with the pointer rather than the
+ * summary: `log=` is the narration the Worker itself wrote, and it is the only
+ * field here the daemon did not derive.
+ */
+export function renderLastEvidence(
+  worker: RedskilledWorkerView,
+  evidence: SilentDeathEvidence,
+): string {
+  const parts = [`born=${worker.started_at}`];
+  if (worker.cpu != null) {
+    parts.push(`cpu=${worker.cpu.cpu_seconds.toFixed(1)}s at ${worker.cpu.sampled_at}`);
+  }
+  if (evidence.signal != null) parts.push(`signal=${evidence.signal}`);
+  if (evidence.systemdResult != null) parts.push(`systemd result=${evidence.systemdResult}`);
+  if (evidence.memoryPeakBytes != null) parts.push(`memory peak=${formatGib(evidence.memoryPeakBytes)}`);
+  const ceiling = worker.memory_ceiling ?? worker.applied_budget?.memory_max ?? null;
+  if (ceiling != null) parts.push(`ceiling=${ceiling}`);
+  if (worker.warnings.length > 0) parts.push(`warnings: ${worker.warnings.join(", ")}`);
+  const tail = lastLineOf(evidence.journalTail);
+  if (tail != null) parts.push(`journal: ${tail}`);
+  parts.push(`log=${worker.log_path ?? "unrecorded"}`);
+  return parts.join("; ");
+}
+
+/**
+ * The postmortem row a silent death earns, or `null` when the death spoke.
+ *
+ * It is built FROM the death record rather than beside it, so every fact the
+ * receipt carried rides the postmortem too and a reader never has to join the
+ * two rows back together to learn what the host saw.
+ */
+export function planSyntheticPostmortem(
+  death: RecordWorkerEventInput,
+): RecordWorkerEventInput | null {
+  if (death.kind !== "worker-death") return null;
+  if (!deathWasSilent(death)) return null;
+  const failureMode = classifySilentDeath(death);
+  return {
+    ...death,
+    kind: "worker-postmortem",
+    failureMode,
+    detail: `synthetic postmortem: failure-mode=${failureMode}; ${renderLastEvidence(death.worker, death)}`,
+  };
+}
+
+/**
+ * Append the postmortem this death earns, if it earns one.
+ *
+ * The one entrance the daemon uses, so the question "is this death silent?" is
+ * asked in exactly one place and every future path that ends a Worker inherits
+ * the answer rather than restating it.
+ */
+export function appendSyntheticPostmortem(
+  append: (postmortem: RecordWorkerEventInput) => void,
+  death: RecordWorkerEventInput,
+): void {
+  const postmortem = planSyntheticPostmortem(death);
+  if (postmortem != null) append(postmortem);
+}
+
+/** Longest journal fragment a postmortem line carries; the rest is in the unit. */
+const JOURNAL_TAIL_BUDGET = 200;
+
+function lastLineOf(text: string | null | undefined): string | null {
+  if (text == null) return null;
+  const lines = text.split("\n").map((line) => line.trim()).filter((line) => line !== "");
+  const last = lines[lines.length - 1];
+  if (last === undefined) return null;
+  return last.length <= JOURNAL_TAIL_BUDGET ? last : `${last.slice(0, JOURNAL_TAIL_BUDGET)}…`;
+}
+
+function formatGib(bytes: number): string {
+  return `${(bytes / 1024 ** 3).toFixed(2)} GiB`;
+}

--- a/apps/redskilled/src/event-lane-decode.ts
+++ b/apps/redskilled/src/event-lane-decode.ts
@@ -82,6 +82,7 @@ export function decodeHostEventRow(record: ToonlRecord): RedskilledHostEvent {
     base_head_sha: text(record.base_head_sha),
     base_commits_ahead: numberOrNull(record.base_commits_ahead),
     heal_kind: text(record.heal_kind),
+    failure_mode: text(record.failure_mode),
     detail: text(record.detail),
     // Legacy rows read exit facts as absent, never as a clean zero exit.
     exit_code: numberOrNull(record.exit_code),

--- a/apps/redskilled/src/event-lane.ts
+++ b/apps/redskilled/src/event-lane.ts
@@ -93,7 +93,8 @@ export type RedskilledWorkerEventKind =
   | "worker-budget-verdict"
   | "worker-budget-grace"
   | "worker-death"
-  | "worker-budget-kill";
+  | "worker-budget-kill"
+  | "worker-postmortem";
 
 export const REDSKILLED_WORKER_EVENT_KINDS = [
   "worker-birth",
@@ -106,6 +107,7 @@ export const REDSKILLED_WORKER_EVENT_KINDS = [
   "worker-budget-grace",
   "worker-death",
   "worker-budget-kill",
+  "worker-postmortem",
 ] as const as readonly [
   "worker-birth",
   "worker-activity",
@@ -117,6 +119,7 @@ export const REDSKILLED_WORKER_EVENT_KINDS = [
   "worker-budget-grace",
   "worker-death",
   "worker-budget-kill",
+  "worker-postmortem",
 ] & {
   includes(
     searchElement:
@@ -217,6 +220,14 @@ export interface RedskilledHostEvent {
   readonly base_commits_ahead: number | null;
   /** Mechanical cure applied on a heal record. */
   readonly heal_kind: string | null;
+  /**
+   * The named failure mode on a synthetic postmortem; absent on every other row.
+   *
+   * Carried STRUCTURALLY beside `detail` for the same reason `sender_class` is:
+   * a reader routes on this word, and one that recovered it by parsing the
+   * daemon's sentence would break the day the sentence was reworded.
+   */
+  readonly failure_mode?: string | null;
   /** Why, for a death or a kill: an exit status, a signal, a budget verdict. */
   readonly detail: string | null;
   /**
@@ -328,6 +339,17 @@ export interface RecordWorkerEventInput {
   readonly baseHeadSha?: string | null;
   readonly baseCommitsAhead?: number | null;
   readonly healKind?: string | null;
+  /** The named failure mode a synthetic postmortem carries (#4176). */
+  readonly failureMode?: string | null;
+  /**
+   * The daemon itself ended this Worker, so the death explains itself (#4176).
+   *
+   * Steers the synthetic postmortem and is never written to the row: it is a
+   * fact about WHO decided, which the deciding call site is the only one that
+   * holds, and a row that carried it would invite a reader to re-derive intent
+   * from a boolean instead of from the kind.
+   */
+  readonly deliberate?: boolean;
 }
 
 /** One positive-depth project the demand loop deliberately did not birth for. */
@@ -371,6 +393,7 @@ export function buildHostEvent(input: RecordEventInput | RecordWorkerEventInput)
     base_head_sha: "baseHeadSha" in input ? input.baseHeadSha ?? null : null,
     base_commits_ahead: "baseCommitsAhead" in input ? input.baseCommitsAhead ?? null : null,
     heal_kind: "healKind" in input ? input.healKind ?? null : null,
+    failure_mode: "failureMode" in input ? input.failureMode ?? null : null,
     detail: input.detail ?? null,
     exit_code: input.exitCode ?? null,
     signal: input.signal ?? null,

--- a/apps/redskilled/tests/daemon-reattach-survivor.test.ts
+++ b/apps/redskilled/tests/daemon-reattach-survivor.test.ts
@@ -330,8 +330,10 @@ describe("a launch client that dies is not a Worker that died", () => {
 
     expect(daemon.workerCount()).toBe(0);
     const events = await readRedskilledEvents(paths.eventLanePath);
-    expect(events.map((event) => event.event)).toEqual(["worker-birth", "worker-death"]);
+    // The kill named no sender, so the death is silent and earns a postmortem (#4176).
+    expect(events.map((event) => event.event)).toEqual(["worker-birth", "worker-death", "worker-postmortem"]);
     expect(events[1]!.signal).toBe("SIGKILL");
+    expect(events[2]).toMatchObject({ failure_mode: "unattributed-kill" });
   });
 });
 

--- a/apps/redskilled/tests/daemon-restart.test.ts
+++ b/apps/redskilled/tests/daemon-restart.test.ts
@@ -143,9 +143,11 @@ describe("a daemon restart re-attaches to its live Workers", () => {
 
     expect(daemon.workerCount()).toBe(0);
     const events = await readRedskilledEvents(paths.eventLanePath);
-    expect(events.map((event) => event.event)).toEqual(["worker-birth", "worker-death"]);
+    // Nothing witnessed the end, so the death carries a postmortem too (#4176).
+    expect(events.map((event) => event.event)).toEqual(["worker-birth", "worker-death", "worker-postmortem"]);
     expect(events[1]!.worker_id).toBe("w-gone");
     expect(events[1]!.detail).toMatch(/no daemon was watching/);
+    expect(events[2]).toMatchObject({ worker_id: "w-gone", failure_mode: "host-vanished" });
   });
 });
 
@@ -387,7 +389,10 @@ describe("a sweep retires a re-attached Worker the host stopped confirming", () 
     expect(retired.map((worker) => worker.worker_id)).toEqual(["w-fading"]);
     expect(daemon.workerCount()).toBe(0);
     const events = await readRedskilledEvents(paths.eventLanePath);
-    expect(events.at(-1)!.event).toBe("worker-death");
+    expect(events.map((event) => event.event)).toContain("worker-death");
+    // A Worker the host stopped confirming died silently (#4176).
+    expect(events.at(-1)!.event).toBe("worker-postmortem");
+    expect(events.at(-1)!.detail).toContain("failure-mode=");
   });
 });
 

--- a/apps/redskilled/tests/dead-record-reaping.test.ts
+++ b/apps/redskilled/tests/dead-record-reaping.test.ts
@@ -78,7 +78,10 @@ describe("a record whose Worker is gone is reaped on the liveness sweep", () => 
     // No restart was needed, and the slot is free.
     expect(daemon.workerCount()).toBe(0);
     const events = await readRedskilledEvents(paths.eventLanePath);
-    expect(events.at(-1)!.event).toBe("worker-death");
+    expect(events.map((event) => event.event)).toContain("worker-death");
+    // A reaped record is a death nobody witnessed, so it carries a postmortem (#4176).
+    expect(events.at(-1)!.event).toBe("worker-postmortem");
+    expect(events.at(-1)!.detail).toContain("failure-mode=");
   });
 
   it("frees the slot before the birth decision, not only when the machine idles", async () => {

--- a/apps/redskilled/tests/death-evidence.test.ts
+++ b/apps/redskilled/tests/death-evidence.test.ts
@@ -1,8 +1,26 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { LANE_RETENTION_REGISTRY } from "@reddb-io/shared/lane-retention.js";
 import { describe, expect, it } from "vitest";
 
 import { observedWorkerDeath } from "../src/daemon/tunables.js";
 import { classifyUnitDeath, resolveUnitDeath } from "../src/daemon/unit-death.js";
-import { buildHostEvent } from "../src/event-lane.js";
+import {
+  appendSyntheticPostmortem,
+  classifySilentDeath,
+  deathWasSilent,
+  planSyntheticPostmortem,
+  renderLastEvidence,
+  SILENT_DEATH_FAILURE_MODES,
+} from "../src/daemon/synthetic-postmortem.js";
+import {
+  buildHostEvent,
+  createRedskilledEventLane,
+  REDSKILLED_EVENT_LANE_FILE,
+  type RecordWorkerEventInput,
+} from "../src/event-lane.js";
 import { decodeHostEventRow } from "../src/event-lane-decode.js";
 import type { RedskilledWorkerView } from "../src/host-state.js";
 import type { RedskilledUnitExitFacts } from "../src/reattach.js";
@@ -184,5 +202,111 @@ describe("the surfaces read the carried verdict rather than deriving a second on
     const record = await deathRecord(receipt({ systemd_result: "success", exit_code: 0 }));
 
     expect(observedWorkerDeath(record)).toBeNull();
+  });
+});
+
+// #4176: a death that explains nothing leaves a synthetic postmortem beside it.
+// The rows the checkout can ACT on already carry their own account; what is left
+// is exactly the set the sweep defers, and that set's failure story would
+// otherwise live only in whoever happened to be watching.
+
+const silentWorker: RedskilledWorkerView = {
+  ...worker,
+  log_path: "/tmp/worker/worker.log.toonl",
+  memory_ceiling: "6G",
+  cpu: { cpu_seconds: 812.35, sampled_at: "2026-08-20T12:29:00.000Z" },
+  warnings: ["placement downgraded to unisolated"],
+};
+
+function death(facts: Partial<RecordWorkerEventInput> = {}): RecordWorkerEventInput {
+  return {
+    kind: "worker-death",
+    worker: silentWorker,
+    ts: "2026-08-20T12:30:00.000Z",
+    detail: "the host no longer confirms this Worker",
+    ...facts,
+  };
+}
+
+describe("a silent death leaves the account the Worker never wrote", () => {
+  it("names the failure mode and the last evidence on a Worker the host stopped confirming", () => {
+    const postmortem = planSyntheticPostmortem(death());
+
+    expect(postmortem).not.toBeNull();
+    expect(postmortem!.kind).toBe("worker-postmortem");
+    expect(postmortem!.failureMode).toBe("host-vanished");
+    expect(postmortem!.detail).toContain("failure-mode=host-vanished");
+    expect(postmortem!.detail).toContain("born=2026-08-20T12:00:00.000Z");
+    expect(postmortem!.detail).toContain("cpu=812.4s at 2026-08-20T12:29:00.000Z");
+    expect(postmortem!.detail).toContain("ceiling=6G");
+    expect(postmortem!.detail).toContain("placement downgraded to unisolated");
+    expect(postmortem!.detail).toContain("log=/tmp/worker/worker.log.toonl");
+  });
+
+  it("reads an unattributed SIGKILL as a kill nobody signed, and quotes the journal", () => {
+    const postmortem = planSyntheticPostmortem(death({
+      signal: "SIGKILL",
+      senderClass: "unknown",
+      confidence: "low",
+      journalTail: "Started red-worker-wD34TH.service.\nMain process exited, code=killed, status=9/KILL",
+    }));
+
+    expect(postmortem!.failureMode).toBe("unattributed-kill");
+    expect(postmortem!.detail).toContain("signal=SIGKILL");
+    expect(postmortem!.detail).toContain("journal: Main process exited, code=killed, status=9/KILL");
+    // Every fact the death record carried rides the postmortem too, so a reader
+    // never has to join the two rows back together.
+    expect(postmortem!.senderClass).toBe("unknown");
+  });
+
+  it("stays silent for a death that already explains itself", () => {
+    expect(planSyntheticPostmortem(death({ exitCode: 0 }))).toBeNull();
+    expect(
+      planSyntheticPostmortem(death({ signal: "SIGTERM", senderClass: "user-signal", confidence: "high" })),
+    ).toBeNull();
+    expect(planSyntheticPostmortem({ ...death(), kind: "worker-birth" })).toBeNull();
+  });
+
+  it("classifies the modes a host can name, and admits when it cannot", () => {
+    expect(classifySilentDeath({ systemdResult: "oom-kill" })).toBe("oom");
+    expect(classifySilentDeath({ senderClass: "oomd" })).toBe("oom");
+    expect(classifySilentDeath({ systemdResult: "timeout" })).toBe("cap-hit");
+    expect(classifySilentDeath({ systemdResult: "watchdog" })).toBe("cap-hit");
+    expect(classifySilentDeath({ signal: "SIGKILL" })).toBe("unattributed-kill");
+    expect(classifySilentDeath({})).toBe("host-vanished");
+    expect(classifySilentDeath({ systemdResult: "exit-code", exitCode: 3 })).toBe("unknown");
+    expect(deathWasSilent({ exitCode: 0 })).toBe(false);
+    expect(deathWasSilent({ senderClass: "oomd", confidence: "high" })).toBe(false);
+    expect(deathWasSilent({})).toBe(true);
+    for (const mode of SILENT_DEATH_FAILURE_MODES) expect(typeof mode).toBe("string");
+    expect(renderLastEvidence(worker, {})).toContain("log=unrecorded");
+    const appended: RecordWorkerEventInput[] = [];
+    appendSyntheticPostmortem((row) => appended.push(row), death());
+    appendSyntheticPostmortem((row) => appended.push(row), death({ exitCode: 0 }));
+    expect(appended.map((row) => row.kind)).toEqual(["worker-postmortem"]);
+  });
+
+  it("rides the daemon's own registered lane, structured field and all", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-postmortem-"));
+    const path = join(root, REDSKILLED_EVENT_LANE_FILE);
+    try {
+      const lane = createRedskilledEventLane(path);
+      await lane.recordWorker(death());
+      await lane.recordWorker(planSyntheticPostmortem(death())!);
+      const rows = await createRedskilledEventLane(path).read();
+
+      expect(rows.map((row) => row.kind)).toEqual(["worker-death", "worker-postmortem"]);
+      expect(rows[1]).toMatchObject({ worker_id: "wD34TH", failure_mode: "host-vanished" });
+      expect(rows[1]!.detail).toContain("failure-mode=host-vanished");
+      expect(LANE_RETENTION_REGISTRY["redskilled-events"].maxBytes).toBeGreaterThan(0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the decoded field honest for a row written before the mode existed", () => {
+    const legacy = decodeHostEventRow({ ts: "2026-08-20T12:30:00.000Z", kind: "worker-death", worker_id: "wD34TH" });
+
+    expect(legacy.failure_mode).toBeNull();
   });
 });

--- a/apps/redskilled/tests/event-lane-query.test.ts
+++ b/apps/redskilled/tests/event-lane-query.test.ts
@@ -86,6 +86,8 @@ function workerEvent(kind: RecordWorkerEventInput["kind"]): RecordWorkerEventInp
       return { ...common, exitCode: 0 };
     case "worker-budget-kill":
       return { ...common, detail: "host memory high-water mark exceeded", signal: "SIGKILL" };
+    case "worker-postmortem":
+      return { ...common, failureMode: "host-vanished", detail: "synthetic postmortem: failure-mode=host-vanished" };
   }
 }
 

--- a/apps/redskilled/tests/public-host-event-contract.test.ts
+++ b/apps/redskilled/tests/public-host-event-contract.test.ts
@@ -17,6 +17,7 @@ const PUBLIC_HOST_EVENT_FIELDS = [
   "detail",
   "event",
   "exit_code",
+  "failure_mode",
   "fork_sha",
   "heal_kind",
   "isolated",


### PR DESCRIPTION
Fixes #4176

Spec #4164's drain hardening, second half. #4175 declared the retry-by-failure-mode table; the two failures it cannot classify are a Worker that comes back after the world moved, and one that never comes back at all.

## Zombie reconciliation

Between the moment a Worker takes a claim and the moment it announces a branch, the claim can be conceded by the staleness sweep, released eagerly by the death sweep (#4136) or taken by another Worker; the Ticket can be closed by somebody else's PR; and `origin/<base>` can advance past the generation it forked from. Nothing on the landing path asked. `doLanding` checked whether the branch was pushable and whether its head still matched the SHA the gate validated (#4134) — never whether the WORK was still wanted — so a zombie's push landed on a Ticket that had moved on, and the queue learned about it from the merge.

`apps/plugin-dev/src/core/zombie-reconciliation.ts` declares the four displacements (`claim-released`, `claim-taken`, `base-moved`, `issue-closed`) and refuses the landing by name with a new `zombie` result reason, symmetric to `stale-head`. The check is opt-in through one `zombieWatch` input, because only a caller that knows the world at the fork can say whether it moved, and a default answer of "zombie" would refuse every landing in the repo.

Nothing a zombie produced is landed. Salvage travels through the tracker instead:

- **a reconciliation Ticket** when the original is no longer ours to write — closed, or claimed by another Worker. It carries the branch, the head SHA and the displacement, and enters triage like any other demand.
- **an evidenced park** when the original is still open and unheld, planned through `transitionLabels` so the one-state-role invariant is proven rather than hand-composed.

The choice is about WHERE the salvage is addressed, never about whether the merge may proceed.

## Synthetic postmortems

#4133 put the unit receipt on the death record and #4136 spent it on a claim, but both work only when the receipt NAMES a sender. An unattributed SIGKILL, a Worker the host stopped confirming, a unit systemd retained no exit details for — all reach the lane as `sender_class: unknown`, which the checkout deliberately defers to a staleness clock. That deferral is correct, and it is also where the failure story evaporated: the row said a Worker died and nothing else.

`apps/redskilled/src/daemon/synthetic-postmortem.ts` appends a second `worker-postmortem` row beside such a death on the daemon's already-registered event lane (`redskilled-events`; no new lane, so the four-way retention obligations are unchanged), carrying:

- the failure mode as a structured `failure_mode` field — `oom`, `cap-hit` and `unknown` spelled exactly as #4175's retry classes so a checkout routes on the word without a translation table, plus `unattributed-kill` and `host-vanished` for what only a host-scoped observer can see;
- the last evidence in one line: birth, CPU burned, ceiling, signal or receipt, journal tail, and the path to the Worker's own narration.

A death the DAEMON decided on is excluded outright (`deliberate`, an input-only flag that never reaches the row): a stop the operator asked for and a release the daemon performed are already accounted, and the decider is the account. The row stays keyed by `worker_id` and decides nothing about recovery — ADR 0130/0144 keep the daemon ignorant of Tickets, labels and trackers, and `daemon-death-evidence-guard` still proves it.

The public host-event field set widens by one — additive, and `failure_mode` decodes as `null` on every row written before it existed.

## Acceptance criteria

- [x] A simulated zombie completion (claim released, base moved) lands nothing and produces a reconciliation Ticket or an evidenced park — `apps/plugin-dev/tests/zombie-reconciliation.test.ts` drives both through `doLanding` and through the planner/executor.
- [x] A simulated silent death leaves a postmortem row naming the failure mode and last evidence — `apps/redskilled/tests/death-evidence.test.ts`, plus the three daemon suites that now observe the row on a real lane (reaped record, restart replay, liveness sweep).
- [x] The evidence rows live in registered lanes and the lane-retention guard stays green — no new lane; the postmortem rides `redskilled-events`.

## Validation

- `pnpm typecheck` — 17/17 green.
- `pnpm -C apps/plugin-dev test:invariants` — 388/388 green (file-size, complexity-coverage, dependency-direction, lane-retention, daemon-death-evidence, declared waits).
- `pnpm -C apps/plugin-dev test` — 5808/5808 green.
- `pnpm -C apps/redskilled test` — 18 failures, all pre-existing on `main`: the 16 known reds, plus `acp-body-control-cut` (undeclared `retry-policy.ts` from #4175, in `packages/worker`, untouched here) and a flaky `ENOTEMPTY` tmp-cleanup race in `github-custody-armed-head` that passes in isolation.
- `pnpm lint` — clean.

`landing.ts` stays exactly at its file-size baseline (1181) and `lifecycle.ts` under its (2482 ≤ 2483): the wiring is paid for by compressing prose, and every new decision lives in a new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789896901&installation_model_id=20659&pr_number=4264&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4264&signature=efa8fed718072c088532e212f275465c433c35b5935998d393653184fc845138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->