### PR TITLE
fix(redskilled): the birth breaker reads a one-shot sink completion as a completion

### DIFF
--- a/.changeset/oneshot-sink-breaker.md
+++ b/.changeset/oneshot-sink-breaker.md
@@ -1,0 +1,10 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The birth breaker reads a one-shot sink completion as a completion. A
+host-event hook runs for seconds and exits 0 — that clean exit IS its whole
+report — but the breaker demanded the queue protocol's promise sentinel, so
+three events inside a minute armed the crash-loop latch forever on any host
+with a hook declared. A clean exit from the host-events project now counts as
+work-reported; a hook that genuinely fails still surfaces.

--- a/apps/redskilled/src/daemon/birth-outcome.ts
+++ b/apps/redskilled/src/daemon/birth-outcome.ts
@@ -38,8 +38,17 @@ export function workerTerminalOutcome(input: {
   readonly exitCode: number | null;
   readonly signal: string | null;
   readonly tail: string | null;
+  /**
+   * A one-shot sink Worker (#4266): a host-event hook or notification runs for
+   * seconds and exits — a clean exit IS its whole report, and demanding the
+   * `<promise>` sentinel of the queue protocol read every completion as a
+   * premature death, so three events inside a minute armed the breaker forever
+   * on any host with a hook declared.
+   */
+  readonly oneShot?: boolean;
 }): RedskilledWorkerBirthOutcome {
   if (input.exitCode !== 0 || input.signal != null) return "unreported";
+  if (input.oneShot === true) return "work-reported";
   const sentinel = input.tail?.match(/<promise>\s*(DONE|BLOCKED|NO MORE TASKS)\s*<\/promise>/i)?.[1];
   if (sentinel == null) return "unreported";
   return sentinel.toUpperCase() === "NO MORE TASKS" ? "no-eligible-work" : "work-reported";

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -96,7 +96,7 @@ import {
 } from "../project-registration.js";
 import { createRedskilledProjectHookRuntime } from "../project-hook.js";
 import { meteredRedskilledEventLane, redskilledMetrics } from "../telemetry-metrics.js";
-import { createRedskilledHostEventSinkRuntime } from "../host-event-sink.js";
+import { createRedskilledHostEventSinkRuntime, REDSKILLED_HOST_EVENT_PROJECT } from "../host-event-sink.js";
 import { detectRedskilledHostTopology } from "../host-topology.js";
 import { pingAnswer } from "./ping-answer.js";
 import {
@@ -1368,7 +1368,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     const reported = tail ?? logLines.get(worker.worker_id)?.line ?? null;
     forgetWorker(worker.worker_id);
     record("worker-death", worker, refusal == null ? death.detail : `session-error: ${refusal}`, {
-      ...death.facts, refusal, birthOutcome: workerTerminalOutcome({ exitCode: code, signal, tail: reported }),
+      ...death.facts, refusal, birthOutcome: workerTerminalOutcome({ exitCode: code, signal, tail: reported,
+        oneShot: worker.project_label === REDSKILLED_HOST_EVENT_PROJECT }),
     });
   }
 

--- a/apps/redskilled/tests/birth-breaker.test.ts
+++ b/apps/redskilled/tests/birth-breaker.test.ts
@@ -38,6 +38,26 @@ function streak(n: number, lifetimeMs: number, nowMs = NOW_MS) {
   return health;
 }
 
+describe("one-shot sink Workers and the breaker (#4266)", () => {
+  it("reads a clean one-shot exit as a completion, sentinel or not", () => {
+    expect(workerTerminalOutcome({ exitCode: 0, signal: null, tail: null, oneShot: true }))
+      .toBe("work-reported");
+    expect(workerTerminalOutcome({ exitCode: 0, signal: null, tail: "removed 1 superseded redwall(s)", oneShot: true }))
+      .toBe("work-reported");
+  });
+
+  it("still surfaces a hook that genuinely failed", () => {
+    expect(workerTerminalOutcome({ exitCode: 1, signal: null, tail: null, oneShot: true })).toBe("unreported");
+    expect(workerTerminalOutcome({ exitCode: null, signal: "SIGKILL", tail: null, oneShot: true })).toBe("unreported");
+  });
+
+  it("changes nothing for demand Workers, which still owe the sentinel", () => {
+    expect(workerTerminalOutcome({ exitCode: 0, signal: null, tail: null })).toBe("unreported");
+    expect(workerTerminalOutcome({ exitCode: 0, signal: null, tail: "<promise>DONE</promise>" }))
+      .toBe("work-reported");
+  });
+});
+
 describe("foldWorkerDeath", () => {
   it("does not halt before the streak completes", () => {
     const health = streak(REDSKILLED_SHORT_LIFE_STREAK - 1, 13_000);


### PR DESCRIPTION
A declared host-event hook is one-shot: seconds of work, exit 0, done. `workerTerminalOutcome` demanded the queue protocol's `<promise>` sentinel, so every completed hook run read as a premature death, the crash-loop latch armed after three events in a minute, and the journal cycled `lost 3 Workers in a row` forever on any host with a hook declared.

Workers of `redskilled/host-events` now carry `oneShot` at the outcome read: exit 0 = `work-reported` (sentinel or not); non-zero/signal still `unreported` (a genuinely failing hook surfaces); demand Workers still owe the sentinel. `lifecycle.ts` stays at 2483 = its cap.

Fixes #4266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789900634&installation_model_id=20659&pr_number=4270&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4270&signature=9609f4aaee73ae4b39ac0c4408638e0787a4def16f7c832cfe3a74e87285c2ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->