### PR TITLE
fix(redskilled): refuse a birth the daemon cannot brief, and let the count-only poll say so

### DIFF
--- a/.changeset/refuse-unbriefable-birth.md
+++ b/.changeset/refuse-unbriefable-birth.md
@@ -1,0 +1,9 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Refuse an item-scoped birth the daemon cannot brief, and make the count-only poll route say so.
+
+A planned birth whose Ticket handoff cannot be composed is now refused before any Worker is spawned, naming the missing fact — a count-only poll, no Ticket listed for the item, an unusable number, an empty title, or a registration with no trunk branch. The refusal rides the demand loop's existing path, so it is journal-visible and rate-limited by the host backoff instead of costing a worktree clone and a host slot every tick. A registration carrying a prompt and no work item still births prompt-only.
+
+The aliased GraphQL discovery route now states `briefing: "count-only"` beside its depth (the REST list route states `"listed"`), so nothing downstream has to read an absent `tickets` field as a drained queue.

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -28,6 +28,7 @@ import type {
 import { randomBytes } from "node:crypto";
 
 import { parkGateBlockedTurn } from "./demand-park.js";
+import { demandBriefVerdict } from "./demand-birth-brief.js";
 import { readProjectTicketBody } from "./acp-github.js";
 import { admitNativeAcpWorker } from "./acp-worker-admission.js";
 import { ACP_AGENT_IDS, type AcpAgentId } from "@reddb-io/protocol-acp";
@@ -44,6 +45,12 @@ import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
 import type { RedskilledPaths } from "./paths.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
+
+// Re-exported where every demand-turn consumer already looks: the briefing facts
+// and the turn they feed are one surface, split across two files only because
+// `demand-birth-brief` must stay callable without this module — the demand loop
+// refuses a birth it cannot brief before it composes any turn at all (#4292).
+export { queueBriefing, refuseUnbriefableBirth, unbriefableBirthRefusal } from "./demand-birth-brief.js";
 
 /** What one unattended turn needs to exist. The daemon's own facts, no client's. */
 export interface DemandTurnDeps {
@@ -122,25 +129,6 @@ export function describeTurnOutcome(response: PromptResponse): string {
 }
 
 /**
- * What the last poll knows about the item a birth is for. PURE.
- *
- * Beside the handoff it feeds rather than in the demand loop: the lifecycle
- * decides that a birth happens, never what the Worker is told about it.
- */
-export function queueBriefing(
-  projects: readonly {
-    readonly project_label: string;
-    readonly tickets?: readonly { readonly id: string; readonly title: string; readonly labels: readonly string[] }[];
-  }[],
-  projectLabel: string,
-  workItem: string | undefined,
-): { readonly id: string; readonly title: string; readonly labels: readonly string[] } | undefined {
-  if (workItem == null) return undefined;
-  return projects.find((project) => project.project_label === projectLabel)
-    ?.tickets?.find((candidate) => candidate.id === workItem);
-}
-
-/**
  * The turn one birth owes, or `null` when this project states no prompt.
  *
  * Pure and separate from the loop that calls it, because the interesting part
@@ -184,11 +172,12 @@ export function demandTurnForBirth(
   const withOrders = briefWithStandingOrders(standingOrders, expanded);
   // The handoff is stated only when every fact it requires is present: a Ticket
   // briefed with an empty title or no trunk is one the Worker refuses, and a
-  // refusal the daemon could have avoided is a Worker born to fail.
+  // refusal the daemon could have avoided is a Worker born to fail. The verdict
+  // is `demand-birth-brief`'s, so the lifecycle can refuse the birth outright
+  // (#4292) off the same rule this handoff is built from.
   const number = Number(ticket?.id);
   const base = registration.trunk?.branch;
-  const briefed = ticket != null && Number.isInteger(number) && number > 0 &&
-    ticket.title !== "" && base != null && base !== "";
+  const briefed = demandBriefVerdict(registration, ticket).briefed;
   return {
     workspacePath: birth.workspace_path,
     prompt: withOrders,

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -77,7 +77,7 @@ import {
   launchProbeArgv,
   launchProbeRefusal,
 } from "../launch-probe.js";
-import { demandTurnForBirth, describeDemandTurn, queueBriefing } from "../acp-demand-turn.js";
+import { demandTurnForBirth, describeDemandTurn, queueBriefing, refuseUnbriefableBirth } from "../acp-demand-turn.js";
 import { createRedskilledRegistrationIntentStore } from "../registration-intent-store.js";
 import {
   buildRegistrationLapse,
@@ -1027,9 +1027,10 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
       for (const birth of plan.births) {
         let launched: LaunchedWorker;
         const registered = registrations.get(birth.project_label);
-        // **A birth nobody speaks to does nothing** (#4100): a project with a
-        // prompt gets the daemon's own unattended turn, not awaited — it is the
-        // Worker's whole life, and a blocked tick would stop every project.
+        // **A birth nobody speaks to does nothing** (#4100): a project with a prompt gets the daemon's own
+        // unattended turn, not awaited — it is the Worker's whole life, and a blocked tick would stop every
+        // project. And **a birth the daemon cannot brief is a birth it does not perform** (#4292): with no
+        // handoff it would echo its prompt and die with the item still queued.
         if (registered?.prompt != null && acpControlPlane != null) {
           try {
             // Read standing orders for this project and prepend to prompt
@@ -1037,19 +1038,17 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
             const standingOrdersText = ordersResult.orders.length > 0
               ? formatStandingOrdersBody(ordersResult.orders)
               : undefined;
+            const polled = lastQueue?.projects ?? [];
+            refuseUnbriefableBirth(registered, birth, polled);
             const turn = demandTurnForBirth(registered, birth, mintHostWorkerId(workers.keys()),
-              queueBriefing(lastQueue?.projects ?? [], birth.project_label, birth.work_item), standingOrdersText)!;
+              queueBriefing(polled, birth.project_label, birth.work_item), standingOrdersText)!;
             void acpControlPlane.runDemandTurn(turn).catch(async (error: unknown) => {
-              await eventLane.recordDemandRefusal({
-                ts: clock(),
-                projectLabel: birth.project_label,
-                detail: `the unattended turn for project ${JSON.stringify(birth.project_label)} failed: ` +
-                  `${error instanceof Error ? error.message : String(error)}`,
-              }).catch(() => undefined);
+              const detail = `the unattended turn for project ${JSON.stringify(birth.project_label)} failed: ${error instanceof Error ? error.message : String(error)}`;
+              await eventLane.recordDemandRefusal({ ts: clock(), projectLabel: birth.project_label, detail }).catch(() => undefined);
             });
           } catch (err) {
-            // A template naming a fact this birth does not have is refused
-            // before anything is spawned, and stated where a stall is read.
+            // A fact this birth does not have — one its template names, or one
+            // its brief requires — is refused before a spawn, where a stall is read.
             refusal = err instanceof Error ? err.message : String(err);
             demandBackoffUntilMs = (Number.isFinite(nowMs) ? nowMs : Date.now()) + demandBackoffMs;
             break;

--- a/apps/redskilled/src/demand-birth-brief.ts
+++ b/apps/redskilled/src/demand-birth-brief.ts
@@ -1,0 +1,144 @@
+/**
+ * demand-birth-brief — whether a planned birth can be briefed, and what is missing.
+ *
+ * **A birth the daemon cannot brief is a birth it does not perform** (#4292).
+ * A Worker enters its Ticket loop only through a handoff; without one the body
+ * takes its third path — echo the prompt back and end the turn — so the item it
+ * was born for stays queued and the planner asks for another on the next tick.
+ * Observed live as 58 Workers in ~15 minutes, each paying a worktree clone and a
+ * host slot to answer `no-workflow-outcome (end_turn)`.
+ *
+ * `demandTurnForBirth` already decided this, and collapsed it to a boolean: the
+ * handoff was simply omitted, and the caller could not tell an unbriefable birth
+ * from a deliberately prompt-only one. The decision lives here instead, stating
+ * WHICH fact is absent, so the lifecycle refuses the birth and an operator reads
+ * the missing fact rather than a Worker's echo. PURE — no daemon, no clock, no
+ * socket; the lifecycle wires one call and the test needs neither.
+ */
+
+/** The one fact whose absence makes a birth unbriefable. */
+export type DemandBriefGap =
+  | "count-only-poll"
+  | "no-ticket"
+  | "unusable-number"
+  | "empty-title"
+  | "no-trunk-branch";
+
+/** What one planned birth's brief came to. PURE. */
+export interface DemandBriefVerdict {
+  readonly briefed: boolean;
+  /** The absent fact, when there is one; never set on a briefed verdict. */
+  readonly gap?: DemandBriefGap;
+}
+
+/** One project as the last poll left it, in the facts a brief is built from. */
+export interface DemandBriefPoll {
+  readonly project_label: string;
+  /**
+   * Whether that poll LISTED what it counted, stated rather than inferred.
+   *
+   * A route that counts without listing carries no `tickets`, and an absent
+   * field reads exactly like a project whose queue drained — which is how a
+   * count-only poll came to plan births nothing could brief.
+   */
+  readonly briefing?: "listed" | "count-only";
+  readonly tickets?: readonly { readonly id: string; readonly title: string; readonly labels: readonly string[] }[];
+}
+
+/**
+ * What the last poll knows about the item a birth is for. PURE.
+ *
+ * Beside the verdict it feeds rather than in the demand loop: the lifecycle
+ * decides that a birth happens, never what the Worker is told about it.
+ */
+export function queueBriefing(
+  projects: readonly DemandBriefPoll[],
+  projectLabel: string,
+  workItem: string | undefined,
+): { readonly id: string; readonly title: string; readonly labels: readonly string[] } | undefined {
+  if (workItem == null) return undefined;
+  return projects.find((project) => project.project_label === projectLabel)
+    ?.tickets?.find((candidate) => candidate.id === workItem);
+}
+
+/**
+ * Whether this birth can state a Ticket handoff, and which fact stops it. PURE.
+ *
+ * Every fact the handoff requires is checked in the order an operator would ask
+ * about it: what the poll could say, then what it said about this item, then
+ * what the registration says about the trunk to branch from.
+ */
+export function demandBriefVerdict(
+  registration: { readonly trunk?: { readonly branch: string } } | undefined,
+  ticket: { readonly id: string; readonly title: string } | undefined,
+  poll?: DemandBriefPoll,
+): DemandBriefVerdict {
+  if (ticket == null) {
+    return { briefed: false, gap: poll?.briefing === "count-only" ? "count-only-poll" : "no-ticket" };
+  }
+  const number = Number(ticket.id);
+  if (!Number.isInteger(number) || number <= 0) return { briefed: false, gap: "unusable-number" };
+  if (ticket.title === "") return { briefed: false, gap: "empty-title" };
+  const base = registration?.trunk?.branch;
+  if (base == null || base === "") return { briefed: false, gap: "no-trunk-branch" };
+  return { briefed: true };
+}
+
+/** Why one absent fact stops a brief, in the words an operator reads. PURE. */
+export function describeDemandBriefGap(gap: DemandBriefGap): string {
+  switch (gap) {
+    case "count-only-poll":
+      return "the last queue poll counted this project without listing it, so it holds no Ticket to hand over";
+    case "no-ticket":
+      return "the last queue poll listed no Ticket for that item";
+    case "unusable-number":
+      return "the Ticket the last poll listed carries no usable number";
+    case "empty-title":
+      return "the Ticket the last poll listed carries an empty title";
+    case "no-trunk-branch":
+      return "this project's registration states no trunk branch";
+  }
+}
+
+/**
+ * The refusal an unbriefable item-scoped birth earns, or `null` to go ahead. PURE.
+ *
+ * `null` for a birth carrying NO work item: a registration that states a prompt
+ * and no item births prompt-only on purpose, and that shape stays legal. The
+ * refusal is only for a birth aimed at a queue item the daemon cannot describe.
+ */
+export function unbriefableBirthRefusal(
+  registration: { readonly trunk?: { readonly branch: string } } | undefined,
+  birth: { readonly project_label: string; readonly work_item?: string },
+  projects: readonly DemandBriefPoll[],
+): string | null {
+  if (birth.work_item == null) return null;
+  const verdict = demandBriefVerdict(
+    registration,
+    queueBriefing(projects, birth.project_label, birth.work_item),
+    projects.find((project) => project.project_label === birth.project_label),
+  );
+  if (verdict.briefed || verdict.gap == null) return null;
+  return (
+    `the daemon cannot brief a Worker for item ${birth.work_item}: ${describeDemandBriefGap(verdict.gap)}, ` +
+    `so a birth would echo its prompt and die with the item still queued`
+  );
+}
+
+/**
+ * Refuse an unbriefable birth, or return so the caller may perform it.
+ *
+ * The decision is `unbriefableBirthRefusal`'s and stays pure; this is the throw
+ * the demand loop's existing refusal path already catches — it arms the host
+ * backoff and states the missing fact where a stall is read. It lives here, and
+ * not as a branch at the call site, because the daemon's start function is a
+ * baselined complexity the ratchet will not let grow.
+ */
+export function refuseUnbriefableBirth(
+  registration: { readonly trunk?: { readonly branch: string } } | undefined,
+  birth: { readonly project_label: string; readonly work_item?: string },
+  projects: readonly DemandBriefPoll[],
+): void {
+  const refused = unbriefableBirthRefusal(registration, birth, projects);
+  if (refused != null) throw new Error(refused);
+}

--- a/apps/redskilled/src/queue-discovery.ts
+++ b/apps/redskilled/src/queue-discovery.ts
@@ -111,6 +111,21 @@ export interface RedskilledProjectQueue {
    * handoff verbatim, never read. Same order and same cap as `items`.
    */
   readonly tickets?: readonly RedskilledQueueTicket[];
+  /**
+   * Whether this poll LISTED what it counted, or only counted it (#4292).
+   *
+   * **An absent list is not an empty queue, and a consumer must not have to
+   * guess which it is.** The count-only GraphQL route answers an integer and
+   * says nothing about items, which downstream read exactly like a project
+   * whose backlog drained — so the daemon planned births against a depth it
+   * held no Ticket for, and every one of them echoed its prompt and died. The
+   * route states its own reach here instead: `count-only` is a poll that can
+   * brief no birth, and only `listed` promises a Ticket per counted item.
+   *
+   * Absent on every outcome but `counted`: a poll that failed listed nothing
+   * and counted nothing, and has no reach to state.
+   */
+  readonly briefing?: "listed" | "count-only";
 }
 
 /** One counted item, in the three facts a Ticket handoff has to state. */
@@ -150,7 +165,12 @@ export function carryQueueItems(
     projects: next.projects.map((project) => {
       if (project.items != null) return project;
       const carried = held.get(project.project_label);
-      return carried == null ? project : { ...project, items: [...carried.items], tickets: [...carried.tickets] };
+      // The carried list is a real list, so the project it lands on can brief
+      // again: leaving `count-only` standing beside it would refuse a birth the
+      // daemon holds every fact for.
+      return carried == null
+        ? project
+        : { ...project, items: [...carried.items], tickets: [...carried.tickets], briefing: "listed" };
     }),
   };
 }
@@ -295,7 +315,10 @@ export function parseQueueDiscoveryResponse(
         project_label: project.project_label,
         outcome: "counted",
         depth,
-        detail: `project ${JSON.stringify(project.project_label)} has ${depth} item(s) matching its selector`,
+        detail:
+          `project ${JSON.stringify(project.project_label)} has ${depth} item(s) matching its selector, counted ` +
+          `without listing them, so this poll can brief no birth`,
+        briefing: "count-only",
       };
     }
     const aliasError = errors.find((candidate) => pathIncludes(candidate.path, alias));
