### PR TITLE
fix(redskilled): the body cut declares retry-policy.ts

### DIFF
--- a/.changeset/body-cut-declares-retry-policy.md
+++ b/.changeset/body-cut-declares-retry-policy.md
@@ -1,0 +1,8 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The Worker body cut declares the retry-policy module. #4175 (landed by an
+autonomous Worker) added `retry-policy.ts` to the Worker's ACP directory
+without the body-control-cut declaration, so the cut's own suite was red on
+main. The module is declared with what it defines and why it runs in the body.

--- a/apps/redskilled/src/acp-body-control-cut.ts
+++ b/apps/redskilled/src/acp-body-control-cut.ts
@@ -109,6 +109,11 @@ export const WORKER_BODY_MODULES: readonly WorkerBodyModule[] = [
     runs: "drives one Ticket from claim to land inside the turn: claim, implement, gate, re-seed in place, publish, land",
   },
   {
+    module: "retry-policy.ts",
+    defines: ["WORKER_FAILURE_RETRY_CLASSES", "WORKER_FAILURE_RETRY_TABLE"],
+    runs: "bounds every retry by its declared failure mode (#4175): the table decides how many times and with what remedy a failed round re-enters",
+  },
+  {
     module: "gate-lock.ts",
     defines: ["acquireHostGateLock"],
     runs: "holds the host-wide slot that keeps two Workers from running Validation at the same time (#4161)",


### PR DESCRIPTION
The autonomous landing of #4175 added `packages/worker/src/acp/retry-policy.ts` without the body-control-cut declaration, leaving `acp-body-control-cut.test.ts` red on main. One declaration entry; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789899893&installation_model_id=20659&pr_number=4269&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4269&signature=190eaf7b7afac4bf4291e377f165caf9b013c90e5653127c8ef0bf1352d85e63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->