### PR TITLE
feat(statusline): the Worker measures its own loc= and pulses it

### DIFF
--- a/.changeset/worker-measures-its-own-loc.md
+++ b/.changeset/worker-measures-its-own-loc.md
@@ -1,0 +1,17 @@
+---
+"@reddb-io/worker": patch
+"@reddb-io/redskilled": patch
+"@reddb-io/redskilled-render": patch
+"@reddb-io/dev": patch
+---
+
+statusline: the Worker measures its own `loc=+X -Y` and pulses it
+
+`loc=` is the one cell on the Worker row that answers "is this Worker producing anything", and it was the one cell #4286 could not restore — the daemon holds no checkout, so deriving the pair its own way would be a git walk per render. That is right about the render path and wrong about where the measurement belongs: the Worker is standing in the Worktree.
+
+- **The Worker measures, once per stage transition.** `measureWorktreeDiff` (`packages/worker/src/acp/worktree-diff.ts`) asks `git merge-base` and then a single `git diff --numstat` from that commit to the WORKING TREE, so committed rounds and the round the implementer is still typing are counted together, each line exactly once. Two diffs summed would double-count every line a later edit touched again, and the cell would climb while the branch stood still. The read is bounded (`WORKTREE_DIFF_TIMEOUT_MS`) and every failure returns `null`; a measurement that could delay a stage is not taken.
+- **The pair rides the route `phase` and `step` already take.** `TicketLoopRecord` gains `diff`, which the loop fills from a new `measureDiff` dep as each stage resolves — "the gate passed" and "the gate passed on +1394 -7397" are different facts, and the second is the useful one. `notifyTicketStage` puts it on the SAME `_meta.redskills.ticketStage` object, so no ACP field and no second channel was added; `sessionUpdateStage` parses it, the pulse carries it, and `applyWorkerPulse` folds it onto the display.
+- **`loc=` is a Worktree fact, and the Worktree outlives the agent.** The cell was gated behind the renderer's `noAgent` rule beside `tks=`/`tls=`/`rsn=`/`txt=`, which count what an agent did this turn. Under ADR 0148 `gate` and `land` are stages the Worker runs, with the diff it just committed sitting right there, so the gate blanked the cell for three of the loop's five stages. The four counters keep the rule; `loc=` does not.
+- **Absent still means unmeasured.** `loc=0` is a Worker that has produced nothing; no cell at all is a Worker nobody measured, and the two are never spelled the same way.
+
+`applyWorkerPulse` moves the pulse fold out of the daemon's lifecycle closure and beside the display type it builds, which retires the last `DAEMON_BOUNDARY_ALLOWANCES` entry.

