### PR TITLE
fix(worker): the execution doors check brief structure, not wording

### DIFF
--- a/.changeset/brief-doors-structural.md
+++ b/.changeset/brief-doors-structural.md
@@ -1,0 +1,15 @@
+---
+"@reddb-io/protocol-acp": patch
+"@reddb-io/shared": patch
+"@reddb-io/worker": patch
+---
+
+The execution doors check brief structure, not wording
+
+The machine-checkable judgement, enforced at the handoff decoder and the
+Worker preflight, refused 41 of 42 live briefs across both registered
+projects, so every drain tick became a birth-and-refuse loop. The judgement
+moves to triage promotion, where the author is present to fix the sentence;
+the decoder and the preflight now refuse only a brief with no
+acceptance-criteria section or an itemless one, via
+`briefContractStructuralRefusal` in `@reddb-io/shared/brief-contract`.

--- a/packages/protocol-acp/ticket.ts
+++ b/packages/protocol-acp/ticket.ts
@@ -56,7 +56,7 @@
 // kept as the yes/no reading of that decision, so every caller that only wants
 // a handoff is unchanged.
 
-import { briefContractRefusal } from "@reddb-io/shared/brief-contract.js";
+import { briefContractStructuralRefusal } from "@reddb-io/shared/brief-contract.js";
 
 /** One Ticket, as the daemon hands it to the Worker body for a turn. */
 export interface RedskillsTicketHandoff {
@@ -152,7 +152,7 @@ export function decodeTicketHandoff(meta: unknown): TicketHandoffDecision {
   if (candidate == null || typeof candidate !== "object") return { kind: "absent" };
   const ticket = candidate as Record<string, unknown>;
   if (!statesRequiredTicketFields(ticket)) return { kind: "absent" };
-  const refusal = briefContractRefusal(ticket.handoff);
+  const refusal = briefContractStructuralRefusal(ticket.handoff);
   if (refusal != null) return { kind: "refused", reason: refusal };
   return {
     kind: "handoff",

--- a/packages/shared/brief-contract.test.ts
+++ b/packages/shared/brief-contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   BRIEF_CONTRACT_REFUSAL_PREFIX,
   briefContractRefusal,
+  briefContractStructuralRefusal,
   lintExecutableAcceptanceCriteria,
 } from "./brief-contract.js";
 
@@ -61,6 +62,28 @@ describe("briefContractRefusal", () => {
   it("spells one refusal for every door, so an operator greps one string", () => {
     expect(briefContractRefusal("no criteria here")).toBe(
       `${BRIEF_CONTRACT_REFUSAL_PREFIX}: missing acceptance-criteria section`,
+    );
+  });
+});
+
+describe("briefContractStructuralRefusal", () => {
+  it("is null for an executable brief", () => {
+    expect(briefContractStructuralRefusal(EXECUTABLE_BRIEF)).toBeNull();
+  });
+
+  it("is null for a vague brief — the execution doors do not judge wording", () => {
+    expect(briefContractStructuralRefusal(VAGUE_BRIEF)).toBeNull();
+  });
+
+  it("refuses a brief with no acceptance-criteria section", () => {
+    expect(briefContractStructuralRefusal("## What to build\n\nSomething.")).toBe(
+      `${BRIEF_CONTRACT_REFUSAL_PREFIX}: missing acceptance-criteria section`,
+    );
+  });
+
+  it("refuses a section that lists nothing", () => {
+    expect(briefContractStructuralRefusal("## Acceptance criteria\n\nProse, no checklist.")).toBe(
+      `${BRIEF_CONTRACT_REFUSAL_PREFIX}: acceptance-criteria section has no checklist items`,
     );
   });
 });

--- a/packages/shared/brief-contract.ts
+++ b/packages/shared/brief-contract.ts
@@ -10,11 +10,14 @@
 // the same lint with a refusal channel, wired into three doors that can each
 // say no before the next one is reached:
 //
-//   1. **Triage promotion** refuses to add `ready-for-agent` (host-side).
-//   2. **The native handoff decoder** refuses a Ticket whose brief is vague,
-//      so the Worker body never enters its Ticket loop with one.
-//   3. **The Worker preflight** withdraws before the claim marker exists, so a
-//      malformed Ticket is never owned by the Worker that noticed.
+//   1. **Triage promotion** refuses to add `ready-for-agent` (host-side), with
+//      the FULL machine-checkable judgement — the author is there to fix it.
+//   2. **The native handoff decoder** refuses a Ticket whose brief carries no
+//      acceptance criteria at all (structural only), so the Worker body never
+//      enters its Ticket loop briefless.
+//   3. **The Worker preflight** withdraws on the same structural check before
+//      the claim marker exists, so a briefless Ticket is never owned by the
+//      Worker that noticed.
 //
 // ## Why the lint lives HERE and not where it was born
 //
@@ -110,6 +113,25 @@ export const BRIEF_CONTRACT_REFUSAL_PREFIX = "brief contract refused";
 export function briefContractRefusal(brief: string): string | null {
   const lint = lintExecutableAcceptanceCriteria(brief);
   return lint.ok ? null : `${BRIEF_CONTRACT_REFUSAL_PREFIX}: ${lint.reason}`;
+}
+
+/**
+ * The STRUCTURAL refusal one brief earns at an execution door, or `null`. PURE.
+ *
+ * The execution doors — the handoff decoder and the Worker preflight — check
+ * only that an acceptance-criteria section exists and lists at least one item.
+ * The machine-checkable judgement stays at triage promotion, where the author
+ * is present to fix the sentence; enforced at the wire it judged 41 of 42 live
+ * briefs too vague and turned every drain into a birth-and-refuse loop
+ * (#4296's grinder wearing the contract's own uniform). A door that refuses
+ * the whole backlog is a door somebody turns off — this one refuses only what
+ * no Validation could ever read: a brief with no criteria at all.
+ */
+export function briefContractStructuralRefusal(brief: string): string | null {
+  const lint = lintExecutableAcceptanceCriteria(brief);
+  if (lint.ok) return null;
+  if (lint.items.length > 0) return null;
+  return `${BRIEF_CONTRACT_REFUSAL_PREFIX}: ${lint.reason}`;
 }
 
 function acceptanceCriteriaSection(body: string): string | undefined {

--- a/packages/worker/src/acp/brief-refusal-turn.test.ts
+++ b/packages/worker/src/acp/brief-refusal-turn.test.ts
@@ -36,9 +36,7 @@ import { runNativeAcpWorker } from "./native-worker.js";
 /** The shape the operator's own Ticket had: prose acceptance criteria. */
 const PROSE_BRIEF = `Decide the token scale.
 
-## Acceptance criteria
-
-- [ ] The decision is recorded on this ticket with its reasoning.
+Record the decision with its reasoning. No acceptance criteria stated.
 `;
 
 const EXECUTABLE_BRIEF = `Implement the slice.
@@ -204,7 +202,7 @@ describe("the Worker body, driven across a real ACP connection", () => {
       expect(ticket?.outcome).toBe("refused");
       expect(ticket?.stage).toBe("brief");
       expect(String(ticket?.detail)).toContain(
-        "brief contract refused: acceptance criteria item is not machine-checkable",
+        "brief contract refused: missing acceptance-criteria section",
       );
       // The sentence is in the transcript too, so a Worker log holds it after
       // the process is gone.

--- a/packages/worker/src/acp/ticket-handoff-contract.test.ts
+++ b/packages/worker/src/acp/ticket-handoff-contract.test.ts
@@ -38,11 +38,18 @@ describe("ticketHandoffFromMeta", () => {
       .toBeUndefined();
   });
 
-  it("refuses a brief whose criteria are present but not machine-checkable", () => {
+  it("accepts a brief whose criteria are present but vague — the wire door is structural", () => {
+    // The machine-checkable judgement belongs to triage promotion; at the wire
+    // it refused 41 of 42 live briefs and turned drains into birth-and-refuse
+    // loops. The decoder now asks only that criteria EXIST.
     const vague = "Fix it.\n\n## Acceptance criteria\n\n- [ ] It should feel snappier.\n";
-    expect(ticketHandoffFromMeta(meta({ ...BASE, handoff: vague }))).toBeUndefined();
-    // The reason survives the decision even though the handoff reader drops it.
-    const decision = decodeTicketHandoff(meta({ ...BASE, handoff: vague }));
+    expect(ticketHandoffFromMeta(meta({ ...BASE, handoff: vague }))).toBeDefined();
+  });
+
+  it("still refuses a brief whose criteria section lists nothing", () => {
+    const empty = "Fix it.\n\n## Acceptance criteria\n\nProse, no checklist.\n";
+    expect(ticketHandoffFromMeta(meta({ ...BASE, handoff: empty }))).toBeUndefined();
+    const decision = decodeTicketHandoff(meta({ ...BASE, handoff: empty }));
     expect(decision.kind).toBe("refused");
     expect(decision.kind === "refused" && decision.reason).toContain("brief contract refused");
   });

--- a/packages/worker/src/acp/ticket-loop.test.ts
+++ b/packages/worker/src/acp/ticket-loop.test.ts
@@ -154,20 +154,24 @@ describe("the brief contract, enforced at the preflight", () => {
     expect(stages(result.records)).toEqual(["claim"]);
   });
 
-  it("quotes the un-checkable item so the refusal names what to fix", async () => {
+  it("lets a vague-but-structured brief through — the preflight is structural", async () => {
+    // Vague wording is triage promotion's problem; a preflight that judges it
+    // withdraws from the whole backlog (41 of 42 live briefs, #4296).
+    const request = vi.fn(async () => ({ version: 1 }));
     const result = await runTicketLoop(
       deps({
         ticket: {
           ...TICKET,
           handoff: "Fix it.\n\n## Acceptance criteria\n\n- [ ] It should feel snappier.\n",
         },
-        request: vi.fn(async () => ({ version: 1 })),
+        request,
       }),
     );
 
-    expect(result.outcome).toBe("refused");
-    if (result.outcome !== "refused") return;
-    expect(result.detail).toContain("It should feel snappier.");
+    // The loop still ends refused further along (the stub answers name no PR),
+    // but the preflight let it through: the claim write was issued.
+    expect(request).toHaveBeenCalled();
+    if (result.outcome === "refused") expect(result.detail).not.toContain("brief contract refused");
   });
 
   it("refuses the lane before the brief, so a scout Ticket says so first", async () => {

--- a/packages/worker/src/acp/ticket-loop.ts
+++ b/packages/worker/src/acp/ticket-loop.ts
@@ -23,7 +23,7 @@
  */
 import type { PromptResponse } from "@agentclientprotocol/sdk";
 import { REDSKILLS_ACP_METHODS } from "@reddb-io/protocol-acp";
-import { briefContractRefusal } from "@reddb-io/shared/brief-contract.js";
+import { briefContractStructuralRefusal } from "@reddb-io/shared/brief-contract.js";
 import { briefWithStandingOrders } from "@reddb-io/shared/standing-orders.js";
 import type { LandCountersignGate } from "@reddb-io/shared/land-countersign.js";
 import { resolveVerifyRequirement } from "@reddb-io/shared/verify-labels.js";
@@ -248,17 +248,19 @@ export async function runTicketLoop(
   // claim this Worker may not honour is one another Worker cannot take either.
   //
   //   1. The lane the labels carry against the mode this Worker holds (#3026).
-  //   2. The brief contract: can this Ticket be finished from its own words?
+  //   2. The brief contract, structurally: does this Ticket carry acceptance
+  //      criteria at all? The machine-checkable judgement stays at triage.
   //
   // The second is a BACKSTOP, not the first line of defence — triage refuses a
-  // vague brief at promotion and the handoff decoder refuses one at the wire —
+  // vague brief at promotion and the handoff decoder refuses a briefless one
+  // at the wire —
   // and it exists because a Worker that discovers the brief is un-actionable
   // AFTER claiming it has already taken the Ticket out of every other Worker's
   // reach. Withdrawing costs nothing; owning a Ticket nobody can finish costs
   // the queue an entry until a sweep concedes it.
   const preflightRefusal =
     laneRunModeRefusal(deps.ticket.labels, deps.runMode) ??
-    briefContractRefusal(deps.ticket.handoff);
+    briefContractStructuralRefusal(deps.ticket.handoff);
   if (preflightRefusal != null) {
     await note({ stage: "claim", ok: false, detail: preflightRefusal });
     return { outcome: "refused", stage: "claim", detail: preflightRefusal, records };


### PR DESCRIPTION
The brief contract's machine-checkable judgement, enforced at the handoff decoder and the Worker preflight, refused **41 of 42 live briefs** across both registered projects — every drain tick became a birth-and-refuse loop (the #4296 grinder wearing the contract's own uniform). The module's own header warned about exactly this: *a first cut that refuses half the backlog is a first cut somebody turns off.*

Instead of turning the contract off, the judgement moves to the door where the author can act on it:

- **Triage promotion keeps the FULL lint** — vague wording is refused before `ready-for-agent` is ever applied, with the author present to fix the sentence.
- **The handoff decoder and the Worker preflight become structural**: they refuse only a brief that carries no acceptance-criteria section or lists no items — the one shape no Validation could ever read. `briefContractStructuralRefusal` is the single spelling of that check, beside the full lint in `@reddb-io/shared/brief-contract`.

Tests: the decoder/preflight cases flip to the structural semantics (a vague-but-structured brief now decodes and claims; an itemless one still refuses), `PROSE_BRIEF` repoints at a structural failure, and the shared contract gains a suite for the new function. The demand-park machinery (#4297) is untouched — any `brief contract refused` detail at stage `brief` still parks.

Refs #4296

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789996236&installation_model_id=20659&pr_number=4300&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4300&signature=449a77e56906729366991a2ea56845011e0310d41b4037b9785f6b3fae71b0f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->