### PR TITLE
feat(statusline): rebuild the Worker lifecycle bar, add the day's landed lines, and let an idle host say what it last did

### DIFF
--- a/.changeset/statusline-progress-status-loc.md
+++ b/.changeset/statusline-progress-status-loc.md
@@ -1,0 +1,13 @@
+---
+"@reddb-io/redskilled-render": patch
+"@reddb-io/redskilled": patch
+"@reddb-io/shared": patch
+"@reddb-io/dev": patch
+---
+
+statusline: rebuild the Worker lifecycle bar, add the day's landed lines, and let an idle host say what it last did
+
+- The lifecycle bar returns to the Worker row. `progressBar` now resolves a position from the phase word through a declared table (`lifecycle-phase.ts`) when a project publishes no `phase_index`/`phase_total` — which is every native Worker, since its pulse carries a ticket stage and nothing else. An undeclared phase draws no bar.
+- `mrg=` gains the trunk's added/removed lines for the operator's calendar day, measured by the repository-activity poll that already counted the merges. It degrades to absent — never to a zero — when the comparison is unreachable or truncated.
+- An idle host renders `idle·<outcome> #<issue> <age>` from the Worker outcome marks the daemon already keeps and already replays from its event lane.
+- The statusline head gives up `iss=`; the dashboard keeps it.

--- a/apps/plugin-dev/src/core/complexity-coverage-guard.ts
+++ b/apps/plugin-dev/src/core/complexity-coverage-guard.ts
@@ -149,7 +149,6 @@ export const COMPLEXITY_COVERAGE_BASELINE: readonly ComplexityCoverageBaselineEn
   { path: "apps/redskilled/src/host-state.ts", name: "isRedskilledUpgradeState", crap: 702 },
   { path: "apps/redskilled/src/project-registration-queue.ts", name: "isQueuePollPlanShape", crap: 420 },
   { path: "apps/redskilled/src/protocol.ts", name: "isRedskilledReapResult", crap: 462 },
-  { path: "apps/redskilled/src/repository-activity-conditional.ts", name: "fetchConditionalRepositoryActivity", crap: 600 },
   { path: "apps/redskilled/src/resource-lease.ts", name: "isRedskilledResourceLease", crap: 306 },
   { path: "apps/redskilled/src/statusline-deaths.ts", name: "buildDeaths", crap: 272 },
   { path: "apps/redskilled/src/worker-placement.ts", name: "selectWorkerPlacementDriver", crap: 272 },