--- a/apps/plugin-dev/src/core/daemon-death-evidence-guard.ts
+++ b/apps/plugin-dev/src/core/daemon-death-evidence-guard.ts
@@ -99,14 +99,11 @@ export interface DaemonBoundaryAllowance {
  * guard exists to refuse: an entry belongs here only when the daemon is holding
  * a value the client chose, unread.
  */
-export const DAEMON_BOUNDARY_ALLOWANCES: readonly DaemonBoundaryAllowance[] = [
-  {
-    path: "apps/redskilled/src/daemon/lifecycle.ts",
-    family: "tracker-issue",
-    reason:
-      "the heartbeat pulse carries the Worker's own published line verbatim; the daemon stores the field and hands it back without reading it (ADR 0140), which is the opposite of knowing what an issue is",
-  },
-];
+// Empty, and paid for rather than waived: `lifecycle.ts` held the last entry
+// because its pulse fold spelled `pulse.issue` inline. The fold moved to
+// `worker-display.ts`, beside the display type it builds and the coercion it
+// calls, so the daemon's lifecycle no longer names a tracker concept at all.
+export const DAEMON_BOUNDARY_ALLOWANCES: readonly DaemonBoundaryAllowance[] = [];
 
 export interface DaemonBoundaryFile {
   /** Repo-relative path, `/`-separated. */

--- a/apps/plugin-dev/src/core/file-size-guard.ts
+++ b/apps/plugin-dev/src/core/file-size-guard.ts
@@ -75,7 +75,7 @@ export const FILE_SIZE_BASELINE: readonly FileSizeBaselineEntry[] = [
   // number and leave the code worse. The entry states the debt with a ceiling;
   // paying it means decomposing the function, not moving its lines.
   // 2026-08-20: standing orders implementation added 8 lines
-  { path: "apps/redskilled/src/daemon/lifecycle.ts", lines: 2483 },
+  { path: "apps/redskilled/src/daemon/lifecycle.ts", lines: 2476 },
   { path: "apps/redskilled/src/cli.ts", lines: 1036 },
   { path: "apps/redskilled/src/client.ts", lines: 1003 },
   { path: "apps/rsp/src/resident-server.ts", lines: 931 },

--- a/apps/redskilled/src/acp-body-control-cut.ts
+++ b/apps/redskilled/src/acp-body-control-cut.ts
@@ -123,6 +123,11 @@ export const WORKER_BODY_MODULES: readonly WorkerBodyModule[] = [
     defines: ["runWorkerLocalGate"],
     runs: "runs the declared gate stages in the Worker's own Worktree, so the re-seed decision is made where the diff is",
   },
+  {
+    module: "worktree-diff.ts",
+    defines: ["measureWorktreeDiff", "parseNumstat"],
+    runs: "measures the Worker's own signed line pair once per stage transition, because the daemon holds no checkout to derive the statusline's `loc=` cell from",
+  },
 ];
 
 /**

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -44,6 +44,7 @@ import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
 import type { RedskilledPaths } from "./paths.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
+import type { RedskilledWorkerPulse } from "./worker-display.js";
 
 /** What one unattended turn needs to exist. The daemon's own facts, no client's. */
 export interface DemandTurnDeps {
@@ -94,7 +95,7 @@ export interface DemandTurnDeps {
    * row reads `hb=?` while the turn streams. The runner stamps the work item at
    * admission and each update's text line as it arrives.
    */
-  readonly pulse?: (pulse: { workerId: string; line?: string; issue?: string; phase?: string; step?: string }) => void;
+  readonly pulse?: (pulse: RedskilledWorkerPulse) => void;
 }
 
 /**
@@ -434,7 +435,11 @@ export function createDemandTurnRunner(
       deps.pulse({
         workerId: born.workerId,
         ...(line == null ? {} : { line }),
-        ...(stage == null ? {} : { phase: stage.phase, ...(stage.step == null ? {} : { step: stage.step }) }),
+        ...(stage == null ? {} : {
+          phase: stage.phase,
+          ...(stage.step == null ? {} : { step: stage.step }),
+          ...(stage.added == null || stage.removed == null ? {} : { added: stage.added, removed: stage.removed }),
+        }),
       });
     };
 
@@ -519,17 +524,43 @@ export function createDemandTurnRunner(
   };
 }
 
-/** The Ticket stage a session update carries (#4181 v2): the statusline's phase cell. PURE. */
-function sessionUpdateStage(params: unknown): { phase: string; step?: string } | null {
+/**
+ * The Ticket stage a session update carries (#4181 v2): the statusline's phase
+ * cell, and the signed line pair beside it. PURE.
+ *
+ * The diff arrives on the SAME `_meta.redskills.ticketStage` object the phase
+ * does, because the Worker measured it at the moment the stage resolved — one
+ * fact, one shape, one route. Each half degrades on its own: a bundle old
+ * enough to publish a stage without a diff still moves the phase cell, and a
+ * pair that is not a finite count is dropped rather than stored as a figure the
+ * renderer would print.
+ */
+function sessionUpdateStage(params: unknown): TicketStagePulse | null {
   const stage = (params as { _meta?: { redskills?: { ticketStage?: unknown } } } | undefined)
     ?._meta?.redskills?.ticketStage;
   if (stage == null || typeof stage !== "object") return null;
-  const record = stage as { stage?: unknown; ok?: unknown; round?: unknown };
+  const record = stage as { stage?: unknown; ok?: unknown; round?: unknown; added?: unknown; removed?: unknown };
   if (typeof record.stage !== "string" || record.stage === "") return null;
+  const added = countField(record.added);
+  const removed = countField(record.removed);
   return {
     phase: record.ok === false ? `${record.stage}!` : record.stage,
     ...(typeof record.round === "number" ? { step: `round ${record.round}` } : {}),
+    ...(added == null || removed == null ? {} : { added, removed }),
   };
+}
+
+/** What one stage notification adds to the Worker display. */
+interface TicketStagePulse {
+  readonly phase: string;
+  readonly step?: string;
+  readonly added?: number;
+  readonly removed?: number;
+}
+
+/** A non-negative finite count, or nothing. PURE. */
+function countField(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
 }
 
 /** The text a session update carries, when it carries any. PURE. */

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -165,7 +165,7 @@ import {
   renderRedskilledDashboard,
   type RedskilledDashboard,
 } from "@reddb-io/redskilled-render";
-import { coerceWorkerDisplay, type RedskilledWorkerDisplayRecord } from "../worker-display.js";
+import { applyWorkerPulse, coerceWorkerDisplay, type RedskilledWorkerDisplayRecord, type RedskilledWorkerPulse } from "../worker-display.js";
 import {
   deriveRedskilledLiveMetrics,
   pruneRedskilledMetricHistory,
@@ -1264,21 +1264,14 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
   }
 
   // #4181: a native Worker's turn events ARE its pulse, stamped where the op stamps.
-  function recordWorkerPulse(
-    pulse: { workerId: string; line?: string; issue?: string; phase?: string; step?: string },
-  ): void {
+  function recordWorkerPulse(pulse: RedskilledWorkerPulse): void {
     if (workers.get(pulse.workerId) == null) return;
     const publishedAt = clock();
     const line = pulse.line?.trim();
     if (line != null && line !== "") {
       logLines.set(pulse.workerId, { line, published_at: publishedAt, source: "heartbeat" });
     }
-    const display = coerceWorkerDisplay({
-      ...(displays.get(pulse.workerId)?.display ?? {}),
-      ...(pulse.issue == null ? {} : { issue: pulse.issue }),
-      ...(pulse.phase == null ? {} : { phase: pulse.phase }),
-      ...(pulse.step == null ? {} : { step: pulse.step }),
-    });
+    const display = applyWorkerPulse(displays.get(pulse.workerId)?.display, pulse);
     if (display != null) displays.set(pulse.workerId, { display, published_at: publishedAt });
   }
 

--- a/apps/redskilled/src/worker-display.ts
+++ b/apps/redskilled/src/worker-display.ts
@@ -111,6 +111,26 @@ export interface RedskilledWorkerDisplay {
   readonly text: number | null;
 }
 
+/**
+ * One pulse: the fields a live Worker's own narration moves on its display.
+ *
+ * A SUBSET of {@link RedskilledWorkerDisplay}, spelled once because both the
+ * turn that mints a pulse and the daemon that folds it in must agree on it —
+ * two inline shapes drifted apart the first time either gained a field.
+ * Everything here is optional and everything absent is left standing: a pulse
+ * says what changed, never what the display is.
+ */
+export interface RedskilledWorkerPulse {
+  readonly workerId: string;
+  readonly line?: string;
+  readonly issue?: string;
+  readonly phase?: string;
+  readonly step?: string;
+  /** The Worker's own signed line pair, measured in its Worktree at the stage. */
+  readonly added?: number;
+  readonly removed?: number;
+}
+
 /** The record the daemon keeps: the published fields, and when they landed. */
 export interface RedskilledWorkerDisplayRecord {
   readonly display: RedskilledWorkerDisplay;
@@ -215,6 +235,33 @@ export function coerceWorkerDisplay(value: unknown): RedskilledWorkerDisplay | n
   }
   display.failed = raw.failed === true;
   return display as unknown as RedskilledWorkerDisplay;
+}
+
+/**
+ * Fold one pulse into the display the daemon already holds. PURE.
+ *
+ * A pulse says WHAT CHANGED. Every field it leaves unstated keeps the value the
+ * last publish gave it, which is what lets a Worker narrate a stage without
+ * re-stating its runner, its model and its start time on every beat.
+ *
+ * The signed pair travels here rather than being derived: the daemon holds no
+ * checkout, so `loc=` can only be what the Worker measured in its own Worktree.
+ * A pulse with no pair leaves the last measurement standing — a Worker mid-stage
+ * has not become unmeasured — and a Worker nobody ever measured keeps a `null`
+ * that renders as an ABSENT cell, never as `loc=0`.
+ */
+export function applyWorkerPulse(
+  previous: RedskilledWorkerDisplay | undefined,
+  pulse: RedskilledWorkerPulse,
+): RedskilledWorkerDisplay | null {
+  return coerceWorkerDisplay({
+    ...(previous ?? {}),
+    ...(pulse.issue == null ? {} : { issue: pulse.issue }),
+    ...(pulse.phase == null ? {} : { phase: pulse.phase }),
+    ...(pulse.step == null ? {} : { step: pulse.step }),
+    ...(pulse.added == null ? {} : { added: pulse.added }),
+    ...(pulse.removed == null ? {} : { removed: pulse.removed }),
+  });
 }
 
 /**

--- a/apps/redskilled/tests/acp-ticket-loop.test.ts
+++ b/apps/redskilled/tests/acp-ticket-loop.test.ts
@@ -62,7 +62,7 @@ interface StubDaemon {
   readonly claims: { issue: number; body: string }[];
   readonly published: RedskilledPublishRequest[];
   readonly landed: RedskilledLandRequest[];
-  readonly stages: { stage: string; ok: boolean; round?: number; detail?: string }[];
+  readonly stages: { stage: string; ok: boolean; round?: number; detail?: string; added?: number; removed?: number }[];
   readonly denials: string[];
 }
 
@@ -148,7 +148,10 @@ async function startWorker(worktree: string, pathPrefix: string): Promise<Runnin
     .onNotification(methods.client.session.update, ({ params }) => {
       const meta = (params._meta as {
         redskills?: {
-          ticketStage?: { stage: string; ok: boolean; round?: number; detail?: string };
+          ticketStage?: {
+          stage: string; ok: boolean; round?: number; detail?: string;
+          added?: number; removed?: number;
+        };
           terminalPolicy?: { reason?: string };
         };
       } | undefined)?.redskills;
@@ -278,6 +281,14 @@ describe("a real `redskilled acp-worker` running one Ticket", () => {
       expect(worker.daemon.stages.map((stage) => stage.stage))
         .toEqual(["claim", "implement", "gate", "publish", "land"]);
       expect(worker.daemon.stages.every((stage) => stage.ok)).toBe(true);
+
+      // and how much it had produced when each stage resolved. The claim is
+      // taken before anything is written, so its honest answer is a measured
+      // zero; every stage after the implementer's one-line file is `+1 -0`.
+      // This is `loc=` at its source: the Worker measuring its own Worktree.
+      expect(worker.daemon.stages.map((stage) => [stage.added, stage.removed])).toEqual([
+        [0, 0], [1, 0], [1, 0], [1, 0], [1, 0],
+      ]);
 
       // the dev bundle was never the body, and never reached for
       expect(worker.argv).toContain("acp-worker");

--- a/apps/redskilled/tests/worker-loc-cell.test.ts
+++ b/apps/redskilled/tests/worker-loc-cell.test.ts
@@ -1,0 +1,198 @@
+// The statusline's `loc=` cell, end to end, from a real Worktree to the row.
+//
+// PR #4286 rebuilt the v3 Worker row and deliberately left `loc=` off it: the
+// daemon can only answer it from something the project publishes, and deriving
+// it daemon-side would be a git walk PER RENDER against a checkout the daemon
+// only knows the path of. That is right about the render path and wrong about
+// where the measurement belongs — the Worker is standing in the Worktree.
+//
+// So the Worker measures its own diff ONCE PER STAGE TRANSITION and the pair
+// rides the route `phase` and `step` already take: the `_meta.redskills.
+// ticketStage` object → the daemon's parse → the pulse → the Worker display →
+// the row. Every link is exercised here against a REAL git repository, because
+// the one thing a fixture pair could not prove is that git was ever asked.
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { measureWorktreeDiff } from "@reddb-io/worker/acp";
+import { stripAnsi } from "@reddb-io/redskilled-render";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+import { createDemandTurnRunner, type DemandTurnAdmission } from "../src/acp-demand-turn.js";
+import type { ActiveWorkflowWorker } from "../src/acp-worker-lifecycle.js";
+import {
+  publishRedskilledWorkerLogLine,
+  readRedskilledDashboardRender,
+} from "../src/client.js";
+import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
+import { resolveRedskilledPaths } from "../src/paths.js";
+import { applyWorkerPulse, type RedskilledWorkerPulse } from "../src/worker-display.js";
+
+const run = promisify(execFile);
+const running: RedskilledDaemon[] = [];
+const roots: string[] = [];
+
+const PROJECT = "acme/widgets";
+const NOW = "2026-08-21T12:10:00.000Z";
+
+afterAll(async () => {
+  for (const daemon of running.splice(0)) await daemon.stop().catch(() => undefined);
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+/** A Worktree on a Ticket branch: one round committed, one round still open. */
+async function ticketWorktree(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "worker-loc-worktree-"));
+  roots.push(root);
+  const git = (...args: string[]): Promise<unknown> => run("git", args, { cwd: root });
+  await git("init", "--initial-branch=main");
+  await git("config", "user.email", "worker@example.invalid");
+  await git("config", "user.name", "Worker");
+  await writeFile(join(root, "trunk.ts"), "one\ntwo\nthree\nfour\n");
+  await git("add", "--all");
+  await git("commit", "-m", "trunk");
+  await git("checkout", "-b", "afk/4286-worker-loc");
+  await writeFile(join(root, "feature.ts"), Array.from({ length: 30 }, (_, i) => `line ${i}`).join("\n") + "\n");
+  await writeFile(join(root, "trunk.ts"), "one\nfour\n");
+  await git("add", "--all");
+  await git("commit", "-m", "round one");
+  // Round two, uncommitted: exactly the state a `loc=` that only read commits
+  // would render as "this Worker has stopped producing".
+  await writeFile(join(root, "trunk.ts"), "one\n");
+  return root;
+}
+
+/** The daemon's own parse of a stage notification — the `sessionUpdateStage` seam. */
+async function pulseFor(stage: Record<string, unknown>): Promise<RedskilledWorkerPulse> {
+  const pulses: RedskilledWorkerPulse[] = [];
+  let notify: ((method: string, params?: unknown) => Promise<void>) | null = null;
+  const turn = createDemandTurnRunner({
+    paths: {} as never,
+    startWorker: (() => { throw new Error("injected admission owns the birth"); }) as never,
+    hostState: () => ({ workers: [] }),
+    sessionJournal: { create: async () => {} } as never,
+    admit: async (input: DemandTurnAdmission) => {
+      notify = input.notify as never;
+      return {
+        workerId: "w-loc",
+        downstreamSessionId: "down",
+        connection: {
+          agent: { request: vi.fn(async () => ({ stopReason: "end_turn", _meta: {} })), notify: vi.fn() },
+          close: vi.fn(),
+        },
+        socket: { destroy: vi.fn(), destroyed: false },
+        endpoint: "/tmp/w-loc.sock",
+        publicSessionId: "",
+        notify: vi.fn(async () => {}),
+        cancelled: false,
+        cleaned: false,
+      } as unknown as ActiveWorkflowWorker;
+    },
+    pulse: (pulse) => void pulses.push(pulse),
+  });
+  await turn({
+    project: { projectId: "github:1", projectLabel: PROJECT, workspacePath: "/tmp/p" } as never,
+    prompt: "p",
+    workItem: "4286",
+  });
+  // The exact frame `notifyTicketStage` writes in packages/worker.
+  await notify!("session/update", {
+    sessionId: "s",
+    update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "" } },
+    _meta: { redskills: { ticketStage: stage } },
+  });
+  return pulses.at(-1)!;
+}
+
+describe("the Worker measures its own diff and the row prints it", () => {
+  let worktree = "";
+  let measured: { added: number; removed: number } | null = null;
+
+  beforeAll(async () => {
+    worktree = await ticketWorktree();
+    measured = await measureWorktreeDiff({ worktree, base: "main" });
+  }, 30_000);
+
+  it("measures committed and uncommitted work in the Worktree it is standing in", () => {
+    // 30 lines of a new committed file, plus three lines removed from trunk.ts
+    // across a commit and an uncommitted edit — each line counted exactly once.
+    expect(measured).toEqual({ added: 30, removed: 3 });
+  });
+
+  it("carries the pair through the stage notification the daemon already parses", async () => {
+    const pulse = await pulseFor({ stage: "implement", ok: true, round: 1, ...measured });
+    expect(pulse).toEqual({
+      workerId: "w-loc", phase: "implement", step: "round 1", added: 30, removed: 3,
+    });
+  });
+
+  it("folds the pair onto the display without disturbing what the Worker published", async () => {
+    const pulse = await pulseFor({ stage: "gate", ok: true, ...measured });
+    const display = applyWorkerPulse(
+      { runner: "claude", model: "claude-opus-5", issue: "#4286" } as never,
+      pulse,
+    );
+    expect(display).toMatchObject({ runner: "claude", issue: "#4286", added: 30, removed: 3 });
+  });
+
+  it("draws `loc=+30 -3` on the row the operator reads", async () => {
+    const root = await mkdtemp(join(tmpdir(), "worker-loc-daemon-"));
+    roots.push(root);
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const daemon = await startRedskilledDaemon({
+      paths,
+      sampleMs: 0,
+      ceiling: UNBOUNDED_HOST_CEILING,
+      stopWorker: () => true,
+      clock: () => NOW,
+    });
+    running.push(daemon);
+    daemon.trackWorker({
+      worker_id: "w-loc",
+      project_label: PROJECT,
+      pid: 4242,
+      started_at: "2026-08-21T12:00:00.000Z",
+      workspace_path: worktree,
+      isolated: true,
+      warnings: [],
+    });
+
+    const pulse = await pulseFor({ stage: "gate", ok: true, round: 1, ...measured });
+    const ack = await publishRedskilledWorkerLogLine(paths, {
+      worker_id: "w-loc",
+      line: "running the gate",
+      display: applyWorkerPulse(
+        { runner: "claude", model: "claude-opus-5", effort: "high", origin: "afk", issue: "#4286" } as never,
+        pulse,
+      )!,
+      session_project: PROJECT,
+    });
+    expect(ack.accepted, ack.detail).toBe(true);
+
+    const dashboard = await readRedskilledDashboardRender(
+      paths,
+      { project: PROJECT, maxWidth: 300 },
+      { sessionProject: PROJECT },
+    );
+    const row = dashboard.rows.find((candidate) => candidate.worker_id === "w-loc");
+    expect(row?.cells.loc).toBe("loc=+30 -3");
+    expect(stripAnsi(row?.line ?? "")).toContain("loc=+30 -3");
+    // Beside the cells #4286 already rebuilt, in the v3 order: after the phase
+    // and its clocks, never in place of them.
+    const line = stripAnsi(row?.line ?? "");
+    expect(line.indexOf("loc=")).toBeGreaterThan(line.indexOf("gate"));
+    expect(line).toContain("iss=#4286");
+  }, 30_000);
+
+  it("leaves the cell absent for a Worker nobody measured — never `loc=0`", async () => {
+    const pulse = await pulseFor({ stage: "claim", ok: true });
+    expect(pulse).toEqual({ workerId: "w-loc", phase: "claim" });
+    expect(applyWorkerPulse(undefined, pulse)?.added).toBeNull();
+    expect(applyWorkerPulse(undefined, pulse)?.removed).toBeNull();
+  });
+});