@@ -479,6 +502,7 @@ async function fetchConditionalQueueDiscovery(
         detail: `project ${JSON.stringify(project.project_label)} has ${depth} item(s) matching its selector`,
         items: queueItemIdentifiers(matched),
         tickets: queueTickets(matched),
+        briefing: "listed",
       });
     } catch (error) {
       const rateLimited = isGithubRateLimitError(error);

--- a/apps/redskilled/tests/demand-birth-brief.test.ts
+++ b/apps/redskilled/tests/demand-birth-brief.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  demandBriefVerdict,
+  describeDemandBriefGap,
+  queueBriefing,
+  refuseUnbriefableBirth,
+  unbriefableBirthRefusal,
+} from "../src/demand-birth-brief.js";
+
+/**
+ * A birth the daemon cannot brief is a birth it does not perform.
+ *
+ * #4292: a prompt-only turn for an item-scoped birth echoes and dies, the item
+ * stays queued, and the planner asks again on the next tick — 58 Workers in a
+ * quarter of an hour, each paying a worktree clone and a host slot.
+ */
+const registration = { trunk: { branch: "main" } };
+const ticket = { id: "518", title: "the tokens drift between themes", labels: ["bug", "ready-for-agent"] };
+const birth = { project_label: "reddb-io/design-system", work_item: "518" };
+const listed = [{ project_label: "reddb-io/design-system", briefing: "listed" as const, tickets: [ticket] }];
+
+describe("which fact stops a birth being briefed", () => {
+  it("briefs when the poll listed the item and the registration states a trunk", () => {
+    expect(demandBriefVerdict(registration, ticket)).toEqual({ briefed: true });
+    expect(unbriefableBirthRefusal(registration, birth, listed)).toBeNull();
+  });
+
+  it("names the count-only poll, which counted a depth it holds no Ticket for", () => {
+    const counted = [{ project_label: "reddb-io/design-system", briefing: "count-only" as const }];
+
+    expect(demandBriefVerdict(registration, undefined, counted[0])).toEqual({
+      briefed: false,
+      gap: "count-only-poll",
+    });
+    expect(unbriefableBirthRefusal(registration, birth, counted)).toBe(
+      "the daemon cannot brief a Worker for item 518: the last queue poll counted this project without listing " +
+        "it, so it holds no Ticket to hand over, so a birth would echo its prompt and die with the item still queued",
+    );
+  });
+
+  it("names the absent Ticket when a listing poll listed some other item", () => {
+    const other = [{ project_label: "reddb-io/design-system", briefing: "listed" as const, tickets: [{ ...ticket, id: "7" }] }];
+
+    expect(unbriefableBirthRefusal(registration, birth, other)).toContain("listed no Ticket for that item");
+  });
+
+  it("names the empty title, which the Worker's own handoff would refuse", () => {
+    const empty = [{ ...listed[0]!, tickets: [{ ...ticket, title: "" }] }];
+
+    expect(demandBriefVerdict(registration, { ...ticket, title: "" })).toEqual({ briefed: false, gap: "empty-title" });
+    expect(unbriefableBirthRefusal(registration, birth, empty)).toContain("carries an empty title");
+  });
+
+  it("names the missing trunk branch, which is what the live loop was short of", () => {
+    expect(demandBriefVerdict({}, ticket)).toEqual({ briefed: false, gap: "no-trunk-branch" });
+    expect(demandBriefVerdict(undefined, ticket)).toEqual({ briefed: false, gap: "no-trunk-branch" });
+    expect(unbriefableBirthRefusal({}, birth, listed)).toBe(
+      "the daemon cannot brief a Worker for item 518: this project's registration states no trunk branch, so a " +
+        "birth would echo its prompt and die with the item still queued",
+    );
+  });
+
+  it("names an unusable number rather than briefing a Ticket nobody can open", () => {
+    expect(demandBriefVerdict(registration, { ...ticket, id: "not-a-number" }).gap).toBe("unusable-number");
+    expect(demandBriefVerdict(registration, { ...ticket, id: "0" }).gap).toBe("unusable-number");
+    expect(describeDemandBriefGap("unusable-number")).toContain("no usable number");
+  });
+
+  it("throws the same refusal where the demand loop already catches one", () => {
+    expect(() => refuseUnbriefableBirth(registration, birth, listed)).not.toThrow();
+    expect(() => refuseUnbriefableBirth({}, birth, listed)).toThrow(/states no trunk branch/);
+  });
+
+  it("leaves a prompt-only birth alone — a registration with no work item births as it always did", () => {
+    expect(unbriefableBirthRefusal(undefined, { project_label: "reddb-io/design-system" }, [])).toBeNull();
+    expect(unbriefableBirthRefusal({}, { project_label: "reddb-io/design-system" }, [])).toBeNull();
+  });
+
+  it("finds the briefing the last poll kept for that item, and nothing for another", () => {
+    expect(queueBriefing(listed, "reddb-io/design-system", "518")).toEqual(ticket);
+    expect(queueBriefing(listed, "reddb-io/design-system", "9")).toBeUndefined();
+    expect(queueBriefing(listed, "reddb-io/red-skills", "518")).toBeUndefined();
+    expect(queueBriefing(listed, "reddb-io/design-system", undefined)).toBeUndefined();
+  });
+});

