### PR TITLE
fix(worker): a refused brief ends the turn and parks its Ticket

### DIFF
--- a/.changeset/refused-brief-is-loud.md
+++ b/.changeset/refused-brief-is-loud.md
@@ -1,0 +1,22 @@
+---
+"@reddb-io/protocol-acp": patch
+"@reddb-io/shared": patch
+"@reddb-io/worker": patch
+"@reddb-io/redskilled": patch
+---
+
+A refused brief ends the turn and parks its Ticket, instead of echoing forever
+
+The wire decoder spelled a brief-contract refusal as `return undefined`, and at
+that door `undefined` means "no Ticket handoff" — the legal prompt-turn shape.
+So a Ticket the contract rejected reached the Worker as an ordinary prompt: it
+echoed, ended `no-workflow-outcome (end_turn)`, and left the item on
+`ready-for-agent` for the planner to birth against every ~15s. Observed on an
+operator's host: ~60 Workers on one item, twice.
+
+The decoder now answers a decision — `absent`, `refused` (carrying the
+contract's sentence), or a handoff — with `ticketHandoffFromMeta` kept as its
+yes/no reading. A Worker handed a refusal ends the turn as
+`refused at brief: <the contract's sentence>`, and the daemon's single park
+door parks the Ticket under `blocked:spec` with that sentence quoted, so the
+ready queue drains by one and the birth loop cannot re-form.

--- a/apps/redskilled/src/acp-body-control-cut.ts
+++ b/apps/redskilled/src/acp-body-control-cut.ts
@@ -109,6 +109,11 @@ export const WORKER_BODY_MODULES: readonly WorkerBodyModule[] = [
     runs: "drives one Ticket from claim to land inside the turn: claim, implement, gate, re-seed in place, publish, land",
   },
   {
+    module: "brief-refusal-turn.ts",
+    defines: ["briefRefusalResponse", "notifyBriefRefusal", "ticketDecisionForTurn"],
+    runs: "ends the turn on a brief the contract refuses, naming the sentence, instead of echoing it back as an ordinary prompt (#4296)",
+  },
+  {
     module: "retry-policy.ts",
     defines: ["WORKER_FAILURE_RETRY_CLASSES", "WORKER_FAILURE_RETRY_TABLE"],
     runs: "bounds every retry by its declared failure mode (#4175): the table decides how many times and with what remedy a failed round re-enters",

--- a/apps/redskilled/src/acp-demand-turn.ts
+++ b/apps/redskilled/src/acp-demand-turn.ts
@@ -27,7 +27,7 @@ import type {
 
 import { randomBytes } from "node:crypto";
 
-import { parkGateBlockedTurn } from "./demand-park.js";
+import { parkTerminalTurn } from "./demand-park.js";
 import { demandBriefVerdict } from "./demand-birth-brief.js";
 import { readProjectTicketBody } from "./acp-github.js";
 import { admitNativeAcpWorker } from "./acp-worker-admission.js";
@@ -81,13 +81,14 @@ export interface DemandTurnDeps {
    */
   readonly record?: (line: DemandTurnRecord) => void;
   /**
-   * What happens to the Ticket after a completed turn whose gate blocked.
+   * What happens to the Ticket after a completed turn whose verdict is terminal
+   * — a gate that blocked (#4160) or a brief the contract refused (#4296).
    *
    * Answers a one-line record of the transition it performed (or refused), or
    * `null` for every other verdict. Absent in tests that assert the turn
-   * alone; the control plane wires `parkGateBlockedTurn` (#4160), because a
-   * gate-blocked Ticket left in the ready queue is re-taken by the very next
-   * birth — the infinite grinder the park exists to end.
+   * alone; the control plane wires `parkTerminalTurn`, because a Ticket left in
+   * the ready queue after a verdict its next birth would reproduce exactly is
+   * re-taken by that very birth — the infinite grinder the park exists to end.
    */
   readonly park?: (
     project: AcpProjectWorkspace,
@@ -339,7 +340,7 @@ export function demandTurnRunnerFor(
     ...(options.evidenceTtlMs == null ? {} : { evidenceTtlMs: options.evidenceTtlMs }),
     ...(options.recordDemandTurn == null ? {} : { record: options.recordDemandTurn }),
     ...(options.workerPulse == null ? {} : { pulse: options.workerPulse }),
-    park: parkGateBlockedTurn(options.githubGateway),
+    park: parkTerminalTurn(options.githubGateway),
   });
 }
 

--- a/apps/redskilled/src/demand-park.ts
+++ b/apps/redskilled/src/demand-park.ts
@@ -1,10 +1,24 @@
-// demand-park — a gate-blocked demand turn moves its Ticket out of the queue.
+// demand-park — a demand turn whose verdict is terminal moves its Ticket out of
+// the queue.
 //
 // #4160: two Workers finished `gate-blocked at feedback` on one Ticket and the
 // Ticket kept `ready-for-agent`, so every freed slot re-birthed a Worker for
 // the same head item — claim spam, duplicate work, an infinite grinder on one
 // issue. A verdict that changes nothing on the tracker is indistinguishable
 // from no verdict: the park is what makes the queue advance.
+//
+// #4296 arrived at the same grinder by a different road: a brief the contract
+// refuses. Nothing was gated, because nothing was claimed — the Worker read the
+// handoff, found the acceptance criteria unexecutable, and ended the turn. Same
+// consequence, so the same door: **ONE park, two terminal verdicts.** A second
+// door would be a second place to forget the `ready-for-agent` removal, and the
+// removal is the only part the loop actually depends on.
+//
+// The two verdicts differ in what they blame and therefore in what they park
+// under. A gate that blocked is `blocked:validation` — the code failed. A brief
+// the contract refuses is `blocked:spec`: nothing is wrong with the tree, the
+// Ticket's own words cannot be executed, and the repair is a human rewriting
+// the acceptance criteria.
 //
 // The transition itself is the Worker engine's own planner (`planTransition`,
 // the single owner of state-label mutations), fed the label vocabulary the
@@ -26,51 +40,118 @@ import { bindAcpProjectGithubWrite } from "./acp-github.js";
 import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 
-/** The one Ticket verdict this module acts on; every other outcome passes by. */
-export interface GateBlockedVerdict {
-  readonly failedStage: string;
-  readonly detail?: string;
-}
+/**
+ * The Ticket verdicts this module acts on; every other outcome passes by.
+ *
+ * `gate-blocked` names the stage that failed. `brief-refused` names none: the
+ * loop never started, so there is no stage to report — only the sentence the
+ * contract wrote.
+ */
+export type ParkVerdict =
+  | { readonly kind: "gate-blocked"; readonly failedStage: string; readonly detail?: string }
+  | { readonly kind: "brief-refused"; readonly detail: string };
 
-/** Read a turn's Ticket verdict and answer only when the gate blocked. PURE. */
-export function gateBlockedVerdictOf(response: {
-  readonly _meta?: unknown;
-}): GateBlockedVerdict | null {
+/**
+ * The stage a wire-door brief refusal names, mirroring the Worker's own
+ * `TICKET_BRIEF_REFUSAL_STAGE`. Spelled here rather than imported because it is
+ * WIRE: the daemon reads whatever the running bundle sent, and a bundle old
+ * enough to send no stage at all must still be readable as "not a brief refusal".
+ */
+const BRIEF_REFUSAL_STAGE = "brief";
+
+/**
+ * Read a turn's Ticket verdict and answer only when the queue must not serve
+ * this item again. PURE.
+ *
+ * A `refused` verdict from any OTHER stage passes by, deliberately: the Ticket
+ * loop refuses at `claim` for a failed claim write and at `land` for a landing
+ * the forge rejected, and both of those are worth retrying. Only the brief
+ * refusal is known to be identical on the next birth, which is what makes it
+ * the one refusal a park may act on.
+ */
+export function parkVerdictOf(response: { readonly _meta?: unknown }): ParkVerdict | null {
   const ticket = (response._meta as { redskills?: { ticket?: unknown } } | undefined)
     ?.redskills?.ticket;
   if (ticket == null || typeof ticket !== "object") return null;
-  const verdict = ticket as { outcome?: unknown; failedStage?: unknown; detail?: unknown };
-  if (verdict.outcome !== "gate-blocked") return null;
+  const verdict = ticket as {
+    outcome?: unknown;
+    stage?: unknown;
+    failedStage?: unknown;
+    detail?: unknown;
+  };
+  if (verdict.outcome === "gate-blocked") {
+    return {
+      kind: "gate-blocked",
+      failedStage: typeof verdict.failedStage === "string" ? verdict.failedStage : "feedback",
+      ...(typeof verdict.detail === "string" ? { detail: verdict.detail } : {}),
+    };
+  }
+  if (
+    verdict.outcome === "refused" &&
+    verdict.stage === BRIEF_REFUSAL_STAGE &&
+    typeof verdict.detail === "string" &&
+    verdict.detail !== ""
+  ) {
+    return { kind: "brief-refused", detail: verdict.detail };
+  }
+  return null;
+}
+
+/**
+ * Which `blocked:*` reason a verdict parks under, and the sentence an operator
+ * reads above the detail block. PURE.
+ *
+ * Split out because the two halves answer to different owners: the reason is
+ * the PROJECT's declared label vocabulary, and the sentence is this module's
+ * account of what happened. Keeping them in one place is what stops a third
+ * verdict from arriving with a label and no explanation.
+ */
+function parkReasonFor(
+  verdict: ParkVerdict,
+  blockedPrefix: string,
+): { readonly reason: string; readonly headline: string; readonly detail: string | undefined } {
+  if (verdict.kind === "gate-blocked") {
+    return {
+      reason: `${blockedPrefix}validation`,
+      headline: `the local gate blocked at \`${verdict.failedStage}\``,
+      detail: verdict.detail,
+    };
+  }
   return {
-    failedStage: typeof verdict.failedStage === "string" ? verdict.failedStage : "feedback",
-    ...(typeof verdict.detail === "string" ? { detail: verdict.detail } : {}),
+    reason: `${blockedPrefix}spec`,
+    headline:
+      "this Ticket's brief cannot be executed as written, so no Worker claimed it " +
+      "and no work was done",
+    detail: verdict.detail,
   };
 }
 
 /**
- * Compose the one tracker mutation that parks a gate-blocked Ticket, or say
- * why none can be composed. The refusal is a sentence, not a throw: a park the
- * planner refuses (a dependency edge still standing, a vocabulary conflict) is
- * an outcome the demand record must carry, never a dead Worker.
+ * Compose the one tracker mutation that parks a Ticket whose turn ended
+ * terminally, or say why none can be composed. The refusal is a sentence, not a
+ * throw: a park the planner refuses (a dependency edge still standing, a
+ * vocabulary conflict) is an outcome the demand record must carry, never a dead
+ * Worker.
  */
-export function gateBlockedParkWrite(input: {
+export function parkWrite(input: {
   readonly workspacePath: string;
   readonly ticket: { readonly number: number; readonly labels: readonly string[] };
   readonly workerId: string;
-  readonly verdict: GateBlockedVerdict;
+  readonly verdict: ParkVerdict;
 }): { readonly request: RedskilledGithubWriteRequest; readonly summary: string } | { readonly refusal: string } {
   const vocabulary = readEngineLabelVocabulary(
     loadEngineConfig(resolve(input.workspacePath, ".red"), { warn: () => undefined }),
   );
+  const parked = parkReasonFor(input.verdict, vocabulary.blockedPrefix);
   const plan = planTransition(
     input.ticket.labels,
-    { kind: "park", reason: `${vocabulary.blockedPrefix}validation` },
+    { kind: "park", reason: parked.reason },
     vocabulary,
   );
   if (isRefused(plan)) return { refusal: plan.reason };
-  const detail = input.verdict.detail == null
+  const detail = parked.detail == null
     ? ""
-    : `\n\n\`\`\`\n${input.verdict.detail.slice(0, 800)}\n\`\`\``;
+    : `\n\n\`\`\`\n${parked.detail.slice(0, 800)}\n\`\`\``;
   return {
     summary: `parked #${input.ticket.number}: +[${plan.add.join(", ")}] -[${plan.remove.join(", ")}]`,
     request: {
@@ -81,8 +162,7 @@ export function gateBlockedParkWrite(input: {
         add: plan.add,
         remove: plan.remove,
         comment:
-          `🤖 AFK park by worker \`${input.workerId}\`: the local gate blocked at ` +
-          `\`${input.verdict.failedStage}\`.${detail}\n\n` +
+          `🤖 AFK park by worker \`${input.workerId}\`: ${parked.headline}.${detail}\n\n` +
           `Requeue with \`/retake ${input.ticket.number}\` once the blocker is repaired.`,
       },
     },
@@ -93,12 +173,12 @@ export function gateBlockedParkWrite(input: {
  * The executor the demand-turn runner calls after a completed Ticket turn.
  *
  * Answers a one-line record of what it did — a park summary, a stated refusal,
- * or `null` when the verdict was not `gate-blocked` — and never throws for a
+ * or `null` when the verdict was neither terminal one — and never throws for a
  * park that could not happen: the turn already finished, and the only thing
  * left to protect is the operator's ability to read why the queue did or did
  * not advance.
  */
-export function parkGateBlockedTurn(
+export function parkTerminalTurn(
   gateway: RedskilledGithubGatewayRegistration | undefined,
 ): (
   project: AcpProjectWorkspace,
@@ -107,7 +187,7 @@ export function parkGateBlockedTurn(
   workerId: string,
 ) => Promise<string | null> {
   return async (project, ticket, response, workerId) => {
-    const verdict = gateBlockedVerdictOf(response);
+    const verdict = parkVerdictOf(response);
     if (verdict == null) return null;
     // The turn's ticket is opaque wire until read here, exactly once.
     const number = Number(ticket.number);
@@ -117,7 +197,7 @@ export function parkGateBlockedTurn(
     if (!Number.isInteger(number) || number <= 0) {
       return `park refused: the turn's ticket names no issue number`;
     }
-    const composed = gateBlockedParkWrite({
+    const composed = parkWrite({
       workspacePath: project.workspacePath,
       ticket: { number, labels },
       workerId,

--- a/apps/redskilled/tests/demand-park.test.ts
+++ b/apps/redskilled/tests/demand-park.test.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { gateBlockedParkWrite, gateBlockedVerdictOf } from "../src/demand-park.js";
+import { parkTerminalTurn, parkVerdictOf, parkWrite } from "../src/demand-park.js";
+import { planHostDemand } from "../src/demand-loop.js";
 import { createDemandTurnRunner, type DemandTurnAdmission, type DemandTurnRecord } from "../src/acp-demand-turn.js";
 import type { ActiveWorkflowWorker } from "../src/acp-worker-lifecycle.js";
 import { validateWriteRequest } from "../src/github-outbox.js";
@@ -18,13 +19,13 @@ import { createRedskilledGithubWriteUpstream } from "../src/github-write.js";
  */
 describe("the gate-blocked verdict is read from the turn's ticket meta", () => {
   it("answers only for gate-blocked", () => {
-    expect(gateBlockedVerdictOf({
+    expect(parkVerdictOf({
       _meta: { redskills: { ticket: { outcome: "gate-blocked", failedStage: "feedback", detail: "pnpm test: red" } } },
-    })).toEqual({ failedStage: "feedback", detail: "pnpm test: red" });
-    expect(gateBlockedVerdictOf({
+    })).toEqual({ kind: "gate-blocked", failedStage: "feedback", detail: "pnpm test: red" });
+    expect(parkVerdictOf({
       _meta: { redskills: { ticket: { outcome: "landed", pullRequest: 7 } } },
     })).toBeNull();
-    expect(gateBlockedVerdictOf({})).toBeNull();
+    expect(parkVerdictOf({})).toBeNull();
   });
 });
 
@@ -32,11 +33,11 @@ describe("the park write moves the Ticket out of the executable queue", () => {
   const workspace = mkdtempSync(join(tmpdir(), "demand-park-"));
 
   it("computes the engine planner's atomic transition under the default vocabulary", () => {
-    const composed = gateBlockedParkWrite({
+    const composed = parkWrite({
       workspacePath: workspace,
       ticket: { number: 4154, labels: ["bug", "ready-for-agent"] },
       workerId: "VSq1",
-      verdict: { failedStage: "feedback", detail: "pnpm test failed" },
+      verdict: { kind: "gate-blocked", failedStage: "feedback", detail: "pnpm test failed" },
     });
 
     expect(composed).toMatchObject({
@@ -55,11 +56,11 @@ describe("the park write moves the Ticket out of the executable queue", () => {
   });
 
   it("carries the failed stage and the gate detail into the comment", () => {
-    const composed = gateBlockedParkWrite({
+    const composed = parkWrite({
       workspacePath: workspace,
       ticket: { number: 9, labels: ["ready-for-agent"] },
       workerId: "W2",
-      verdict: { failedStage: "post_done", detail: "assert red" },
+      verdict: { kind: "gate-blocked", failedStage: "post_done", detail: "assert red" },
     });
 
     if ("refusal" in composed) throw new Error(composed.refusal);
@@ -205,5 +206,173 @@ describe("a completed gate-blocked turn is parked by the runner", () => {
     await run({ project, prompt: "p" });
 
     expect(park).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * #4296: the same grinder, reached by a different road.
+ *
+ * A brief the contract refuses is not a gate that blocked — nothing was
+ * claimed, gated or committed — but it costs the queue the same way, and it
+ * costs it FOREVER, because the next birth reads the identical brief and
+ * refuses identically. The park is what makes the second tick find nothing.
+ */
+describe("a Ticket whose brief the contract refused is parked as a spec block", () => {
+  const workspace = mkdtempSync(join(tmpdir(), "demand-park-brief-"));
+  const REFUSAL =
+    "brief contract refused: acceptance criteria item is not machine-checkable: " +
+    "The decision is recorded on this ticket with its reasoning.";
+
+  it("reads the refusal off the turn, and passes every other refusal by", () => {
+    expect(parkVerdictOf({
+      _meta: { redskills: { ticket: { outcome: "refused", stage: "brief", detail: REFUSAL } } },
+    })).toEqual({ kind: "brief-refused", detail: REFUSAL });
+    // The loop's own refusals are worth retrying, so they are not parks.
+    expect(parkVerdictOf({
+      _meta: { redskills: { ticket: { outcome: "refused", stage: "claim", detail: "forge 502" } } },
+    })).toBeNull();
+    expect(parkVerdictOf({
+      _meta: { redskills: { ticket: { outcome: "refused", stage: "land", detail: "rejected" } } },
+    })).toBeNull();
+    // A bundle that names the stage but says nothing is not a readable refusal.
+    expect(parkVerdictOf({
+      _meta: { redskills: { ticket: { outcome: "refused", stage: "brief" } } },
+    })).toBeNull();
+  });
+
+  it("parks under the spec reason and quotes the contract's sentence", () => {
+    const composed = parkWrite({
+      workspacePath: workspace,
+      ticket: { number: 518, labels: ["ready-for-agent"] },
+      workerId: "W7",
+      verdict: { kind: "brief-refused", detail: REFUSAL },
+    });
+
+    if ("refusal" in composed) throw new Error(composed.refusal);
+    expect(composed.request.write).toMatchObject({
+      kind: "issue-transition",
+      issue: 518,
+      add: expect.arrayContaining(["ready-for-human", "blocked:spec"]),
+      remove: ["ready-for-agent"],
+    });
+    const comment = (composed.request.write as { comment?: string }).comment ?? "";
+    expect(comment).toContain("brief cannot be executed as written");
+    expect(comment).toContain("not machine-checkable");
+    expect(comment).toContain("/retake 518");
+    // The gate's blame does not follow a Ticket nothing gated.
+    expect(comment).not.toContain("local gate");
+  });
+});
+
+/**
+ * The whole point of the park, stated as the loop it ends: tick, refuse, park,
+ * tick again — and the second tick has nothing to birth for.
+ */
+describe("two demand ticks over one refused item produce one park and one birth", () => {
+  it("drains the queue by one instead of re-birthing forever", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "demand-park-loop-"));
+    const REFUSAL = "brief contract refused: acceptance criteria item is not machine-checkable: prose.";
+    // The tracker, in the only part of it this loop reads: one issue's labels.
+    const labels = new Set(["ready-for-agent"]);
+    const applied: unknown[] = [];
+
+    const project = {
+      projectId: "github:1",
+      projectLabel: "o/r",
+      workspacePath: workspace,
+    } as never;
+
+    // The park executor the control plane wires, over a gateway that applies
+    // the transition to the label set the next tick will read.
+    const park = parkTerminalTurn({
+      credentialForProject: async () => ({ profile: "personal", credential: {} }),
+      gateway: {
+        forProject: () => ({
+          write: async (params: { readonly write: { readonly add: readonly string[]; readonly remove: readonly string[] } }) => {
+            applied.push(params);
+            for (const label of params.write.remove) labels.delete(label);
+            for (const label of params.write.add) labels.add(label);
+            return {};
+          },
+        }),
+      },
+    } as never);
+
+    const records: DemandTurnRecord[] = [];
+    const prompted: string[] = [];
+    const run = createDemandTurnRunner({
+      paths: {} as never,
+      startWorker: (() => { throw new Error("injected admission owns the birth"); }) as never,
+      hostState: () => ({ workers: [] }),
+      sessionJournal: { create: async () => {} } as never,
+      admit: async (_input: DemandTurnAdmission) => {
+        prompted.push("birth");
+        return {
+          workerId: `W${prompted.length}`,
+          downstreamSessionId: "down",
+          connection: {
+            agent: {
+              // The turn's answer, exactly as the transport hands it back.
+              request: async () => ({
+                stopReason: "end_turn",
+                _meta: { redskills: { ticket: { outcome: "refused", stage: "brief", detail: REFUSAL } } },
+              }),
+              notify: vi.fn(),
+            },
+            close: vi.fn(),
+          },
+          socket: { destroy: vi.fn(), destroyed: false },
+          endpoint: "/tmp/W.sock",
+          publicSessionId: "",
+          notify: vi.fn(async () => {}),
+          cancelled: false,
+          cleaned: false,
+        } as never;
+      },
+      record: (line) => void records.push(line),
+      park,
+    });
+
+    // What the planner can see about this project, recomputed from the tracker.
+    const tick = () => {
+      const ready = labels.has("ready-for-agent");
+      return planHostDemand({
+        projects: [{
+          project_label: "o/r",
+          target: 1,
+          workspace_path: workspace,
+          argv: [],
+          items: ready ? ["518"] : [],
+        } as never],
+        queue: { "o/r": ready ? 1 : 0 },
+        live: { "o/r": 0 },
+        nowMs: 0,
+      });
+    };
+
+    const first = tick();
+    expect(first.births).toHaveLength(1);
+    expect(first.births[0]?.work_item).toBe("518");
+    await run({
+      project,
+      prompt: "p",
+      workItem: "518",
+      ticket: { number: 518, labels: [...labels] },
+    });
+
+    // One park, and the Ticket left the executable queue carrying the reason.
+    expect(applied).toHaveLength(1);
+    expect(labels.has("ready-for-agent")).toBe(false);
+    expect(labels.has("blocked:spec")).toBe(true);
+    expect(records.filter((record) => record.event === "demand-park")).toHaveLength(1);
+    expect(records.find((record) => record.event === "demand-turn-completed")?.detail)
+      .toContain("refused at brief");
+
+    // The second tick over the same project has nothing to birth for, so the
+    // ~15s re-birth that burned ~60 Workers on one item cannot re-form.
+    const second = tick();
+    expect(second.births).toHaveLength(0);
+    expect(second.intents[0]?.outcome).toBe("queue-drained");
+    expect(prompted).toHaveLength(1);
   });
 });

--- a/packages/protocol-acp/ticket.ts
+++ b/packages/protocol-acp/ticket.ts
@@ -29,13 +29,34 @@
 // acceptance criteria? — and refuses the handoff when it does not, exactly the
 // way it refuses a missing `base`.
 //
-// The refusal is `undefined` rather than a throw, unchanged and for the
-// original reason: the same Worker body serves ordinary prompt turns, so a
-// decoder that threw would fail every turn that never claimed to carry a
-// Ticket. What that costs is a diagnostic, which is why the door AFTER this one
-// — the Worker preflight in the Ticket loop — states the refusal in words.
+// The refusal is not a throw, unchanged and for the original reason: the same
+// Worker body serves ordinary prompt turns, so a decoder that threw would fail
+// every turn that never claimed to carry a Ticket.
+//
+// ## Absent and refused are not the same answer (#4296)
+//
+// #4139 spelled the brief refusal as `return undefined`, "exactly the way it
+// refuses a missing `base`". At this door `undefined` means **no Ticket
+// handoff**, and the Worker's fallback for that is not a refusal — it is the
+// ordinary prompt path: echo the prompt, end the turn. So a Ticket the contract
+// rejected produced `no-workflow-outcome (end_turn)`, the daemon read a healthy
+// turn, the item kept `ready-for-agent`, and the planner birthed again every
+// ~15s. Observed on an operator's host: ~60 Workers on one item, twice.
+//
+// **A fail-closed check that answers `undefined` into a path whose fallback is
+// "echo" is not fail-closed; it is fail-silent-and-loop.** The missing-`base`
+// precedent it copied is safe only because a daemon never states a handoff
+// without a base — it never states one with a brief it composed itself either,
+// which is precisely why a refused brief has to reach the Worker as a REASON.
+//
+// So the decoder answers a decision: `absent` (nothing claimed a Ticket, or the
+// shape is not one — the legal prompt-turn answer, unchanged), `refused` (a
+// complete handoff arrived and the brief contract rejected it, carrying the
+// contract's own sentence), or the handoff itself. `ticketHandoffFromMeta` is
+// kept as the yes/no reading of that decision, so every caller that only wants
+// a handoff is unchanged.
 
-import { briefStatesExecutableAcceptance } from "@reddb-io/shared/brief-contract.js";
+import { briefContractRefusal } from "@reddb-io/shared/brief-contract.js";
 
 /** One Ticket, as the daemon hands it to the Worker body for a turn. */
 export interface RedskillsTicketHandoff {
@@ -91,28 +112,73 @@ type RequiredTicketFields = Pick<
 >;
 
 /**
- * The Ticket a turn's `_meta` carries, or `undefined` when it carries none.
+ * What one turn's `_meta` says about a Ticket, in the three answers that differ.
+ *
+ * `absent` and `refused` are separate cases on purpose: they used to share
+ * `undefined`, and the Worker's handling of "absent" is to run an ordinary
+ * prompt turn — which turned a refused brief into a silent echo and an endless
+ * re-birth (#4296).
+ */
+export type TicketHandoffDecision =
+  /**
+   * This turn claims no Ticket — nothing under `_meta.redskills.ticket`, or a
+   * shape that is not a handoff. The legal prompt-turn answer, and the reason
+   * a malformed shape stays here: an ordinary turn's unrelated `_meta` must
+   * not be read as a Ticket somebody got wrong.
+   */
+  | { readonly kind: "absent" }
+  /**
+   * A complete handoff arrived and the brief contract rejected it. The reason
+   * is the lint's own sentence, verbatim, because whoever is sent back needs
+   * to know which acceptance-criteria item to fix.
+   */
+  | { readonly kind: "refused"; readonly reason: string }
+  /** A handoff the decoder accepts, refinements included. */
+  | { readonly kind: "handoff"; readonly ticket: RedskillsTicketHandoff };
+
+/**
+ * Read a turn's `_meta` into the decision it states. PURE.
  *
  * A turn without a Ticket is not an error: the same Worker body serves ordinary
  * prompt turns, and a parser that threw would make every one of them fail on
- * the absence of something they never claimed to have. A MALFORMED Ticket is
- * refused the same way, and since #4139 a vague brief counts as malformed.
+ * the absence of something they never claimed to have. A structurally malformed
+ * Ticket is `absent` for the same reason — the wire decoder still refuses every
+ * invalid shape exactly as it did. A brief the contract rejects is `refused`,
+ * and it is the one refusal that keeps its reason: the daemon composed that
+ * brief itself, so somebody upstream can act on the sentence.
+ */
+export function decodeTicketHandoff(meta: unknown): TicketHandoffDecision {
+  const candidate = (meta as { redskills?: { ticket?: unknown } } | undefined)?.redskills?.ticket;
+  if (candidate == null || typeof candidate !== "object") return { kind: "absent" };
+  const ticket = candidate as Record<string, unknown>;
+  if (!statesRequiredTicketFields(ticket)) return { kind: "absent" };
+  const refusal = briefContractRefusal(ticket.handoff);
+  if (refusal != null) return { kind: "refused", reason: refusal };
+  return {
+    kind: "handoff",
+    ticket: {
+      number: ticket.number,
+      title: ticket.title,
+      labels: ticket.labels,
+      base: ticket.base,
+      handoff: ticket.handoff,
+      worker_id: ticket.worker_id,
+      ...optionalTicketFields(ticket),
+    },
+  };
+}
+
+/**
+ * The Ticket a turn's `_meta` carries, or `undefined` when it carries none the
+ * decoder accepts.
+ *
+ * The yes/no reading of {@link decodeTicketHandoff}, for the callers that only
+ * ever wanted a handoff. A caller that must tell a refusal from an absence — the
+ * Worker deciding what KIND of turn this is — asks the decision instead.
  */
 export function ticketHandoffFromMeta(meta: unknown): RedskillsTicketHandoff | undefined {
-  const candidate = (meta as { redskills?: { ticket?: unknown } } | undefined)?.redskills?.ticket;
-  if (candidate == null || typeof candidate !== "object") return undefined;
-  const ticket = candidate as Record<string, unknown>;
-  if (!statesRequiredTicketFields(ticket)) return undefined;
-  if (!briefStatesExecutableAcceptance(ticket.handoff)) return undefined;
-  return {
-    number: ticket.number,
-    title: ticket.title,
-    labels: ticket.labels,
-    base: ticket.base,
-    handoff: ticket.handoff,
-    worker_id: ticket.worker_id,
-    ...optionalTicketFields(ticket),
-  };
+  const decision = decodeTicketHandoff(meta);
+  return decision.kind === "handoff" ? decision.ticket : undefined;
 }
 
 /** Every required field present, of the right type, and non-empty. */

--- a/packages/shared/brief-contract.test.ts
+++ b/packages/shared/brief-contract.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   BRIEF_CONTRACT_REFUSAL_PREFIX,
   briefContractRefusal,
-  briefStatesExecutableAcceptance,
   lintExecutableAcceptanceCriteria,
 } from "./brief-contract.js";
 
@@ -45,14 +44,6 @@ describe("lintExecutableAcceptanceCriteria", () => {
       .toBe("missing acceptance-criteria section");
     expect(lintExecutableAcceptanceCriteria("## Acceptance criteria\n\nProse, no checklist.").reason)
       .toBe("acceptance-criteria section has no checklist items");
-  });
-});
-
-describe("briefStatesExecutableAcceptance", () => {
-  it("is the lint's verdict as a predicate, for the decoder that has no room for a reason", () => {
-    expect(briefStatesExecutableAcceptance(EXECUTABLE_BRIEF)).toBe(true);
-    expect(briefStatesExecutableAcceptance(VAGUE_BRIEF)).toBe(false);
-    expect(briefStatesExecutableAcceptance("")).toBe(false);
   });
 });
 

--- a/packages/shared/brief-contract.ts
+++ b/packages/shared/brief-contract.ts
@@ -100,17 +100,6 @@ export function lintExecutableAcceptanceCriteria(body: string): AcceptanceCriter
 export const BRIEF_CONTRACT_REFUSAL_PREFIX = "brief contract refused";
 
 /**
- * True when the brief carries executable acceptance criteria. PURE.
- *
- * The predicate the DECODER wants: a decoder has no channel to say why (it
- * answers `undefined` or a handoff), so it asks the yes/no question and leaves
- * the findings to the doors that can quote them.
- */
-export function briefStatesExecutableAcceptance(brief: string): boolean {
-  return lintExecutableAcceptanceCriteria(brief).ok;
-}
-
-/**
  * The refusal one brief earns, or `null` when it satisfies the contract. PURE.
  *
  * The lint's finding travels VERBATIM: the whole point of refusing at a door is

--- a/packages/worker/src/acp/brief-refusal-turn.test.ts
+++ b/packages/worker/src/acp/brief-refusal-turn.test.ts
@@ -1,0 +1,250 @@
+// A brief the contract refuses ends the turn saying so (issue #4296).
+//
+// The defect this pins was invisible in exactly the way a decoder's `undefined`
+// is invisible: the Worker read "no Ticket handoff", took the ordinary prompt
+// path, echoed and ended `end_turn`. The daemon read a healthy turn, the item
+// kept `ready-for-agent`, and the planner birthed again every ~15s — ~60
+// Workers on one item, twice, on an operator's machine.
+//
+// So the assertions are about the two answers being DIFFERENT: a refused brief
+// carries the contract's sentence out of the turn, and an absent handoff still
+// walks the legal prompt path it always walked.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Server, Socket } from "node:net";
+
+import { client, methods } from "@agentclientprotocol/sdk";
+import {
+  ACP_PROTOCOL_VERSION,
+  REDSKILLS_ACP_METHODS,
+  REDSKILLS_WIRE_MAJOR,
+  bindWorkerRendezvous,
+  closeServer,
+  removeAcpEndpoint,
+  socketStream,
+} from "@reddb-io/protocol-acp";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  TICKET_BRIEF_REFUSAL_STAGE,
+  briefRefusalResponse,
+  ticketDecisionForTurn,
+} from "./brief-refusal-turn.js";
+import { runNativeAcpWorker } from "./native-worker.js";
+
+/** The shape the operator's own Ticket had: prose acceptance criteria. */
+const PROSE_BRIEF = `Decide the token scale.
+
+## Acceptance criteria
+
+- [ ] The decision is recorded on this ticket with its reasoning.
+`;
+
+const EXECUTABLE_BRIEF = `Implement the slice.
+
+## Acceptance criteria
+
+- [ ] Running \`pnpm -C packages/worker test\` passes.
+`;
+
+const ticketMeta = (handoff: string): unknown => ({
+  redskills: {
+    ticket: {
+      number: 518,
+      title: "Decide the token scale",
+      labels: ["ready-for-agent"],
+      base: "main",
+      handoff,
+      worker_id: "host:VSk6WPt",
+    },
+  },
+});
+
+describe("the turn's Ticket decision", () => {
+  it("keeps a refusal a refusal instead of collapsing it into an absence", () => {
+    const decision = ticketDecisionForTurn(ticketMeta(PROSE_BRIEF), undefined);
+    expect(decision.kind).toBe("refused");
+    expect(decision.kind === "refused" && decision.reason)
+      .toContain("brief contract refused");
+  });
+
+  it("falls back to the session's Ticket only when the turn states none", () => {
+    expect(ticketDecisionForTurn(undefined, ticketMeta(EXECUTABLE_BRIEF)).kind).toBe("handoff");
+    // A session refusal is not laundered by a prompt that claims no Ticket.
+    expect(ticketDecisionForTurn(undefined, ticketMeta(PROSE_BRIEF)).kind).toBe("refused");
+    // The turn's own Ticket wins when it states one.
+    expect(ticketDecisionForTurn(ticketMeta(EXECUTABLE_BRIEF), ticketMeta(PROSE_BRIEF)).kind)
+      .toBe("handoff");
+  });
+
+  it("answers absent for an ordinary prompt turn and for a malformed shape", () => {
+    expect(ticketDecisionForTurn(undefined, undefined).kind).toBe("absent");
+    expect(ticketDecisionForTurn({ redskills: { ticket: "not-an-object" } }, undefined).kind)
+      .toBe("absent");
+    expect(ticketDecisionForTurn({ redskills: { ticket: { number: 5 } } }, undefined).kind)
+      .toBe("absent");
+  });
+});
+
+describe("the refusal the turn answers with", () => {
+  it("is a terminal Ticket verdict, not a completion", () => {
+    const response = briefRefusalResponse("brief contract refused: item is not machine-checkable");
+    expect(response.stopReason).toBe("end_turn");
+    expect(response._meta).toEqual({
+      redskills: {
+        ticket: {
+          outcome: "refused",
+          stage: TICKET_BRIEF_REFUSAL_STAGE,
+          detail: "brief contract refused: item is not machine-checkable",
+        },
+      },
+    });
+    // Only a landed Ticket is a completion; naming this one would tell the
+    // daemon to close a Ticket nothing shipped.
+    expect((response._meta as { redskills: Record<string, unknown> }).redskills)
+      .not.toHaveProperty("workflowOutcome");
+  });
+});
+
+describe("the Worker body, driven across a real ACP connection", () => {
+  const roots: string[] = [];
+  const servers: Server[] = [];
+  const sockets: Socket[] = [];
+
+  afterEach(async () => {
+    for (const socket of sockets.splice(0)) socket.destroy();
+    for (const server of servers.splice(0)) await closeServer(server);
+    for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+  });
+
+  /** One request against the Worker, typed only where the assertions look. */
+  type WorkerRequest = (method: string, params: unknown) => Promise<{
+    readonly sessionId?: string;
+    readonly stopReason?: string;
+    readonly _meta?: unknown;
+  }>;
+
+  async function connectWorker(): Promise<{
+    readonly cwd: string;
+    readonly request: WorkerRequest;
+    readonly updates: unknown[];
+    readonly published: unknown[];
+    readonly finish: () => Promise<void>;
+  }> {
+    const root = await mkdtemp(join(tmpdir(), "worker-brief-refusal-"));
+    roots.push(root);
+    const socketPath = join(root, "worker.sock");
+    const rendezvous = await bindWorkerRendezvous(socketPath);
+    servers.push(rendezvous.server);
+    // The child endpoint is never reached on either path under test: a refused
+    // brief ends before the loop, and the echo path spawns nothing.
+    const worker = runNativeAcpWorker(socketPath, {
+      agent: "redcode",
+      transport: "stdio",
+      command: process.execPath,
+      args: ["-e", "process.exit(0)"],
+    });
+    const socket = await rendezvous.connected;
+    sockets.push(socket);
+    rendezvous.server.close();
+
+    const updates: unknown[] = [];
+    const published: unknown[] = [];
+    const parent = client({ name: "stub parent" })
+      .onNotification(methods.client.session.update, ({ params }) => void updates.push(params))
+      .onRequest(
+        REDSKILLS_ACP_METHODS.publish,
+        (value: unknown) => value as never,
+        ({ params }) => {
+          published.push(params);
+          return { receipt: "stub" };
+        },
+      );
+    const connection = parent.connect(socketStream(socket));
+    await connection.agent.request(methods.agent.initialize, {
+      protocolVersion: ACP_PROTOCOL_VERSION,
+      clientCapabilities: {},
+      clientInfo: { name: "stub parent", version: "1" },
+      _meta: { redskills: { wireMajor: REDSKILLS_WIRE_MAJOR } },
+    });
+    return {
+      cwd: root,
+      // Bound: the SDK's `request` reaches for its own connection state, and a
+      // detached method reference loses it.
+      request: ((method, params) =>
+        connection.agent.request(method as never, params as never)) as WorkerRequest,
+      updates,
+      published,
+      finish: async () => {
+        connection.close();
+        socket.destroy();
+        await worker;
+        await removeAcpEndpoint(socketPath);
+      },
+    };
+  }
+
+  it("refuses the turn, naming the contract's sentence, and publishes nothing", async () => {
+    const worker = await connectWorker();
+    try {
+      const session = await worker.request(methods.agent.session.new, {
+        cwd: worker.cwd,
+        mcpServers: [],
+      });
+      const response = await worker.request(methods.agent.session.prompt, {
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "work the ticket" }],
+        _meta: ticketMeta(PROSE_BRIEF),
+      });
+
+      expect(response.stopReason).toBe("end_turn");
+      const ticket = (response._meta as { redskills?: { ticket?: Record<string, unknown> } })
+        ?.redskills?.ticket;
+      expect(ticket?.outcome).toBe("refused");
+      expect(ticket?.stage).toBe("brief");
+      expect(String(ticket?.detail)).toContain(
+        "brief contract refused: acceptance criteria item is not machine-checkable",
+      );
+      // The sentence is in the transcript too, so a Worker log holds it after
+      // the process is gone.
+      const said = worker.updates
+        .map((update) => (update as {
+          update?: { content?: { text?: string } };
+        }).update?.content?.text ?? "")
+        .join("");
+      expect(said).toContain("brief contract refused");
+      // Nothing was claimed, gated or committed, so nothing may reach a remote.
+      expect(worker.published).toHaveLength(0);
+    } finally {
+      await worker.finish();
+    }
+  }, 30_000);
+
+  it("leaves an absent handoff on the legal prompt path, unchanged", async () => {
+    const worker = await connectWorker();
+    try {
+      const session = await worker.request(methods.agent.session.new, {
+        cwd: worker.cwd,
+        mcpServers: [],
+      });
+      const response = await worker.request(methods.agent.session.prompt, {
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "complete workflow" }],
+      });
+
+      expect(response.stopReason).toBe("end_turn");
+      const meta = (response._meta as { redskills?: Record<string, unknown> })?.redskills;
+      expect(meta?.workflowOutcome).toBe("completion");
+      expect(meta?.ticket).toBeUndefined();
+      const said = worker.updates
+        .map((update) => (update as {
+          update?: { content?: { text?: string } };
+        }).update?.content?.text ?? "")
+        .join("");
+      expect(said).toContain("native Worker completed: complete workflow");
+    } finally {
+      await worker.finish();
+    }
+  }, 30_000);
+});

--- a/packages/worker/src/acp/brief-refusal-turn.ts
+++ b/packages/worker/src/acp/brief-refusal-turn.ts
@@ -1,0 +1,106 @@
+/**
+ * brief-refusal-turn — what a Worker does when the brief it was handed is one
+ * the contract refuses (#4296).
+ *
+ * **A Worker handed a brief nobody can execute must END THE TURN SAYING SO.**
+ * Before this, the wire decoder answered `undefined` for a refused brief and
+ * the Worker read that as "this turn carries no Ticket": it took the ordinary
+ * prompt path, echoed, and ended `no-workflow-outcome (end_turn)`. The daemon
+ * saw a healthy turn over a Ticket that never left `ready-for-agent`, so the
+ * planner birthed another Worker on the next tick — ~60 of them on one item,
+ * ~15s apart, on an operator's machine.
+ *
+ * The refusal travels the way every other terminal Ticket verdict travels:
+ * `_meta.redskills.ticket`, so `describeTurnOutcome` names it and the daemon's
+ * single park door can act on it. Nothing new is invented for it — a second
+ * channel for one more terminal outcome is a second thing the daemon has to
+ * learn to read.
+ *
+ * The brief is NOT re-linted here. The decision arrives already made from the
+ * wire decoder, carrying the contract's own sentence, because a refusal that
+ * re-derives its reason is a refusal that can disagree with the door that
+ * refused.
+ */
+import { methods, type AgentContext, type PromptResponse } from "@agentclientprotocol/sdk";
+import { decodeTicketHandoff, type TicketHandoffDecision } from "@reddb-io/protocol-acp";
+
+/**
+ * The stage a wire-door brief refusal names.
+ *
+ * Deliberately NOT one of {@link import("./ticket-loop.js").TicketLoopStage}'s
+ * five: the loop never ran. A reader who sees `refused at brief` knows no claim
+ * was placed, no Worktree was touched and no comment was written — which is
+ * exactly the difference between this and the loop's own `refused at claim`.
+ */
+export const TICKET_BRIEF_REFUSAL_STAGE = "brief";
+
+/**
+ * Which Ticket decision governs this turn: the prompt's, else the session's.
+ * PURE.
+ *
+ * The prompt's `_meta` wins whenever it states ANYTHING — a handoff or a
+ * refusal — because that is the Ticket this turn was opened for. The session's
+ * is the fallback for the daemon that stated the Ticket once, at `session/new`,
+ * and prompts against it afterwards. A refusal on either side is still a
+ * refusal: an absent decision may never launder one.
+ */
+export function ticketDecisionForTurn(
+  turnMeta: unknown,
+  sessionMeta: unknown,
+): TicketHandoffDecision {
+  const fromTurn = decodeTicketHandoff(turnMeta);
+  return fromTurn.kind === "absent" ? decodeTicketHandoff(sessionMeta) : fromTurn;
+}
+
+/**
+ * The turn's answer for a refused brief: terminal, named, and carrying the
+ * contract's sentence. PURE.
+ *
+ * `end_turn` rather than a cancellation: nothing was interrupted, the Worker
+ * read its instructions and found them unexecutable. `workflowOutcome` stays
+ * absent for the same reason a gate block leaves it absent — only a landed
+ * Ticket is a completion, and naming this one would tell the daemon to close a
+ * Ticket nothing shipped.
+ */
+export function briefRefusalResponse(reason: string): PromptResponse {
+  return {
+    stopReason: "end_turn",
+    _meta: {
+      redskills: {
+        ticket: {
+          outcome: "refused",
+          stage: TICKET_BRIEF_REFUSAL_STAGE,
+          detail: reason,
+        },
+      },
+    },
+  } satisfies PromptResponse;
+}
+
+/**
+ * Say the refusal out loud on the session, before the turn's answer carries it.
+ *
+ * Two readers, one notification: the sentence goes in the transcript a human
+ * reads, and the `ticketStage` cell moves the statusline's phase to `brief!` so
+ * an operator watching a drain sees WHICH item stopped and why without opening
+ * a log.
+ */
+export function notifyBriefRefusal(
+  parent: AgentContext,
+  sessionId: string,
+  reason: string,
+): Promise<void> {
+  return parent.notify(methods.client.session.update, {
+    sessionId,
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: `${reason}\n` },
+    },
+    _meta: {
+      redskills: {
+        lifecycle: { event: `ticket-${TICKET_BRIEF_REFUSAL_STAGE}-blocked` },
+        ticketStage: { stage: TICKET_BRIEF_REFUSAL_STAGE, ok: false, detail: reason },
+      },
+    },
+  });
+}

--- a/packages/worker/src/acp/native-worker.ts
+++ b/packages/worker/src/acp/native-worker.ts
@@ -32,6 +32,7 @@ import {
   type AcpSessionRecoveryCheckpoint,
   type RedskillsTicketHandoff,
 } from "@reddb-io/protocol-acp";
+import { briefRefusalResponse, notifyBriefRefusal, ticketDecisionForTurn } from "./brief-refusal-turn.js";
 import { WorkflowChildAgent } from "./child-agent.js";
 import { acquireHostGateLock } from "./gate-lock.js";
 import { runWorkerLocalGate } from "./local-gate.js";
@@ -207,9 +208,17 @@ export async function runNativeAcpWorker(socketPath: string, childEndpoint: AcpE
         recoveries.delete(params.sessionId);
         await notifySessionRecovery(parent, params.sessionId, recovery);
       }
-      const ticket = ticketHandoffFromMeta(params._meta) ?? ticketHandoffFromMeta(held.request._meta);
-      if (ticket != null) {
-        return await runTicketTurn(params.sessionId, held, ticket, parent, controller.signal);
+      // Three answers, three paths — and the middle one is the whole of #4296.
+      // A brief the contract refuses used to arrive here as "no Ticket", which
+      // fell through to the echo below and left the item queued for the next
+      // birth. It is now a terminal verdict this turn states in words.
+      const decision = ticketDecisionForTurn(params._meta, held.request._meta);
+      if (decision.kind === "refused") {
+        await notifyBriefRefusal(parent, params.sessionId, decision.reason);
+        return briefRefusalResponse(decision.reason);
+      }
+      if (decision.kind === "handoff") {
+        return await runTicketTurn(params.sessionId, held, decision.ticket, parent, controller.signal);
       }
       const prompt = promptText(params);
       if (prompt.includes("delegate child")) {

--- a/packages/worker/src/acp/ticket-handoff-contract.test.ts
+++ b/packages/worker/src/acp/ticket-handoff-contract.test.ts
@@ -1,11 +1,14 @@
-// The native ticket-handoff decoder's refusals (Ticket #4139).
+// The native ticket-handoff decoder's refusals (Ticket #4139, #4296).
 //
-// The decoder's whole answer is "a handoff" or "nothing", so a refusal is only
-// ever observable as `undefined`. That makes it exactly the kind of behaviour a
-// test has to pin field by field: nothing in the type system distinguishes "no
-// Ticket on this turn" from "a Ticket this Worker must not take".
+// `ticketHandoffFromMeta` answers "a handoff" or "nothing", so its refusals are
+// only ever observable as `undefined`. That makes them exactly the kind of
+// behaviour a test has to pin field by field: nothing in the type system
+// distinguishes "no Ticket on this turn" from "a Ticket this Worker must not
+// take". Since #4296 the underlying decision DOES distinguish them, and the two
+// halves are pinned together here — a structural refusal is still an absence,
+// and a refused brief is a refusal carrying its reason.
 import { describe, expect, it } from "vitest";
-import { ticketHandoffFromMeta } from "@reddb-io/protocol-acp";
+import { decodeTicketHandoff, ticketHandoffFromMeta } from "@reddb-io/protocol-acp";
 
 const EXECUTABLE_BRIEF = `Implement the slice.
 
@@ -38,9 +41,16 @@ describe("ticketHandoffFromMeta", () => {
   it("refuses a brief whose criteria are present but not machine-checkable", () => {
     const vague = "Fix it.\n\n## Acceptance criteria\n\n- [ ] It should feel snappier.\n";
     expect(ticketHandoffFromMeta(meta({ ...BASE, handoff: vague }))).toBeUndefined();
+    // The reason survives the decision even though the handoff reader drops it.
+    const decision = decodeTicketHandoff(meta({ ...BASE, handoff: vague }));
+    expect(decision.kind).toBe("refused");
+    expect(decision.kind === "refused" && decision.reason).toContain("brief contract refused");
   });
 
-  it("refuses a missing required field the same way it refuses a vague brief", () => {
+  it("refuses a missing required field as an absence, not as a stated refusal", () => {
+    // Structural refusals stay ABSENT, deliberately: an ordinary prompt turn's
+    // unrelated `_meta` must never be read as a Ticket somebody got wrong.
+    expect(decodeTicketHandoff(meta({ ...BASE, number: 0 })).kind).toBe("absent");
     expect(ticketHandoffFromMeta(meta({ ...BASE, number: 0 }))).toBeUndefined();
     expect(ticketHandoffFromMeta(meta({ ...BASE, number: 1.5 }))).toBeUndefined();
     expect(ticketHandoffFromMeta(meta({ ...BASE, title: "" }))).toBeUndefined();


### PR DESCRIPTION
Fixes #4296

## The defect, reproduced before it was fixed

A scratch vitest against the real functions, on a body whose acceptance criteria are prose:

```
briefContractRefusal(body)
→ "brief contract refused: acceptance criteria item is not machine-checkable:
   The decision is recorded on this ticket with its reasoning."

ticketHandoffFromMeta(meta)   // complete meta: ticket + base + handoff all present
→ undefined
```

At that door `undefined` means **no Ticket handoff**, and `runPromptTurn`'s fallback for that is not a refusal — it is the ordinary prompt path: echo, end the turn. The daemon had composed a complete brief, so #4292's unbriefable-birth guard did not fire; the item kept `ready-for-agent`; the planner birthed again every ~15s. ~60 Workers on one item, twice, on the operator's machine.

**A fail-closed check that answers `undefined` into a path whose fallback is "echo" is not fail-closed; it is fail-silent-and-loop.**

## What changed

**Absent and refused stop being the same answer.** `decodeTicketHandoff` (`packages/protocol-acp/ticket.ts`) answers a decision — `absent`, `refused` carrying the lint's own sentence, or the handoff. The WIRE decoder still refuses every invalid shape exactly as before: a structurally malformed ticket stays `absent`, because an ordinary prompt turn's unrelated `_meta` must never be read as a Ticket somebody got wrong. `ticketHandoffFromMeta` is kept as the yes/no reading of that decision, so all of its callers are unchanged.

**A Worker handed a refused brief refuses the turn** (`packages/worker/src/acp/brief-refusal-turn.ts`), saying the sentence on the session and answering a terminal verdict in `_meta.redskills.ticket` — the same channel the ticket loop's `refused` outcome already travels, so `describeTurnOutcome` names it:

```
refused at brief: brief contract refused: acceptance criteria item is not machine-checkable: The decision is recorded on this ticket with its reasoning.
```

instead of `no-workflow-outcome (end_turn)`. An absent handoff takes the legal prompt path, unchanged.

**The daemon parks the Ticket on that outcome** through the door #4177/#4160 already built — `apps/redskilled/src/demand-park.ts` gains the second terminal verdict rather than a second door. A brief refusal parks under `blocked:spec`, not `blocked:validation`: nothing is wrong with the tree, the Ticket's own words cannot be executed, and the repair is a human rewriting the acceptance criteria. This is what an operator sees on the Ticket:

> 🤖 AFK park by worker `VSq1`: this Ticket's brief cannot be executed as written, so no Worker claimed it and no work was done.
>
> ```
> brief contract refused: acceptance criteria item is not machine-checkable: The decision is recorded on this ticket with its reasoning.
> ```
>
> Requeue with `/retake 518` once the blocker is repaired.

with `+[ready-for-human, blocked:spec] -[ready-for-agent]`, so the item leaves the executable queue.

A `refused` verdict from any **other** stage still passes the park by, deliberately: the loop refuses at `claim` for a failed claim write and at `land` for a landing the forge rejected, and both are worth retrying. Only the brief refusal is known to be identical on the next birth.

`briefStatesExecutableAcceptance` is deleted. It existed only because "a decoder has no channel to say why"; the decoder now has one, and it had no other caller.

The brief contract's strictness is untouched — #4296 defers that to the maintainer.

## Tests

- `packages/worker/src/acp/brief-refusal-turn.test.ts` — the Worker body driven across a **real ACP connection**: a refused brief comes back `refused at brief` with the sentence in the transcript and **nothing published**; an absent handoff still completes on the legal prompt path.
- `apps/redskilled/tests/demand-park.test.ts` — the loop cannot re-form: two consecutive `planHostDemand` ticks over one refused item produce **one birth and one park**, and the second tick reads `queue-drained`.
- `packages/worker/src/acp/ticket-handoff-contract.test.ts` — a structural refusal is still an absence; a refused brief is a refusal that carries its reason.

## Validation

| Command | Result |
| --- | --- |
| `pnpm typecheck` (root, `--force`) | 17/17 green |
| `pnpm -C apps/plugin-dev test:invariants` | 37 files, **494 tests green** |
| `pnpm -C apps/redskilled exec vitest run tests/demand-park.test.ts tests/demand-turn.test.ts tests/demand-loop.test.ts` | **51 green** (12 / 20 / 19) |
| `pnpm -C packages/worker exec vitest run src/acp/` | 13/14 files green; the only red is the pre-existing `local-gate` (4) |
| `pnpm -C packages/worker exec vitest run` (whole package) | 1888 green; red is exactly the known baseline — `local-gate` (4) + `validation-cone` (2) |
| `pnpm -C apps/redskilled exec vitest run` (whole package) | 1280 green. The full-suite run found one red beyond the known baseline that WAS mine — ADR 0148's body/control-cut inventory did not know the new module — fixed in the second commit and re-run green. `daemon-stop` (1) and `github-custody-armed-head` (2) pass in isolation and touch nothing here; `demand-loop`'s `#4292` case is a temp-dir teardown race (`ENOTEMPTY` on rmdir), 2 of 3 runs green, unrelated. |
| GitHub Actions on the pushed head | green: `test`, `test-shard (1-4)`, `test-packages`, `typecheck`, `acp-local-transport` (ubuntu + windows), `plugin-structural-smoke`, `scope`, `workflow-security` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V