--- a/apps/redskilled/tests/worker-pulse.test.ts
+++ b/apps/redskilled/tests/worker-pulse.test.ts
@@ -62,6 +62,54 @@ describe("a demand turn stamps its Worker's pulse", () => {
     await seenNotify!("session/update", { sessionId: "s", update: { sessionUpdate: "plan" } });
     expect(pulses[2]).toEqual({ workerId: "W1" });
   });
+
+  it("carries the Worker's own measured diff off the stage it was measured at", async () => {
+    // The daemon holds no checkout, so `loc=` can only be what the Worker
+    // measured in its own Worktree. It rides the SAME `_meta.redskills.
+    // ticketStage` object `phase` and `step` do — one fact, one route.
+    const pulses: Array<Record<string, unknown>> = [];
+    let seenNotify: ((method: string, params?: unknown) => Promise<void>) | null = null;
+    const run = createDemandTurnRunner({
+      paths: {} as never,
+      startWorker: (() => { throw new Error("injected admission owns the birth"); }) as never,
+      hostState: () => ({ workers: [] }),
+      sessionJournal: { create: async () => {} } as never,
+      admit: async (input: DemandTurnAdmission) => {
+        seenNotify = input.notify as never;
+        return workerStub();
+      },
+      pulse: (pulse) => void pulses.push(pulse as never),
+    });
+    await run({ project, prompt: "p", workItem: "4286" });
+
+    const stage = (extra: Record<string, unknown>): unknown => ({
+      sessionId: "s",
+      update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "" } },
+      _meta: { redskills: { ticketStage: { stage: "gate", ok: true, round: 1, ...extra } } },
+    });
+
+    await seenNotify!("session/update", stage({ added: 1394, removed: 7397 }));
+    expect(pulses.at(-1)).toEqual({
+      workerId: "W1", phase: "gate", step: "round 1", added: 1394, removed: 7397,
+    });
+
+    // A bundle old enough to publish a stage without a diff still moves the
+    // phase cell; half a pair is no pair, and neither half is stored.
+    await seenNotify!("session/update", stage({}));
+    expect(pulses.at(-1)).toEqual({ workerId: "W1", phase: "gate", step: "round 1" });
+    await seenNotify!("session/update", stage({ added: 12 }));
+    expect(pulses.at(-1)).toEqual({ workerId: "W1", phase: "gate", step: "round 1" });
+    await seenNotify!("session/update", stage({ added: "12", removed: -3 }));
+    expect(pulses.at(-1)).toEqual({ workerId: "W1", phase: "gate", step: "round 1" });
+  });
+
+  it("stores a measured zero and an absence differently on the display", () => {
+    // `loc=0` is a Worker that has produced nothing; an ABSENT cell is a Worker
+    // nobody measured. A renderer cannot tell them apart if the daemon cannot.
+    expect(coerceWorkerDisplay({ phase: "claim", added: 0, removed: 0 })!.added).toBe(0);
+    expect(coerceWorkerDisplay({ phase: "claim" })!.added).toBeNull();
+    expect(coerceWorkerDisplay({ phase: "claim" })!.removed).toBeNull();
+  });
 });
 
 describe("a display that published no heartbeat gets the age of its last pulse", () => {

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -356,7 +356,17 @@ export function workerCells(
     // all?". Keeping only one would either redraw a waiting Worker as a silent
     // one or print a diffstat for a Worker that has no agent.
     hb: declaredWaitCell(display, generatedAt) ?? `hb=${display.heartbeat ?? "?"}`,
-    loc: noAgent ? "" : formatSignedPair(display.added, display.removed),
+    // **`loc=` is a WORKTREE fact, and the Worktree outlives the agent.** The
+    // four cells below it count what an agent did this turn, so a phase with no
+    // agent has no figure to print. Lines on disk are not like that: the Worker
+    // measures them in its own checkout at every stage transition, and under
+    // ADR 0148 `gate` and `land` are stages that Worker runs — with the diff it
+    // just committed sitting right there. Gating this on `noAgent` blanked the
+    // cell for three of the loop's five stages, so a Worker deep in a large
+    // change read as one that had produced nothing at exactly the moment the
+    // operator was asking. An absence here still means unmeasured: nothing but
+    // the Worker standing in the Worktree ever publishes the pair.
+    loc: formatSignedPair(display.added, display.removed),
     tks: noAgent || display.tokens == null ? "" : `tks=${formatCount(display.tokens)}`,
     ctx: display.context == null ? "" : `ctx=${formatCount(display.context)}`,
     tls: noAgent || display.tools == null ? "" : `tls=${display.tools}`,

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -304,9 +304,14 @@ describe("the statusline Worker table (#3151)", () => {
   ])("omits agent activity cells from a %s row", (_kind, workerDisplay) => {
     const doc = payload({ workers: [worker({ display: workerDisplay })] });
     const row = stripAnsi(renderRedskilledStatusline(doc, { ...LOCAL, maxWidth: 240 }).lines[1]!);
-    for (const key of ["loc=", "tks=", "tls=", "rsn=", "txt="]) expect(row).not.toContain(key);
+    for (const key of ["tks=", "tls=", "rsn=", "txt="]) expect(row).not.toContain(key);
     expect(row).toContain("ctx=108k");
     expect(row).toContain("hb=3s");
+    // `loc=` is NOT one of them: the four above count what an agent did this
+    // turn, and lines on disk are a Worktree fact the Worker measured for
+    // itself. Under ADR 0148 `gate` and `land` are stages the Worker runs, so
+    // blanking the pair there hides the diff at the moment it is largest.
+    expect(row).toContain("loc=+120 -8");
   });
 
   it("keeps loc on the row at the default width — annotations yield first", () => {

--- a/packages/worker/src/acp/index.ts
+++ b/packages/worker/src/acp/index.ts
@@ -85,3 +85,9 @@ export {
   type WorkerBudgetGraceControl,
   type WorkerBudgetGraceEnvelope,
 } from "./budget-grace.js";
+export {
+  measureWorktreeDiff,
+  parseNumstat,
+  WORKTREE_DIFF_TIMEOUT_MS,
+  type WorktreeDiffStat,
+} from "./worktree-diff.js";

--- a/packages/worker/src/acp/native-worker.ts
+++ b/packages/worker/src/acp/native-worker.ts
@@ -37,6 +37,7 @@ import { acquireHostGateLock } from "./gate-lock.js";
 import { runWorkerLocalGate } from "./local-gate.js";
 import { createWorkerPublisher, worktreeHead, type WorkerPublisher } from "./publish-request.js";
 import { runTicketLoop, type TicketLoopRecord, type TicketLoopResult } from "./ticket-loop.js";
+import { measureWorktreeDiff } from "./worktree-diff.js";
 
 /** One public session this Worker holds, and what it retains across its turns. */
 interface HeldSession {
@@ -186,6 +187,8 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
       },
       publisher: held.publisher,
       narrate: (record) => notifyTicketStage(parent, sessionId, record),
+      // The Worktree is here, so the measurement is here (#4286 follow-up).
+      measureDiff: () => measureWorktreeDiff({ worktree: held.request.cwd, base: ticket.base }),
     });
     return ticketResponse(result);
   }
@@ -408,6 +411,9 @@ function notifyTicketStage(
           ok: record.ok,
           ...(record.round == null ? {} : { round: record.round }),
           ...(record.detail == null ? {} : { detail: record.detail }),
+          // The signed pair rides the SAME `_meta` shape `phase` and `step`
+          // already travel in, so the daemon gains a cell rather than a channel.
+          ...(record.diff == null ? {} : { added: record.diff.added, removed: record.diff.removed }),
         },
       },
     },

