### PR TITLE
feat(acp): the socket reads both JSON-RPC and TOON-RPC, and answers in kind

### DIFF
--- a/.changeset/acp-dual-dialect-stream.md
+++ b/.changeset/acp-dual-dialect-stream.md
@@ -1,0 +1,15 @@
+---
+"@reddb-io/protocol-acp": patch
+"@reddb-io/redskilled": patch
+---
+
+The ACP socket reads both JSON-RPC 2.0 and TOON-RPC 1.0, and answers in kind
+
+`socketStream` now rides a dual-dialect codec: every frame is sniffed on its
+own bytes (a `{` opens one line of JSON; anything else is a TOON document
+terminated by a blank line — the resident wire's proven framing, reused), the
+SDK above the stream always sees `jsonrpc: "2.0"` objects whatever the wire
+wore, and writes answer in the dialect the peer last used, opening in JSON.
+Nothing is observable until a TOON-writing peer ships; flipping one caller's
+`preferred` to `"toon"` is the whole second slice. External agents keep
+speaking plain JSON-RPC through the same door, unconfigured.

--- a/apps/redskilled/src/acp-client.ts
+++ b/apps/redskilled/src/acp-client.ts
@@ -5,15 +5,14 @@
  * This object owns only one live ACP connection and its public session id.
  */
 import { connect, type Socket } from "node:net";
-import { Readable, Writable } from "node:stream";
 import {
   client,
   methods,
-  ndJsonStream,
   type RequestPermissionRequest,
   type RequestPermissionResponse,
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
+import { socketStream } from "@reddb-io/protocol-acp";
 import { ensureRedskilledDaemon } from "./client.js";
 import { resolveRedskilledClientEndpoint } from "./client-rendezvous.js";
 import {
@@ -165,10 +164,7 @@ export async function connectRedskillsProjectAcp(
       app = app.onRequest(methods.client.session.requestPermission, ({ params }) =>
         options.requestPermission!(params));
     }
-    const connection = app.connect(ndJsonStream(
-      Writable.toWeb(socket) as WritableStream<Uint8Array>,
-      Readable.toWeb(socket) as ReadableStream<Uint8Array>,
-    ));
+    const connection = app.connect(socketStream(socket));
     await connection.agent.request(methods.agent.initialize, {
       protocolVersion: 1,
       clientCapabilities: {},

--- a/apps/redskilled/tests/acp-dual-dialect-stream.test.ts
+++ b/apps/redskilled/tests/acp-dual-dialect-stream.test.ts
@@ -1,0 +1,163 @@
+// The ACP socket's dual-dialect codec (packages/protocol-acp).
+//
+// What is proven here: the framing rules hold per frame, the envelope is
+// rewritten at the boundary in both directions, writes answer in the dialect
+// the peer last proved, and — the part that matters — an unmodified ACP SDK
+// connection completes a real request/response round trip when one end of the
+// wire is writing TOON-RPC. The resident-wire framing itself is proven in
+// `packages/shared/resident-wire.test.ts`; nothing here respells it.
+import { describe, expect, it } from "vitest";
+import { dualDialectStream } from "@reddb-io/protocol-acp";
+
+function bytePipe(): {
+  readable: ReadableStream<Uint8Array>;
+  push: (text: string) => void;
+  end: () => void;
+} {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const readable = new ReadableStream<Uint8Array>({ start(c) { controller = c; } });
+  const encoder = new TextEncoder();
+  return {
+    readable,
+    push: (text) => controller.enqueue(encoder.encode(text)),
+    end: () => controller.close(),
+  };
+}
+
+function byteSink(): { writable: WritableStream<Uint8Array>; text: () => string } {
+  const chunks: Uint8Array[] = [];
+  const writable = new WritableStream<Uint8Array>({ write(chunk) { chunks.push(chunk); } });
+  return { writable, text: () => chunks.map((c) => new TextDecoder().decode(c)).join("") };
+}
+
+async function readMessages(readable: ReadableStream<unknown>, count: number): Promise<unknown[]> {
+  const reader = readable.getReader();
+  const out: unknown[] = [];
+  while (out.length < count) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out.push(value);
+  }
+  reader.releaseLock();
+  return out;
+}
+
+describe("the ACP dual-dialect codec", () => {
+  it("reads a JSON line and a TOON document off the same stream, as jsonrpc objects", async () => {
+    const pipe = bytePipe();
+    const stream = dualDialectStream(byteSink().writable, pipe.readable);
+
+    pipe.push('{"jsonrpc":"2.0","method":"ping","id":1}\n');
+    pipe.push('toonrpc: "1.0"\nmethod: pong\nid: 2\n\n');
+
+    const messages = await readMessages(stream.readable, 2);
+    expect(messages[0]).toEqual({ jsonrpc: "2.0", method: "ping", id: 1 });
+    // The consumer sees the JSON-RPC envelope whatever the wire wore.
+    expect(messages[1]).toEqual({ jsonrpc: "2.0", method: "pong", id: 2 });
+  });
+
+  it("reassembles a frame split across chunks", async () => {
+    const pipe = bytePipe();
+    const stream = dualDialectStream(byteSink().writable, pipe.readable);
+
+    pipe.push('toonrpc: "1.0"\nmeth');
+    pipe.push("od: ping\nid: 9\n");
+    pipe.push("\n");
+
+    const [message] = await readMessages(stream.readable, 1);
+    expect(message).toEqual({ jsonrpc: "2.0", method: "ping", id: 9 });
+  });
+
+  it("writes JSON before any peer has proven a dialect — shipping this changes nothing", async () => {
+    const out = byteSink();
+    const stream = dualDialectStream(out.writable, bytePipe().readable);
+
+    const writer = stream.writable.getWriter();
+    await writer.write({ jsonrpc: "2.0", method: "hello", id: 1 });
+    writer.releaseLock();
+
+    expect(out.text()).toBe('{"jsonrpc":"2.0","method":"hello","id":1}\n');
+  });
+
+  it("answers a TOON peer in TOON, wearing the toonrpc envelope", async () => {
+    const pipe = bytePipe();
+    const out = byteSink();
+    const stream = dualDialectStream(out.writable, pipe.readable);
+
+    pipe.push('toonrpc: "1.0"\nmethod: ping\nid: 1\n\n');
+    await readMessages(stream.readable, 1);
+
+    const writer = stream.writable.getWriter();
+    await writer.write({ jsonrpc: "2.0", result: "pong", id: 1 });
+    writer.releaseLock();
+
+    const written = out.text();
+    expect(written.startsWith("toonrpc:")).toBe(true);
+    expect(written.endsWith("\n\n")).toBe(true);
+    expect(written).toContain("result: pong");
+    expect(written).not.toContain("jsonrpc");
+  });
+
+  it("keeps answering a JSON peer in JSON even when preferred is toon", async () => {
+    const pipe = bytePipe();
+    const out = byteSink();
+    const stream = dualDialectStream(out.writable, pipe.readable, { preferred: "toon" });
+
+    pipe.push('{"jsonrpc":"2.0","method":"ping","id":1}\n');
+    await readMessages(stream.readable, 1);
+
+    const writer = stream.writable.getWriter();
+    await writer.write({ jsonrpc: "2.0", result: "pong", id: 1 });
+    writer.releaseLock();
+
+    expect(out.text()).toBe('{"jsonrpc":"2.0","result":"pong","id":1}\n');
+  });
+
+  it("round-trips payload strings that contain blank lines through the TOON framing", async () => {
+    const out = byteSink();
+    const stream = dualDialectStream(out.writable, bytePipe().readable, { preferred: "toon" });
+
+    const text = "line one\n\nline two";
+    const writer = stream.writable.getWriter();
+    await writer.write({ jsonrpc: "2.0", method: "say", params: { text }, id: 1 });
+    writer.releaseLock();
+
+    const echo = bytePipe();
+    const reread = dualDialectStream(byteSink().writable, echo.readable);
+    echo.push(out.text());
+    const [message] = await readMessages(reread.readable, 1);
+    expect((message as { params: { text: string } }).params.text).toBe(text);
+  });
+
+  it("carries a full SDK round trip with one end writing TOON", async () => {
+    const { client, agent, methods } = await import("@agentclientprotocol/sdk");
+    // Two byte pipes, crossed: what one side writes, the other reads.
+    const aToB = bytePipe();
+    const bToA = bytePipe();
+
+    const sideA = dualDialectStream(
+      new WritableStream<Uint8Array>({
+        write(chunk) { aToB.push(new TextDecoder().decode(chunk)); },
+      }),
+      bToA.readable,
+      { preferred: "toon" },
+    );
+    const sideB = dualDialectStream(
+      new WritableStream<Uint8Array>({
+        write(chunk) { bToA.push(new TextDecoder().decode(chunk)); },
+      }),
+      aToB.readable,
+    );
+
+    agent()
+      .onRequest(methods.agent.initialize, () => ({ protocolVersion: 1, agentCapabilities: {} }))
+      .connect(sideB);
+    const clientSide = client().connect(sideA);
+
+    const answer = await clientSide.agent.request(methods.agent.initialize, {
+      protocolVersion: 1,
+      clientCapabilities: {},
+    });
+    expect(answer.protocolVersion).toBe(1);
+  });
+});

--- a/packages/protocol-acp/dual-dialect-stream.ts
+++ b/packages/protocol-acp/dual-dialect-stream.ts
@@ -1,0 +1,120 @@
+// dual-dialect-stream — the ACP socket's byte codec, speaking JSON-RPC 2.0 and
+// TOON-RPC 1.0 on one stream.
+//
+// The ACP SDK's `Stream` is a pair of OBJECT streams: everything above it —
+// the connection, the `_redskills/*` methods, compat — never sees wire bytes,
+// so the dialect is decided here and nowhere else. The framing and the
+// downgrade-safe rules are the resident wire's, reused rather than respelled
+// (`@reddb-io/shared/resident-wire.js` owns them, and its tests prove them):
+//
+// 1. **Every frame is sniffed on its own bytes.** A frame opening with `{` is
+//    one line of JSON; anything else is a TOON document terminated by a blank
+//    line. No peer is told, asked, or configured — which is what lets the five
+//    external agents keep speaking plain JSON-RPC through the same door.
+// 2. **The consumer always sees `jsonrpc: "2.0"` objects.** On the TOON wire
+//    the envelope field is `toonrpc: "1.0"` (the TOON-RPC 1.0 spelling of the
+//    same JSON-RPC 2.0 semantics); the codec rewrites the envelope at the
+//    boundary in both directions, so the SDK stack rides either dialect
+//    unmodified.
+// 3. **Writes answer in kind.** Until the peer has proven a dialect by sending
+//    a frame, writes use `preferred` — default `"json"`, so shipping this
+//    codec changes nothing observable until a peer that WRITES TOON exists.
+//    Flipping a single caller's `preferred` later is the whole second slice.
+import type { Stream } from "@agentclientprotocol/sdk";
+import {
+  encodeWireFrame,
+  takeWireFrame,
+  decodeWireFrame,
+  type ResidentWireDialect,
+} from "@reddb-io/shared/resident-wire.js";
+
+/** The envelope markers, spelled once: JSON-RPC 2.0 on JSON, TOON-RPC 1.0 on TOON. */
+export const JSONRPC_ENVELOPE_VERSION = "2.0";
+export const TOONRPC_ENVELOPE_VERSION = "1.0";
+
+export interface DualDialectOptions {
+  /** Dialect written before the peer has proven one. Default `"json"`. */
+  preferred?: ResidentWireDialect;
+}
+
+type WireMessage = Record<string, unknown>;
+
+/**
+ * A drop-in for `ndJsonStream(output, input)` that reads both dialects and
+ * answers in the one the peer last used.
+ */
+export function dualDialectStream(
+  output: WritableStream<Uint8Array>,
+  input: ReadableStream<Uint8Array>,
+  options?: DualDialectOptions,
+): Stream {
+  const preferred: ResidentWireDialect = options?.preferred ?? "json";
+  let peerDialect: ResidentWireDialect | undefined;
+  const textEncoder = new TextEncoder();
+  const writer = output.getWriter();
+
+  const writable = new WritableStream<WireMessage>({
+    async write(message) {
+      const dialect = peerDialect ?? preferred;
+      await writer.write(textEncoder.encode(encodeWireFrame(outboundEnvelope(message, dialect), dialect)));
+    },
+    async close() {
+      await writer.close();
+    },
+    async abort(reason) {
+      await writer.abort(reason as Error);
+    },
+  });
+
+  let buffer = "";
+  const readable = new ReadableStream<WireMessage>({
+    async start(controller) {
+      const textDecoder = new TextDecoder();
+      const reader = input.getReader();
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += textDecoder.decode(value, { stream: true });
+          for (;;) {
+            const taken = takeWireFrame(buffer);
+            if (taken === null) break;
+            buffer = taken.rest;
+            peerDialect = taken.dialect;
+            controller.enqueue(inboundEnvelope(decodeWireFrame(taken.frame)));
+          }
+        }
+        controller.close();
+      } catch (error) {
+        controller.error(error);
+      } finally {
+        reader.releaseLock();
+      }
+    },
+  });
+
+  return { writable, readable } as Stream;
+}
+
+/**
+ * The envelope a message wears on the wire: `toonrpc: "1.0"` on TOON frames,
+ * `jsonrpc: "2.0"` on JSON frames. Everything else travels untouched.
+ */
+function outboundEnvelope(message: WireMessage, dialect: ResidentWireDialect): WireMessage {
+  if (dialect !== "toon") return message;
+  const { jsonrpc: _jsonrpc, ...rest } = message;
+  return { toonrpc: TOONRPC_ENVELOPE_VERSION, ...rest };
+}
+
+/**
+ * The envelope the SDK expects, whatever the wire wore. A TOON frame that kept
+ * a `jsonrpc` field (a peer that framed TOON without adopting the TOON-RPC
+ * envelope) is normalized the same way.
+ */
+function inboundEnvelope(decoded: unknown): WireMessage {
+  if (typeof decoded !== "object" || decoded === null || Array.isArray(decoded)) {
+    return { jsonrpc: JSONRPC_ENVELOPE_VERSION, invalid: decoded } as WireMessage;
+  }
+  const { toonrpc: _toonrpc, jsonrpc: _jsonrpc, ...rest } = decoded as WireMessage;
+  return { jsonrpc: JSONRPC_ENVELOPE_VERSION, ...rest };
+}

--- a/packages/protocol-acp/index.ts
+++ b/packages/protocol-acp/index.ts
@@ -6,6 +6,7 @@
 // local Unix-socket / Named Pipe transport, and the `_redskills/*` methods.
 export * from "./brain.js";
 export * from "./compat.js";
+export * from "./dual-dialect-stream.js";
 export * from "./endpoint.js";
 export * from "./github-request.js";
 export * from "./github-write.js";

--- a/packages/protocol-acp/package.json
+++ b/packages/protocol-acp/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.30",
   "private": true,
   "type": "module",
-  "description": "The shared RedSkills ACP wire (ADR 0148, ADR 0145 §2-3, ADR 0153): ACP v1/v2 compat and draft-revision gating, the RedSkills wire major, the Unix-socket / Named Pipe local transport, and the `_redskills/*` method schemas. Depended on by the daemon, the Worker and the stateless adapters.",
+  "description": "The shared RedSkills ACP wire (ADR 0148, ADR 0145 \u00a72-3, ADR 0153): ACP v1/v2 compat and draft-revision gating, the RedSkills wire major, the Unix-socket / Named Pipe local transport, and the `_redskills/*` method schemas. Depended on by the daemon, the Worker and the stateless adapters.",
   "license": "Apache-2.0",
   "exports": {
     ".": "./index.ts",
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "1.3.0",
-    "@reddb-io/shared": "workspace:*"
+    "@reddb-io/shared": "workspace:*",
+    "@reddb-io/toon": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/protocol-acp/transport.ts
+++ b/packages/protocol-acp/transport.ts
@@ -11,10 +11,14 @@
 import { rm } from "node:fs/promises";
 import { connect, createServer, type Server, type Socket } from "node:net";
 import { Readable, Writable } from "node:stream";
-import { ndJsonStream, type Stream } from "@agentclientprotocol/sdk";
+import { type Stream } from "@agentclientprotocol/sdk";
+import { dualDialectStream } from "./dual-dialect-stream.js";
 
 export function socketStream(socket: Socket): Stream {
-  return ndJsonStream(
+  // Dual-dialect, readers first: this codec ACCEPTS JSON-RPC and TOON-RPC on
+  // every ACP socket and still WRITES JSON until a peer proves TOON — so the
+  // swap is observable to nobody until a TOON-writing peer ships.
+  return dualDialectStream(
     Writable.toWeb(socket) as WritableStream<Uint8Array>,
     Readable.toWeb(socket) as ReadableStream<Uint8Array>,
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,13 +45,23 @@ importers:
         specifier: ^5.6.0
         version: 5.9.3
 
-  apps/worker-container:
-    devDependencies:
-      vitest:
+  apps/herdr-plugin-redskilled:
+    dependencies:
+      '@reddb-io/brand-tokens':
+        specifier: workspace:*
+        version: link:../../packages/brand-tokens
+      '@reddb-io/build-info':
+        specifier: workspace:*
+        version: link:../../packages/build-info
+      '@reddb-io/toon':
         specifier: 'catalog:'
-        version: 2.1.9(@types/node@25.9.5)
+        version: 0.26.2
+    devDependencies:
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.24.2
 
-  benchmarks/code-understanding:
+  apps/host-opencode:
     dependencies:
       '@reddb-io/build-info':
         specifier: workspace:*
@@ -59,9 +69,6 @@ importers:
       '@reddb-io/shared':
         specifier: workspace:*
         version: link:../../packages/shared
-      '@reddb-io/toon':
-        specifier: 'catalog:'
-        version: 0.26.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -79,30 +86,61 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.20.1)
 
-  benchmarks/memory:
+  apps/mcp-browser:
     dependencies:
-      '@reddb-io/build-info':
+      '@reddb-io/browser-bridge':
         specifier: workspace:*
-        version: link:../../packages/build-info
-      '@reddb-io/sdk':
-        specifier: 1.23.1
-        version: 1.23.1
-      '@reddb-io/shared':
+        version: link:../../packages/browser-bridge
+      '@reddb-io/cdp-driver':
         specifier: workspace:*
-        version: link:../../packages/shared
+        version: link:../../packages/cdp-driver
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
-      esbuild:
-        specifier: 'catalog:'
-        version: 0.24.2
       tsx:
         specifier: 'catalog:'
         version: 4.23.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.20.1)
+
+  apps/mcp-navigator:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.29.0(zod@3.25.76)
+      '@reddb-io/build-info':
+        specifier: workspace:*
+        version: link:../../packages/build-info
+      '@reddb-io/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      vscode-languageserver-protocol:
+        specifier: ^3.17.5
+        version: 3.18.2
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.5
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.1
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@25.9.5)
 
   apps/plugin-brain:
     dependencies:
@@ -149,40 +187,6 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.20.1)
-
-  apps/mcp-navigator:
-    dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: 'catalog:'
-        version: 1.29.0(zod@3.25.76)
-      '@reddb-io/build-info':
-        specifier: workspace:*
-        version: link:../../packages/build-info
-      '@reddb-io/shared':
-        specifier: workspace:*
-        version: link:../../packages/shared
-      vscode-languageserver-protocol:
-        specifier: ^3.17.5
-        version: 3.18.2
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
-    devDependencies:
-      '@types/node':
-        specifier: ^25.9.1
-        version: 25.9.5
-      esbuild:
-        specifier: ^0.28.0
-        version: 0.28.1
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.1
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
-      vitest:
-        specifier: 'catalog:'
-        version: 2.1.9(@types/node@25.9.5)
 
   apps/plugin-dev:
     dependencies:
@@ -242,22 +246,6 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.20.1)
 
-  apps/herdr-plugin-redskilled:
-    dependencies:
-      '@reddb-io/brand-tokens':
-        specifier: workspace:*
-        version: link:../../packages/brand-tokens
-      '@reddb-io/build-info':
-        specifier: workspace:*
-        version: link:../../packages/build-info
-      '@reddb-io/toon':
-        specifier: 'catalog:'
-        version: 0.26.2
-    devDependencies:
-      esbuild:
-        specifier: 'catalog:'
-        version: 0.24.2
-
   apps/plugin-memory:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -303,53 +291,6 @@ importers:
       esbuild:
         specifier: 'catalog:'
         version: 0.24.2
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.1
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
-      vitest:
-        specifier: 'catalog:'
-        version: 2.1.9(@types/node@22.20.1)
-
-  apps/host-opencode:
-    dependencies:
-      '@reddb-io/build-info':
-        specifier: workspace:*
-        version: link:../../packages/build-info
-      '@reddb-io/shared':
-        specifier: workspace:*
-        version: link:../../packages/shared
-    devDependencies:
-      '@types/node':
-        specifier: 'catalog:'
-        version: 22.20.1
-      esbuild:
-        specifier: 'catalog:'
-        version: 0.24.2
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.1
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
-      vitest:
-        specifier: 'catalog:'
-        version: 2.1.9(@types/node@22.20.1)
-
-  apps/mcp-browser:
-    dependencies:
-      '@reddb-io/browser-bridge':
-        specifier: workspace:*
-        version: link:../../packages/browser-bridge
-      '@reddb-io/cdp-driver':
-        specifier: workspace:*
-        version: link:../../packages/cdp-driver
-    devDependencies:
-      '@types/node':
-        specifier: 'catalog:'
-        version: 22.20.1
       tsx:
         specifier: 'catalog:'
         version: 4.23.1
@@ -529,6 +470,65 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.20.1)
 
