### PR TITLE
fix(redskilled): every Agent declares its unattended posture, and opencode gets its own DB

### DIFF
--- a/.changeset/every-runner-postured.md
+++ b/.changeset/every-runner-postured.md
@@ -1,0 +1,25 @@
+---
+"@reddb-io/redskilled": patch
+"@reddb-io/protocol-acp": patch
+"@reddb-io/worker": patch
+"@reddb-io/red-skills-dev": patch
+---
+
+Every catalog Agent declares its unattended posture, and opencode gets its own DB
+
+Admission is generic, but only two of the five Agents could actually finish a
+turn: claude-code and pi had no unattended posture declared at all, and opencode
+had neither a posture nor per-Worker DB isolation despite using `opencode.db` —
+the exact file redcode#58 is about.
+
+`unattendedPosture` is now a REQUIRED descriptor field, so a sixth Agent cannot
+land unpostured, and the conformance matrix pins the table against the catalog
+in both directions. The postures were probed, not guessed: claude-code-acp
+parses no argv at all, so its posture is the ACP session mode `bypassPermissions`
+(observed live: two refused permission requests and a dead turn on defaults;
+zero requests, `end_turn` and the file written with the mode set), which now
+travels on the endpoint and is applied by the Worker right after `session/new`.
+pi-acp accepts exactly one argument, `--terminal-login`, and never routes a tool
+call through a permission request, so it is `none-needed` with that reason.
+opencode and redcode share one permission engine and now share one DB-isolation
+branch, each Worker's child getting its own database in its disposable workspace.

--- a/.changeset/every-runner-postured.md
+++ b/.changeset/every-runner-postured.md
@@ -2,7 +2,7 @@
 "@reddb-io/redskilled": patch
 "@reddb-io/protocol-acp": patch
 "@reddb-io/worker": patch
-"@reddb-io/red-skills-dev": patch
+"@reddb-io/dev": patch
 ---
 
 Every catalog Agent declares its unattended posture, and opencode gets its own DB

--- a/apps/redskilled/src/acp-agent-catalog.ts
+++ b/apps/redskilled/src/acp-agent-catalog.ts
@@ -12,12 +12,24 @@ import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
 import { ACP_AGENT_IDS, type AcpAgentId, type AcpEndpoint } from "@reddb-io/protocol-acp";
+import {
+  ACP_UNATTENDED_POSTURES,
+  unattendedLaunchArgs,
+  unattendedSessionMode,
+  type AcpUnattendedPosture,
+} from "./acp-unattended-posture.js";
 
 // The Agent identities and the resolved endpoint are shared wire (ADR 0148):
 // the Worker body reads an endpoint it never resolves, so it must not have to
 // import this catalog to do it. Re-exported here so daemon-side callers keep
 // asking the authority that owns discovery.
 export { ACP_AGENT_IDS, type AcpAgentId, type AcpEndpoint };