--- a/apps/plugin-dev/src/core/file-size-guard.ts
+++ b/apps/plugin-dev/src/core/file-size-guard.ts
@@ -78,7 +78,6 @@ export const FILE_SIZE_BASELINE: readonly FileSizeBaselineEntry[] = [
   { path: "apps/redskilled/src/daemon/lifecycle.ts", lines: 2483 },
   { path: "apps/redskilled/src/cli.ts", lines: 1036 },
   { path: "apps/redskilled/src/client.ts", lines: 1003 },
-  { path: "apps/redskilled/src/statusline-payload.ts", lines: 864 },
   { path: "apps/rsp/src/resident-server.ts", lines: 931 },
   { path: "apps/rsp/src/two-axis-benchmark.ts", lines: 878 },
   { path: "apps/rsp/tests/cli.helpers.ts", lines: 828 },

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -169,6 +169,8 @@ import { coerceWorkerDisplay, type RedskilledWorkerDisplayRecord } from "../work
 import {
   deriveRedskilledLiveMetrics,
   pruneRedskilledMetricHistory,
+  replayedOutcomeMark,
+  witnessedOutcomeMark,
   type RedskilledWorkerMetricObservation,
   type RedskilledWorkerOutcomeMark,
 } from "../live-metrics.js";
@@ -748,6 +750,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       now: clock(),
       reattachedWorkerIds: [...reattached],
       repositoryActivity: lastActivity,
+      outcomes: outcomeMarks,
       // Two windows of the cadence IN FORCE: a threshold pinned to the attended
       // one would report an idle host's deliberate back-off as a stopped poller.
       activityStalenessMs: REDSKILLED_ACTIVITY_STALENESS_FACTOR * activityPoller.cadenceMs(),
@@ -1720,7 +1723,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
         : {}),
     };
     if (kind === "worker-death" || kind === "worker-budget-kill") {
-      const mark: RedskilledWorkerOutcomeMark = { worker_id: worker.worker_id, ts, outcome: kind };
+      const mark = witnessedOutcomeMark(worker, ts, kind, displays.get(worker.worker_id)?.display, facts.birthOutcome);
       outcomeMarks = pruneRedskilledMetricHistory([...outcomeMarks, mark], (entry) => entry.ts, { now: clock() });
       rememberObservedDeath(
         buildHostEvent(input),
@@ -2224,11 +2227,8 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   // operator the machine finished nothing, when what happened is that the
   // process holding the count was replaced.
   outcomeMarks = pruneRedskilledMetricHistory(
-    laneEvents
-      .filter((event) => event.event === "worker-death" || event.event === "worker-budget-kill")
-      .map((event) => ({ worker_id: event.worker_id, ts: event.ts, outcome: event.event })),
-    (mark) => mark.ts,
-    { now: clock() },
+    laneEvents.filter((e) => e.event === "worker-death" || e.event === "worker-budget-kill").map(replayedOutcomeMark),
+    (mark) => mark.ts, { now: clock() },
   );
   observations = replayRedskilledMetricObservations(laneEvents, clock());
   for (const observation of observations) metricCheckpoints.set(observation.worker_id, observation);

--- a/apps/redskilled/src/live-metrics.ts
+++ b/apps/redskilled/src/live-metrics.ts
@@ -68,12 +68,81 @@ export interface RedskilledWorkerMetricObservation {
   readonly model: string | null;
 }
 
-/** One Worker's ending, as the host event lane recorded it. */
+/**
+ * One Worker's ending, as the host event lane recorded it.
+ *
+ * The rate derivation reads only `ts`; the four fields beside it are what an
+ * IDLE host has left to say. A machine with no live Worker renders `idle` and
+ * nothing else, so a drain that landed thirty seconds ago and one that died an
+ * hour ago look identical at a glance — and the facts that separate them were
+ * already in the daemon's hand at the moment it recorded the death.
+ *
+ * Every added field is OPTIONAL because the same marks are replayed from the
+ * event lane by a restarted daemon (`lifecycle.ts`), and a lane row carries the
+ * project and the kind but never the Worker's own account of its work. A mark
+ * recovered from history says less than one witnessed live, and says so.
+ */
 export interface RedskilledWorkerOutcomeMark {
   readonly worker_id: string;
   readonly ts: string;
   /** The lane's own event kind, carried unread. */
   readonly outcome: string;
+  /** Which project ended, so an idle line never reports another repository's. */
+  readonly project_label?: string;
+  /** The work item, exactly as the Worker published it; never parsed here. */
+  readonly issue?: string | null;
+  /** The last phase the Worker pulsed, `!`-suffixed when that stage refused. */
+  readonly phase?: string | null;
+  /** What the Worker REPORTED before ending, in the birth-outcome vocabulary. */
+  readonly birth_outcome?: string | null;
+}
+
+/**
+ * The mark for an ending this daemon WITNESSED, with what the Worker had said.
+ *
+ * The display record is the Worker's own published account — the daemon reads
+ * two fields off it and parses neither (ADR 0130 rule 3). Reading them HERE, at
+ * the moment of death, is the only chance there is: the display map is cleared
+ * the instant the Worker is forgotten.
+ */
+export function witnessedOutcomeMark(
+  worker: { readonly worker_id: string; readonly project_label: string },
+  ts: string,
+  kind: string,
+  display: { readonly issue: string | null; readonly phase: string | null } | undefined,
+  birthOutcome: string | undefined,
+): RedskilledWorkerOutcomeMark {
+  return {
+    worker_id: worker.worker_id,
+    ts,
+    outcome: kind,
+    project_label: worker.project_label,
+    issue: display?.issue ?? null,
+    phase: display?.phase ?? null,
+    birth_outcome: birthOutcome ?? null,
+  };
+}
+
+/**
+ * The mark for an ending REPLAYED off the lane by a successor daemon.
+ *
+ * It carries strictly less: the lane row holds the project and the kind, and the
+ * Worker's account of its own work was never written there. A successor that
+ * filled the gap with a plausible default would be inventing history, so the
+ * fields it cannot know stay `null` and every reader degrades on them.
+ */
+export function replayedOutcomeMark(
+  event: { readonly worker_id: string; readonly ts: string; readonly event: string; readonly project_label: string },
+): RedskilledWorkerOutcomeMark {
+  return {
+    worker_id: event.worker_id,
+    ts: event.ts,
+    outcome: event.event,
+    project_label: event.project_label,
+    issue: null,
+    phase: null,
+    birth_outcome: null,
+  };
 }
 
 /**

--- a/apps/redskilled/src/repository-activity-conditional.ts
+++ b/apps/redskilled/src/repository-activity-conditional.ts
@@ -12,6 +12,7 @@ import type {
   RedskilledActivityOperation,
   RedskilledActivityQueueLabels,
   RedskilledActivityRateLimit,
+  RedskilledActivityTransport,
   RedskilledProjectActivity,
   RedskilledRepositoryActivity,
 } from "./repository-activity.js";
@@ -27,6 +28,109 @@ const REDSKILLED_MERGED_TODAY_OPERATION: GithubAttributedOperation = {
   key: "redskilled merged-today poll",
   budget: "search",
 };
+const REDSKILLED_TRUNK_LINES_OPERATION: GithubAttributedOperation = {
+  key: "redskilled trunk-lines-today poll",
+  budget: "rest",
+};
+
+/**
+ * Most files one comparison reports before GitHub truncates it.
+ *
+ * A truncated comparison is not a small day: it is an UNKNOWN one, and summing a
+ * truncated list would report the first 300 files of a large landing as the
+ * whole of it. At the cap the answer becomes an absence.
+ */
+const REDSKILLED_COMPARE_FILE_CAP = 300;
+
+/** Lines the trunk gained and lost over a span; `null` for a span nobody could measure. */
+export interface RedskilledTrunkLines {
+  readonly added: number | null;
+  readonly removed: number | null;
+}
+
+/** What a poll answers with when it could not measure the trunk at all. */
+const TRUNK_LINES_UNANSWERED: RedskilledTrunkLines = { added: null, removed: null };
+
+/**
+ * The lines that LANDED on the trunk since `since`, in two conditional reads.
+ *
+ * **The day's commits carry both ends of the span.** The listing is newest-first,
+ * so its head is the trunk tip and the FIRST PARENT of its tail is where the
+ * trunk stood when the day began — one read yields the comparison's base and
+ * head, where naming each separately would have cost two.
+ *
+ * Every failure degrades to {@link TRUNK_LINES_UNANSWERED} rather than throwing:
+ * this figure rides along with the panorama refresh, and a trunk the token
+ * cannot compare must not cost the caller its open-issue and merge counts.
+ */
+export async function fetchTrunkLinesToday(
+  request: {
+    readonly owner: string;
+    readonly repo: string;
+    readonly since: string;
+    readonly list: NonNullable<RedskilledActivityTransport["conditionalList"]>;
+    readonly object: RedskilledActivityTransport["conditionalObject"];
+  },
+): Promise<{ readonly lines: RedskilledTrunkLines; readonly requestCount: number }> {
+  const { owner, repo, since } = request;
+  if (request.object == null) return { lines: TRUNK_LINES_UNANSWERED, requestCount: 0 };
+  const repository = `${owner}/${repo}`;
+  let requestCount = 0;
+  try {
+    const commitParams = { owner, repo, since };
+    const commits = await request.list({
+      cacheKey: `activity:${repository}:trunk-commits:${since}`,
+      route: "GET /repos/{owner}/{repo}/commits",
+      parameters: commitParams,
+      operation: REDSKILLED_TRUNK_LINES_OPERATION,
+    });
+    requestCount += commits.requestCount;
+    // A real, measured zero: the trunk has not moved today. Distinct from every
+    // absence below, and the one case that may legitimately render nothing.
+    if (commits.data.length === 0) return { lines: { added: 0, removed: 0 }, requestCount };
+    const head = stringValue(commits.data[0]?.sha);
+    const base = firstParentSha(commits.data[commits.data.length - 1]);
+    if (head === "" || base === "") return { lines: TRUNK_LINES_UNANSWERED, requestCount };
+    const compare = await request.object({
+      cacheKey: `activity:${repository}:trunk-lines:${base}...${head}`,
+      route: "GET /repos/{owner}/{repo}/compare/{basehead}",
+      parameters: { owner, repo, basehead: `${base}...${head}` },
+      operation: REDSKILLED_TRUNK_LINES_OPERATION,
+    });
+    requestCount += compare.requestCount;
+    return { lines: sumComparedFiles(compare.data.files), requestCount };
+  } catch {
+    // Deliberately silent: the caller's own catch reports a failed PANORAMA, and
+    // a trunk comparison that failed on its own has not cost anyone a count.
+    return { lines: TRUNK_LINES_UNANSWERED, requestCount };
+  }
+}
+
+/** Add up a comparison's per-file diffstat; a truncated list answers nothing. PURE. */
+function sumComparedFiles(files: unknown): RedskilledTrunkLines {
+  if (!Array.isArray(files) || files.length >= REDSKILLED_COMPARE_FILE_CAP) {
+    return TRUNK_LINES_UNANSWERED;
+  }
+  let added = 0;
+  let removed = 0;
+  for (const file of files) {
+    if (!isRecord(file)) return TRUNK_LINES_UNANSWERED;
+    const plus = file.additions;
+    const minus = file.deletions;
+    if (!Number.isSafeInteger(plus) || !Number.isSafeInteger(minus)) return TRUNK_LINES_UNANSWERED;
+    added += plus as number;
+    removed += minus as number;
+  }
+  return { added, removed };
+}
+
+/** The trunk-side parent of one commit — where the trunk stood before it. PURE. */
+function firstParentSha(commit: Record<string, unknown> | undefined): string {
+  const parents = commit?.parents;
+  if (!Array.isArray(parents) || parents.length === 0) return "";
+  const first = parents[0];
+  return isRecord(first) ? stringValue(first.sha) : "";
+}
 
 export async function fetchConditionalRepositoryActivity(
   input: FetchRepositoryActivityInput,
@@ -90,7 +194,15 @@ export async function fetchConditionalRepositoryActivity(
           parameters: mergedParams,
           operation: REDSKILLED_MERGED_TODAY_OPERATION,
         });
-        requestCount += prAnswer.requestCount + closedAnswer.requestCount + mergedAnswer.requestCount;
+        const trunk = await fetchTrunkLinesToday({
+          owner: project.owner,
+          repo: project.name,
+          since: operation.merged_since,
+          list,
+          object: input.transport.conditionalObject,
+        });
+        requestCount += prAnswer.requestCount + closedAnswer.requestCount + mergedAnswer.requestCount +
+          trunk.requestCount;
         for (const headers of [prAnswer.headers, closedAnswer.headers, mergedAnswer.headers]) {
           rateLimit = mergeActivityRateLimit(rateLimit, activityRateLimitFromHeaders(headers));
         }
@@ -105,6 +217,8 @@ export async function fetchConditionalRepositoryActivity(
           open_issues: openIssues.length,
           recently_closed: recentlyClosed,
           merged_today: mergedAnswer.data.total_count,
+          trunk_lines_added: trunk.lines.added,
+          trunk_lines_removed: trunk.lines.removed,
           ready_queue: queue.ready_queue,
           human_queue: queue.human_queue,
         };
@@ -119,6 +233,8 @@ export async function fetchConditionalRepositoryActivity(
           open_issues: panorama.open_issues,
           recently_closed: panorama.recently_closed,
           merged_today: panorama.merged_today,
+          trunk_lines_added: panorama.trunk_lines_added ?? null,
+          trunk_lines_removed: panorama.trunk_lines_removed ?? null,
           ...queue,
         },
         panorama_fetched_at: refreshPanorama ? input.now : held?.panorama_fetched_at ?? input.previous?.fetched_at ?? input.now,

--- a/apps/redskilled/src/repository-activity.ts
+++ b/apps/redskilled/src/repository-activity.ts
@@ -170,6 +170,22 @@ export interface RedskilledActivityCounts {
   /** Issues and pull requests closed inside the window the fetch asked for. */
   readonly recently_closed: number;
   /**
+   * Lines the trunk GAINED since the operator's calendar day began; `null` when
+   * this poll could not answer.
+   *
+   * Beside `merged_today` because they answer the same question at two
+   * granularities — how much shipped today — and because they are counted in
+   * ONE poll: the statusline may not spend a git walk, a second request budget
+   * or its own clock on a figure the daemon already reaches GitHub for.
+   *
+   * **`null` is an absence and never a zero.** A day with no commits is `0`; a
+   * diff too large for one comparison, an unreachable trunk and a spent quota
+   * are three different failures and none of them is a quiet day.
+   */
+  readonly trunk_lines_added?: number | null;
+  /** Lines the trunk LOST over the same span, on the same terms. */
+  readonly trunk_lines_removed?: number | null;
+  /**
    * Open Issues carrying this project's ready label; `null` when none was named.
    *
    * **Counted off the representation the open-Issue count already paid for.**
@@ -363,6 +379,11 @@ export function parseRepositoryActivityResponse(
             open_issues: openIssues,
             merged_today: mergedToday,
             recently_closed: recentlyClosed,
+            // The aliased query asks for no comparison, so this migration path
+            // states the absence rather than a zero the conditional poll would
+            // have answered with a real number.
+            trunk_lines_added: null,
+            trunk_lines_removed: null,
             // The aliased query asks for no label breakdown, so this path
             // produces no queue counters — and says so with `null` rather than
             // handing a consumer two zeros it would render as a drained queue.
@@ -440,6 +461,17 @@ export interface RedskilledActivityTransport {
   conditionalCount?(
     input: RedskilledConditionalListRequest,
   ): Promise<{ readonly data: { readonly total_count: number }; readonly headers: GithubResponseHeaders; readonly requestCount: number }>;
+  /**
+   * One conditional REST read whose body is an OBJECT rather than a page.
+   *
+   * `conditionalList` unwraps a paginated array and `conditionalCount` unwraps a
+   * search total; a comparison is neither. Rather than teach either of them a
+   * third shape, this returns the record and lets the caller read the fields it
+   * declared it needed — the transport stays a transport.
+   */
+  conditionalObject?(
+    input: RedskilledConditionalListRequest,
+  ): Promise<{ readonly data: Record<string, unknown>; readonly headers: GithubResponseHeaders; readonly requestCount: number }>;
 }
 
 export interface FetchRepositoryActivityInput {
@@ -535,6 +567,15 @@ export function createGitHubActivityTransport(options: {
     });
   transport.conditionalCount = async (input) => {
     const answer = await client.conditionalRest<{ total_count: number }>({
+      cacheKey: input.cacheKey,
+      route: input.route,
+      parameters: input.parameters,
+      operation: input.operation,
+    });
+    return { data: answer.data, headers: answer.headers, requestCount: 1 };
+  };
+  transport.conditionalObject = async (input) => {
+    const answer = await client.conditionalRest<Record<string, unknown>>({
       cacheKey: input.cacheKey,
       route: input.route,
       parameters: input.parameters,

--- a/apps/redskilled/src/statusline-last-outcome.ts
+++ b/apps/redskilled/src/statusline-last-outcome.ts
@@ -1,0 +1,68 @@
+/**
+ * statusline-last-outcome — the newest Worker ending, for a line with no Worker
+ * to report.
+ *
+ * **An idle host is not a silent one.** `0w idle` is what the line says when
+ * nothing is running, and it says exactly the same thing on a machine that
+ * landed a Ticket a minute ago and on one whose drain died an hour back. The
+ * daemon already holds the difference: it keeps a mark per Worker ending for its
+ * own outcome rate, replayed from `redskilled.log.toonl` on restart. This module
+ * is the one hop from that history to the payload.
+ *
+ * **Facts here, vocabulary there.** Nothing in this module decides whether an
+ * ending is a landing or a park — that word is chosen in
+ * `@reddb-io/redskilled-render/last-outcome.js`, beside every other word on the
+ * line. The daemon publishes what it witnessed and stops.
+ *
+ * **No new lane and no new read.** The marks are already in memory and already
+ * bounded by the metric history's retention, so the newest one costs a scan of a
+ * list the process was keeping anyway.
+ *
+ * PURE.
+ */
+import type { RedskilledWorkerOutcomeMark } from "./live-metrics.js";
+
+/** One Worker ending, as the payload carries it. */
+export interface RedskilledStatuslineLastOutcome {
+  /** The lane's event kind — `worker-death` or `worker-budget-kill`. */
+  readonly kind: string;
+  readonly ts: string;
+  readonly project_label: string | null;
+  /** The work item exactly as the Worker published it; never parsed here. */
+  readonly issue: string | null;
+  /** The last phase the Worker pulsed, `!`-suffixed when that stage refused. */
+  readonly phase: string | null;
+  /** What the Worker reported before ending, in the birth-outcome vocabulary. */
+  readonly birth_outcome: string | null;
+}
+
+/**
+ * The newest ending this host recorded; `null` when it has recorded none. PURE.
+ *
+ * Newest by the mark's own instant rather than by list position: the boot replay
+ * appends a predecessor's history to a list this generation also writes to, and
+ * a reader trusting the order would report a replayed ending as the current one.
+ * A mark whose instant will not parse loses to any that will — it cannot be
+ * dated, and an undatable ending has no age to print beside it.
+ */
+export function buildLastOutcome(
+  marks: readonly RedskilledWorkerOutcomeMark[] | undefined,
+): RedskilledStatuslineLastOutcome | null {
+  let newest: RedskilledWorkerOutcomeMark | null = null;
+  let newestMs = Number.NEGATIVE_INFINITY;
+  for (const mark of marks ?? []) {
+    const at = Date.parse(mark.ts);
+    if (!Number.isFinite(at) || at < newestMs) continue;
+    newest = mark;
+    newestMs = at;
+  }
+  if (newest == null) return null;
+  return {
+    kind: newest.outcome,
+    ts: newest.ts,
+    project_label: newest.project_label ?? null,
+    issue: newest.issue ?? null,
+    phase: newest.phase ?? null,
+    birth_outcome: newest.birth_outcome ?? null,
+  };
+}

--- a/apps/redskilled/src/statusline-payload-guard.ts
+++ b/apps/redskilled/src/statusline-payload-guard.ts
@@ -1,0 +1,112 @@
+/**
+ * statusline-payload-guard — is this record a complete statusline payload?
+ *
+ * **A fail-closed check is a domain, not a tail.** The payload document, its
+ * assembly and this validator were one 864-line file, so a reader asking "what
+ * does a client accept" walked four hundred lines of aggregation to find out —
+ * the same accumulation the file-size ratchet exists to refuse. Splitting it
+ * puts the question and its answer in one place and drops the payload module
+ * back under the threshold it had a declared debt against.
+ *
+ * The shape check is DELIBERATELY partial and deliberately structural: it asks
+ * for the fields a consumer would crash without, and it asks about their types
+ * rather than their values. A daemon that predates an OPTIONAL block still
+ * produces a valid payload — that is what makes the block optional — so every
+ * later addition is checked only when present.
+ *
+ * PURE.
+ */
+import { isGithubBalanceReport } from "@reddb-io/github";
+import { isRedskilledActivityReport } from "./activity-report.js";
+import { isRedskilledStatuslineMetrics } from "./live-metrics.js";
+import { isRedskilledRemoteCounterReport } from "./remote-counters.js";
+import { isStatuslineDeaths } from "./statusline-deaths.js";
+import type { RedskilledStatuslinePayload } from "./statusline-payload.js";
+
+/** True when `value` is a complete payload — a client's fail-closed check. */
+export function isRedskilledStatuslinePayload(value: unknown): value is RedskilledStatuslinePayload {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const payload = value as Record<string, unknown>;
+  const daemon = payload.daemon as Record<string, unknown> | undefined;
+  const staleness = payload.staleness as Record<string, unknown> | undefined;
+  const host = payload.host as Record<string, unknown> | undefined;
+  return payload.version === 1 &&
+    typeof payload.generated_at === "string" &&
+    daemon != null && typeof daemon === "object" &&
+    Number.isInteger(daemon.pid) &&
+    typeof daemon.daemon_version === "string" &&
+    typeof daemon.protocol_version === "number" &&
+    staleness != null && typeof staleness === "object" &&
+    typeof staleness.stale === "boolean" &&
+    typeof staleness.threshold_ms === "number" &&
+    Array.isArray(staleness.unmeasured_workers) &&
+    host != null && typeof host === "object" &&
+    Number.isInteger(host.worker_count) &&
+    Number.isInteger(host.project_count) &&
+    typeof host.observed_rss_bytes === "number" &&
+    Array.isArray(payload.projects) &&
+    Array.isArray(payload.workers) &&
+    // Absent is accepted for the same reason the activity report's is: a daemon
+    // older than this field answers completely without it, and a consumer that
+    // rejected the whole payload would lose the Worker set over a fact it only
+    // needed to tell an idle project from an unknown one.
+    (payload.known_projects === undefined ||
+      (Array.isArray(payload.known_projects) && payload.known_projects.every((label) => typeof label === "string"))) &&
+    (payload.registered_projects === undefined ||
+      (Array.isArray(payload.registered_projects) &&
+        payload.registered_projects.every((label) => typeof label === "string"))) &&
+    (payload.lapsed_projects === undefined ||
+      (Array.isArray(payload.lapsed_projects) && payload.lapsed_projects.every(isStatuslineLapse))) &&
+    (payload.stopped_projects === undefined ||
+      (Array.isArray(payload.stopped_projects) && payload.stopped_projects.every(isStatuslineStop))) &&
+    (payload.orphaned_projects === undefined ||
+      (Array.isArray(payload.orphaned_projects) &&
+        payload.orphaned_projects.every((label) => typeof label === "string"))) &&
+    // Absent is accepted, malformed is not: a daemon older than the activity
+    // poller answers a newer client's read, and rejecting its whole payload over
+    // a field this consumer did not ask for would lose the Worker set — the very
+    // version skew one host-scoped daemon exists to stop managing (ADR 0130).
+    (payload.repository_activity === undefined || isRedskilledActivityReport(payload.repository_activity)) &&
+    // Absent is accepted for the same reason, and for one more: this block is
+    // newer than the report beside it, so a daemon one release behind serves
+    // every counter's value without their per-counter ages.
+    (payload.remote_counters === undefined || isRedskilledRemoteCounterReport(payload.remote_counters)) &&
+    // Absent is accepted for the same reason: a daemon older than the balance
+    // poller answers completely without it, and a consumer that rejected the
+    // whole payload would lose the Worker set over a badge.
+    (payload.github_balance === undefined || isGithubBalanceReport(payload.github_balance)) &&
+    // Absent is accepted for the reason the two project lists are: a daemon that
+    // predates the reaper, or the engine block, answers completely without them,
+    // and rejecting the whole payload would lose the Worker set over a field this
+    // consumer only needed for a badge (ADR 0130 rule 3).
+    (payload.deaths === undefined || isStatuslineDeaths(payload.deaths)) &&
+    (payload.engine === undefined || isStatuslineEngine(payload.engine)) &&
+    (payload.metrics === undefined || isRedskilledStatuslineMetrics(payload.metrics));
+}
+
+function isStatuslineLapse(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const lapse = value as Record<string, unknown>;
+  return typeof lapse.project_label === "string" &&
+    typeof lapse.at === "string" &&
+    (lapse.registered_at === undefined || typeof lapse.registered_at === "string") &&
+    (lapse.standing === undefined || typeof lapse.standing === "boolean") &&
+    (lapse.queue_depth === undefined || Number.isInteger(lapse.queue_depth)) &&
+    typeof lapse.reason === "string";
+}
+
+function isStatuslineStop(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const stopped = value as Record<string, unknown>;
+  return typeof stopped.project_label === "string" &&
+    typeof stopped.at === "string" &&
+    (stopped.standing === undefined || typeof stopped.standing === "boolean") &&
+    (stopped.queue_depth === undefined || Number.isInteger(stopped.queue_depth));
+}
+
+function isStatuslineEngine(value: unknown): boolean {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const engine = value as Record<string, unknown>;
+  return typeof engine.running_version === "string" &&
+    (engine.published_version === null || typeof engine.published_version === "string");
+}

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -22,23 +22,21 @@
  */
 import {
   buildGithubBalanceReport,
-  isGithubBalanceReport,
   type GithubBalance,
   type GithubBalanceReport,
 } from "@reddb-io/github";
 import { measureHostConsumption, type RedskilledHostCeiling, type RedskilledHostConsumption } from "./admission.js";
 import type { RedskilledBudgetAccounting } from "./budget-accounting.js";
 import type { RedskilledHostState, RedskilledRegistrationLapse, RedskilledRegistrationStop, RedskilledRssSource, RedskilledWorkerView } from "./host-state.js";
-import { isRedskilledStatuslineMetrics, type RedskilledStatuslineMetrics } from "./live-metrics.js";
+import type { RedskilledStatuslineMetrics, RedskilledWorkerOutcomeMark } from "./live-metrics.js";
+import { buildLastOutcome, type RedskilledStatuslineLastOutcome } from "./statusline-last-outcome.js";
 import { resolveEnforcedBudget, type RedskilledBudgetName, type RedskilledRssReading } from "./memory-sampler.js";
 import {
   buildActivityReport,
-  isRedskilledActivityReport,
   type RedskilledActivityReport,
 } from "./activity-report.js";
 import {
   buildRemoteCounterReport,
-  isRedskilledRemoteCounterReport,
   type RedskilledRemoteCounterReport,
 } from "./remote-counters.js";
 import type { RedskilledRepositoryActivity } from "./repository-activity.js";
@@ -47,7 +45,6 @@ import { displayWithDerivedHeartbeat, type RedskilledWorkerDisplay, type Redskil
 import {
   buildDeaths,
   REDSKILLED_RECENT_DEATH_LIMIT,
-  isStatuslineDeaths,
   type RedskilledDeathObservation,
   type RedskilledStatuslineDeaths,
 } from "./statusline-deaths.js";
@@ -384,6 +381,11 @@ export interface RedskilledStatuslinePayload {
    */
   readonly engine?: RedskilledStatuslineEngine;
   /**
+   * The newest Worker ending this host recorded; `null` when it has recorded
+   * none, absent on a daemon that predates the block.
+   */
+  readonly last_outcome?: RedskilledStatuslineLastOutcome | null;
+  /**
    * The rates this daemon derived from the facts it alone holds.
    *
    * Here rather than computed per surface for the reason the activity counts and
@@ -477,6 +479,15 @@ export interface BuildStatuslinePayloadInput {
    * and this document stays a pure function of its inputs.
    */
   readonly metrics?: RedskilledStatuslineMetrics;
+  /**
+   * Every Worker ending this host still holds, newest last.
+   *
+   * The same list the rates are derived from, passed once and read twice: the
+   * count answers "how fast" and the newest entry answers "what just happened",
+   * and a second source for the second question would be a second authority on
+   * one history.
+   */
+  readonly outcomes?: readonly RedskilledWorkerOutcomeMark[];
 }
 
 /** The payload document. PURE — every aggregate is derived from the Worker set. */
@@ -584,6 +595,9 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
             healthyFleet: (input.hostState.registrations ?? []).length > 0 && (input.hostState.registrations ?? []).every((registration) => input.hostState.workers.filter((worker) => worker.project_label === registration.project_label).length >= Math.max(0, registration.target)),
           }),
         }),
+    // What an idle line says instead of nothing. `null` is a host that has ended
+    // no Worker; the field is absent only on a caller that passed no history.
+    ...(input.outcomes === undefined ? {} : { last_outcome: buildLastOutcome(input.outcomes) }),
     engine: buildEngine(input.hostState),
     // Echoed, never recomputed: the rates rest on a history only the daemon
     // holds, and a second derivation here would be a second authority on them.
@@ -775,90 +789,6 @@ function instant(value: string): number | null {
   return Number.isFinite(ms) ? ms : null;
 }
 
-/** True when `value` is a complete payload — a client's fail-closed check. */
-export function isRedskilledStatuslinePayload(value: unknown): value is RedskilledStatuslinePayload {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const payload = value as Record<string, unknown>;
-  const daemon = payload.daemon as Record<string, unknown> | undefined;
-  const staleness = payload.staleness as Record<string, unknown> | undefined;
-  const host = payload.host as Record<string, unknown> | undefined;
-  return payload.version === 1 &&
-    typeof payload.generated_at === "string" &&
-    daemon != null && typeof daemon === "object" &&
-    Number.isInteger(daemon.pid) &&
-    typeof daemon.daemon_version === "string" &&
-    typeof daemon.protocol_version === "number" &&
-    staleness != null && typeof staleness === "object" &&
-    typeof staleness.stale === "boolean" &&
-    typeof staleness.threshold_ms === "number" &&
-    Array.isArray(staleness.unmeasured_workers) &&
-    host != null && typeof host === "object" &&
-    Number.isInteger(host.worker_count) &&
-    Number.isInteger(host.project_count) &&
-    typeof host.observed_rss_bytes === "number" &&
-    Array.isArray(payload.projects) &&
-    Array.isArray(payload.workers) &&
-    // Absent is accepted for the same reason the activity report's is: a daemon
-    // older than this field answers completely without it, and a consumer that
-    // rejected the whole payload would lose the Worker set over a fact it only
-    // needed to tell an idle project from an unknown one.
-    (payload.known_projects === undefined ||
-      (Array.isArray(payload.known_projects) && payload.known_projects.every((label) => typeof label === "string"))) &&
-    (payload.registered_projects === undefined ||
-      (Array.isArray(payload.registered_projects) &&
-        payload.registered_projects.every((label) => typeof label === "string"))) &&
-    (payload.lapsed_projects === undefined ||
-      (Array.isArray(payload.lapsed_projects) && payload.lapsed_projects.every(isStatuslineLapse))) &&
-    (payload.stopped_projects === undefined ||
-      (Array.isArray(payload.stopped_projects) && payload.stopped_projects.every(isStatuslineStop))) &&
-    (payload.orphaned_projects === undefined ||
-      (Array.isArray(payload.orphaned_projects) &&
-        payload.orphaned_projects.every((label) => typeof label === "string"))) &&
-    // Absent is accepted, malformed is not: a daemon older than the activity
-    // poller answers a newer client's read, and rejecting its whole payload over
-    // a field this consumer did not ask for would lose the Worker set — the very
-    // version skew one host-scoped daemon exists to stop managing (ADR 0130).
-    (payload.repository_activity === undefined || isRedskilledActivityReport(payload.repository_activity)) &&
-    // Absent is accepted for the same reason, and for one more: this block is
-    // newer than the report beside it, so a daemon one release behind serves
-    // every counter's value without their per-counter ages.
-    (payload.remote_counters === undefined || isRedskilledRemoteCounterReport(payload.remote_counters)) &&
-    // Absent is accepted for the same reason: a daemon older than the balance
-    // poller answers completely without it, and a consumer that rejected the
-    // whole payload would lose the Worker set over a badge.
-    (payload.github_balance === undefined || isGithubBalanceReport(payload.github_balance)) &&
-    // Absent is accepted for the reason the two project lists are: a daemon that
-    // predates the reaper, or the engine block, answers completely without them,
-    // and rejecting the whole payload would lose the Worker set over a field this
-    // consumer only needed for a badge (ADR 0130 rule 3).
-    (payload.deaths === undefined || isStatuslineDeaths(payload.deaths)) &&
-    (payload.engine === undefined || isStatuslineEngine(payload.engine)) &&
-    (payload.metrics === undefined || isRedskilledStatuslineMetrics(payload.metrics));
-}
-
-function isStatuslineLapse(value: unknown): boolean {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const lapse = value as Record<string, unknown>;
-  return typeof lapse.project_label === "string" &&
-    typeof lapse.at === "string" &&
-    (lapse.registered_at === undefined || typeof lapse.registered_at === "string") &&
-    (lapse.standing === undefined || typeof lapse.standing === "boolean") &&
-    (lapse.queue_depth === undefined || Number.isInteger(lapse.queue_depth)) &&
-    typeof lapse.reason === "string";
-}
-
-function isStatuslineStop(value: unknown): boolean {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const stopped = value as Record<string, unknown>;
-  return typeof stopped.project_label === "string" &&
-    typeof stopped.at === "string" &&
-    (stopped.standing === undefined || typeof stopped.standing === "boolean") &&
-    (stopped.queue_depth === undefined || Number.isInteger(stopped.queue_depth));
-}
-
-function isStatuslineEngine(value: unknown): boolean {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const engine = value as Record<string, unknown>;
-  return typeof engine.running_version === "string" &&
-    (engine.published_version === null || typeof engine.published_version === "string");
-}
+// The fail-closed shape check moved to its own module (see the note there);
+// re-exported so every consumer keeps the import it already had.
+export { isRedskilledStatuslinePayload } from "./statusline-payload-guard.js";

--- a/apps/redskilled/tests/repository-activity.test.ts
+++ b/apps/redskilled/tests/repository-activity.test.ts
@@ -179,11 +179,15 @@ describe("counts are stored and returned, never interpreted", () => {
     // A genuinely empty tracker IS a zero — this is the only outcome that carries one.
     // The queue counters stay null even here: the aliased query asked for no
     // label breakdown, so nothing counted them and nothing may read as drained.
+    // The trunk lines stay null for the same reason: this path runs no
+    // comparison, and an unasked measurement is an absence, not a quiet day.
     expect(activity.projects[1]!.counts).toEqual({
       open_pull_requests: 0,
       open_issues: 0,
       recently_closed: 0,
       merged_today: 0,
+      trunk_lines_added: null,
+      trunk_lines_removed: null,
       ready_queue: null,
       human_queue: null,
     });
@@ -470,6 +474,8 @@ describe("the daemon serves the counts it polled", () => {
       open_issues: 9,
       merged_today: 0,
       recently_closed: 2,
+      trunk_lines_added: null,
+      trunk_lines_removed: null,
       ready_queue: null,
       human_queue: null,
     });

--- a/apps/redskilled/tests/statusline-payload.test.ts
+++ b/apps/redskilled/tests/statusline-payload.test.ts
@@ -482,7 +482,10 @@ describe("the remote-counter block", () => {
       { ...REDSKILLED_STATUSLINE_DEFAULTS, project: "acme/widgets" },
     ).line);
 
-    expect(line).toContain("rdy=1 iss=24 pr=3 mrg=7");
+    // Three of the four: the LINE gave `iss` up to the day's landed volume, and
+    // the dashboard — which has the width — still prints it.
+    expect(line).toContain("rdy=1 pr=3 mrg=7");
+    expect(line).not.toContain("iss=");
     expect(line).not.toContain("cpr=");
   });
 

--- a/apps/redskilled/tests/statusline-string.test.ts
+++ b/apps/redskilled/tests/statusline-string.test.ts
@@ -350,6 +350,10 @@ describe("one renderer, machine-wide", () => {
     // the shared renderer; neither draws an independent statusline.
     "apps/redskilled/src/statusline-probe.ts",
     "apps/redskilled/src/statusline-command.ts",
+    // The payload's own fail-closed shape check, split out of it so the payload
+    // module dropped back under the file-size threshold. It imports the payload
+    // TYPE to be the guard FOR it; it renders nothing.
+    "apps/redskilled/src/statusline-payload-guard.ts",
   ]);
 
   it("keeps every other surface — every agent host included — on the string", () => {

--- a/apps/redskilled/tests/statusline-trunk-lines.test.ts
+++ b/apps/redskilled/tests/statusline-trunk-lines.test.ts
@@ -1,0 +1,232 @@
+/**
+ * The two facts an idle line and a shipped-today figure rest on.
+ *
+ * Both are extensions of history the daemon already keeps — the repository
+ * activity poll and the Worker outcome marks — so the claims here are about what
+ * each one does when it CANNOT answer, which is the only way either of them can
+ * lie to an operator.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  fetchConditionalRepositoryActivity,
+  fetchTrunkLinesToday,
+} from "../src/repository-activity-conditional.js";
+import { buildRepositoryActivityQuery } from "../src/repository-activity.js";
+import { replayedOutcomeMark, witnessedOutcomeMark } from "../src/live-metrics.js";
+import { buildLastOutcome } from "../src/statusline-last-outcome.js";
+
+const HEADERS = {};
+
+const answer = <T>(data: T) => ({ data, headers: HEADERS, requestCount: 1 });
+
+const commits = (rows: readonly Record<string, unknown>[]) => async () => answer(rows);
+
+describe("fetchTrunkLinesToday measures what landed, or says it could not", () => {
+  const request = (list: unknown, object: unknown) => ({
+    owner: "acme",
+    repo: "widgets",
+    since: "2026-08-21T00:00:00.000Z",
+    list: list as never,
+    object: object as never,
+  });
+
+  it("takes both ends of the day's span from ONE commit listing", async () => {
+    const routes: string[] = [];
+    const result = await fetchTrunkLinesToday(request(
+      async (input: unknown) => {
+        routes.push((input as { route: string }).route);
+        return answer([
+          { sha: "head", parents: [{ sha: "mid" }] },
+          { sha: "first", parents: [{ sha: "yesterday" }] },
+        ]);
+      },
+      async (input: unknown) => {
+        routes.push((input as { route: string }).route);
+        expect((input as { parameters: { basehead: string } }).parameters.basehead)
+          .toBe("yesterday...head");
+        return answer({ files: [{ additions: 12, deletions: 3 }, { additions: 400, deletions: 97 }] });
+      },
+    ));
+
+    expect(result.lines).toEqual({ added: 412, removed: 100 });
+    expect(routes).toEqual([
+      "GET /repos/{owner}/{repo}/commits",
+      "GET /repos/{owner}/{repo}/compare/{basehead}",
+    ]);
+  });
+
+  it("answers a real zero for a day the trunk did not move, and spends one request", async () => {
+    const result = await fetchTrunkLinesToday(request(commits([]) as never, async () => {
+      throw new Error("a day with no commits needs no comparison");
+    }));
+
+    expect(result.lines).toEqual({ added: 0, removed: 0 });
+    expect(result.requestCount).toBe(1);
+  });
+
+  it("states an absence, never a zero, when the comparison is truncated", async () => {
+    const files = Array.from({ length: 300 }, () => ({ additions: 1, deletions: 1 }));
+    const result = await fetchTrunkLinesToday(request(
+      commits([{ sha: "head", parents: [{ sha: "yesterday" }] }]) as never,
+      async () => answer({ files }),
+    ));
+
+    expect(result.lines).toEqual({ added: null, removed: null });
+  });
+
+  it("states an absence when the comparison carries no file list at all", async () => {
+    const result = await fetchTrunkLinesToday(request(
+      commits([{ sha: "head", parents: [{ sha: "yesterday" }] }]) as never,
+      async () => answer({}),
+    ));
+
+    expect(result.lines).toEqual({ added: null, removed: null });
+  });
+
+  it("costs the caller nothing when the trunk is unreachable", async () => {
+    const result = await fetchTrunkLinesToday(request(
+      async () => {
+        throw new Error("the host token cannot see acme/widgets");
+      },
+      async () => answer({ files: [] }),
+    ));
+
+    expect(result.lines).toEqual({ added: null, removed: null });
+  });
+
+  it("asks nothing of a transport that cannot read an object body", async () => {
+    const result = await fetchTrunkLinesToday(request(
+      async () => {
+        throw new Error("this listing must never be reached");
+      },
+      undefined,
+    ));
+
+    expect(result).toEqual({ lines: { added: null, removed: null }, requestCount: 0 });
+  });
+});
+
+describe("the newest Worker ending is what an idle host has left to say", () => {
+  const worker = { worker_id: "w1", project_label: "red-skills" };
+
+  it("keeps the Worker's own account of its work, read at the moment of death", () => {
+    expect(witnessedOutcomeMark(
+      worker,
+      "2026-08-21T11:57:00.000Z",
+      "worker-death",
+      { issue: "#4175", phase: "land" },
+      "work-reported",
+    )).toEqual({
+      worker_id: "w1",
+      ts: "2026-08-21T11:57:00.000Z",
+      outcome: "worker-death",
+      project_label: "red-skills",
+      issue: "#4175",
+      phase: "land",
+      birth_outcome: "work-reported",
+    });
+  });
+
+  it("carries strictly less from a lane replay, and says so with nulls", () => {
+    expect(replayedOutcomeMark({
+      worker_id: "w1",
+      ts: "2026-08-21T11:57:00.000Z",
+      event: "worker-budget-kill",
+      project_label: "red-skills",
+    })).toEqual({
+      worker_id: "w1",
+      ts: "2026-08-21T11:57:00.000Z",
+      outcome: "worker-budget-kill",
+      project_label: "red-skills",
+      issue: null,
+      phase: null,
+      birth_outcome: null,
+    });
+  });
+
+  it("picks the newest by instant, not by position, so a replay cannot pass for now", () => {
+    const replayed = replayedOutcomeMark({
+      worker_id: "old",
+      ts: "2026-08-21T09:00:00.000Z",
+      event: "worker-death",
+      project_label: "red-skills",
+    });
+    const live = witnessedOutcomeMark(
+      worker,
+      "2026-08-21T11:57:00.000Z",
+      "worker-death",
+      { issue: "#4175", phase: "land" },
+      "work-reported",
+    );
+
+    expect(buildLastOutcome([live, replayed])?.ts).toBe("2026-08-21T11:57:00.000Z");
+  });
+
+  it("has nothing to say on a host that has ended no Worker", () => {
+    expect(buildLastOutcome([])).toBeNull();
+    expect(buildLastOutcome(undefined)).toBeNull();
+  });
+
+  it("refuses an ending it cannot date, because an undated one has no age to print", () => {
+    expect(buildLastOutcome([replayedOutcomeMark({
+      worker_id: "w1",
+      ts: "not-an-instant",
+      event: "worker-death",
+      project_label: "red-skills",
+    })])).toBeNull();
+  });
+});
+
+describe("fetchConditionalRepositoryActivity carries the day's lines with the panorama", () => {
+  const project = { project_label: "acme/widgets", owner: "acme", name: "widgets" };
+  const NOW = "2026-08-21T12:00:00.000Z";
+
+  const transport = (
+    compare: Record<string, unknown>,
+  ): never => {
+    const base = (async () => {
+      throw new Error("this poll never issues GraphQL");
+    }) as unknown as Record<string, unknown>;
+    base.conditionalList = async (input: { route: string }) => {
+      if (input.route === "GET /repos/{owner}/{repo}/commits") {
+        return answer([{ sha: "head", parents: [{ sha: "yesterday" }] }]);
+      }
+      if (input.route === "GET /repos/{owner}/{repo}/pulls") return answer([{ number: 1 }, { number: 2 }]);
+      return answer([]);
+    };
+    base.conditionalCount = async () => answer({ total_count: 61 });
+    base.conditionalObject = async () => answer(compare);
+    return base as never;
+  };
+
+  const poll = async (compare: Record<string, unknown>) => {
+    const operation = buildRepositoryActivityQuery([project], { now: NOW });
+    return await fetchConditionalRepositoryActivity(
+      { projects: [project], hostTokenRef: "host", transport: transport(compare), now: NOW },
+      operation,
+    );
+  };
+
+  it("puts the measured lines on the same counts as the merge total", async () => {
+    const activity = await poll({ files: [{ additions: 900, deletions: 40 }] });
+
+    expect(activity.projects[0]!.counts).toMatchObject({
+      merged_today: 61,
+      open_pull_requests: 2,
+      trunk_lines_added: 900,
+      trunk_lines_removed: 40,
+    });
+  });
+
+  it("keeps the panorama when only the comparison failed", async () => {
+    const activity = await poll({});
+
+    expect(activity.projects[0]!.outcome).toBe("counted");
+    expect(activity.projects[0]!.counts).toMatchObject({
+      merged_today: 61,
+      trunk_lines_added: null,
+      trunk_lines_removed: null,
+    });
+  });
+});

--- a/packages/redskilled-render/counters.ts
+++ b/packages/redskilled-render/counters.ts
@@ -20,6 +20,7 @@
  *
  * PURE.
  */
+import { humanizeTokens } from "@reddb-io/shared/statusline-bedrock.js";
 import { formatDuration } from "./format.js";
 import type {
   RedskilledRenderActivityProject,
@@ -41,11 +42,36 @@ export const REDSKILLED_COUNTER_LABELS: ReadonlyArray<{
 ];
 
 /**
+ * The counters the ONE-LINE density prints, out of the four a table can afford.
+ *
+ * `iss` — the repository's total open issues — is the one that left. The line
+ * was already at 119 columns of a ~120 budget, and two cells the operator asked
+ * for needed the width: what the host just finished, and how much landed today.
+ * Something had to go, and of the four this is the only number that neither
+ * drives an action nor measures output: `rdy` is the drain's fuel, `pr` is what
+ * awaits review, `mrg` is the day's result, and a slow-moving backlog total is
+ * read on a dashboard, not glanced at between keystrokes.
+ *
+ * It is DROPPED FROM ONE DENSITY, never from the payload: `dashboardCounts`
+ * still carries `open_issues`, the table still prints it, and the daemon still
+ * polls it. A number removed from a document is a number nobody can get back;
+ * a number removed from a line is a layout decision.
+ */
+export const REDSKILLED_LINE_COUNTER_NAMES: readonly RedskilledRenderCounterName[] = [
+  "ready_queue",
+  "open_pull_requests",
+  "merged_today",
+];
+
+/**
  * The counter tokens for one project, ready to be joined into a head. PURE.
  *
  * Ordered `rdy iss pr mrg`: the actionable queue first, then the compact
  * repository panorama. The older seven-day `cpr` and human-queue cells remain
  * available as structured dashboard counts but no longer spend tail width.
+ *
+ * `only` narrows the set for a density that cannot afford all four; the ORDER
+ * stays this module's, so no caller can reshuffle the row it prints.
  *
  * A daemon that predates the counter block still renders `pr`/`iss` from the
  * poll-dated counts (ADR 0130 rule 3); it simply cannot date them
@@ -54,15 +80,51 @@ export const REDSKILLED_COUNTER_LABELS: ReadonlyArray<{
 export function remoteCounterTokens(
   payload: RedskilledRenderPayload,
   project: string | null,
+  only?: readonly RedskilledRenderCounterName[],
 ): readonly string[] {
   const block = counterProject(payload, project);
   const activity = activityProject(payload, project);
   const tokens: string[] = [];
   for (const { name, key } of REDSKILLED_COUNTER_LABELS) {
+    if (only != null && !only.includes(name)) continue;
     const token = counterToken(key, block?.counters[name], fallbackValue(activity, name));
     if (token != null) tokens.push(token);
   }
   return tokens;
+}
+
+/**
+ * The day's LANDED lines, as the one token that sits beside `mrg=`. PURE.
+ *
+ * **`loc=` and this are two different questions.** The bedrock's `loc=` is the
+ * working tree against its base — what the operator is HOLDING — and this is
+ * what actually reached the trunk since the calendar day began. An operator
+ * asking "how much did we ship today" was reading the first and getting the
+ * second's answer only by coincidence.
+ *
+ * Drawn from the repository-activity poll that already counted `merged_today`,
+ * never from a git walk: this function is on the render path, and the render
+ * path opens nothing.
+ *
+ * `null` when the poll carried no measurement — the counters module's own rule,
+ * one layer along: `rdy=0` is a drained queue and an absent `rdy` is a queue
+ * nobody counted, and a `+0 -0` printed for an unreachable trunk would state the
+ * calmest possible day for the noisiest possible failure. A measured zero is
+ * absent too, but for the opposite reason: it is the no-zero-noise rule every
+ * other cell on this line already follows.
+ */
+export function trunkLinesToken(
+  payload: RedskilledRenderPayload,
+  project: string | null,
+): string | null {
+  const counts = activityProject(payload, project)?.counts;
+  const added = counts?.trunk_lines_added;
+  const removed = counts?.trunk_lines_removed;
+  if (added == null || removed == null) return null;
+  const parts: string[] = [];
+  if (added > 0) parts.push(`+${humanizeTokens(added, { fractionalThousands: true })}`);
+  if (removed > 0) parts.push(`-${humanizeTokens(removed, { fractionalThousands: true })}`);
+  return parts.length === 0 ? null : parts.join(" ");
 }
 
 /** The repo-global counts a header carries as structure, each `null` when unpolled. */

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -12,11 +12,14 @@
  * the payload's own `generated_at`, so the dashboard and the statusline beside it
  * can only disagree if a pure function is impure.
  *
- * **Nothing here learns the pipeline.** The progress bar is drawn from the two
- * integers a project published (`phase_index`, `phase_total`) and from nothing
- * else. A renderer that knew what `coding` or `validating` meant would be
- * carrying castle semantics, which ADR 0130 rule 3 keeps out of the host lane
- * entirely — and this module runs on both sides of it.
+ * **The pipeline stays a position, never a meaning.** The progress bar is drawn
+ * from two integers: the pair a project published (`phase_index`,
+ * `phase_total`), or — when it published none — the pair `./lifecycle-phase.js`
+ * resolves from the phase word. Neither this module nor that one knows what
+ * `coding` or `validating` DO; a declared table says only which of five cells a
+ * word sits in, which is presentation, not the castle semantics ADR 0130 rule 3
+ * keeps out of the host lane. An undeclared word resolves to nothing and draws
+ * no bar, so the renderer can never invent a place in a pipeline it cannot see.
  *
  * **Host-side session facts stay absent rather than faked.** The context window
  * and the Pro/Max 5h/7d usage windows arrive from a Claude Code stdin payload
@@ -31,6 +34,7 @@ import {
   type RedskilledDashboardCounts,
 } from "./counters.js";
 import { projectLines, throughputLines, trendMark } from "./dashboard-sections.js";
+import { resolveLifecyclePosition } from "./lifecycle-phase.js";
 import {
   clamp,
   flattenPublishedLine,
@@ -381,18 +385,35 @@ function declaredWaitCell(display: RedskilledRenderWorkerDisplay, generatedAt: s
 /**
  * The pipeline bar, drawn from two integers and no vocabulary. PURE.
  *
- * `index` completed cells, one cursor, and the rest ahead. A project that
- * published no position gets no bar at all — a bar with an invented cursor would
- * put a Worker somewhere in a pipeline this module cannot see.
+ * `index` completed cells, one cursor, and the rest ahead. A Worker whose
+ * position is neither published NOR resolvable from its phase gets no bar at all
+ * — a bar with an invented cursor would put a Worker somewhere in a pipeline
+ * this module cannot see.
+ *
+ * **The published pair wins; the phase word is the fallback.** A project that
+ * states its own `phase_index`/`phase_total` is describing a pipeline this
+ * module does not own, and a declared table would be a second opinion on it.
+ * A native Worker publishes no pair at all — its pulse carries a ticket stage
+ * and nothing else — which is why every live Worker's bar rendered empty until
+ * `./lifecycle-phase.js` gave the stage word a position.
  */
 export function progressBar(display: RedskilledRenderWorkerDisplay): string {
   const total = display.phase_total;
   const index = display.phase_index;
-  if (total == null || total <= 0 || index == null || index < 0) return "";
-  const done = Math.min(Math.floor(index), Math.floor(total));
-  if (done >= total) return BAR_DONE.repeat(Math.floor(total));
-  const cursor = display.failed ? BAR_FAILED : BAR_CURSOR;
-  return `${BAR_DONE.repeat(done)}${cursor}${BAR_AHEAD.repeat(Math.floor(total) - done - 1)}`;
+  if (total != null && total > 0 && index != null && index >= 0) {
+    return barGlyphs(Math.floor(index), Math.floor(total), display.failed);
+  }
+  const position = resolveLifecyclePosition(display.phase);
+  if (position == null) return "";
+  return barGlyphs(position.index, position.total, position.failed || display.failed);
+}
+
+/** `done` filled cells, one cursor, the rest ahead — a finished bar is all fill. PURE. */
+function barGlyphs(index: number, total: number, failed: boolean): string {
+  const done = Math.min(index, total);
+  if (done >= total) return BAR_DONE.repeat(total);
+  const cursor = failed ? BAR_FAILED : BAR_CURSOR;
+  return `${BAR_DONE.repeat(done)}${cursor}${BAR_AHEAD.repeat(total - done - 1)}`;
 }
 
 /**

--- a/packages/redskilled-render/last-outcome.ts
+++ b/packages/redskilled-render/last-outcome.ts
@@ -1,0 +1,129 @@
+/**
+ * last-outcome — what an idle host has to say for itself.
+ *
+ * **`idle` alone is two facts wearing one word.** A drain that landed a Ticket
+ * thirty seconds ago and a drain that died an hour ago both render `0w idle`, so
+ * the one glance the statusline exists for cannot separate a machine at rest
+ * from a machine that stopped. The daemon already recorded both endings; nothing
+ * carried them the last hop to the line.
+ *
+ * **The daemon stores facts; this module chooses the word.** Which stage the
+ * Worker was in, what it reported, and which event kind ended it are three
+ * things the daemon witnesses. Turning them into `landed`, `parked` or `lost` is
+ * a rendering decision, and putting it here rather than at the recording site
+ * keeps the daemon out of a vocabulary it would then have to keep — and keeps
+ * the whole choice in the one package that already owns every other word on the
+ * line.
+ *
+ * **No new lane.** The marks this reads are the ones the daemon keeps for its
+ * own outcome rate, replayed on restart from `redskilled.log.toonl`. A restarted
+ * daemon's replay carries the project and the kind but not the Worker's own
+ * account of its work, so a recovered mark renders a coarser word and no issue
+ * number — less, honestly, rather than the same amount confidently.
+ *
+ * PURE.
+ */
+import { formatDuration } from "./format.js";
+import type { RedskilledRenderLastOutcome } from "./payload.js";
+
+/**
+ * The words an idle line may end with, each paired with what earns it.
+ *
+ * Ordered as the resolver tries them: the first row whose condition holds wins,
+ * so a budget kill is never re-read as a clean finish just because the Worker
+ * had reached its last stage.
+ *
+ * Declared as a table rather than a `switch` so the set is enumerable by a test
+ * and so a new ending is a row, not a branch. `unknown` is deliberately absent:
+ * a mark matching nothing renders no cell, because the plain `idle` an operator
+ * already understands beats a word invented to fill the slot.
+ */
+export const REDSKILLED_LAST_OUTCOME_WORDS = [
+  {
+    word: "killed",
+    why: "the host ended this Worker on its resource budget, whatever it was doing",
+    matches: (mark: RedskilledRenderLastOutcome): boolean => mark.kind === "worker-budget-kill",
+  },
+  {
+    word: "parked",
+    why: "the Worker's last stage reported `ok: false` — it stopped on a refusal, not on a finish",
+    matches: (mark: RedskilledRenderLastOutcome): boolean => (mark.phase ?? "").endsWith("!"),
+  },
+  {
+    word: "landed",
+    why: "the Worker reported its work done from the stage that reaches the trunk",
+    matches: (mark: RedskilledRenderLastOutcome): boolean =>
+      mark.birth_outcome === "work-reported" && LANDING_STAGES.has((mark.phase ?? "").toLowerCase()),
+  },
+  {
+    word: "done",
+    why: "the Worker reported its work done from an earlier stage; what reached the trunk is the trunk's to say",
+    matches: (mark: RedskilledRenderLastOutcome): boolean => mark.birth_outcome === "work-reported",
+  },
+  {
+    word: "no-work",
+    why: "the Worker booted, read the queue, found nothing eligible and said so",
+    matches: (mark: RedskilledRenderLastOutcome): boolean => mark.birth_outcome === "no-eligible-work",
+  },
+  {
+    word: "lost",
+    why: "the Worker ended without reporting anything — a crash, a signal, a non-zero exit",
+    matches: (mark: RedskilledRenderLastOutcome): boolean => mark.birth_outcome === "unreported",
+  },
+] as const;
+
+/**
+ * The stages from which "I am done" also means "it reached the trunk".
+ *
+ * `land` is the ticket loop's last stage and `merging` is its macro phase; a
+ * Worker reporting done from `implement` finished something else. The
+ * distinction is why `done` exists beside `landed` rather than every clean exit
+ * claiming a landing the daemon never witnessed.
+ */
+const LANDING_STAGES = new Set(["land", "merging", "merge", "cascade", "done"]);
+
+/**
+ * The word for one ending; `null` when no declared row claims it. PURE.
+ */
+export function lastOutcomeWord(mark: RedskilledRenderLastOutcome): string | null {
+  return REDSKILLED_LAST_OUTCOME_WORDS.find((row) => row.matches(mark))?.word ?? null;
+}
+
+/**
+ * The idle cell: `idle·landed #4175 3m`, or plain `idle`. PURE.
+ *
+ * The age is the distance from the ending to the payload's own instant, never a
+ * clock this module reads — a render that dated itself would put a second
+ * authority on "how long ago" beside the one every other cell answers to.
+ *
+ * Four things each degrade one piece and keep the rest: a host that has never
+ * run a Worker renders `idle`; an ending in another project renders `idle`,
+ * because one repository's last landing on a shared machine is not this
+ * repository's news; a replayed mark with no work item renders the word without
+ * a number; and an unreadable instant renders the word without an age.
+ */
+export function idleCell(
+  mark: RedskilledRenderLastOutcome | null | undefined,
+  project: string | null,
+  generatedAt: string,
+): string {
+  if (mark == null) return "idle";
+  if (project != null && mark.project_label != null && mark.project_label !== project) return "idle";
+  const word = lastOutcomeWord(mark);
+  if (word == null) return "idle";
+  const ended = Date.parse(mark.ts);
+  const now = Date.parse(generatedAt);
+  const age = Number.isFinite(ended) && Number.isFinite(now)
+    ? compactAge(Math.max(0, now - ended))
+    : null;
+  const issue = mark.issue == null || mark.issue === "" ? null : `#${mark.issue.replace(/^#/, "")}`;
+  return [`idle·${word}`, issue, age].filter((part): part is string => part != null).join(" ");
+}
+
+/** An age without zero-valued trailing units (`3m`, not `3m0s`). PURE. */
+function compactAge(ageMs: number): string {
+  return formatDuration(ageMs)
+    .replace(/m0s$/, "m")
+    .replace(/h0m$/, "h")
+    .replace(/d0h$/, "d");
+}

--- a/packages/redskilled-render/lifecycle-phase.ts
+++ b/packages/redskilled-render/lifecycle-phase.ts
@@ -1,0 +1,123 @@
+/**
+ * lifecycle-phase — where a live Worker stands in its pipeline, as two integers.
+ *
+ * **The bar was drawn once, declared successor-owned, and then drawn by nobody.**
+ * `0f4f7acc8` gave the statusline a lifecycle bar in the dev bundle's themed
+ * renderer; `911f83b66` deleted that renderer on the claim that "the Worker rows
+ * are the daemon renderer's". The daemon renderer draws `wid`, `iss` and `hb`
+ * and has never drawn a bar — the same cutover-to-a-successor-that-did-not-exist
+ * defect PR #4274 found for the Bedrock. This module is the successor arriving.
+ *
+ * **A position, never a picture.** The glyphs, the cursor and the paint already
+ * exist once in `./dashboard.js` (`progressBar`, `colourWorkerCell`), shared by
+ * every density. What was missing is the only thing the daemon could not answer:
+ * a Worker publishes a ticket STAGE on its pulse and no `phase_index`/
+ * `phase_total`, so the numeric bar rendered empty for every live Worker. This
+ * module turns the stage word into that pair and nothing else.
+ *
+ * **The mapping is a DECLARED TABLE, not a guess.** Two vocabularies exist and
+ * both are already owned elsewhere: the macro phases the bar has always had five
+ * cells for, and `TICKET_LOOP_STAGES` from `@reddb-io/worker`. Folding one into
+ * the other in a table means a new stage lands as one row here rather than as a
+ * silent misplacement of the cursor — and a stage NOBODY declared resolves to
+ * `null`, which renders no bar at all. A bar of unknown position is worse than
+ * no bar: it states a place in a pipeline this module cannot see.
+ *
+ * The stage a Worker publishes carries its own failure signal — the daemon's
+ * demand turn appends `!` when the ticket stage reported `ok: false` — so the
+ * cursor's colour is read off the same word as its position rather than from a
+ * second channel that could disagree with it.
+ *
+ * PURE.
+ */
+
+/**
+ * The five cells a lifecycle bar has, in order.
+ *
+ * These are the macro phases the deleted renderer drew and the dashboard's
+ * `phase` column still spells; keeping them is what makes the rebuilt bar the
+ * SAME bar rather than a second one beside it.
+ */
+export const REDSKILLED_MACRO_PHASES = [
+  "setup",
+  "coding",
+  "validating",
+  "merging",
+  "done",
+] as const;
+
+export type RedskilledMacroPhase = (typeof REDSKILLED_MACRO_PHASES)[number];
+
+/**
+ * Every phase word a Worker may publish, folded onto its macro phase.
+ *
+ * Three vocabularies meet here and each row says which one it came from:
+ *
+ *   - `TICKET_LOOP_STAGES` (`@reddb-io/worker`) — what a native Worker pulses
+ *     today. `publish` and `land` are ONE macro phase because the bar has five
+ *     cells and both are the same answer to "where is this work": on its way to
+ *     the trunk.
+ *   - the macro phases themselves, so a project that already publishes them
+ *     passes through instead of falling off the table.
+ *   - the landing phases the deleted renderer folded into `merging`, kept
+ *     verbatim so a bundle still spelling them keeps its cursor.
+ *
+ * Declared as data rather than as a `switch` so the guard tests can enumerate
+ * it, and so adding a stage is one row rather than an edit to a control flow.
+ */
+export const REDSKILLED_PHASE_MACRO_TABLE: Readonly<Record<string, RedskilledMacroPhase>> = {
+  // TICKET_LOOP_STAGES
+  claim: "setup",
+  implement: "coding",
+  gate: "validating",
+  publish: "merging",
+  land: "merging",
+  // the macro phases themselves
+  setup: "setup",
+  coding: "coding",
+  validating: "validating",
+  merging: "merging",
+  done: "done",
+  // the landing phases `0f4f7acc8` folded into `merging`
+  "push-pr": "merging",
+  merge: "merging",
+  cascade: "merging",
+};
+
+/** Where one Worker stands, ready for the bar the dashboard already draws. */
+export interface RedskilledLifecyclePosition {
+  readonly macro: RedskilledMacroPhase;
+  /** Completed cells ahead of the cursor. */
+  readonly index: number;
+  /** Always {@link REDSKILLED_MACRO_PHASES}.length — stated so the caller needs no import. */
+  readonly total: number;
+  /** The stage reported `ok: false`; the cursor turns to the failure glyph. */
+  readonly failed: boolean;
+}
+
+/**
+ * Resolve a published phase word to a bar position. PURE.
+ *
+ * `null` for an absent, empty or UNDECLARED word — the caller renders no bar.
+ * The trailing `!` the daemon appends to a stage that reported `ok: false`
+ * (`acp-demand-turn.ts`) is stripped before the lookup and returned as
+ * {@link RedskilledLifecyclePosition.failed}, because a failed `gate` is still
+ * at `gate`: losing its position to keep its alarm would tell the operator less.
+ */
+export function resolveLifecyclePosition(
+  phase: string | null | undefined,
+): RedskilledLifecyclePosition | null {
+  if (phase == null) return null;
+  const trimmed = phase.trim();
+  if (trimmed === "") return null;
+  const failed = trimmed.endsWith("!");
+  const word = (failed ? trimmed.slice(0, -1) : trimmed).toLowerCase();
+  const macro = REDSKILLED_PHASE_MACRO_TABLE[word];
+  if (macro === undefined) return null;
+  const total = REDSKILLED_MACRO_PHASES.length;
+  const cell = REDSKILLED_MACRO_PHASES.indexOf(macro);
+  // The TERMINAL phase has nothing ahead of it, so it completes the bar rather
+  // than parking a cursor on the last cell: `done` with a step still to go would
+  // draw the one state where there is no next step as though there were one.
+  return { macro, index: cell === total - 1 ? total : cell, total, failed };
+}

--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -37,7 +37,8 @@ import {
   type RedskilledDashboardCells,
   type RedskilledDashboardColumn,
 } from "./dashboard.js";
-import { remoteCounterTokens } from "./counters.js";
+import { REDSKILLED_LINE_COUNTER_NAMES, remoteCounterTokens, trunkLinesToken } from "./counters.js";
+import { idleCell } from "./last-outcome.js";
 import { clamp, flattenPublishedLine, formatBytes, formatDuration, pad, width } from "./format.js";
 import {
   BUDGET_BAND_MARK,
@@ -312,7 +313,12 @@ function renderHead(
     parts.push(memoryFigure(payload, options));
   } else if (match === "matched" || match === "unregistered") {
     parts.push(workerActivity(workers, workers.length));
-    if (workers.length === 0) parts.push("idle");
+    // An idle host says what it last DID. `idle` alone reads the same on a
+    // machine that landed a Ticket a minute ago and one that has been dead for
+    // an hour, and the daemon already recorded which of those this is.
+    if (workers.length === 0) {
+      parts.push(idleCell(payload.last_outcome, options.project, payload.generated_at));
+    }
   } else if (match === "name-only") {
     // The Workers still count — they are running — but the line says out loud
     // that the host holds no registration, and it never says `idle`: a project
@@ -330,7 +336,14 @@ function renderHead(
   // they render in `local` alone: a `global` head speaks for the host, and one
   // repository's queue depth on it would be attributed to every project on the
   // machine.
-  if (options.mode !== "global") parts.push(...remoteCounterTokens(payload, options.project));
+  if (options.mode !== "global") {
+    parts.push(...remoteCounterTokens(payload, options.project, REDSKILLED_LINE_COUNTER_NAMES));
+    // Beside `mrg=` because it is the same poll answering the same question at a
+    // finer grain: how much shipped today. The bedrock's `loc=` sits at the far
+    // end of the line and answers the other one — what is still in hand.
+    const landed = trunkLinesToken(payload, options.project);
+    if (landed != null) parts.push(landed);
+  }
   if (options.mode !== "global" && (match === "matched" || match === "unregistered" || match === "name-only")) {
     parts.push(memoryFigure(payload, options));
   }

--- a/packages/redskilled-render/payload.ts
+++ b/packages/redskilled-render/payload.ts
@@ -320,12 +320,44 @@ export interface RedskilledRenderHourlyHistory {
   readonly tickets_per_hour: RedskilledRenderHourlySeries;
 }
 
+/**
+ * One Worker ending, as the daemon witnessed or replayed it.
+ *
+ * Every field but `kind` and `ts` is nullable because a mark REPLAYED from the
+ * event lane after a daemon restart carries the project and the kind and nothing
+ * the Worker said about its own work. `./last-outcome.js` turns these facts into
+ * the word an idle line prints; nothing here is a word.
+ */
+export interface RedskilledRenderLastOutcome {
+  /** The lane's event kind — `worker-death` or `worker-budget-kill`. */
+  readonly kind: string;
+  /** When the daemon recorded the ending. */
+  readonly ts: string;
+  readonly project_label: string | null;
+  /** The work item as the Worker published it; never parsed by any renderer. */
+  readonly issue: string | null;
+  /** The last phase pulsed, `!`-suffixed when that stage refused. */
+  readonly phase: string | null;
+  /** What the Worker reported before ending, in the birth-outcome vocabulary. */
+  readonly birth_outcome: string | null;
+}
+
 /** One project's repository counts; `null` for every outcome but a count. */
 export interface RedskilledRenderActivityCounts {
   readonly open_pull_requests: number;
   readonly open_issues: number;
   readonly merged_today?: number;
   readonly recently_closed: number;
+  /**
+   * Lines the trunk gained today, from the SAME poll that counted the merges.
+   *
+   * Optional and nullable for two different facts: absent is a daemon that
+   * predates the figure, `null` is a poll that could not measure it, and neither
+   * is a zero — a quiet day is `0` and reads as one.
+   */
+  readonly trunk_lines_added?: number | null;
+  /** Lines the trunk lost today, on the same terms. */
+  readonly trunk_lines_removed?: number | null;
 }
 
 export interface RedskilledRenderActivityProject {
@@ -460,6 +492,12 @@ export interface RedskilledRenderPayload {
   readonly deaths?: RedskilledRenderDeaths;
   readonly engine?: RedskilledRenderEngine;
   readonly metrics?: RedskilledRenderMetrics;
+  /**
+   * The newest Worker ending this host recorded; `null` when it has recorded
+   * none, absent on a daemon that predates the block. What an idle line says
+   * instead of nothing.
+   */
+  readonly last_outcome?: RedskilledRenderLastOutcome | null;
   /**
    * Which count-scaling extras the composer deliberately left out.
    *

--- a/packages/redskilled-render/tests/counters.test.ts
+++ b/packages/redskilled-render/tests/counters.test.ts
@@ -14,6 +14,7 @@ import {
   remoteCounterTokens,
   stripAnsi,
 } from "../index.js";
+import { trunkLinesToken } from "../counters.js";
 import { counters, payload } from "./fixture.js";
 
 const LOCAL = { ...REDSKILLED_STATUSLINE_DEFAULTS, project: "acme/widgets" };
@@ -27,7 +28,7 @@ describe("remote counters ride the daemon payload", () => {
       renderRedskilledStatusline(payload({ remote_counters: counters(FIVE) }), LOCAL).line,
     );
 
-    expect(line).toBe("1w rdy=5 iss=24 pr=3 mrg=7 512M v3.3.11");
+    expect(line).toBe("1w rdy=5 pr=3 mrg=7 512M v3.3.11");
     expect(line).not.toContain("acme/widgets");
   });
 
@@ -45,9 +46,9 @@ describe("remote counters ride the daemon payload", () => {
       ).line,
     );
 
-    expect(fresh).toContain("rdy=5 iss=24 pr=3 mrg=7");
+    expect(fresh).toContain("rdy=5 pr=3 mrg=7");
     expect(fresh).not.toContain("(");
-    expect(stale).toContain("rdy=5(15m) iss=24(15m) pr=3(15m) mrg=7(15m)");
+    expect(stale).toContain("rdy=5(15m) pr=3(15m) mrg=7(15m)");
   });
 
   it("costs the line nothing for a counter this poll never produced", () => {
@@ -60,7 +61,7 @@ describe("remote counters ride the daemon payload", () => {
 
     // NOT `rdy=0`: a queue nobody counted and a queue that drained are different
     // facts, and only one of them is a number.
-    expect(line).toContain("iss=24 pr=3");
+    expect(line).toContain("pr=3");
     expect(line).not.toContain("rdy=");
     expect(line).not.toContain("hmn=");
   });
@@ -91,13 +92,16 @@ describe("remote counters ride the daemon payload", () => {
     const line = stripAnsi(renderRedskilledStatusline(document, LOCAL).line);
     const header = stripAnsi(renderRedskilledDashboard(document, TABLE).header.line);
 
-    // The table separates its parts and the line does not; the counters, their
-    // order and their ages are the same poll either way.
+    // The table separates its parts and the line does not; a counter both draw
+    // carries the same value and the same age either way. The LINE draws three
+    // of the four — `iss` costs width the day's landed volume needed more, and
+    // the table, which has the room, keeps it.
     expect(header).toContain("rdy=5(15m) · iss=24(15m) · pr=3(15m) · mrg=7(15m)");
     expect(header).not.toContain("!counts stale");
-    for (const token of ["rdy=5(15m)", "iss=24(15m)", "pr=3(15m)", "mrg=7(15m)"]) {
+    for (const token of ["rdy=5(15m)", "pr=3(15m)", "mrg=7(15m)"]) {
       expect(line).toContain(token);
     }
+    expect(line).not.toContain("iss=");
     expect(renderRedskilledDashboard(document, TABLE).header.counts).toMatchObject({
       open_pull_requests: 3,
       merged_today: 7,
@@ -130,11 +134,83 @@ describe("remote counters ride the daemon payload", () => {
     const line = stripAnsi(renderRedskilledStatusline(document, LOCAL).line);
     const header = stripAnsi(renderRedskilledDashboard(document, TABLE).header.line);
 
-    expect(line).toContain("iss=24 pr=3");
+    expect(line).toContain("pr=3");
     expect(line).not.toContain("cpr=");
     expect(line).not.toContain("rdy=");
     expect(header).toContain("iss=24 · pr=3");
     expect(header).not.toContain("cpr=");
     expect(header).toContain("!counts stale");
+  });
+});
+
+describe("the day's landed lines ride the same poll as the merge count", () => {
+  const activity = (
+    counts: Record<string, number | null> | null,
+    project = "acme/widgets",
+  ) => ({
+    fetched_at: "2026-08-03T00:02:00.000Z",
+    age_ms: 5_000,
+    stale: false,
+    reason: "fetched 5000ms ago",
+    projects: [{ project_label: project, repository: project, counts: counts as never }],
+  });
+
+  it("renders the landed volume beside the merge counter", () => {
+    const line = stripAnsi(
+      renderRedskilledStatusline(
+        payload({
+          remote_counters: counters(FIVE),
+          repository_activity: activity({
+            open_pull_requests: 3,
+            open_issues: 24,
+            recently_closed: 1,
+            merged_today: 7,
+            trunk_lines_added: 12_400,
+            trunk_lines_removed: 3_100,
+          }),
+        }),
+        LOCAL,
+      ).line,
+    );
+
+    expect(line).toContain("mrg=7 +12.4k -3.1k");
+  });
+
+  it("humanizes through the one humanizer, keeping a whole thousand whole", () => {
+    expect(
+      trunkLinesToken(
+        payload({ repository_activity: activity({ trunk_lines_added: 12_000, trunk_lines_removed: 940 }) }),
+        "acme/widgets",
+      ),
+    ).toBe("+12k -940");
+  });
+
+  it("states an absence rather than a calm zero when the poll could not measure", () => {
+    expect(
+      trunkLinesToken(
+        payload({ repository_activity: activity({ trunk_lines_added: null, trunk_lines_removed: null }) }),
+        "acme/widgets",
+      ),
+    ).toBeNull();
+  });
+
+  it("says nothing on a day the trunk did not move — the no-zero-noise rule", () => {
+    expect(
+      trunkLinesToken(
+        payload({ repository_activity: activity({ trunk_lines_added: 0, trunk_lines_removed: 0 }) }),
+        "acme/widgets",
+      ),
+    ).toBeNull();
+  });
+
+  it("says nothing for a daemon that predates the measurement, and for another project's", () => {
+    expect(trunkLinesToken(payload({ repository_activity: activity({ merged_today: 7 }) }), "acme/widgets"))
+      .toBeNull();
+    expect(
+      trunkLinesToken(
+        payload({ repository_activity: activity({ trunk_lines_added: 5, trunk_lines_removed: 1 }, "other/repo") }),
+        "acme/widgets",
+      ),
+    ).toBeNull();
   });
 });

--- a/packages/redskilled-render/tests/last-outcome.test.ts
+++ b/packages/redskilled-render/tests/last-outcome.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { idleCell, lastOutcomeWord, REDSKILLED_LAST_OUTCOME_WORDS } from "../last-outcome.js";
+import type { RedskilledRenderLastOutcome } from "../payload.js";
+
+const NOW = "2026-08-21T12:00:00.000Z";
+
+const ending = (fields: Partial<RedskilledRenderLastOutcome> = {}): RedskilledRenderLastOutcome => ({
+  kind: "worker-death",
+  ts: "2026-08-21T11:57:00.000Z",
+  project_label: "red-skills",
+  issue: "#4175",
+  phase: "land",
+  birth_outcome: "work-reported",
+  ...fields,
+});
+
+describe("lastOutcomeWord", () => {
+  it("names a Worker that reported done from the stage that reaches the trunk", () => {
+    expect(lastOutcomeWord(ending())).toBe("landed");
+  });
+
+  it("says done, not landed, when the report came from an earlier stage", () => {
+    expect(lastOutcomeWord(ending({ phase: "implement" }))).toBe("done");
+  });
+
+  it("reads the stage's own refusal mark as a park, whatever the Worker reported", () => {
+    expect(lastOutcomeWord(ending({ phase: "gate!", birth_outcome: "work-reported" }))).toBe("parked");
+  });
+
+  it("lets a budget kill outrank every other reading of the same ending", () => {
+    expect(lastOutcomeWord(ending({ kind: "worker-budget-kill" }))).toBe("killed");
+  });
+
+  it("separates a drained queue from a crash", () => {
+    expect(lastOutcomeWord(ending({ phase: null, birth_outcome: "no-eligible-work" }))).toBe("no-work");
+    expect(lastOutcomeWord(ending({ phase: null, birth_outcome: "unreported" }))).toBe("lost");
+  });
+
+  it("names nothing for an ending no declared row claims", () => {
+    expect(lastOutcomeWord(ending({ phase: null, birth_outcome: null }))).toBeNull();
+  });
+
+  it("gives every declared word a reason a reader can check", () => {
+    for (const row of REDSKILLED_LAST_OUTCOME_WORDS) {
+      expect(row.why.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe("idleCell", () => {
+  it("says what just happened, and how long ago", () => {
+    expect(idleCell(ending(), "red-skills", NOW)).toBe("idle·landed #4175 3m");
+  });
+
+  it("does not repeat a hash the project already published", () => {
+    expect(idleCell(ending({ issue: "4175" }), "red-skills", NOW)).toBe("idle·landed #4175 3m");
+  });
+
+  it("renders plain idle on a host that has ended no Worker", () => {
+    expect(idleCell(null, "red-skills", NOW)).toBe("idle");
+    expect(idleCell(undefined, "red-skills", NOW)).toBe("idle");
+  });
+
+  it("keeps another project's ending off this project's line", () => {
+    expect(idleCell(ending({ project_label: "other/repo" }), "red-skills", NOW)).toBe("idle");
+  });
+
+  it("drops the work item a replayed mark could not carry, and keeps the rest", () => {
+    const replayed = ending({ issue: null, phase: null, birth_outcome: null, kind: "worker-budget-kill" });
+    expect(idleCell(replayed, "red-skills", NOW)).toBe("idle·killed 3m");
+  });
+
+  it("keeps the word when the ending carries no readable instant", () => {
+    expect(idleCell(ending({ ts: "not-an-instant" }), "red-skills", NOW)).toBe("idle·landed #4175");
+  });
+
+  it("dates the ending against the payload's instant, never a clock of its own", () => {
+    expect(idleCell(ending(), "red-skills", "2026-08-21T12:12:00.000Z")).toBe("idle·landed #4175 15m");
+  });
+});

--- a/packages/redskilled-render/tests/lifecycle-phase.test.ts
+++ b/packages/redskilled-render/tests/lifecycle-phase.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { progressBar } from "../dashboard.js";
+import {
+  REDSKILLED_MACRO_PHASES,
+  REDSKILLED_PHASE_MACRO_TABLE,
+  resolveLifecyclePosition,
+} from "../lifecycle-phase.js";
+import { REDSKILLED_RENDER_DISPLAY_ABSENT } from "../payload.js";
+import { phaseActivityCell } from "../worker-cells.js";
+
+/** The stages `@reddb-io/worker` pulses, restated so a drift here is visible. */
+const TICKET_LOOP_STAGES = ["claim", "implement", "gate", "publish", "land"] as const;
+
+const display = (fields: Record<string, unknown>) => ({
+  ...REDSKILLED_RENDER_DISPLAY_ABSENT,
+  ...fields,
+});
+
+describe("resolveLifecyclePosition", () => {
+  it("gives every ticket-loop stage a declared cell", () => {
+    for (const stage of TICKET_LOOP_STAGES) {
+      const position = resolveLifecyclePosition(stage);
+      expect(position, `stage ${stage} has no declared macro phase`).not.toBeNull();
+      expect(REDSKILLED_MACRO_PHASES).toContain(position!.macro);
+      expect(position!.total).toBe(REDSKILLED_MACRO_PHASES.length);
+    }
+  });
+
+  it("walks the pipeline forward, and folds publish and land onto one cell", () => {
+    expect(resolveLifecyclePosition("claim")?.index).toBe(0);
+    expect(resolveLifecyclePosition("implement")?.index).toBe(1);
+    expect(resolveLifecyclePosition("gate")?.index).toBe(2);
+    expect(resolveLifecyclePosition("publish")?.index).toBe(3);
+    expect(resolveLifecyclePosition("land")?.index).toBe(3);
+  });
+
+  it("reads the stage's own refusal mark as the cursor's failure, keeping its place", () => {
+    expect(resolveLifecyclePosition("gate!")).toEqual({
+      macro: "validating",
+      index: 2,
+      total: 5,
+      failed: true,
+    });
+  });
+
+  it("resolves nothing for an absent, empty or undeclared word", () => {
+    expect(resolveLifecyclePosition(null)).toBeNull();
+    expect(resolveLifecyclePosition("")).toBeNull();
+    expect(resolveLifecyclePosition("   ")).toBeNull();
+    expect(resolveLifecyclePosition("reticulating-splines")).toBeNull();
+  });
+
+  it("declares every macro phase as its own row, so a project publishing one passes through", () => {
+    for (const macro of REDSKILLED_MACRO_PHASES) {
+      expect(REDSKILLED_PHASE_MACRO_TABLE[macro]).toBe(macro);
+    }
+  });
+});
+
+describe("progressBar", () => {
+  it("draws a bar for a live Worker that publishes only a stage", () => {
+    expect(progressBar(display({ phase: "claim" }))).toBe("▶░░░░");
+    expect(progressBar(display({ phase: "implement" }))).toBe("█▶░░░");
+    expect(progressBar(display({ phase: "gate" }))).toBe("██▶░░");
+    expect(progressBar(display({ phase: "land" }))).toBe("███▶░");
+  });
+
+  it("fills the whole bar when the work is done", () => {
+    expect(progressBar(display({ phase: "done" }))).toBe("█████");
+  });
+
+  it("spends the failure cursor on a stage that refused", () => {
+    expect(progressBar(display({ phase: "gate!" }))).toBe("██✗░░");
+  });
+
+  it("draws NO bar rather than a bar of unknown position", () => {
+    expect(progressBar(display({ phase: null }))).toBe("");
+    expect(progressBar(display({ phase: "sharpening-pencils" }))).toBe("");
+  });
+
+  it("lets a project's own published position win over the declared table", () => {
+    // `claim` would resolve to cell 0; the published pair says otherwise and owns
+    // a pipeline this renderer does not.
+    expect(progressBar(display({ phase: "claim", phase_index: 2, phase_total: 3 }))).toBe("██▶");
+  });
+});
+
+describe("phaseActivityCell", () => {
+  it("positions the phase from the same resolution the bar uses", () => {
+    expect(phaseActivityCell(display({ phase: "gate", step: "round 2" }))).toBe("gate 3/5 · round 2");
+  });
+
+  it("leaves an undeclared phase its bare word and no invented ordinal", () => {
+    expect(phaseActivityCell(display({ phase: "napping" }))).toBe("napping");
+  });
+});

--- a/packages/redskilled-render/worker-cells.ts
+++ b/packages/redskilled-render/worker-cells.ts
@@ -1,13 +1,24 @@
 import { formatDuration } from "./format.js";
+import { resolveLifecyclePosition } from "./lifecycle-phase.js";
 import type { RedskilledRenderWorker, RedskilledRenderWorkerDisplay } from "./payload.js";
 
-/** Macro position and momentary verb, with their axes visible in the grammar. */
+/**
+ * Macro position and momentary verb, with their axes visible in the grammar.
+ *
+ * The position comes from the published pair when there is one and from the
+ * phase word's declared cell otherwise — the SAME resolution the bar beside it
+ * uses, so the cell can never state `gate 3/5` beside a bar drawn at a different
+ * cursor. A phase no table declares keeps its bare word and gains no ordinal.
+ */
 export function phaseActivityCell(display: RedskilledRenderWorkerDisplay): string {
   const phase = display.phase;
   const total = display.phase_total;
   const index = display.phase_index;
-  const positioned = phase != null && total != null && total > 0 && index != null && index >= 0
-    ? `${phase} ${Math.min(Math.floor(index) + 1, Math.floor(total))}/${Math.floor(total)}`
+  const resolved = total != null && total > 0 && index != null && index >= 0
+    ? { index: Math.floor(index), total: Math.floor(total) }
+    : resolveLifecyclePosition(phase);
+  const positioned = phase != null && resolved != null
+    ? `${phase} ${Math.min(resolved.index + 1, resolved.total)}/${resolved.total}`
     : phase;
   return [positioned, display.step].filter((part): part is string => Boolean(part)).join(" · ");
 }

--- a/packages/shared/statusline-bedrock.test.ts
+++ b/packages/shared/statusline-bedrock.test.ts
@@ -68,6 +68,22 @@ describe("renderStatuslineBedrock assembles the zero-network half", () => {
   });
 });
 
+describe("humanizeTokens is the line's ONE spelling of a large number", () => {
+  it("keeps its default shape, so no existing cell changes width", () => {
+    expect(humanizeTokens(940)).toBe("940");
+    expect(humanizeTokens(12_400)).toBe("12k");
+    expect(humanizeTokens(2_400_000)).toBe("2.4M");
+  });
+
+  it("keeps the thousands digit for a caller that asks, and drops a bare .0", () => {
+    expect(humanizeTokens(12_400, { fractionalThousands: true })).toBe("12.4k");
+    expect(humanizeTokens(3_100, { fractionalThousands: true })).toBe("3.1k");
+    expect(humanizeTokens(12_000, { fractionalThousands: true })).toBe("12k");
+    expect(humanizeTokens(940, { fractionalThousands: true })).toBe("940");
+    expect(humanizeTokens(2_400_000, { fractionalThousands: true })).toBe("2.4M");
+  });
+});
+
 describe("composeStatuslineLines draws the bedrock/tail seam", () => {
   it("leads the header with the bedrock and passes the rest of the tail through", () => {
     expect(composeStatuslineLines("BEDROCK", ["head line", "worker row"])).toEqual([

--- a/packages/shared/statusline-bedrock.ts
+++ b/packages/shared/statusline-bedrock.ts
@@ -83,13 +83,37 @@ export interface StatuslineBedrockInput {
   localDiff?: LocalDiffInput;
 }
 
+/** How much resolution {@link humanizeTokens} keeps at the thousands scale. */
+export interface HumanizeTokensOptions {
+  /**
+   * Render thousands as `12.4k` rather than `12k`.
+   *
+   * Off by default because the bedrock's context cell has always spelled `47k`
+   * and a digit added there would be a digit taken from something else. It is ON
+   * for the day's landed lines, where the difference between `12k` and `12.4k`
+   * is the difference between a rounded impression and a figure, and where the
+   * two-token pair is read as one measurement.
+   */
+  readonly fractionalThousands?: boolean;
+}
+
 /**
- * Humanizes a token count the way statusline.sh does: `X.XM` at/above 1e6,
+ * Humanizes a count the way statusline.sh does: `X.XM` at/above 1e6,
  * integer-division `Xk` at/above 1e3, raw integer below.
+ *
+ * **One humanizer for every figure on the line.** Named for tokens because that
+ * is what it was first asked, but the shape is the line's house style for a
+ * large number, and a second spelling of it beside the first is how `12k` and
+ * `12K` end up on one row. A caller wanting more resolution asks for it here
+ * rather than rounding for itself.
  */
-export function humanizeTokens(tokens: number): string {
+export function humanizeTokens(tokens: number, options: HumanizeTokensOptions = {}): string {
   if (tokens >= 1000000) return `${(tokens / 1000000).toFixed(1)}M`;
-  if (tokens >= 1000) return `${Math.floor(tokens / 1000)}k`;
+  if (tokens >= 1000) {
+    if (options.fractionalThousands !== true) return `${Math.floor(tokens / 1000)}k`;
+    // A trailing `.0` is a digit that carries nothing; `12.0k` is `12k`.
+    return `${Number((tokens / 1000).toFixed(1))}k`;
+  }
   return String(tokens);
 }
 


### PR DESCRIPTION
## What the operator asked for

Three things. One of them was a **correction mid-flight**: not a context-usage bar — the **Worker lifecycle progress bar**, which existed and was deleted.

---

## 1. The lifecycle bar, rebuilt in the daemon renderer

**It was declared successor-owned and then drawn by nobody.** `0f4f7acc8` ("feat(statusline): render worker lifecycle progress bar", Refs #2495) added it to the dev bundle's `statusline-style.ts`. `911f83b66` ("refactor(dev): the dead themed renderer leaves whole") deleted that renderer, claiming *"the prompt line is now bedrock + daemon tail … and the Worker rows are the daemon renderer's"*. The daemon renderer never drew them — it renders `Nw`, `idle`, and (since #4181/#4216) a live Worker's id, issue and heartbeat. **This is the same defect class PR #4274 found for the Bedrock: a cutover to a successor that did not exist.**

`plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md:106` has been telling operators to expect "one row per live Worker — each with its progress bar, `run=`/`org=`/`iss=`, `phase·activity`, elapsed and `hb=`" the whole time. That sentence is true again as of this PR.

**Most of the machinery was still standing.** `packages/redskilled-render/dashboard.ts` already declares a `bar` column, already draws `█ ▶ ✗ ░`, and `palette.ts` already publishes the intensity ramp (`BAR_DONE`/`BAR_CURRENT`/`BAR_AHEAD`, plus `SPOTLIGHT` for the failure cursor) those glyphs are painted with. What was missing was the one thing the daemon could not answer: `progressBar` needed `phase_index`/`phase_total`, and a native Worker publishes **neither** — its pulse carries a ticket stage (`acp-demand-turn.ts` reads `_meta.redskills.ticketStage`) and nothing else. So the bar rendered empty for every live Worker.

New `packages/redskilled-render/lifecycle-phase.ts` closes exactly that gap with **one declared table**:

| published phase | macro phase | source |
| --- | --- | --- |
| `claim` | `setup` | `TICKET_LOOP_STAGES` |
| `implement` | `coding` | `TICKET_LOOP_STAGES` |
| `gate` | `validating` | `TICKET_LOOP_STAGES` |
| `publish`, `land` | `merging` | `TICKET_LOOP_STAGES` |
| `setup` … `done` | itself | the macro phases, passed through |
| `push-pr`, `merge`, `cascade` | `merging` | kept verbatim from `0f4f7acc8` |

Rules it holds:

- **A published pair still wins.** A project stating its own `phase_index`/`phase_total` is describing a pipeline this renderer does not own, and a table would be a second opinion on it.
- **An undeclared phase draws no bar.** A bar of unknown position states a place in a pipeline the renderer cannot see.
- **`failed` comes off the same word as the position.** The daemon appends `!` to a stage that reported `ok: false`; a failed `gate` keeps its cell and changes its cursor.
- **The terminal phase fills the bar** rather than parking a cursor on the last cell.
- **`phase·activity` resolves through the same function**, so `gate 3/5` can never disagree with the cursor beside it.

### The bar, at every phase (observed)

| phase | `NO_COLOR` | painted |
| --- | --- | --- |
| `claim` | `▶░░░░` | `\e[38;2;255;255;255m▶\e[38;2;51;57;73m░░░░` |
| `implement` | `█▶░░░` | `\e[38;2;179;184;196m█\e[38;2;255;255;255m▶\e[38;2;51;57;73m░░░` |
| `gate` | `██▶░░` | `\e[38;2;179;184;196m██\e[38;2;255;255;255m▶\e[38;2;51;57;73m░░` |
| `gate!` (failed) | `██✗░░` | `\e[38;2;179;184;196m██\e[38;2;255;32;86m✗\e[38;2;51;57;73m░░` |
| `land` | `███▶░` | `\e[38;2;179;184;196m███\e[38;2;255;255;255m▶\e[38;2;51;57;73m░` |
| `done` | `█████` | `\e[38;2;179;184;196m█████` |
| `napping` (undeclared) | *(empty)* | *(empty)* |

`255;32;86` is `red.500` — the brand's one spotlight, spent on the failure cursor and nothing else. `NO_COLOR` is honest because the paint decision lives in the daemon's adapter, not in the pure renderer.

### Per-Worker `loc=`: deliberately NOT added

The daemon holds a Worker's diffstat only when the project publishes `added`/`removed` on its heartbeat, and the `loc` cell already renders when it does. Deriving it any other way means a git walk against a Worker's workspace **on the render path**, which is exactly what the brief said not to do. Left out.

---

## 2. The day's landed volume, beside `mrg=`

`loc=` is the working tree against its base — *what am I holding*. The operator asked what has actually **landed**.

`RedskilledActivityCounts` gains `trunk_lines_added` / `trunk_lines_removed`, measured by **the poll that already counts `merged_today`** — two conditional REST reads inside the existing 4-minute panorama refresh. No second git walk, nothing on the render path, no new poller.

**One read yields both ends of the span.** The day's commit listing is newest-first, so its head is the trunk tip and the **first parent of its tail** is where the trunk stood when the day began; naming each separately would have cost two requests. A third transport method (`conditionalObject`) carries the comparison, because a compare body is neither a page nor a search total and teaching either unwrapper a third shape would make the transport stop being a transport.

**It degrades to absent, never to a zero.** Unreachable trunk, spent quota, a comparison GitHub truncated at 300 files, or a daemon that predates the field — all render nothing. A day the trunk genuinely did not move is a measured `0` and also prints nothing, which is the no-zero-noise rule every other cell on the line already follows. A trunk comparison that fails on its own never costs the caller its open-issue and merge counts.

Humanized through **the one humanizer**: `humanizeTokens` gained an opt-in `fractionalThousands` (12 400 → `12.4k`, 12 000 → `12k`, trailing `.0` dropped) rather than being forked. Its default output is byte-identical, so no existing cell changed width.

---

## 3. `idle·<what just happened>`

Today an idle host renders `0w idle` whether it landed a Ticket a minute ago or died an hour back. **The daemon already recorded the difference** — it keeps a `RedskilledWorkerOutcomeMark` per Worker ending for its own outcome rate, and replays them from `~/.red/redskilled/redskilled.log.toonl` on restart. No new lane; the mark now also carries the project, the work item and the phase the Worker published, and what it reported before ending. Those are read **at the moment of death**, because the display map is cleared the instant the Worker is forgotten.

**The daemon stores facts; the renderer chooses the word** (`last-outcome.ts`, one ordered table):

| word | earned by |
| --- | --- |
| `killed` | the host ended it on its resource budget — outranks every other reading |
| `parked` | the last stage reported `ok: false` |
| `landed` | reported done **from the stage that reaches the trunk** |
| `done` | reported done from an earlier stage — what reached the trunk is the trunk's to say |
| `no-work` | booted, read the queue, found nothing eligible, said so |
| `lost` | ended reporting nothing: a crash, a signal, a non-zero exit |

`landed` and `done` are separate on purpose: ADR 0130 rule 3 means the daemon must not claim a repository fact it never witnessed, so a clean exit from `implement` does not get to claim a landing.

Four independent degradations: a host that never ran a Worker renders plain `idle`; another project's ending renders plain `idle` (one repository's landing on a shared machine is not this repository's news); a **replayed** mark renders the word without a work item, because a lane row never carried one; an undatable ending renders the word without an age.

---

## Observed lines

Built with `pnpm -C apps/redskilled bundle`, then the brief's command. This machine had a live Worker on #4282 at the `claim` stage, and the **running daemon is 4.1.26** — the pre-merge build — so `mrg=61` correctly carries no landed-lines cell.

**`NO_COLOR=1`:**

```
red-skills (feat/statusline-progress-st…) v4.1.26 Fable 5 ctx=47k 24% 5h=23% 7d=41% loc=+561 -133 · 1w rdy=1 pr=0 mrg=61 392M v4.1.26 †800
VSxa4yh  iss=#4282  ▶░░░░  claim 1/5  age=5m42s  hb=25s
```

**Painted (`cat -v`):**

```
^[[48;2;255;32;86m^[[38;2;7;8;10m» ^[[1mred-skills^[[22m (feat/statusline-progress-st…) v4.1.26^[[49m^[[38;2;139;145;161m ^[[48;2;18;20;27m^[[38;2;244;245;247mFable 5^[[49m^[[38;2;139;145;161m ^[[38;2;244;245;247mctx=^[[39m47k 24%^[[38;2;139;145;161m ^[[38;2;244;245;247m5h=^[[39m23%^[[38;2;139;145;161m ^[[38;2;244;245;247m7d=^[[39m41%^[[38;2;139;145;161m ^[[38;2;244;245;247mloc=^[[39m+561 -133^[[0m · 1w rdy=1 pr=0 mrg=61 392M v4.1.26 †800
^[[49m^[[38;2;139;145;161m^[[1mVSxa4yh^[[22m  ^[[38;2;244;245;247miss=^[[39m#4282^[[38;2;139;145;161m  ^[[38;2;255;255;255m▶^[[38;2;51;57;73m░░░░^[[38;2;139;145;161m  claim 1/5  ^[[38;2;244;245;247mage=^[[39m5m43s^[[38;2;139;145;161m  ^[[38;2;244;245;247mhb=^[[39m26s^[[38;2;139;145;161m^[[0m
```

**The idle cell and the landed lines**, rendered from the payload the post-merge daemon produces (a live daemon on this build is needed to show them from the socket, and starting one would displace the operator's own):

```
0w idle·landed #4175 2m5s rdy=1 pr=0 mrg=61 +12.4k -3.1k 512M v3.3.11   ← landed, with the day measured
0w idle·parked #4282 5s rdy=1 pr=0 mrg=61 512M v3.3.11                  ← parked; poll could not measure → absent
0w idle rdy=1 pr=0 mrg=61 512M v3.3.11                                  ← a host that has never run one
```

---

## Width: `iss=` is the cell that left, and why

The brief's own example line is **119 columns** against a ~120 budget. The two new **head** cells cost about 29. Something had to go, so the statusline head gives up `iss=`.

Of the four counters it is the only one that neither drives an action nor measures output: `rdy` is the drain's fuel, `pr` is what awaits review, `mrg` is the day's result, and a slow-moving open-issue total is read on a dashboard, not glanced at between keystrokes. **It is dropped from ONE DENSITY, never from the payload** — `dashboardCounts` still carries `open_issues`, the dashboard header still prints it, and the daemon still polls it. A number removed from a document is one nobody can get back; a number removed from a line is a layout decision.

| line | columns |
| --- | --- |
| today (brief's example) | 119 |
| after — busy host | 121 |
| after — idle, poll could not measure | 129 |
| after — idle, day measured (worst case) | 142 |
| Worker row (its own line, own budget) | 55 |

**Stated plainly: the worst case is 142, not ≤120.** The lifecycle bar costs the head nothing — it lives on the Worker row, which has its own budget and comes in at 55 — and the two new head cells are mutually exclusive with each other's busiest case (`idle·…` appears only when no Worker is live). Nothing is silently truncated. Dropping a second existing cell would have to take `pr=`, `mrg=`, the memory figure or the engine version, and each of those is a fact the operator asked to keep or a skew signal (`v…⇡`) that exists precisely for the moment it disagrees. Say the word and the next slice takes another.

---

## Debt paid on the way through

- `apps/redskilled/src/statusline-payload.ts` **864 → 794 lines**: its fail-closed shape check moved to `statusline-payload-guard.ts`, and the file **left the file-size baseline** rather than having its number raised.
- `fetchConditionalRepositoryActivity` — the production poll path — got its **first direct test** and **left the complexity-coverage baseline** (CRAP 600 → uncovered no longer applies).
- Both baselines shrank; neither gained an entry.

## Validation

| check | result |
| --- | --- |
| `pnpm typecheck` | 17/17 tasks green |
| `pnpm -C apps/plugin-dev test:invariants` | **494 passed** (file-size, complexity-coverage, dependency-direction, statusline-command-doc, countersign vocabulary, declared waits, …) |
| `pnpm lint` (oxlint) | clean |
| `packages/redskilled-render` | 108 passed (6 files, 2 new) |
| plugin-dev + `packages/shared` statusline suites | 200 passed (11 files) |
| `apps/redskilled` statusline / activity / metrics / dashboard suites | 194 passed (16 files, 1 new) |
| end-to-end | bundle built, both forms above observed |

No doc changed, so the byte-identical-copy sweep and `pnpm pi:packages:build` were not triggered. Changeset: patch on `@reddb-io/redskilled-render`, `@reddb-io/redskilled`, `@reddb-io/shared`, `@reddb-io/dev`.

Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789931913&installation_model_id=20659&pr_number=4286&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4286&signature=daa0d6522c16538f1c98034a2ae596fb3100569fc6b6f3c74ceeafe532a01e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->