--- a/packages/worker/src/acp/ticket-loop.test.ts
+++ b/packages/worker/src/acp/ticket-loop.test.ts
@@ -546,3 +546,63 @@ describe("the Ticket loop lands nothing nobody judged (#4138)", () => {
     expect(result.outcome).toBe("landed");
   });
 });
+
+describe("the loop measures how much the Worktree holds, stage by stage", () => {
+  it("stamps each record with the diff and narrates the stamped record", async () => {
+    // Once per STAGE TRANSITION, never per render: the loop is the only place
+    // that knows a stage resolved, so the read is bounded by the arc rather
+    // than by whoever is watching. Five stages, five measurements.
+    const measured: number[] = [];
+    const narrated: TicketLoopRecord[] = [];
+    let round = 0;
+    const result = await runTicketLoop(
+      deps({
+        measureDiff: async () => {
+          round += 12;
+          measured.push(round);
+          return { added: round, removed: 1 };
+        },
+        narrate: (record) => void narrated.push(record),
+      }),
+    );
+
+    expect(result.outcome).toBe("landed");
+    expect(measured).toHaveLength(5);
+    expect(narrated.map((record) => record.diff)).toEqual([
+      { added: 12, removed: 1 },
+      { added: 24, removed: 1 },
+      { added: 36, removed: 1 },
+      { added: 48, removed: 1 },
+      { added: 60, removed: 1 },
+    ]);
+    // The narrated record and the retained record are the SAME record; a diff
+    // the Worker log holds and the wire does not is a diff nobody can read.
+    expect((result as { records: readonly TicketLoopRecord[] }).records.map((r) => r.diff))
+      .toEqual(narrated.map((record) => record.diff));
+  });
+
+  it("leaves the record bare when the measurement says nothing, and never stops a stage", async () => {
+    const narrated: TicketLoopRecord[] = [];
+    const result = await runTicketLoop(
+      deps({
+        // A shallow clone, a first commit, a git that never answered — and a
+        // measurement that throws outright. Neither costs the loop its arc.
+        measureDiff: async () => {
+          if (narrated.length % 2 === 0) throw new Error("git is not answering");
+          return null;
+        },
+        narrate: (record) => void narrated.push(record),
+      }),
+    );
+
+    expect(result.outcome).toBe("landed");
+    expect(stages(narrated)).toEqual(["claim", "implement", "gate", "publish", "land"]);
+    for (const record of narrated) expect(record.diff).toBeUndefined();
+  });
+
+  it("stays absent for a loop nobody gave a measurement to", async () => {
+    const narrated: TicketLoopRecord[] = [];
+    await runTicketLoop(deps({ narrate: (record) => void narrated.push(record) }));
+    expect(narrated.every((record) => record.diff === undefined)).toBe(true);
+  });
+});