+  apps/worker-container:
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@25.9.5)
+
+  benchmarks/code-understanding:
+    dependencies:
+      '@reddb-io/build-info':
+        specifier: workspace:*
+        version: link:../../packages/build-info
+      '@reddb-io/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@reddb-io/toon':
+        specifier: 'catalog:'
+        version: 0.26.2
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.1
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.24.2
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.20.1)
+
+  benchmarks/memory:
+    dependencies:
+      '@reddb-io/build-info':
+        specifier: workspace:*
+        version: link:../../packages/build-info
+      '@reddb-io/sdk':
+        specifier: 1.23.1
+        version: 1.23.1
+      '@reddb-io/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.1
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.24.2
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   packages/brain-store:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -622,6 +622,9 @@ importers:
       '@reddb-io/shared':
         specifier: workspace:*
         version: link:../shared
+      '@reddb-io/toon':
+        specifier: 'catalog:'
+        version: 0.26.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
The ACP SDK's `Stream` is a pair of **object** streams — the connection, the `_redskills/*` methods and compat never see wire bytes — so the dialect is decided in exactly one place: `socketStream` in `@reddb-io/protocol-acp`. It now rides a dual-dialect codec built on the resident wire's proven framing (`takeWireFrame`/`decodeWireFrame`/`encodeWireFrame` from `@reddb-io/shared/resident-wire.js` — one spelling of framing in the repo, not two):