--- a/apps/redskilled/tests/demand-loop.test.ts
+++ b/apps/redskilled/tests/demand-loop.test.ts
@@ -469,6 +469,68 @@ describe("the daemon drives the demand loop itself", () => {
     expect(second.refusal).toBeNull();
   });
 
+  it("refuses an item-scoped birth it cannot brief, naming the missing fact and spawning nothing (#4292)", async () => {
+    // The live loop: 58 Workers in a quarter of an hour, each one born for an
+    // item it was never told about, echoing its prompt and dying while the item
+    // stayed queued. Here the registration states no trunk, so no handoff can
+    // be composed — the birth must not happen at all.
+    const launched: LaunchWorkerOptions[] = [];
+    const workspace = await scratch("redskilled-workspace-");
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      demandMs: 0,
+      launch: recordingLaunch(launched),
+      queueDiscovery: { intervalMs: 0, transport: listingTransport([{ number: 518, title: "the tokens drift", labels: [] }]) },
+    });
+    running.push(daemon);
+
+    daemon.registerProject({
+      ...registration("reddb-io/design-system", 1, workspace),
+      queue_poll: { owner: "reddb-io", repo: "design-system", labels: ["ready-for-agent"] },
+      prompt: "Work issue #{{work_item}} to a merged PR",
+    });
+    await daemon.pollQueueDiscovery();
+    const demand = await daemon.driveDemand();
+
+    expect(launched).toEqual([]);
+    expect(demand.granted).toEqual([]);
+    expect(demand.refusal).toBe(
+      "the daemon cannot brief a Worker for item 518: this project's registration states no trunk branch, so a " +
+        "birth would echo its prompt and die with the item still queued",
+    );
+    // Rate-limited by the same backoff every other host refusal arms, so an
+    // unbriefable queue costs one journal line a window rather than a Worker a tick.
+    expect(demand.retry_after).not.toBeNull();
+  });
+
+  it("still births prompt-only for a registration that carries a prompt and no work item (#4292)", async () => {
+    // The deliberate shape stays legal: a count-only poll lists nothing, so the
+    // planner hands out no work item and the turn is the prompt the project wrote.
+    const launched: LaunchWorkerOptions[] = [];
+    const workspace = await scratch("redskilled-workspace-");
+    const daemon = await startRedskilledDaemon({
+      paths: await sessionPaths(),
+      ceiling: UNBOUNDED_HOST_CEILING,
+      sampleMs: 0,
+      demandMs: 0,
+      launch: recordingLaunch(launched),
+      queueDiscovery: { intervalMs: 0, transport: async () => answer([3]) },
+    });
+    running.push(daemon);
+
+    daemon.registerProject({
+      ...registration("reddb-io/design-system", 1, workspace),
+      prompt: "Take the next thing on the board",
+    });
+    await daemon.pollQueueDiscovery();
+    const demand = await daemon.driveDemand();
+
+    expect(demand.refusal).toBeNull();
+    expect(demand.projects[0]!.outcome).toBe("asking");
+  });
+
   it("holds the daemon alive while a registration stands, so the loop outlives the session", async () => {
     const daemon = await startRedskilledDaemon({
       paths: await sessionPaths(),
@@ -492,6 +554,16 @@ describe("the daemon drives the demand loop itself", () => {
     expect(held.hostState().registrations ?? []).toHaveLength(1);
   });
 });
+
+/** A transport whose REST lane LISTS what it counts, the way production's does. */
+function listingTransport(items: readonly Record<string, unknown>[]) {
+  const transport = (async () => answer([items.length])) as never as {
+    (query: string): Promise<unknown>;
+    conditionalList?: (input: unknown) => Promise<unknown>;
+  };
+  transport.conditionalList = async () => ({ data: [...items], headers: {}, requestCount: 1 });
+  return transport as never;
+}
 
 /** One aliased answer, in the shape the tracker gives it back. */
 function answer(depths: readonly number[]): unknown {

--- a/apps/redskilled/tests/queue-discovery.test.ts
+++ b/apps/redskilled/tests/queue-discovery.test.ts
@@ -16,6 +16,7 @@ import {
   emptyQueueDiscovery,
   fetchQueueDiscovery,
   isRedskilledQueueReport,
+  carryQueueItems,
   planQueueDiscoveryBatches,
   REDSKILLED_QUEUE_BATCH_SIZE,
   REDSKILLED_QUEUE_STALENESS_MS,
@@ -125,6 +126,70 @@ describe("the batch bound is covered, never truncated", () => {
   it("states a default bound one request can hold", () => {
     expect(Number.isInteger(REDSKILLED_QUEUE_BATCH_SIZE)).toBe(true);
     expect(REDSKILLED_QUEUE_BATCH_SIZE).toBeGreaterThan(0);
+  });
+});
+
+describe("a poll states its own reach, so nothing downstream infers it (#4292)", () => {
+  it("says the aliased count route counted without listing, and can brief no birth", async () => {
+    const discovery = await fetchQueueDiscovery({
+      projects: [selector(0)],
+      now: NOW,
+      transport: async () => answer([7]),
+    });
+
+    expect(discovery.projects[0]).toMatchObject({ outcome: "counted", depth: 7, briefing: "count-only" });
+    expect(discovery.projects[0]!.items).toBeUndefined();
+    expect(discovery.projects[0]!.tickets).toBeUndefined();
+    expect(discovery.projects[0]!.detail).toContain("can brief no birth");
+  });
+
+  it("says the REST list route listed what it counted, and hands over the Tickets", async () => {
+    const transport = (async () => answer([2])) as never as {
+      (query: string): Promise<unknown>;
+      conditionalList?: (input: unknown) => Promise<unknown>;
+    };
+    transport.conditionalList = async () => ({
+      data: [{ number: 518, title: "the tokens drift", labels: [{ name: "bug" }] }, { number: 7, title: "t", labels: [] }],
+      headers: {},
+      requestCount: 1,
+    });
+    const discovery = await fetchQueueDiscovery({
+      projects: [{ ...selector(0), poll: { owner: "acme", repo: "p0", labels: ["ready-for-agent"] } }],
+      now: NOW,
+      transport: transport as never,
+    });
+
+    expect(discovery.projects[0]).toMatchObject({ outcome: "counted", depth: 2, briefing: "listed" });
+    expect(discovery.projects[0]!.tickets).toEqual([
+      { id: "518", title: "the tokens drift", labels: ["bug"] },
+      { id: "7", title: "t", labels: [] },
+    ]);
+  });
+
+  it("carries a previous list onto a poll that could not list, and says it can brief again", () => {
+    const previous = {
+      version: 1 as const,
+      fetched_at: NOW,
+      request_count: 1,
+      project_count: 1,
+      batch_size: 1,
+      rate_limit: { remaining: null, reset_at: null, exhausted: false },
+      projects: [{
+        project_label: "acme/p0",
+        outcome: "counted" as const,
+        depth: 1,
+        detail: "d",
+        items: ["518"],
+        tickets: [{ id: "518", title: "the tokens drift", labels: [] }],
+        briefing: "listed" as const,
+      }],
+    };
+    const next = {
+      ...previous,
+      projects: [{ project_label: "acme/p0", outcome: "unreachable" as const, depth: null, detail: "d" }],
+    };
+
+    expect(carryQueueItems(next, previous).projects[0]).toMatchObject({ briefing: "listed", items: ["518"] });
   });
 });
 


### PR DESCRIPTION
Fixes #4292

## What was happening

A planned birth whose Ticket handoff could not be composed was performed anyway. `demandTurnForBirth` collapsed the decision to a boolean (`briefed`) and simply omitted the handoff; `apps/redskilled/src/daemon/lifecycle.ts` births a Worker for the resulting prompt-only turn. The Worker then takes `runPromptTurn`'s third path — echo the prompt, end the turn, `no-workflow-outcome (end_turn)` — after paying a worktree clone and a host slot. The item stays queued and the planner asks for another on the next tick, forever, every ~15s.

## What changed

**A birth the daemon cannot brief is a birth it does not perform.**

- New pure module `apps/redskilled/src/demand-birth-brief.ts` holds the decision beside the turn it feeds and states *which* fact is absent: `count-only-poll`, `no-ticket`, `unusable-number`, `empty-title`, `no-trunk-branch`. `demandTurnForBirth` now reads its `briefed` from the same verdict, so the handoff and the refusal cannot drift.
- The lifecycle wires one call. The refusal rides the demand loop's **existing** path — the `refusal` variable, `demandBackoffUntilMs`, and the `eventLane.recordDemandRefusal` sweep over birth-eligible-but-ungranted intents — so it is journal-visible and rate-limited by the host backoff rather than a new loud loop.
- The deliberate shape stays legal: a registration carrying a prompt and **no** work item still births prompt-only, pinned by its own daemon-level test.
- The `if` lives in the new module (`refuseUnbriefableBirth`) rather than at the call site, because `startRedskilledDaemon` is a baselined complexity the ratchet will not let grow (it went 422 → 423 with the branch inline).

### The line an operator now sees

The host lane records, for the project that was birth-eligible and got nothing:

```
project "reddb-io/design-system" was birth-eligible but the host refused it: the daemon cannot brief a Worker for item 518: this project's registration states no trunk branch, so a birth would echo its prompt and die with the item still queued
```

The clause after the colon is the part that varies — e.g. `the last queue poll counted this project without listing it, so it holds no Ticket to hand over`, `the last queue poll listed no Ticket for that item`, `the Ticket the last poll listed carries an empty title`, `the Ticket the last poll listed carries no usable number`.

## The route asymmetry: which resolution and why

**Chosen: the outcome states that it cannot brief** (the second option the issue and AC 4 allow), not a widened GraphQL selection.

`RedskilledProjectQueue` gains `briefing?: "listed" | "count-only"`. The aliased GraphQL route answers `count-only` beside its depth (and says so in its `detail`); the conditional REST route answers `listed`; `carryQueueItems` flips a carried list back to `listed`, because the tickets it carried are real. Nothing downstream has to read an absent `tickets` field as a drained queue.

Two reasons the query was not widened instead:

1. **Cost.** `search(…, first: 1) { issueCount }` costs 1 rate-limit point per alias. `first: 32 { nodes { number title labels(first: 20) } }` costs ~7 per alias by GitHub's nested-connection formula — at the 15s queue cadence that is ~1,680 points/hour for **one** project, and the batched lane spans up to 50 aliases per query. This is the daemon's hot poll path.
2. **Labels are load-bearing, so a cheap partial selection would invent a fact.** `ticket.labels` is a required field of the handoff (`packages/protocol-acp/ticket.ts:128` — a non-array degrades the turn to a plain prompt turn) and is branched on twice: the lane→run-mode preflight refusal before the claim (`packages/worker/src/acp/ticket-loop.ts:235` → `packages/worker/src/engine/lane-run-mode.ts:76`) and the gate-blocked park's label transition (`apps/redskilled/src/demand-park.ts:114`). Dropping `labels` from the selection to keep the cost at 1 point would ship `labels: []` — silently disabling both gates.

## Verifying the issue's diagnosis

Everything in the issue checked out **except one inference**, worth recording:

- ✅ `demandTurnForBirth`'s `briefed` conjunction, and the prompt-only turn it falls back to.
- ✅ The lifecycle births for it anyway.
- ✅ REST route pushes `items` **and** `tickets`; `parseQueueDiscoveryResponse` pushes neither.
- ⚠️ **"a registration whose poll plan is absent counts a depth the planner will happily birth against"** — not quite, and not the path that produced the live line. The planner only assigns `birth.work_item` from `project.items` (`apps/redskilled/src/demand-loop.ts:355-364`), so a count-only poll yields births with **no** work item, i.e. the legal prompt-only shape. The observed verdict names `on item 518`, so that project's poll *did* list items — which means the missing fact there was `trunk.branch` on the registration (or an empty title), not the route. Also note `items` and `tickets` are always in lockstep on the REST lane (`queueItemIdentifiers` is `queueTickets(…).map(id)`), so `no-ticket` cannot arise from that route alone. The count-only hole is real (a stale carried list, or the next consumer of `items`) and is closed here, but the live 58-Worker loop was the trunk-branch case.

## Tests

- `apps/redskilled/tests/demand-birth-brief.test.ts` (new, 9 tests) — one per gap, over the pure planner; plus the prompt-only-birth-stays-legal case and the thrower.
- `apps/redskilled/tests/demand-loop.test.ts` — two daemon-level tests: an item-scoped birth is refused with the exact sentence, launches nothing and arms `retry_after`; a prompt-with-no-work-item registration still births. Confirmed non-vacuous (the first fails on this branch with the guard removed).
- `apps/redskilled/tests/queue-discovery.test.ts` — the count-only route says `count-only` and carries no items; the REST route says `listed` and hands over the Tickets; a carried list restores `listed`.

## Validation

- `pnpm typecheck` — 17/17 green.
- `pnpm -C apps/plugin-dev test:invariants` — 494/494 green (file-size: `lifecycle.ts` 2483 → 2482; complexity baseline unchanged at 422).
- `pnpm exec oxlint apps/redskilled/{src,tests}` — clean.
- `pnpm -C apps/redskilled exec vitest run` — 1274 passed, 18 failed, all pre-existing on clean `main`: acp-control-plane (2), acp-control-plane-layout (1), acp-ticket-loop (2), acp-publication (1), acp-conformance (4), telemetry-metrics (3), worker-birth (1), resource-incidents (1), registration-counter-poll (1), conditional-polling (2 — verified failing on a stashed clean tree at this SHA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789940465&installation_model_id=20659&pr_number=4294&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4294&signature=3e80901f7a07d389b9cc3e52d3237bb7e68d64b17da77d599cf28f9df94971ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->