--- a/packages/worker/src/acp/ticket-loop.ts
+++ b/packages/worker/src/acp/ticket-loop.ts
@@ -34,6 +34,7 @@ import {
   type GateStageOutcome,
 } from "../engine/gate-stage-order.js";
 import { laneRunModeRefusal } from "../engine/lane-run-mode.js";
+import type { WorktreeDiffStat } from "./worktree-diff.js";
 import type {
   WorkerPublication,
   WorkerPublisher,
@@ -136,6 +137,16 @@ export interface TicketLoopDeps {
   readonly publisher: WorkerPublisher;
   /** Narrates each stage as it resolves, for the Worker log. */
   readonly narrate?: (record: TicketLoopRecord) => Promise<void> | void;
+  /**
+   * Measures the Worktree against the Ticket's base, for the record's `diff`.
+   *
+   * **Once per stage transition, never per render.** The loop is the only place
+   * that knows a stage resolved, which makes it the only place the read is
+   * bounded by the arc rather than by whoever is watching. A measurement that
+   * throws or answers `null` leaves the record without a diff and the cell
+   * absent; it never stops a stage.
+   */
+  readonly measureDiff?: () => Promise<WorktreeDiffStat | null>;
   /** Test seam over the wall clock, so a record's timestamp is not a guess. */
   readonly now?: () => Date;
   /**
@@ -157,6 +168,16 @@ export interface TicketLoopRecord {
   readonly ok: boolean;
   readonly round?: number;
   readonly detail?: string;
+  /**
+   * How much this Worktree holds over its base at the moment the stage
+   * resolved, when {@link TicketLoopDeps.measureDiff} could say.
+   *
+   * Part of the OUTCOME, not an annotation on it: "the gate passed" and "the
+   * gate passed on +1394 -7397" are different facts, and the second is the one
+   * that tells an operator the Worker is producing rather than merely alive.
+   * Absent when nothing measured — never a zero standing in for unknown.
+   */
+  readonly diff?: WorktreeDiffStat;
 }
 
 export type TicketLoopResult =
@@ -213,9 +234,13 @@ export async function runTicketLoop(
   const budget = Math.max(0, Math.trunc(deps.reseedBudget ?? 0));
 
   const note = async (record: TicketLoopRecord): Promise<TicketLoopRecord> => {
-    records.push(record);
-    await deps.narrate?.(record);
-    return record;
+    const diff = deps.measureDiff == null
+      ? null
+      : await deps.measureDiff().catch(() => null);
+    const noted = diff == null ? record : { ...record, diff };
+    records.push(noted);
+    await deps.narrate?.(noted);
+    return noted;
   };
 
   // ---- preflight ---------------------------------------------------------

--- a/packages/worker/src/acp/worktree-diff.test.ts
+++ b/packages/worker/src/acp/worktree-diff.test.ts
@@ -1,0 +1,96 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { measureWorktreeDiff, parseNumstat, WORKTREE_DIFF_TIMEOUT_MS } from "./worktree-diff.js";
+
+const run = promisify(execFile);
+
+describe("parseNumstat", () => {
+  it("sums both sides of every text file git reported", () => {
+    expect(parseNumstat("12\t3\ta.ts\n5\t0\tb.ts\n")).toEqual({ added: 17, removed: 3 });
+  });
+
+  it("skips a binary file rather than reading its dashes as zero", () => {
+    // `Number("-")` is NaN, and one NaN poisons the whole total.
+    expect(parseNumstat("4\t1\ta.ts\n-\t-\tlogo.png\n")).toEqual({ added: 4, removed: 1 });
+  });
+
+  it("answers a measured zero for an empty diff — not an absence", () => {
+    expect(parseNumstat("")).toEqual({ added: 0, removed: 0 });
+  });
+});
+
+describe("measureWorktreeDiff", () => {
+  it("gives the cell up rather than guessing when git cannot answer", async () => {
+    const stat = await measureWorktreeDiff({
+      worktree: "/nowhere",
+      base: "main",
+      exec: async (args) => ({ code: 1, stdout: args.join(" ") }),
+    });
+    expect(stat).toBeNull();
+  });
+
+  it("falls back to the base ref when there is no merge base", async () => {
+    const seen: string[][] = [];
+    const stat = await measureWorktreeDiff({
+      worktree: "/w",
+      base: "main",
+      exec: async (args) => {
+        seen.push([...args]);
+        if (args[0] === "merge-base") return { code: 128, stdout: "" };
+        return { code: 0, stdout: "9\t2\tsrc/a.ts\n" };
+      },
+    });
+    expect(stat).toEqual({ added: 9, removed: 2 });
+    expect(seen[1]).toEqual(["diff", "--numstat", "main"]);
+  });
+
+  it("bounds itself, so a stage transition never waits on a diff", () => {
+    expect(WORKTREE_DIFF_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(WORKTREE_DIFF_TIMEOUT_MS).toBeLessThanOrEqual(10_000);
+  });
+});
+
+describe("measureWorktreeDiff against a real git worktree", () => {
+  let repo = "";
+
+  beforeAll(async () => {
+    repo = await mkdtemp(join(tmpdir(), "red-worktree-diff-"));
+    const git = (...args: string[]): Promise<unknown> => run("git", args, { cwd: repo });
+    await git("init", "--initial-branch=main");
+    await git("config", "user.email", "worker@example.test");
+    await git("config", "user.name", "Worker");
+    await writeFile(join(repo, "base.txt"), "one\ntwo\nthree\n");
+    await git("add", ".");
+    await git("commit", "-m", "base");
+    await git("checkout", "-b", "red/worker/1");
+    // Round one: committed.
+    await writeFile(join(repo, "committed.ts"), "a\nb\nc\nd\n");
+    await writeFile(join(repo, "base.txt"), "one\nthree\n");
+    await git("add", ".");
+    await git("commit", "-m", "round one");
+    // Round two: still in the editor, exactly the state the cell must show.
+    await writeFile(join(repo, "committed.ts"), "a\nb\nc\nd\ne\nf\n");
+  });
+
+  afterAll(async () => {
+    if (repo !== "") await rm(repo, { recursive: true, force: true });
+  });
+
+  it("counts committed and uncommitted work, each line once", async () => {
+    // 4 committed + 2 uncommitted added in committed.ts, 1 removed in base.txt.
+    // The committed line that round two edited again is NOT counted twice.
+    expect(await measureWorktreeDiff({ worktree: repo, base: "main" }))
+      .toEqual({ added: 6, removed: 1 });
+  });
+
+  it("answers a measured zero on the base itself", async () => {
+    await run("git", ["stash", "--include-untracked"], { cwd: repo });
+    await run("git", ["checkout", "main"], { cwd: repo });
+    expect(await measureWorktreeDiff({ worktree: repo, base: "main" }))
+      .toEqual({ added: 0, removed: 0 });
+  });
+});

--- a/packages/worker/src/acp/worktree-diff.ts
+++ b/packages/worker/src/acp/worktree-diff.ts
@@ -1,0 +1,119 @@
+/**
+ * worktree-diff — how much this Worker has actually produced, measured by the
+ * Worker, in its own Worktree (#4286 follow-up).
+ *
+ * **The measurement belongs where the Worktree is.** The statusline's `loc=`
+ * cell answers the one question no other cell on the Worker row answers — is
+ * this Worker producing anything, or is it alive and idle — and the daemon
+ * cannot answer it. It holds no checkout: deriving the figure daemon-side would
+ * be a git walk per render, against a directory the daemon only knows the path
+ * of. So the Worker measures its own diff ONCE PER STAGE TRANSITION and pulses
+ * the pair; the daemon stores what it was handed and the renderer prints it,
+ * exactly as `phase` and `step` already travel.
+ *
+ * **One diff, against the merge base, including uncommitted work.** Two diffs
+ * summed — `base...HEAD` for the commits plus `HEAD` for the working tree —
+ * double-count every line a later edit touched again, so the cell would climb
+ * while the branch stood still. `git merge-base` then a single `git diff` from
+ * that commit to the WORKING TREE is one coherent diff: it holds the committed
+ * rounds and the round the implementer is still typing, each line once. An
+ * agent mid-implement has committed nothing, and the cell still moves.
+ *
+ * The one thing it does not see is an untracked file, which git will not
+ * diffstat without being told the file exists. Counting those means reading
+ * arbitrary files on every stage transition, which is the per-render cost this
+ * module exists to refuse — and the round's commit brings them in a stage later.
+ *
+ * **A measurement that could delay a stage is not taken.** The read is bounded
+ * by {@link WORKTREE_DIFF_TIMEOUT_MS} and every failure — no merge base, a
+ * shallow clone, a git that never answered — returns `null`, which renders as
+ * an ABSENT cell. `loc=0` is a Worker that has produced nothing; absence is a
+ * Worker nobody measured, and the two must never be spelled the same way.
+ */
+import { execFile } from "node:child_process";
+
+/** The signed pair one Worktree's diff comes to. */
+export interface WorktreeDiffStat {
+  readonly added: number;
+  readonly removed: number;
+}
+
+/**
+ * How long the Worker waits for git before giving the cell up.
+ *
+ * Generous against a cold page cache on a large repository, and far short of
+ * anything a stage transition would notice. The bound is enforced by
+ * `execFile`'s own kill, so nothing here polls and no wait is declared.
+ */
+export const WORKTREE_DIFF_TIMEOUT_MS = 5_000;
+
+/** How a command was run; the seam a test drives without a git on PATH. */
+export type WorktreeDiffExec = (
+  args: readonly string[],
+) => Promise<{ readonly code: number; readonly stdout: string }>;
+
+export interface WorktreeDiffOptions {
+  /** The Worker's own checkout — `held.request.cwd`, never another Worker's. */
+  readonly worktree: string;
+  /** The trunk the Ticket is opened against, from the handoff. */
+  readonly base: string;
+  readonly timeoutMs?: number;
+  readonly exec?: WorktreeDiffExec;
+}
+
+/**
+ * Sum one `git diff --numstat` output. PURE.
+ *
+ * A binary file reports `-` on both sides rather than a count; it is skipped
+ * instead of read as zero, because a binary asset is not a line of work and
+ * `Number("-")` is `NaN` waiting to poison the total.
+ */
+export function parseNumstat(output: string): WorktreeDiffStat {
+  let added = 0;
+  let removed = 0;
+  for (const line of output.split("\n")) {
+    const [left, right] = line.split("\t");
+    if (left == null || right == null) continue;
+    const plus = Number(left);
+    const minus = Number(right);
+    if (!Number.isFinite(plus) || !Number.isFinite(minus)) continue;
+    added += plus;
+    removed += minus;
+  }
+  return { added, removed };
+}
+
+/**
+ * Measure this Worktree against the Ticket's base, or say nothing.
+ *
+ * The merge base is asked for first so a base branch that has advanced since
+ * the Worker cut its branch does not show up as the Worker DELETING the lines
+ * trunk gained. When git cannot name one — a fixture repository, a shallow
+ * clone, a first commit — the diff is taken from the base ref directly, and
+ * only a base that is not a commit at all gives up.
+ */
+export async function measureWorktreeDiff(
+  options: WorktreeDiffOptions,
+): Promise<WorktreeDiffStat | null> {
+  const run = options.exec ?? gitExec(options.worktree, options.timeoutMs ?? WORKTREE_DIFF_TIMEOUT_MS);
+  const mergeBase = await run(["merge-base", options.base, "HEAD"]);
+  const from = mergeBase.code === 0 ? mergeBase.stdout.trim() : options.base;
+  if (from === "") return null;
+  const diff = await run(["diff", "--numstat", from]);
+  return diff.code === 0 ? parseNumstat(diff.stdout) : null;
+}
+
+/** One bounded `git` in the Worktree; a git that never answered is `code` non-zero. */
+function gitExec(worktree: string, timeoutMs: number): WorktreeDiffExec {
+  return (args) =>
+    new Promise((resolve) => {
+      execFile(
+        "git",
+        [...args],
+        { cwd: worktree, timeout: timeoutMs, maxBuffer: 32 * 1024 * 1024 },
+        (error, stdout) => {
+          resolve({ code: error == null ? 0 : 1, stdout: String(stdout) });
+        },
+      );
+    });
+}


### PR DESCRIPTION
`loc=` is the one cell on the Worker row that answers **"is this Worker producing anything"**, and it was the one cell #4286 could not restore — its stated reason: *"the daemon can only answer it from a heartbeat the project publishes, and deriving it otherwise is a git walk per render."* That is right about the RENDER path and wrong about where the measurement belongs. The Worker is standing in the Worktree.

## The Worker measures, once per stage transition

`measureWorktreeDiff` (`packages/worker/src/acp/worktree-diff.ts`) asks `git merge-base <base> HEAD` and then a single `git diff --numstat <mergeBase>` — from that commit to the **working tree**, so committed rounds and the round the implementer is still typing are one coherent diff.

Two diffs summed (`base...HEAD` for the commits plus `HEAD` for the working tree) would double-count every line a later edit touched again, and the cell would climb while the branch stood still. One diff counts each line exactly once.

The read is bounded (`WORKTREE_DIFF_TIMEOUT_MS`, enforced by `execFile`'s own kill — no poll, no `DECLARED_WAITS` entry) and every failure returns `null`. A measurement that could delay a stage is not taken. ~5 stages per turn, never per render.

## The pair rides the route `phase` and `step` already take

No new ACP field and no second channel:

```
runTicketLoop's note()  →  TicketLoopRecord.diff
  → notifyTicketStage   →  _meta.redskills.ticketStage.{added,removed}
  → sessionUpdateStage  →  deps.pulse({workerId, phase, step, added, removed})
  → recordWorkerPulse   →  applyWorkerPulse  →  the Worker display
  → workerCells         →  loc=+X -Y
```

`TicketLoopRecord` gains `diff` because "the gate passed" and "the gate passed on +1394 -7397" are different facts, and the second is the one that tells an operator the Worker is producing rather than merely alive.

## `loc=` is a WORKTREE fact, and the Worktree outlives the agent

One renderer change was required. `loc` sat behind `dashboard.ts`'s `noAgent` gate beside `tks=`/`tls=`/`rsn=`/`txt=` — cells that count what an *agent* did this turn — and `LANDING_PHASES` holds `gate`. Under ADR 0148 `gate` and `land` are stages the **Worker** runs, with the diff it just committed sitting right there, so the gate blanked the cell for three of the loop's five stages: a Worker deep in a large change would have flickered `+30 -3 → (gone) → +30 -3`. The four agent counters keep the rule; `loc=` does not. An absence here still means unmeasured — nothing but the Worker standing in the Worktree ever publishes the pair.

**Absent ≠ zero.** `loc=0` is a Worker that has produced nothing; no cell at all is a Worker nobody measured.

## Observed

The daemon bundle builds (`pnpm -C apps/redskilled bundle` → 1.7mb, `merge-base` present in the output, `--version` answers). The live Worker on this host is running the released 4.1.27 bundle, which predates this change, so the row below is **from the test, not from that Worker** — `apps/redskilled/tests/worker-loc-cell.test.ts` drives the whole route against a **real git repository**: a branch with one committed round (a 30-line new file, two lines cut from trunk) plus one uncommitted round (one more line cut), a real `redskilled` daemon over a real socket, and the row read back through `readRedskilledDashboardRender`:

```
w-loc  run=claude opus-5 high  org=landing  iss=#4286  ██▶░░  gate 3/5 · round 1  age=10m0s  hb=0s  loc=+30 -3
```

`+30 -3` is the real `git diff --numstat`: 30 added committed, 2 removed committed, 1 removed uncommitted — the uncommitted line is what a commits-only reading would have hidden. The `gate` phase is deliberate: that is the row the old `noAgent` gate blanked.

## Where the measurement is taken

`packages/worker/src/acp/worktree-diff.ts`, called from `native-worker.ts`'s `measureDiff` dep with `held.request.cwd` and `ticket.base` — the Worker's own checkout, in the Worker's own process.

## Validation

| Suite | Result |
| --- | --- |
| root `pnpm typecheck` | 17/17 |
| root `pnpm lint` | clean |
| `pnpm -C apps/plugin-dev test:invariants` | **494/494** |
| `packages/redskilled-render` (all) | 108/108 |
| redskilled statusline + display + body-control-cut + pulse + loc-cell | 150/150 |
| `packages/worker` `src/acp` | 87 pass, 4 fail — all in `local-gate.test.ts`, pre-existing (`apps/plugin-dev/added.ts` vs `apps/dev/added.ts`, fallout of the `apps/<kind>-<name>` rename in 22af6de40) |

`apps/redskilled/tests/acp-ticket-loop.test.ts` gained the stage-by-stage `[[0,0],[1,0],[1,0],[1,0],[1,0]]` assertion — the claim measured before anything is written, then the implementer's one-line file. It does **not** execute today: those two cases are on the pre-existing red list, failing at `expected 'refused' to be 'landed'` well before reaching it.

New exported functions carry naming tests in their own package (`measureWorktreeDiff`, `parseNumstat` in `packages/worker`; `applyWorkerPulse` in `apps/redskilled`). `worktree-diff.ts` is declared in `WORKER_BODY_MODULES`. `lifecycle.ts` shrinks 2483 → 2476, and its baseline entry is lowered to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789938620&installation_model_id=20659&pr_number=4291&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4291&signature=602d2cd97a977e2b640a006ccf0d571136cc34a5031815b3a49d1538c9d49b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->