+export {
+  ACP_UNATTENDED_POSTURES,
+  unattendedPostureFor,
+  unattendedSessionMode,
+  type AcpUnattendedPosture,
+} from "./acp-unattended-posture.js";
 
 export const ACP_AGENT_REQUIRED_CAPABILITIES = [
   "session/new",
@@ -36,30 +48,31 @@ export interface AcpAdapterArtifact {
   readonly bin?: string;
 }
 
-export interface NativeAcpAgentDescriptor {
+/**
+ * What every Agent declares, whatever kind it is.
+ *
+ * `unattendedPosture` is REQUIRED, and that is the whole point: three of the
+ * five Agents were admissible and undeployable at once because a missing
+ * posture reads exactly like an Agent that needs none (#4278). A sixth Agent
+ * cannot land unpostured, because a descriptor without the field does not
+ * compile.
+ */
+interface AcpAgentDescriptorBase {
   readonly id: AcpAgentId;
   readonly label: string;
+  /** How this Agent is made able to work with nobody at the keyboard. */
+  readonly unattendedPosture: AcpUnattendedPosture;
+}
+
+export interface NativeAcpAgentDescriptor extends AcpAgentDescriptorBase {
   readonly kind: "native";
   /** Native ACP argv; the first element is the executable. */
   readonly command: readonly [string, ...string[]];
 }
 
-export interface AdapterAcpAgentDescriptor {
-  readonly id: AcpAgentId;
-  readonly label: string;
+export interface AdapterAcpAgentDescriptor extends AcpAgentDescriptorBase {
   readonly kind: "adapter";
   readonly artifact: AcpAdapterArtifact;
-  /**
-   * Arguments the adapter is LAUNCHED with, after the bin.
-   *
-   * A Worker's child runs unattended: nobody answers a permission dialog, so
-   * an adapter whose defaults ask for approval aborts its turn on the first
-   * write. The launch declares the unattended posture instead — the same
-   * trust the native redcode child already runs with, because the product's
-   * isolation is the disposable Worker workspace and its cgroup, not the
-   * adapter's own prompt-for-approval loop.
-   */
-  readonly launchArgs?: readonly string[];
 }
 
 export type AcpAgentDescriptor = NativeAcpAgentDescriptor | AdapterAcpAgentDescriptor;
@@ -69,7 +82,13 @@ export type AcpAgentDescriptor = NativeAcpAgentDescriptor | AdapterAcpAgentDescr
  * deliberately exact: changing either is a reviewed catalog update.
  */
 export const ACP_AGENT_CATALOG: readonly AcpAgentDescriptor[] = [
-  { id: "redcode", label: "Redcode", kind: "native", command: ["redcode", "acp"] },
+  {
+    id: "redcode",
+    label: "Redcode",
+    kind: "native",
+    command: ["redcode", "acp"],
+    unattendedPosture: ACP_UNATTENDED_POSTURES.redcode,
+  },
   {
     id: "claude-code",
     label: "Claude Code",
@@ -81,6 +100,7 @@ export const ACP_AGENT_CATALOG: readonly AcpAgentDescriptor[] = [
       entrypoint: "package/dist/index.js",
       bin: "claude-code-acp",
     },
+    unattendedPosture: ACP_UNATTENDED_POSTURES["claude-code"],
   },
   {
     id: "codex",
@@ -93,7 +113,7 @@ export const ACP_AGENT_CATALOG: readonly AcpAgentDescriptor[] = [
       entrypoint: "package/bin/codex-acp.js",
       bin: "codex-acp",
     },
-    launchArgs: ["-c", "approval_policy=never", "-c", "sandbox_mode=danger-full-access"],
+    unattendedPosture: ACP_UNATTENDED_POSTURES.codex,
   },
   {
     id: "pi",
@@ -106,8 +126,15 @@ export const ACP_AGENT_CATALOG: readonly AcpAgentDescriptor[] = [
       entrypoint: "package/dist/index.js",
       bin: "pi-acp",
     },
+    unattendedPosture: ACP_UNATTENDED_POSTURES.pi,
   },
-  { id: "opencode", label: "OpenCode", kind: "native", command: ["opencode", "acp"] },
+  {
+    id: "opencode",
+    label: "OpenCode",
+    kind: "native",
+    command: ["opencode", "acp"],
+    unattendedPosture: ACP_UNATTENDED_POSTURES.opencode,
+  },
 ] as const;
 
 /** Credential-free launch projection handed to a Worker. */
@@ -341,26 +368,32 @@ export function declaredChildAgentEndpoint(id: AcpAgentId): AcpEndpoint {
   if (descriptor.artifact.bin == null) {
     throw new AcpAgentUnavailableError(id, "its pinned adapter declares no launchable bin");
   }
+  const sessionMode = unattendedSessionMode(descriptor.unattendedPosture);
   return {
     agent: id,
     transport: "stdio",
     command: "npx",
+    ...(sessionMode == null ? {} : { unattendedSessionMode: sessionMode }),
     args: [
       "-y",
       "-p",
       `${descriptor.artifact.package}@${descriptor.artifact.version}`,
       descriptor.artifact.bin,
-      ...(descriptor.launchArgs ?? []),
+      ...unattendedLaunchArgs(descriptor.unattendedPosture),
     ],
   };
 }
 
 function nativeEndpoint(descriptor: NativeAcpAgentDescriptor): AcpEndpoint {
+  const sessionMode = unattendedSessionMode(descriptor.unattendedPosture);
   return {
     agent: descriptor.id,
     transport: "stdio",
     command: descriptor.command[0],
-    args: descriptor.command.slice(1),
+    ...(sessionMode == null ? {} : { unattendedSessionMode: sessionMode }),
+    // A native Agent carries its posture the same way an adapter does; the
+    // seam is the launch, not the kind (#4278).
+    args: [...descriptor.command.slice(1), ...unattendedLaunchArgs(descriptor.unattendedPosture)],
   };
 }
 
@@ -431,6 +464,7 @@ function assertDescriptors(descriptors: readonly AcpAgentDescriptor[]): void {
   for (const descriptor of descriptors) {
     if (seen.has(descriptor.id)) throw new Error(`duplicate ACP Agent descriptor: ${descriptor.id}`);
     seen.add(descriptor.id);
+    assertPosture(descriptor);
     if (descriptor.kind === "adapter") {
       if (!/^\d+\.\d+\.\d+$/.test(descriptor.artifact.version)) {
         throw new Error(`ACP adapter ${descriptor.id} must use an exact semantic version`);
@@ -439,6 +473,22 @@ function assertDescriptors(descriptors: readonly AcpAgentDescriptor[]): void {
         throw new Error(`ACP adapter ${descriptor.id} has an unsafe entrypoint`);
       }
     }
+  }
+}
+
+/**
+ * A posture that establishes nothing is worse than none: it reads as a decision
+ * somebody made. Empty args, an empty mode id and an empty reason all fail here.
+ */
+function assertPosture(descriptor: AcpAgentDescriptor): void {
+  const posture = descriptor.unattendedPosture;
+  const stated = posture.kind === "launch-args"
+    ? posture.args.length > 0 && posture.args.every((arg) => arg.length > 0)
+    : posture.kind === "session-mode"
+      ? posture.modeId.length > 0
+      : posture.reason.length > 0;
+  if (!stated) {
+    throw new Error(`ACP Agent ${descriptor.id} declares an empty ${posture.kind} unattended posture`);
   }
 }
 

--- a/apps/redskilled/src/acp-agent-home.ts
+++ b/apps/redskilled/src/acp-agent-home.ts
@@ -13,16 +13,27 @@ import { join } from "node:path";
 import type { AcpAgentId } from "@reddb-io/protocol-acp";
 import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
 
+/**
+ * The Agents that keep their state in an `opencode.db` and must not share one.
+ *
+ * redcode is opencode's engine, so the failure is the same engine's: redcode#58
+ * observed concurrent instances on one DB dying mid-turn on "database is
+ * locked". opencode reached the same catalog with no isolation at all (#4278) —
+ * the very file the bug is about, and the reason this is ONE branch rather than
+ * the literal written twice.
+ */
+const OPENCODE_ENGINE_AGENTS = new Set<AcpAgentId>(["redcode", "opencode"]);
+
 /** The env one child Agent needs to stand apart from its siblings and the operator. PURE. */
 export function childAgentWorkspaceEnv(
   agent: AcpAgentId,
   workspacePath: string,
   homeDirPath: string = homedir(),
 ): Record<string, string> {
-  // redcode#58: concurrent redcode instances sharing one opencode.db die on
-  // "database is locked" mid-turn, so each Worker's child gets its own DB in
-  // the Worker's disposable workspace — it dies with the workspace.
-  if (agent === "redcode") return { OPENCODE_DB: join(workspacePath, "redcode.db") };
+  // Each Worker's child gets its own DB inside the Worker's disposable
+  // workspace, named for the Agent that owns it — so the file dies with the
+  // workspace and two Agents in one workspace never collide either.
+  if (OPENCODE_ENGINE_AGENTS.has(agent)) return { OPENCODE_DB: join(workspacePath, `${agent}.db`) };
   if (agent === "codex") return { CODEX_HOME: codexAgentHome(homeDirPath) };
   return {};
 }

--- a/apps/redskilled/src/acp-unattended-posture.ts
+++ b/apps/redskilled/src/acp-unattended-posture.ts
@@ -1,0 +1,137 @@
+/**
+ * acp-unattended-posture — how each catalog Agent is made able to WORK unattended.
+ *
+ * A Worker's turn runs with nobody at the keyboard, and `acp-permission.ts` is
+ * deliberate about what that means: an uncovered decision is `hitl-required`,
+ * which the child receives as `outcome: cancelled`. Every coding Agent shipped
+ * today reads a cancelled permission as an INTERRUPT and aborts the whole turn.
+ * So an Agent left on its ask-for-approval defaults is admitted, investigates,
+ * decides, calls its first write — and dies there. That was observed live for
+ * codex (#4230: `aborted by user after 0.1s`, stopReason `cancelled`) and again
+ * for claude-code while this module was written (#4278).
+ *
+ * The posture is therefore DECLARED, per Agent, beside the evidence that found
+ * it — and it is declared for ALL of them, including the ones that need
+ * nothing, because "this Agent needs nothing" is a finding somebody made and
+ * not an absence a reader can tell apart from an omission. The descriptor type
+ * requires the field, so a sixth Agent cannot land unpostured.
+ *
+ * What a posture grants is the trust the disposable Worker workspace already
+ * carries (ADR 0148): the product's isolation is that workspace, its cgroup and
+ * the Worker's terminal policy — never the child's own prompt-for-approval
+ * loop, which nobody is there to answer.
+ *
+ * A posture is not per-Worker ISOLATION. Isolation is `acp-agent-home.ts`, and
+ * the two are declared apart because an Agent can need one without the other.
+ */
+import type { AcpAgentId } from "@reddb-io/protocol-acp";
+
+/**
+ * The one mechanism that grants one Agent its unattended posture.
+ *
+ * Each arm carries exactly what its mechanism consumes; a single shape with
+ * three optional fields would let an Agent declare a posture establishing
+ * nothing. Neither mechanism arm is adapter-only — a native Agent launched from
+ * PATH carries a posture the same way.
+ */
+export type AcpUnattendedPosture =
+  /** Arguments appended after the launch command. */
+  | {
+    readonly kind: "launch-args";
+    readonly args: readonly [string, ...string[]];
+    readonly evidence: string;
+  }
+  /** An ACP `session/set_mode` the Worker issues right after `session/new`. */
+  | {
+    readonly kind: "session-mode";
+    readonly modeId: string;
+    readonly evidence: string;
+  }
+  /** The Agent never asks. The reason is the finding, not a shrug. */
+  | { readonly kind: "none-needed"; readonly reason: string };
+
+/**
+ * What the opencode permission engine allows before anybody configures it.
+ *
+ * redcode and opencode are the same engine, and its built-in table (read out of
+ * the shipped `opencode` 1.18.18 binary, and the reason every live redcode
+ * drain has worked unpostured) allows every tool by default, allows `edit` for
+ * paths under the session cwd and the temp dir, and reserves `ask` for edits
+ * OUTSIDE them. A Worker's child is launched with its own worktree as cwd, so
+ * the work it was born to do is inside the allowed set.
+ */
+const OPENCODE_ENGINE_DEFAULTS =
+  "redcode and opencode share one permission engine whose built-in table is `{\"*\":\"allow\", …}` with "
+  + "`edit` allowed under the session cwd and the temp dir. A Worker's child runs with its own worktree as "
+  + "cwd, so its work never leaves the allowed set and no ACP permission request is raised.";
+
+/**
+ * Every Agent's posture, keyed by the wire's own id list.
+ *
+ * `Record<AcpAgentId, …>` is total by construction: a sixth id fails to compile
+ * here before it can reach a Worker unpostured.
+ */
+export const ACP_UNATTENDED_POSTURES: Readonly<Record<AcpAgentId, AcpUnattendedPosture>> = {
+  redcode: {
+    kind: "none-needed",
+    reason: `redcode is the product's own child and asks for nothing: ${OPENCODE_ENGINE_DEFAULTS}`,
+  },
+  // Probed 2026-08-21 against the pinned artifact over stdio. DEFAULT: the
+  // session opens `currentModeId: "default"` and the first file write raises
+  // `session/request_permission` ("Write …/PROBE.txt"); answered the way an
+  // unattended turn answers it, the turn ends with nothing written. With
+  // `session/set_mode` → `bypassPermissions` sent first: zero permission
+  // requests, `stopReason: "end_turn"`, the file on disk.
+  "claude-code": {
+    kind: "session-mode",
+    modeId: "bypassPermissions",
+    evidence:
+      "claude-code-acp@0.16.2 parses no argv at all (`--help` prints nothing; `dist/index.js` reads none), so "
+      + "no launch flag can carry this. Its `session/new` advertises `bypassPermissions` among the session "
+      + "modes, and setting it takes a probed write from two refused permission requests to `end_turn` with "
+      + "the file written.",
+  },
+  // #4230, observed live on 4.1.15 before this module existed.
+  codex: {
+    kind: "launch-args",
+    args: ["-c", "approval_policy=never", "-c", "sandbox_mode=danger-full-access"],
+    evidence:
+      "codex-acp@0.16.0 forwards `-c key=value` into codex's own config. Left on its defaults it aborted the "
+      + "turn on the first apply_patch ('aborted by user after 0.1s', turn_aborted reason interrupted, "
+      + "stopReason cancelled).",
+  },
+  // Probed 2026-08-21: `pi-acp --help` prints nothing, and `dist/index.js`
+  // tests process.argv for exactly one token, `--terminal-login`. Its only
+  // `conn.requestPermission` callers are `handleExtensionSelect` and
+  // `handleExtensionConfirm` — UI a pi EXTENSION raises. An ordinary tool call
+  // never reaches the client, because the adapter runs `pi --mode rpc` and pi
+  // reads, writes and executes locally (its README says so under Limitations:
+  // "No ACP filesystem delegation and no ACP terminal delegation. pi
+  // reads/writes and executes locally.").
+  pi: {
+    kind: "none-needed",
+    reason:
+      "pi-acp@0.0.33 accepts exactly one argument, `--terminal-login`, and exposes no permission surface for "
+      + "tool calls: it runs `pi --mode rpc`, which reads, writes and executes locally, so a write never "
+      + "becomes an ACP permission request. Only a pi extension's own select/confirm UI reaches the client.",
+  },
+  opencode: {
+    kind: "none-needed",
+    reason: `opencode asks for nothing inside its own workspace: ${OPENCODE_ENGINE_DEFAULTS}`,
+  },
+};
+
+/** One Agent's declared posture. PURE. */
+export function unattendedPostureFor(agent: AcpAgentId): AcpUnattendedPosture {
+  return ACP_UNATTENDED_POSTURES[agent];
+}
+
+/** The arguments a posture appends to the launch, or none. PURE. */
+export function unattendedLaunchArgs(posture: AcpUnattendedPosture): readonly string[] {
+  return posture.kind === "launch-args" ? posture.args : [];
+}
+
+/** The ACP session mode a posture asks for after `session/new`, or none. PURE. */
+export function unattendedSessionMode(posture: AcpUnattendedPosture): string | undefined {
+  return posture.kind === "session-mode" ? posture.modeId : undefined;
+}

--- a/apps/redskilled/src/acp-worker-admission.ts
+++ b/apps/redskilled/src/acp-worker-admission.ts
@@ -319,6 +319,11 @@ export function nativeWorkerSpec(
       "--socket", endpoint,
       "--child-agent", childAgent.agent,
       "--child-command", childAgent.command,
+      // The unattended posture of an Agent that parses no argv (#4278): the
+      // Worker sets it as a session mode, so it has to reach the Worker.
+      ...(childAgent.unattendedSessionMode == null
+        ? []
+        : ["--child-session-mode", childAgent.unattendedSessionMode]),
       // Inline form, because an adapter's args start with dashes (`-y`, `-p`)
       // and the pair form reads the next dash token as a flag, not a value.
       ...childAgent.args.map((arg) => `--child-arg=${arg}`),

--- a/apps/redskilled/tests/acp-agent-catalog.test.ts
+++ b/apps/redskilled/tests/acp-agent-catalog.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   ACP_AGENT_CATALOG,
+  ACP_UNATTENDED_POSTURES,
   ACP_AGENT_IDS,
   ACP_AGENT_REQUIRED_CAPABILITIES,
   AcpAgentCatalog,
@@ -166,6 +167,7 @@ function adapterDescriptor(id: "pi", version: string, bytes: Uint8Array): AcpAge
       integrity: integrityOf(bytes),
       entrypoint: "package/dist/index.js",
     },
+    unattendedPosture: ACP_UNATTENDED_POSTURES.pi,
   };
 }
 

--- a/apps/redskilled/tests/acp-agent-conformance.test.ts
+++ b/apps/redskilled/tests/acp-agent-conformance.test.ts
@@ -9,9 +9,12 @@ import { ACP_AGENT_IDS, type AcpAgentId, type AcpEndpoint } from "@reddb-io/prot
 import {
   ACP_AGENT_CATALOG,
   ACP_AGENT_REQUIRED_CAPABILITIES,
+  ACP_UNATTENDED_POSTURES,
   AcpAgentCatalog,
+  declaredChildAgentEndpoint,
   type AcpAgentDescriptor,
   type AcpAgentProbeResult,
+  type AcpUnattendedPosture,
 } from "../src/acp-agent-catalog.js";
 
 /**
@@ -30,14 +33,23 @@ interface AgentCase {
   readonly kind: "native" | "adapter";
   /** Native argv, executable first; adapters resolve their argv from the pin. */
   readonly command?: readonly [string, ...string[]];
+  /**
+   * The kind of unattended posture this Agent is expected to declare.
+   *
+   * Named here rather than read from the catalog: a matrix that reads the
+   * catalog agrees with it by construction, and the whole failure this row
+   * exists for is three Agents that were admissible and undeployable because
+   * nobody had written down what makes them able to work (#4278).
+   */
+  readonly posture: AcpUnattendedPosture["kind"];
 }
 
 const AGENT_MATRIX: readonly AgentCase[] = [
-  { id: "redcode", label: "Redcode", kind: "native", command: ["redcode", "acp"] },
-  { id: "claude-code", label: "Claude Code", kind: "adapter" },
-  { id: "codex", label: "Codex", kind: "adapter" },
-  { id: "pi", label: "Pi", kind: "adapter" },
-  { id: "opencode", label: "OpenCode", kind: "native", command: ["opencode", "acp"] },
+  { id: "redcode", label: "Redcode", kind: "native", command: ["redcode", "acp"], posture: "none-needed" },
+  { id: "claude-code", label: "Claude Code", kind: "adapter", posture: "session-mode" },
+  { id: "codex", label: "Codex", kind: "adapter", posture: "launch-args" },
+  { id: "pi", label: "Pi", kind: "adapter", posture: "none-needed" },
+  { id: "opencode", label: "OpenCode", kind: "native", command: ["opencode", "acp"], posture: "none-needed" },
 ] as const;
 
 const roots: string[] = [];
@@ -140,6 +152,56 @@ describe("the focused ACP Agent conformance matrix", () => {
       expect(descriptor).not.toHaveProperty("artifact");
     },
   );
+
+  it.each(AGENT_MATRIX)("declares how $label works with nobody at the keyboard", (agent) => {
+    const posture = descriptorFor(agent.id).unattendedPosture;
+    expect(posture.kind).toBe(agent.posture);
+    // The catalog and the declaration table are the same object, never two
+    // tables a reader has to reconcile.
+    expect(posture).toBe(ACP_UNATTENDED_POSTURES[agent.id]);
+
+    // A posture that establishes nothing is worse than none: it reads as a
+    // decision somebody made. Every arm has to SAY something.
+    if (posture.kind === "launch-args") {
+      expect(posture.args.length).toBeGreaterThan(0);
+      expect(posture.evidence.length).toBeGreaterThan(20);
+    } else if (posture.kind === "session-mode") {
+      expect(posture.modeId).not.toBe("");
+      expect(posture.evidence.length).toBeGreaterThan(20);
+    } else {
+      expect(posture.reason.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("declares a posture for every catalog Agent and only for catalog Agents", () => {
+    // Direction one: no Agent is admissible without a stated posture. This is
+    // the drift that shipped — claude-code, pi and opencode were each reachable
+    // and each unable to finish a turn.
+    for (const descriptor of ACP_AGENT_CATALOG) {
+      expect(ACP_UNATTENDED_POSTURES[descriptor.id]).toBe(descriptor.unattendedPosture);
+    }
+    // Direction two: a posture for an Agent nobody can reach is fiction that
+    // outlives the Agent it described.
+    expect(Object.keys(ACP_UNATTENDED_POSTURES).sort())
+      .toEqual(ACP_AGENT_CATALOG.map((descriptor) => descriptor.id).sort());
+  });
+
+  it.each(AGENT_MATRIX)("carries $label's posture on the endpoint a Worker is handed", (agent) => {
+    const endpoint = declaredChildAgentEndpoint(agent.id);
+    const posture = ACP_UNATTENDED_POSTURES[agent.id];
+
+    // A posture declared and not carried is a posture that never happened: the
+    // endpoint is the ONLY thing that crosses the body/control cut.
+    if (posture.kind === "launch-args") {
+      expect(endpoint.args.slice(-posture.args.length)).toEqual([...posture.args]);
+      expect(endpoint.unattendedSessionMode).toBeUndefined();
+    } else if (posture.kind === "session-mode") {
+      expect(endpoint.unattendedSessionMode).toBe(posture.modeId);
+    } else {
+      expect(endpoint.unattendedSessionMode).toBeUndefined();
+      if (agent.command) expect([endpoint.command, ...endpoint.args]).toEqual([...agent.command]);
+    }
+  });
 
   it("demands the same baseline capabilities of every Agent in the matrix", () => {
     expect([...ACP_AGENT_REQUIRED_CAPABILITIES]).toEqual([

--- a/apps/redskilled/tests/acp-unattended-posture.test.ts
+++ b/apps/redskilled/tests/acp-unattended-posture.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { ACP_AGENT_IDS } from "@reddb-io/protocol-acp";
+import {
+  ACP_UNATTENDED_POSTURES,
+  unattendedLaunchArgs,
+  unattendedPostureFor,
+  unattendedSessionMode,
+} from "../src/acp-unattended-posture.js";
+
+/**
+ * The posture declaration itself (#4278).
+ *
+ * The conformance matrix pins WHICH posture each Agent has; this pins that the
+ * three readers agree on what a posture MEANS — a launch-args posture must not
+ * also look like a session-mode one, and a `none-needed` Agent must produce
+ * neither, or an Agent that needs nothing would still be launched with something.
+ */
+describe("the declared unattended posture", () => {
+  it("answers for every Agent the wire knows, and for no other", () => {
+    expect(Object.keys(ACP_UNATTENDED_POSTURES).sort()).toEqual([...ACP_AGENT_IDS].sort());
+    for (const agent of ACP_AGENT_IDS) {
+      expect(unattendedPostureFor(agent)).toBe(ACP_UNATTENDED_POSTURES[agent]);
+    }
+  });
+
+  it("reads a launch-args posture as arguments and nothing else", () => {
+    const posture = unattendedPostureFor("codex");
+    expect(unattendedLaunchArgs(posture)).toEqual([
+      "-c",
+      "approval_policy=never",
+      "-c",
+      "sandbox_mode=danger-full-access",
+    ]);
+    expect(unattendedSessionMode(posture)).toBeUndefined();
+  });
+
+  it("reads a session-mode posture as a mode and nothing else", () => {
+    const posture = unattendedPostureFor("claude-code");
+    expect(unattendedSessionMode(posture)).toBe("bypassPermissions");
+    expect(unattendedLaunchArgs(posture)).toEqual([]);
+  });
+
+  it("launches a none-needed Agent with nothing added", () => {
+    for (const agent of ["redcode", "pi", "opencode"] as const) {
+      const posture = unattendedPostureFor(agent);
+      expect(posture.kind).toBe("none-needed");
+      expect(unattendedLaunchArgs(posture)).toEqual([]);
+      expect(unattendedSessionMode(posture)).toBeUndefined();
+    }
+  });
+});

--- a/apps/redskilled/tests/runner-honored-admission.test.ts
+++ b/apps/redskilled/tests/runner-honored-admission.test.ts
@@ -110,11 +110,33 @@ describe("the registered runner reaches the born Worker", () => {
     ]);
     expect(codexSpec.env?.OPENCODE_DB).toBeUndefined();
     expect(codexSpec.env?.CODEX_HOME).toBe(codexAgentHome());
+    // codex takes its posture from argv, so no session mode rides along.
+    expect(codexArgs).not.toContain("--child-session-mode");
 
     const redcodeSpec = nativeWorkerSpec(project, workspace, "/tmp/sock/x.sock", "/tmp/runtime", "afk");
     const redcodeArgs = redcodeSpec.args ?? [];
     expect(redcodeArgs[redcodeArgs.indexOf("--child-agent") + 1]).toBe("redcode");
     expect(redcodeSpec.env?.OPENCODE_DB).toBe(join(workspace.workspacePath, "redcode.db"));
+    expect(redcodeArgs).not.toContain("--child-session-mode");
+  });
+
+  it("hands claude-code the session mode that is its only unattended door", () => {
+    // claude-code-acp parses no argv, so its posture cannot ride the launch —
+    // it has to reach the Worker, which sets it right after `session/new`.
+    const spec = nativeWorkerSpec(project, workspace, "/tmp/sock/x.sock", "/tmp/runtime", "afk", "claude-code");
+    const args = spec.args ?? [];
+    expect(args[args.indexOf("--child-agent") + 1]).toBe("claude-code");
+    expect(args[args.indexOf("--child-session-mode") + 1]).toBe("bypassPermissions");
+  });
+
+  it("gives opencode its own per-Worker DB, the file redcode#58 is about", () => {
+    // opencode reached the catalog sharing one `opencode.db` across every
+    // concurrent Worker — the exact "database is locked" death redcode already
+    // got isolation for (#4278). One branch, one literal, both Agents.
+    const spec = nativeWorkerSpec(project, workspace, "/tmp/sock/x.sock", "/tmp/runtime", "afk", "opencode");
+    expect(spec.env?.OPENCODE_DB).toBe(join(workspace.workspacePath, "opencode.db"));
+    expect(spec.env?.OPENCODE_DB).not.toBe(childAgentWorkspaceEnv("redcode", workspace.workspacePath).OPENCODE_DB);
+    expect(spec.env?.CODEX_HOME).toBeUndefined();
   });
 });
 
@@ -154,6 +176,6 @@ describe("the daemon-owned codex home", () => {
     const home = await mkdtemp(join(tmpdir(), "redskilled-agent-home-"));
     roots.push(home);
     await ensureChildAgentHome("redcode", home);
-    expect(childAgentWorkspaceEnv("opencode", "/tmp/w", home)).toEqual({});
+    expect(childAgentWorkspaceEnv("pi", "/tmp/w", home)).toEqual({});
   });
 });

--- a/packages/protocol-acp/endpoint.ts
+++ b/packages/protocol-acp/endpoint.ts
@@ -19,4 +19,15 @@ export interface AcpEndpoint {
   readonly transport: "stdio";
   readonly command: string;
   readonly args: readonly string[];
+  /**
+   * The ACP session mode the Worker must set right after `session/new`.
+   *
+   * Some Agents take their unattended posture from argv and some take it from a
+   * session mode — claude-code-acp parses no argv at all, and `bypassPermissions`
+   * is the only door it has (#4278). The mode travels ON the endpoint because
+   * the endpoint is already the one thing that crosses the body/control cut:
+   * the daemon's catalog decides it, and the Worker applies what it was handed
+   * without ever asking which Agent it is holding.
+   */
+  readonly unattendedSessionMode?: string;
 }

--- a/packages/worker/src/acp/child-agent.ts
+++ b/packages/worker/src/acp/child-agent.ts
@@ -225,6 +225,19 @@ export class WorkflowChildAgent {
           : { additionalDirectories: [...this.#options.additionalDirectories] }),
         _meta: { redskills: { delegation: DELEGATION_SCOPE } },
       });
+      // **The unattended posture is established BEFORE the first prompt.**
+      // Nobody answers a permission dialog here, and `acp-permission.ts` turns
+      // an uncovered decision into `cancelled` — which every shipped Agent
+      // reads as an interrupt and aborts the whole turn on. claude-code-acp
+      // parses no argv, so a session mode is the only door it has (#4278); if
+      // the mode is refused the child cannot work, and failing here is a birth
+      // that explains itself rather than a turn that dies on its first write.
+      if (endpoint.unattendedSessionMode != null) {
+        await connection.agent.request(methods.agent.session.setMode, {
+          sessionId: session.sessionId,
+          modeId: endpoint.unattendedSessionMode,
+        });
+      }
       const active = {
         child,
         connection,

--- a/packages/worker/src/acp/command.ts
+++ b/packages/worker/src/acp/command.ts
@@ -15,6 +15,7 @@ const ACP_WORKER_FLAGS = {
   "child-agent": { kind: "value", coerce: requireAcpAgentId },
   "child-command": { kind: "value", coerce: (raw: string) => raw },
   "child-arg": { kind: "value", type: "array", coerce: (raw: string) => raw },
+  "child-session-mode": { kind: "value", coerce: (raw: string) => raw },
 } as const;
 
 export async function runAcpWorkerCommand(args: readonly string[]): Promise<number> {
@@ -23,11 +24,14 @@ export async function runAcpWorkerCommand(args: readonly string[]): Promise<numb
   if (values["child-agent"] == null || values["child-command"] == null) {
     throw new Error("acp-worker requires a daemon-selected child ACP Agent endpoint");
   }
+  const sessionMode = values["child-session-mode"];
   return await runNativeAcpWorker(values.socket, {
     agent: values["child-agent"],
     transport: "stdio",
     command: values["child-command"],
     args: values["child-arg"] ?? [],
+    // The daemon's catalog chose it; this restates it and decides nothing.
+    ...(sessionMode == null || sessionMode === "" ? {} : { unattendedSessionMode: sessionMode }),
   });
 }
 

--- a/packaging/pi/dev/skills/engineering/afk/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/afk/SKILL.md
@@ -155,6 +155,9 @@ Read the focused reference before touching that concern:
 - Runner-specific behavior: [`runner-claude.md`](./runner-claude.md),
   [`runner-codex.md`](./runner-codex.md), [`runner-opencode.md`](./runner-opencode.md),
   and fallback [`runner-hermes.md`](./runner-hermes.md).
+- What makes each Agent able to work with nobody at the keyboard, and the
+  evidence behind each answer:
+  [`runner-unattended-posture.md`](./runner-unattended-posture.md).
 - Liveness, stall protection and lane-idle rules:
   [`docs/LIVENESS.md`](./docs/LIVENESS.md).
 - Config, env overrides, lifecycle hooks, sandbox/runner/model settings, the

--- a/packaging/pi/dev/skills/engineering/afk/runner-claude.md
+++ b/packaging/pi/dev/skills/engineering/afk/runner-claude.md
@@ -1,5 +1,9 @@
 # Runner: Claude
 
+> **Unattended posture.** What makes this Agent able to work with nobody at the
+> keyboard — and the evidence behind it — is
+> [`runner-unattended-posture.md`](./runner-unattended-posture.md).
+
 How `/afk` invokes Claude as the inner agent for one issue.
 
 ## Spawn Command

--- a/packaging/pi/dev/skills/engineering/afk/runner-codex.md
+++ b/packaging/pi/dev/skills/engineering/afk/runner-codex.md
@@ -1,5 +1,9 @@
 # Runner: Codex
 
+> **Unattended posture.** What makes this Agent able to work with nobody at the
+> keyboard — and the evidence behind it — is
+> [`runner-unattended-posture.md`](./runner-unattended-posture.md).
+
 How `/afk` invokes Codex as the inner agent for one issue.
 
 ## Spawn Command

--- a/packaging/pi/dev/skills/engineering/afk/runner-opencode.md
+++ b/packaging/pi/dev/skills/engineering/afk/runner-opencode.md
@@ -1,5 +1,9 @@
 # Runner: OpenCode
 
+> **Unattended posture.** What makes this Agent able to work with nobody at the
+> keyboard — and the evidence behind it — is
+> [`runner-unattended-posture.md`](./runner-unattended-posture.md).
+
 How `/afk` invokes OpenCode as the inner agent for one issue (ADR 0059, amended).
 OpenCode is the **API-auth** runner: it reaches OpenAI-compatible endpoints
 through its own `<provider>/<model>` slug and an API key, with no host session

--- a/packaging/pi/dev/skills/engineering/afk/runner-unattended-posture.md
+++ b/packaging/pi/dev/skills/engineering/afk/runner-unattended-posture.md
@@ -1,0 +1,89 @@
+# Runner: the unattended posture of every Agent
+
+What makes each catalog Agent able to WORK with nobody at the keyboard, and the
+evidence behind each answer. The declaration lives in
+`apps/redskilled/src/acp-unattended-posture.ts`; this is the operator's copy.
+
+## Why a posture exists at all
+
+A Worker's turn runs unattended. When its child Agent asks for permission, the
+daemon has nobody to ask, so `acp-permission.ts` answers `hitl-required` — which
+reaches the child as `outcome: cancelled`. **Every coding Agent shipped today
+reads a cancelled permission as an interrupt and aborts the whole turn.** An
+Agent left on its ask-for-approval defaults is therefore born, investigates,
+decides, calls its first write, and dies there with nothing committed.
+
+That is not a theory. It was observed live for codex (`aborted by user after
+0.1s`, `turn_aborted reason: interrupted`, stopReason `cancelled`) and again for
+claude-code while this table was written.
+
+**A posture is not isolation.** Isolation — a per-Worker database, a daemon-owned
+home — is `acp-agent-home.ts`, and an Agent can need one without the other.
+
+## The table
+
+| Agent | Kind | Unattended posture | Per-Worker isolation |
+| --- | --- | --- | --- |
+| **redcode** | native | `none-needed` — asks for nothing inside its own workspace | `OPENCODE_DB` in the Worker workspace |
+| **claude-code** | adapter | `session-mode` → `bypassPermissions`, set right after `session/new` | none |
+| **codex** | adapter | `launch-args` → `-c approval_policy=never -c sandbox_mode=danger-full-access` | daemon-owned `CODEX_HOME`, seeded from the operator login |
+| **pi** | adapter | `none-needed` — exposes no permission surface for tool calls | none |
+| **opencode** | native | `none-needed` — same engine and same defaults as redcode | `OPENCODE_DB` in the Worker workspace |
+
+## The evidence behind each answer
+
+**redcode — `none-needed`.** redcode is opencode's engine, whose built-in
+permission table allows every tool and allows `edit` for paths under the session
+cwd and the temp dir, reserving `ask` for edits outside them. A Worker's child
+runs with its own worktree as cwd, so the work it was born to do never leaves
+the allowed set. This is why every live drain to date has worked unpostured.
+
+**claude-code — `session-mode: bypassPermissions`.** Probed against the pinned
+`@zed-industries/claude-code-acp@0.16.2` over stdio. `--help` prints nothing and
+`dist/index.js` reads no argv at all, so **no launch flag can carry this** — the
+session mode is the only door. On defaults the session opens
+`currentModeId: "default"` and the first file write raises
+`session/request_permission` ("Write …/PROBE.txt"); answered the way an
+unattended turn answers, the turn ends with nothing written. With
+`session/set_mode` → `bypassPermissions` sent first: zero permission requests,
+`stopReason: "end_turn"`, the file on disk.
+
+**codex — `launch-args`.** `codex-acp` forwards `-c key=value` into codex's own
+config, so the posture rides the launch. Found by the live failure above.
+
+**pi — `none-needed`.** `pi-acp --help` prints nothing, and `dist/index.js`
+tests `process.argv` for exactly one token: `--terminal-login`. There is no
+permission flag to declare. There is also nothing to declare it FOR: its only
+`requestPermission` callers handle a pi *extension's* select/confirm UI, never a
+tool call. The adapter runs `pi --mode rpc`, and pi reads, writes and executes
+locally — its README says so under Limitations — so a write never becomes an ACP
+permission request.
+
+**opencode — `none-needed`.** The same engine and the same built-in table as
+redcode, read out of the shipped `opencode` binary. The live end-to-end probe
+could not be completed on the development host: `opencode acp` initialises and
+then never answers `session/new` there, because no model provider is configured
+for it.
+
+## Per-Worker isolation
+
+redcode and opencode share one branch, not one file: concurrent instances on a
+single `opencode.db` die mid-turn on "database is locked" (redcode#58), so each
+Worker's child gets its own DB named for its Agent inside the Worker's
+disposable workspace, and the file dies with the workspace.
+
+codex gets a daemon-owned `CODEX_HOME` instead, seeded with the operator's login
+and nothing else: the first codex Worker on a host died on the operator's own
+`~/.codex/config.toml` naming a model the pinned adapter cannot run.
+
+## Adding a sixth Agent
+
+The descriptor type REQUIRES `unattendedPosture`, so an Agent with no posture
+does not compile, and the conformance matrix
+(`apps/redskilled/tests/acp-agent-conformance.test.ts`) pins the table against
+the catalog in both directions — an Agent with no posture fails, and a posture
+for an Agent nobody can reach fails too.
+
+Probe the artifact; do not guess a flag. `none-needed` is a legitimate answer
+and requires a stated reason, because an Agent that needs nothing and an Agent
+nobody checked look identical in an empty field.

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -155,6 +155,9 @@ Read the focused reference before touching that concern:
 - Runner-specific behavior: [`runner-claude.md`](./runner-claude.md),
   [`runner-codex.md`](./runner-codex.md), [`runner-opencode.md`](./runner-opencode.md),
   and fallback [`runner-hermes.md`](./runner-hermes.md).
+- What makes each Agent able to work with nobody at the keyboard, and the
+  evidence behind each answer:
+  [`runner-unattended-posture.md`](./runner-unattended-posture.md).
 - Liveness, stall protection and lane-idle rules:
   [`docs/LIVENESS.md`](./docs/LIVENESS.md).
 - Config, env overrides, lifecycle hooks, sandbox/runner/model settings, the

--- a/plugins/dev/skills/engineering/afk/runner-claude.md
+++ b/plugins/dev/skills/engineering/afk/runner-claude.md
@@ -1,5 +1,9 @@
 # Runner: Claude
 
+> **Unattended posture.** What makes this Agent able to work with nobody at the
+> keyboard — and the evidence behind it — is
+> [`runner-unattended-posture.md`](./runner-unattended-posture.md).
+
 How `/afk` invokes Claude as the inner agent for one issue.
 
 ## Spawn Command

--- a/plugins/dev/skills/engineering/afk/runner-codex.md
+++ b/plugins/dev/skills/engineering/afk/runner-codex.md
@@ -1,5 +1,9 @@
 # Runner: Codex
 
+> **Unattended posture.** What makes this Agent able to work with nobody at the
+> keyboard — and the evidence behind it — is
+> [`runner-unattended-posture.md`](./runner-unattended-posture.md).
+
 How `/afk` invokes Codex as the inner agent for one issue.
 
 ## Spawn Command

--- a/plugins/dev/skills/engineering/afk/runner-opencode.md
+++ b/plugins/dev/skills/engineering/afk/runner-opencode.md
@@ -1,5 +1,9 @@
 # Runner: OpenCode
 
+> **Unattended posture.** What makes this Agent able to work with nobody at the
+> keyboard — and the evidence behind it — is
+> [`runner-unattended-posture.md`](./runner-unattended-posture.md).
+
 How `/afk` invokes OpenCode as the inner agent for one issue (ADR 0059, amended).
 OpenCode is the **API-auth** runner: it reaches OpenAI-compatible endpoints
 through its own `<provider>/<model>` slug and an API key, with no host session

--- a/plugins/dev/skills/engineering/afk/runner-unattended-posture.md
+++ b/plugins/dev/skills/engineering/afk/runner-unattended-posture.md
@@ -1,0 +1,89 @@
+# Runner: the unattended posture of every Agent
+
+What makes each catalog Agent able to WORK with nobody at the keyboard, and the
+evidence behind each answer. The declaration lives in
+`apps/redskilled/src/acp-unattended-posture.ts`; this is the operator's copy.
+
+## Why a posture exists at all
+
+A Worker's turn runs unattended. When its child Agent asks for permission, the
+daemon has nobody to ask, so `acp-permission.ts` answers `hitl-required` — which
+reaches the child as `outcome: cancelled`. **Every coding Agent shipped today
+reads a cancelled permission as an interrupt and aborts the whole turn.** An
+Agent left on its ask-for-approval defaults is therefore born, investigates,
+decides, calls its first write, and dies there with nothing committed.
+
+That is not a theory. It was observed live for codex (`aborted by user after
+0.1s`, `turn_aborted reason: interrupted`, stopReason `cancelled`) and again for
+claude-code while this table was written.
+
+**A posture is not isolation.** Isolation — a per-Worker database, a daemon-owned
+home — is `acp-agent-home.ts`, and an Agent can need one without the other.
+
+## The table
+
+| Agent | Kind | Unattended posture | Per-Worker isolation |
+| --- | --- | --- | --- |
+| **redcode** | native | `none-needed` — asks for nothing inside its own workspace | `OPENCODE_DB` in the Worker workspace |
+| **claude-code** | adapter | `session-mode` → `bypassPermissions`, set right after `session/new` | none |
+| **codex** | adapter | `launch-args` → `-c approval_policy=never -c sandbox_mode=danger-full-access` | daemon-owned `CODEX_HOME`, seeded from the operator login |
+| **pi** | adapter | `none-needed` — exposes no permission surface for tool calls | none |
+| **opencode** | native | `none-needed` — same engine and same defaults as redcode | `OPENCODE_DB` in the Worker workspace |
+
+## The evidence behind each answer
+
+**redcode — `none-needed`.** redcode is opencode's engine, whose built-in
+permission table allows every tool and allows `edit` for paths under the session
+cwd and the temp dir, reserving `ask` for edits outside them. A Worker's child
+runs with its own worktree as cwd, so the work it was born to do never leaves
+the allowed set. This is why every live drain to date has worked unpostured.
+
+**claude-code — `session-mode: bypassPermissions`.** Probed against the pinned
+`@zed-industries/claude-code-acp@0.16.2` over stdio. `--help` prints nothing and
+`dist/index.js` reads no argv at all, so **no launch flag can carry this** — the
+session mode is the only door. On defaults the session opens
+`currentModeId: "default"` and the first file write raises
+`session/request_permission` ("Write …/PROBE.txt"); answered the way an
+unattended turn answers, the turn ends with nothing written. With
+`session/set_mode` → `bypassPermissions` sent first: zero permission requests,
+`stopReason: "end_turn"`, the file on disk.
+
+**codex — `launch-args`.** `codex-acp` forwards `-c key=value` into codex's own
+config, so the posture rides the launch. Found by the live failure above.
+
+**pi — `none-needed`.** `pi-acp --help` prints nothing, and `dist/index.js`
+tests `process.argv` for exactly one token: `--terminal-login`. There is no
+permission flag to declare. There is also nothing to declare it FOR: its only
+`requestPermission` callers handle a pi *extension's* select/confirm UI, never a
+tool call. The adapter runs `pi --mode rpc`, and pi reads, writes and executes
+locally — its README says so under Limitations — so a write never becomes an ACP
+permission request.
+
+**opencode — `none-needed`.** The same engine and the same built-in table as
+redcode, read out of the shipped `opencode` binary. The live end-to-end probe
+could not be completed on the development host: `opencode acp` initialises and
+then never answers `session/new` there, because no model provider is configured
+for it.
+
+## Per-Worker isolation
+
+redcode and opencode share one branch, not one file: concurrent instances on a
+single `opencode.db` die mid-turn on "database is locked" (redcode#58), so each
+Worker's child gets its own DB named for its Agent inside the Worker's
+disposable workspace, and the file dies with the workspace.
+
+codex gets a daemon-owned `CODEX_HOME` instead, seeded with the operator's login
+and nothing else: the first codex Worker on a host died on the operator's own
+`~/.codex/config.toml` naming a model the pinned adapter cannot run.
+
+## Adding a sixth Agent
+
+The descriptor type REQUIRES `unattendedPosture`, so an Agent with no posture
+does not compile, and the conformance matrix
+(`apps/redskilled/tests/acp-agent-conformance.test.ts`) pins the table against
+the catalog in both directions — an Agent with no posture fails, and a posture
+for an Agent nobody can reach fails too.
+
+Probe the artifact; do not guess a flag. `none-needed` is a legitimate answer
+and requires a stated reason, because an Agent that needs nothing and an Agent
+nobody checked look identical in an empty field.


### PR DESCRIPTION
Fixes #4278

Admission became generic, but only two of the five Agents could actually finish a turn. An Agent left on its ask-for-approval defaults is born, investigates, decides, calls its first write — and dies there: an unattended turn answers `hitl-required`, the child receives `outcome: cancelled`, and every shipped Agent reads that as an interrupt. codex proved it live (#4230); claude-code and pi were in exactly that state, and opencode had neither a posture nor per-Worker isolation despite using `opencode.db`, the very file redcode#58 is about.

## What changed

- **`unattendedPosture` is a REQUIRED field on both descriptor kinds** (`apps/redskilled/src/acp-unattended-posture.ts`), a discriminated union of `launch-args` / `session-mode` / `none-needed`, each arm carrying exactly what its mechanism consumes plus the evidence or reason behind it. A sixth Agent cannot land unpostured — a descriptor without the field does not compile, and the table is a `Record<AcpAgentId, …>` that a sixth id breaks.
- **Neither mechanism is adapter-only.** A native Agent launched from PATH carries a posture the same way, so the seam is the launch, not the kind.
- **The conformance matrix asserts the declaration in both directions** — every catalog entry has a posture, every declared posture belongs to a live catalog entry — and additionally asserts that the endpoint a Worker is handed actually CARRIES what was declared. A posture nothing carries is a posture that never happened.
- **opencode shares redcode's isolation branch** rather than the literal written twice: each Worker's child gets its own DB, named for its Agent, inside the disposable workspace it dies with.
- **Operator docs**: `plugins/dev/skills/engineering/afk/runner-unattended-posture.md`, linked from the /afk SKILL.md and pointed at from `runner-claude.md`, `runner-codex.md` and `runner-opencode.md`. Pi mirrors regenerated.

## What I probed, and what I found

Every adapter was probed on the pinned artifact on this host. Nothing here is a guessed flag.

**claude-code — `session-mode: bypassPermissions`.** `npx -y -p @zed-industries/claude-code-acp@0.16.2 claude-code-acp --help` prints **nothing** (only npm's rename-deprecation warning), and `dist/index.js` reads no argv at all — it loads managed settings and calls `runAcp()`. So **no launch flag can carry this posture; the session mode is the only door.** Driven over stdio with `initialize` + `session/new` + a `session/prompt` that writes a file:

```
# defaults
MODES: currentModeId "default"; availableModes default, acceptEdits, plan, dontAsk, bypassPermissions
PERMISSION ASKED: "Write /tmp/probe-cc-default-yIXfKz/PROBE.txt"
PERMISSION ASKED: "Write /tmp/probe-cc-default-yIXfKz/PROBE.txt"
RESULT: permissionRequests=2 fileWritten=false

# with session/set_mode -> bypassPermissions before the prompt
SET_MODE: {}
PROMPT: {"stopReason":"end_turn"}
RESULT: permissionRequests=0 fileWritten=true content="OK"
```

The permission requests above were answered the way an unattended turn answers them (`outcome: cancelled`), which is exactly the codex failure shape. Source corroboration in `dist/acp-agent.js`: `const permissionMode = "default"` at session creation, and the auto-allow at `session.permissionMode === "bypassPermissions"`.

**pi — `none-needed`.** `npx -y -p pi-acp@0.0.33 pi-acp --help` prints **nothing** and exits 0. `dist/index.js` tests `process.argv` for exactly one token: `--terminal-login`. There is no permission flag to declare, and nothing to declare it for — the only `conn.requestPermission` callers are `handleExtensionSelect` and `handleExtensionConfirm`, i.e. UI a pi *extension* raises, never a tool call. The adapter spawns `pi --mode rpc --no-themes` and pi reads, writes and executes locally (its README, under Limitations: "No ACP filesystem delegation and no ACP terminal delegation. pi reads/writes and executes locally."). Declared `none-needed` with that as the stated reason. `pi` is not installed on this host, so no live turn was driven.

**opencode — `none-needed`.** `opencode acp --help` exposes only `--print-logs`, `--log-level`, `--pure`, `--port`, `--hostname`, `--mdns`, `--cors`, `--cwd` — **no permission flag**. `OPENCODE_PERMISSION` exists (a JSON blob merged into config `permission`), but it is not needed: the built-in table read out of the shipped `opencode` 1.18.18 binary is `{"*":"allow", …}` with `edit` allowed for paths under the session cwd and the temp dir and `ask` reserved for edits outside them. A Worker's child runs with its own worktree as cwd. **The live end-to-end probe could not be completed on this host**: `opencode acp` initialises ("setup connection", "global event connected") and then never answers `session/new`, because no model provider is configured for it here. Reported as observed rather than claimed.

**redcode — `none-needed`.** Same engine and same default table as opencode, which is why every live drain to date has worked unpostured. The live write probe was inconclusive on this host for an unrelated reason: `session/new` succeeded, and `session/prompt` returned `Token Plan usage limit reached` from the provider before any tool ran.

**codex — `launch-args`** (unchanged, #4230): `-c approval_policy=never -c sandbox_mode=danger-full-access`.

## Validation

- root `pnpm typecheck` — green (17/17)
- `pnpm -C apps/plugin-dev test:invariants` — green, **494/494**
- `pnpm -C apps/redskilled exec vitest run tests/acp-agent-conformance.test.ts tests/acp-agent-catalog.test.ts tests/runner-honored-admission.test.ts tests/acp-unattended-posture.test.ts` — **54 passed**
- `packages/worker` acp suites — green apart from the pre-existing `local-gate` (4)
- `apps/redskilled` `acp-conformance` still red at its known pre-existing 4; unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789923588&installation_model_id=20659&pr_number=4279&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4279&signature=f864edac81edfe09549117ed9d22417c530e6a5f993110f1a0771b0ed2e86019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->