### PR TITLE
fix(redskilled): a claude-code child authenticates in a home of its own

### DIFF
--- a/.changeset/claude-code-child-credential.md
+++ b/.changeset/claude-code-child-credential.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+A claude-code child authenticates as the operator, in a home of its own. The
+first live claude-code drain was born, claimed its Ticket and worked — then
+died on `Authentication required`: #4278 declared its unattended posture and
+left its credential half undeclared, so the child ran with no login at all.
+The credential homes are now one declared table (env var, operator file,
+login command) covering codex and claude-code, seeded and re-seeded the same
+way, and a host with no login is refused by name before a Worker is born.

--- a/apps/redskilled/src/acp-agent-home.ts
+++ b/apps/redskilled/src/acp-agent-home.ts
@@ -24,6 +24,39 @@ import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
  */
 const OPENCODE_ENGINE_AGENTS = new Set<AcpAgentId>(["redcode", "opencode"]);
 
+/**
+ * The Agents whose credential the daemon seeds into a home of its own.
+ *
+ * An Agent that authenticates through a login file cannot use the operator's
+ * home: a Worker inherits no interactive dotfiles (that is the point — the
+ * operator's `~/.codex/config.toml` named a model the pinned adapter could not
+ * run), and inheriting nothing means it authenticates as nobody. Observed as
+ * `Authentication required` on the first live claude-code drain (#4278's
+ * posture half was proven while its credential half was not). Each entry
+ * states the env var the Agent reads, the operator file it logs into, and the
+ * file name inside the daemon's home.
+ */
+const CREDENTIAL_HOMES = {
+  codex: { env: "CODEX_HOME", operatorDir: ".codex", file: "auth.json", login: "codex login" },
+  "claude-code": {
+    env: "CLAUDE_CONFIG_DIR",
+    operatorDir: ".claude",
+    file: ".credentials.json",
+    login: "claude login",
+  },
+} as const satisfies Partial<Record<AcpAgentId, {
+  readonly env: string;
+  readonly operatorDir: string;
+  readonly file: string;
+  readonly login: string;
+}>>;
+
+type CredentialAgent = keyof typeof CREDENTIAL_HOMES;
+
+function credentialHome(agent: AcpAgentId): (typeof CREDENTIAL_HOMES)[CredentialAgent] | undefined {
+  return (CREDENTIAL_HOMES as Record<string, (typeof CREDENTIAL_HOMES)[CredentialAgent] | undefined>)[agent];
+}
+
 /** The env one child Agent needs to stand apart from its siblings and the operator. PURE. */
 export function childAgentWorkspaceEnv(
   agent: AcpAgentId,
@@ -34,13 +67,19 @@ export function childAgentWorkspaceEnv(
   // workspace, named for the Agent that owns it — so the file dies with the
   // workspace and two Agents in one workspace never collide either.
   if (OPENCODE_ENGINE_AGENTS.has(agent)) return { OPENCODE_DB: join(workspacePath, `${agent}.db`) };
-  if (agent === "codex") return { CODEX_HOME: codexAgentHome(homeDirPath) };
+  const credential = credentialHome(agent);
+  if (credential != null) return { [credential.env]: agentCredentialHome(agent, homeDirPath) };
   return {};
 }
 
-/** The daemon-owned codex home; the operator's `~/.codex` is never a Worker's. */
+/** The daemon-owned home for one Agent; the operator's own is never a Worker's. */
+export function agentCredentialHome(agent: AcpAgentId, homeDirPath: string = homedir()): string {
+  return join(redskilledHomeDir(homeDirPath), "agent-homes", agent);
+}
+
+/** The daemon-owned codex home. Kept as the name its callers already import. */
 export function codexAgentHome(homeDirPath: string = homedir()): string {
-  return join(redskilledHomeDir(homeDirPath), "agent-homes", "codex");
+  return agentCredentialHome("codex", homeDirPath);
 }
 
 /**
@@ -52,16 +91,18 @@ export function codexAgentHome(homeDirPath: string = homedir()): string {
  * loudly here, before a Worker is born to fail on it.
  */
 export async function ensureChildAgentHome(agent: AcpAgentId, homeDirPath: string = homedir()): Promise<void> {
-  if (agent !== "codex") return;
-  const home = codexAgentHome(homeDirPath);
+  const credential = credentialHome(agent);
+  if (credential == null) return;
+  const home = agentCredentialHome(agent, homeDirPath);
   await mkdir(home, { recursive: true, mode: 0o700 });
-  const seeded = join(home, "auth.json");
-  const operator = join(homeDirPath, ".codex", "auth.json");
+  const seeded = join(home, credential.file);
+  const operator = join(homeDirPath, credential.operatorDir, credential.file);
   const [seededAt, operatorAt] = await Promise.all([mtimeOf(seeded), mtimeOf(operator)]);
   if (operatorAt == null) {
     if (seededAt != null) return;
     throw new Error(
-      "codex has no host login: ~/.codex/auth.json is absent. Run `codex login` as the operator first.",
+      `${agent} has no host login: ~/${credential.operatorDir}/${credential.file} is absent. ` +
+        `Run \`${credential.login}\` as the operator first.`,
     );
   }
   if (seededAt == null || operatorAt > seededAt) {

--- a/apps/redskilled/tests/runner-honored-admission.test.ts
+++ b/apps/redskilled/tests/runner-honored-admission.test.ts
@@ -140,6 +140,42 @@ describe("the registered runner reaches the born Worker", () => {
   });
 });
 
+describe("the daemon-owned claude-code credential home (#4278 follow-up)", () => {
+  it("points the adapter at a daemon-owned config dir, never the operator's", () => {
+    const env = childAgentWorkspaceEnv("claude-code", "/tmp/w", "/home/op");
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/home/op/.red/redskilled/agent-homes/claude-code");
+    expect(env.CLAUDE_CONFIG_DIR).not.toContain("/home/op/.claude");
+  });
+
+  it("seeds the operator credential, re-seeds on re-login, and keeps a child's own refresh", async () => {
+    const home = await mkdtemp(join(tmpdir(), "redskilled-cc-home-"));
+    roots.push(home);
+    await mkdir(join(home, ".claude"), { recursive: true });
+    await writeFile(join(home, ".claude", ".credentials.json"), '{"t":"operator-1"}');
+
+    await ensureChildAgentHome("claude-code", home);
+    const seeded = join(home, ".red/redskilled/agent-homes/claude-code/.credentials.json");
+    expect(await readFile(seeded, "utf8")).toBe('{"t":"operator-1"}');
+    expect(((await stat(seeded)).mode & 0o777)).toBe(0o600);
+
+    await writeFile(seeded, '{"t":"child-refreshed"}');
+    const past = new Date(Date.now() - 60_000);
+    await utimes(join(home, ".claude", ".credentials.json"), past, past);
+    await ensureChildAgentHome("claude-code", home);
+    expect(await readFile(seeded, "utf8")).toBe('{"t":"child-refreshed"}');
+
+    await writeFile(join(home, ".claude", ".credentials.json"), '{"t":"operator-2"}');
+    await ensureChildAgentHome("claude-code", home);
+    expect(await readFile(seeded, "utf8")).toBe('{"t":"operator-2"}');
+  });
+
+  it("refuses by name when the operator never logged in, naming the login command", async () => {
+    const home = await mkdtemp(join(tmpdir(), "redskilled-cc-home-"));
+    roots.push(home);
+    await expect(ensureChildAgentHome("claude-code", home)).rejects.toThrow(/claude login/);
+  });
+});
+
 describe("the daemon-owned codex home", () => {
   it("is refused loudly when the operator never logged in", async () => {
     const home = await mkdtemp(join(tmpdir(), "redskilled-agent-home-"));


### PR DESCRIPTION
The first live claude-code drain (worker `VSxHdBZ` on #4282, 4.1.25) proved #4278's posture half and exposed the half nobody declared: born, claimed, worked, then `Authentication required`. A Worker inherits no interactive dotfiles **by design**; for an Agent that authenticates through a login file that means authenticating as nobody.

Credential homes are now one declared table — env var, operator file, login command — covering codex (`CODEX_HOME`/`~/.codex/auth.json`) and claude-code (`CLAUDE_CONFIG_DIR`/`~/.claude/.credentials.json`), with the seeding, re-seed-on-relogin, never-clobber-the-child's-refresh and by-name refusal shared. `CLAUDE_CONFIG_DIR` was read out of the pinned adapter's own `dist/settings.js`, not guessed.

Refs #4278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789928710&installation_model_id=20659&pr_number=4284&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4284&signature=87b2238cc43e2307a4abc6221f8e225666696fcc35e02b68ab83e8a347677f52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->