- **Per-frame sniffing**: `{` opens one line of JSON; anything else is a TOON document terminated by a blank line.
- **Envelope rewritten at the boundary**: the SDK always sees `jsonrpc: "2.0"` objects; on the TOON wire the envelope is `toonrpc: "1.0"` (TOON-RPC 1.0 = JSON-RPC 2.0 semantics in TOON), both directions.
- **Writes answer in kind**, opening in JSON — shipping this changes nothing observable until a TOON-writing peer exists. Flipping one caller's `preferred` to `"toon"` is the whole second slice. The five external agents keep speaking plain JSON-RPC through the same door, unconfigured.

`acp-client.ts` stops respelling `socketStream`'s expression with a direct `ndJsonStream` call and routes through the one choke point. The stdio edge toward external child agents (`child-agent.ts`) deliberately stays `ndJsonStream` — that edge is the Agent Client Protocol's own contract.

Proven in `apps/redskilled/tests/acp-dual-dialect-stream.test.ts` (7 cases), including a full SDK request/response round trip with one end writing TOON. Locally green: the 505 repo invariants, the serialization guard, `wire-dialect` and the ACP conformance suite. The `acp-control-plane-layout` headroom failure (726 > 700) and the 4 `local-gate` reds pre-exist on `origin/main` and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790000300&installation_model_id=20659&pr_number=4302&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4302&signature=54e607673d960563bcd20351a45f4562aa2faa506aa14aa4b489a879b508b451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->