### PR TITLE
feat(redskilled): the statusline ships as its own lean bundle

### DIFF
--- a/.changeset/lean-statusline-bundle.md
+++ b/.changeset/lean-statusline-bundle.md
@@ -1,0 +1,16 @@
+---
+"@reddb-io/redskilled": patch
+"@reddb-io/dev": patch
+---
+
+The statusline ships as its own lean bundle, ending the 1.2s-per-render tax
+
+Every prompt render invoked the full daemon bundle, whose import-time
+initialization costs ~1.2s of module evaluation before the statusline runs
+(node itself boots in ~70ms). The statusline now also ships as
+`statusline.bundle.min.mjs` — same command module, same render, none of the
+daemon's import graph — evaluating in ~0.19s. The daemon stabilizes it beside
+its own bundle as `statusline-<version>.bundle.min.mjs` (a name deliberately
+outside the `redskilled-*` glob, so version sorting can never hand the lean
+renderer to the daemon half), and the published statusline command prefers it,
+falling back to the full bundle on hosts that predate it.

--- a/apps/plugin-dev/tests/statusline-command-doc.test.ts
+++ b/apps/plugin-dev/tests/statusline-command-doc.test.ts
@@ -7,6 +7,7 @@ import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
 import {
   redskilledStableBundleDir,
   redskilledStableBundleName,
+  redskilledStatuslineBundleName,
   stabilizeRedskilledEntry,
 } from "@reddb-io/redskilled/stable-bundle";
 import { REDSKILLED_RENDER_ABSENCE } from "@reddb-io/redskilled-render";
@@ -47,6 +48,15 @@ function scratchHome(): string {
 }
 
 /** A fake HOME holding one daemon bundle that prints a line. */
+function hostWithLeanAndDaemonBundles(leanLine: string, daemonLine: string): string {
+  const home = hostWithDaemonBundleOnly(daemonLine);
+  writeFileSync(
+    join(redskilledStableBundleDir(home), redskilledStatuslineBundleName("1.0.0")),
+    `console.log(${JSON.stringify(leanLine)});\n`,
+  );
+  return home;
+}
+
 function hostWithDaemonBundleOnly(line: string): string {
   const home = scratchHome();
   const bundles = redskilledStableBundleDir(home);
@@ -173,6 +183,16 @@ describe("documented statusLine command (#3073)", () => {
     expect(run.stdout).toContain("» fixture (main) Opus");
     expect(run.status, run.stderr).toBe(0);
   });
+
+  it("prefers the lean renderer over the daemon bundle when both are stabilized", () => {
+    const run = renderStatusline(
+      hostWithLeanAndDaemonBundles("lean renderer spoke", "daemon bundle spoke"),
+    );
+
+    expect(run.stdout).toContain("lean renderer spoke");
+    expect(run.stdout).not.toContain("daemon bundle spoke");
+    expect(run.status, run.stderr).toBe(0);
+  });
 });
 
 describe("daemon bundle resolution (#3074)", () => {
@@ -222,6 +242,22 @@ describe("daemon bundle resolution (#3074)", () => {
       statuslineGlobResolves(body, minted),
       `no published glob resolves ${minted} — globs: ${statuslineBundleGlobs(body).join(", ")}`,
     ).toBe(true);
+    // The lean renderer the daemon stabilizes beside its own bundle resolves
+    // too, and it is tried FIRST: a per-render invocation must not pay the
+    // daemon bundle's import-time initialization when the lean copy exists.
+    const leanMinted = redskilledStatuslineBundleName(PROVISIONED_VERSION);
+    expect(
+      statuslineGlobResolves(body, leanMinted),
+      `no published glob resolves ${leanMinted} — globs: ${statuslineBundleGlobs(body).join(", ")}`,
+    ).toBe(true);
+    const globs = statuslineBundleGlobs(body);
+    expect(globs.indexOf("statusline-*.bundle.min.mjs")).toBeLessThan(
+      globs.indexOf("redskilled-*.bundle.min.mjs"),
+    );
+    // And the daemon's own glob never swallows the lean renderer: the sort -V
+    // tail of `redskilled-*` must keep resolving the DAEMON bundle.
+    const daemonHalf = 'd=$(ls -1 "$HOME"/.red/redskilled/bundles/redskilled-*.bundle.min.mjs)';
+    expect(statuslineGlobResolves(daemonHalf, leanMinted)).toBe(false);
     // `""` yields the segments below the operator home, which is exactly the
     // part the shell spells after its own `"$HOME"`.
     expect(body).toContain(`${redskilledStableBundleDir("")}/redskilled-`);

--- a/apps/redskilled/package.json
+++ b/apps/redskilled/package.json
@@ -41,7 +41,7 @@
     "./worker-workspace": "./src/worker-workspace.ts",
     "./statusline-command": "./src/statusline-command.ts"
   },
-  "description": "redskilled — the host-scoped RedSkills control plane: one singleton per machine owns Project control state and Worker lifecycle.",
+  "description": "redskilled \u2014 the host-scoped RedSkills control plane: one singleton per machine owns Project control state and Worker lifecycle.",
   "license": "Apache-2.0",
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
@@ -55,11 +55,13 @@
     "test:acp-harvest-deadline": "vitest run tests/acp-harvest-deadline.test.ts",
     "test:placement-contract": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/placement-contract.test.ts",
     "test:github-gateway": "NODE_OPTIONS=--max-old-space-size=4096 vitest run tests/github-gateway.test.ts",
-    "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/redskilled.bundle.min.mjs --asset redskilled.bundle.min.mjs --minify --reddb-from-package",
+    "bundle": "pnpm run bundle:daemon && pnpm run bundle:statusline",
     "build": "pnpm run typecheck && pnpm run bundle",
     "build:native": "node-gyp rebuild --directory=native",
     "serve": "tsx src/cli.ts serve",
-    "diagnose:resources": "tsx scripts/resource-incident-harness.ts"
+    "diagnose:resources": "tsx scripts/resource-incident-harness.ts",
+    "bundle:daemon": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/redskilled.bundle.min.mjs --asset redskilled.bundle.min.mjs --minify --reddb-from-package",
+    "bundle:statusline": "node ../../scripts/bundle-app.mjs --entry src/statusline-main.ts --outfile ../../dist/statusline.bundle.min.mjs --asset statusline.bundle.min.mjs --minify --reddb-from-package"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "1.3.0",

--- a/apps/redskilled/src/stable-bundle.ts
+++ b/apps/redskilled/src/stable-bundle.ts
@@ -47,6 +47,21 @@ export function redskilledStableBundleName(version: string): string {
   return `redskilled-${version}.bundle.min.mjs`;
 }
 
+/**
+ * The statusline renderer's stable name for one version.
+ *
+ * Deliberately NOT under the `redskilled-` prefix: the published statusline
+ * command resolves the daemon half with `redskilled-*.bundle.min.mjs | sort -V
+ * | tail -1`, and a `redskilled-statusline-…` file would win that sort and put
+ * the lean renderer where the daemon bundle was expected.
+ */
+export function redskilledStatuslineBundleName(version: string): string {
+  return `statusline-${version}.bundle.min.mjs`;
+}
+
+/** The unversioned asset the package ships beside the daemon bundle. */
+export const STATUSLINE_BUNDLE_ASSET = "statusline.bundle.min.mjs";
+
 const VERSIONED_BASENAME = /^redskilled-(.+)\.bundle\.min\.mjs$/;
 
 export interface StabilizableRedskilledEntry {
@@ -109,6 +124,19 @@ export function stabilizeRedskilledEntry<T extends StabilizableRedskilledEntry>(
       const temporary = `${target}.${process.pid}.tmp`;
       writeFileSync(temporary, readFileSync(source), { mode: 0o755 });
       renameSync(temporary, target);
+    }
+    // The statusline renderer ships BESIDE the daemon bundle in the package
+    // dist, and the published statusline command resolves it from this same
+    // stable directory — so it is stabilized in the same breath, under its own
+    // versioned name. Best-effort like everything here: a package without the
+    // sibling (an older release) stabilizes the daemon alone and loses only
+    // the lean renderer, never the entry.
+    const sibling = join(resolve(source), "..", STATUSLINE_BUNDLE_ASSET);
+    const siblingTarget = join(stableDir, redskilledStatuslineBundleName(version));
+    if (exists(sibling) && !exists(siblingTarget)) {
+      const temporary = `${siblingTarget}.${process.pid}.tmp`;
+      writeFileSync(temporary, readFileSync(sibling), { mode: 0o755 });
+      renameSync(temporary, siblingTarget);
     }
   } catch {
     return entry;

--- a/apps/redskilled/src/statusline-main.ts
+++ b/apps/redskilled/src/statusline-main.ts
@@ -1,0 +1,34 @@
+// statusline-main — the lean entry the prompt host runs on EVERY render.
+//
+// The statusline used to be a subcommand of the full daemon bundle, which made
+// each prompt render pay the whole daemon's import-time initialization —
+// measured at ~1.2s of module evaluation (schema construction and module init;
+// node itself boots in ~70ms) before a single statusline line ran. A status
+// producer that costs a second per keystroke-adjacent render is a tax on every
+// session on the machine, so the statusline ships as its OWN bundle: same
+// command module, same render, none of the daemon's import graph.
+//
+// The full bundle keeps its `statusline` subcommand — one command surface, two
+// carriers — and the published shell prefers this bundle when the daemon has
+// stabilized one, falling back to the full bundle on hosts that predate it.
+import { runStatusline } from "./statusline-command.js";
+
+const invokedDirectly = process.argv[1] != null &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
+  // The host may invoke `<bundle> statusline` (the full bundle's spelling) or
+  // bare `<bundle>`; both reach the one command.
+  const argv = process.argv.slice(2);
+  runStatusline(argv[0] === "statusline" ? argv.slice(1) : argv).then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (err: unknown) => {
+      process.stderr.write(`statusline: ${err instanceof Error ? err.message : String(err)}\n`);
+      // The statusline contract: always exit 0 — an outage must not render as
+      // a failed prompt hook.
+      process.exitCode = 0;
+    },
+  );
+}

--- a/apps/redskilled/tests/stable-bundle.test.ts
+++ b/apps/redskilled/tests/stable-bundle.test.ts
@@ -15,6 +15,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   redskilledStableBundleDir,
   redskilledStableBundleName,
+  redskilledStatuslineBundleName,
+  STATUSLINE_BUNDLE_ASSET,
   stabilizeRedskilledEntry,
 } from "../src/stable-bundle.js";
 import { requireRedskilledReplacementEntry } from "../src/self-replace.js";
@@ -53,6 +55,42 @@ describe("stabilizing an entry into the daemon home", () => {
     // Idempotent: a second pass finds the copy and copies nothing.
     const again = stabilizeRedskilledEntry(entry, { homeDir });
     expect(again.entry).toBe(target);
+  });
+
+  it("stabilizes the statusline sibling beside the daemon bundle, under its own name", async () => {
+    const { homeDir, sourceDir } = await scratch();
+    const source = join(sourceDir, "redskilled-4.0.0.bundle.min.mjs");
+    await writeFile(source, "the daemon bytes");
+    await writeFile(join(sourceDir, STATUSLINE_BUNDLE_ASSET), "the lean renderer bytes");
+
+    stabilizeRedskilledEntry({ command: "/usr/bin/node", args: [source], entry: source }, { homeDir });
+
+    const sibling = join(
+      redskilledStableBundleDir(homeDir),
+      redskilledStatuslineBundleName("4.0.0"),
+    );
+    expect(readFileSync(sibling, "utf8")).toBe("the lean renderer bytes");
+    // The sibling's name stays OUT of the daemon glob: `redskilled-*` sorted by
+    // version must never resolve the lean renderer as the daemon bundle.
+    expect(redskilledStatuslineBundleName("4.0.0").startsWith("redskilled-")).toBe(false);
+  });
+
+  it("stabilizes the daemon alone when the package carries no statusline sibling", async () => {
+    const { homeDir, sourceDir } = await scratch();
+    const source = join(sourceDir, "redskilled-4.0.0.bundle.min.mjs");
+    await writeFile(source, "the daemon bytes");
+
+    const stable = stabilizeRedskilledEntry(
+      { command: "/usr/bin/node", args: [source], entry: source },
+      { homeDir },
+    );
+
+    expect(stable.entry).toBe(
+      join(redskilledStableBundleDir(homeDir), redskilledStableBundleName("4.0.0")),
+    );
+    expect(
+      existsSync(join(redskilledStableBundleDir(homeDir), redskilledStatuslineBundleName("4.0.0"))),
+    ).toBe(false);
   });
 
   it("returns an already-stable entry unchanged", async () => {

--- a/packaging/npm/scripts/prepare.mjs
+++ b/packaging/npm/scripts/prepare.mjs
@@ -49,6 +49,7 @@ const BUNDLES = [
   { dest: "rsp.bundle.min.mjs", sources: ["rsp.bundle.min.mjs"] },
   { dest: "rsp-core.bundle.min.mjs", sources: ["rsp-core.bundle.min.mjs"] },
   { dest: "redskilled.bundle.min.mjs", sources: ["redskilled.bundle.min.mjs"] },
+  { dest: "statusline.bundle.min.mjs", sources: ["statusline.bundle.min.mjs"] },
 ];
 
 for (const relativePath of HOST_WIRING_FILES) {

--- a/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/packaging/pi/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -213,7 +213,7 @@ Decide whether to wire it up for this project:
   {
     "statusLine": {
       "type": "command",
-      "command": "sh -c 'N=$(command -v node 2>/dev/null || ls -1 /usr/local/bin/node /opt/homebrew/bin/node /usr/bin/node \"$HOME\"/.volta/bin/node \"$HOME\"/.asdf/shims/node \"$HOME\"/.nodenv/shims/node \"$HOME\"/.nvm/versions/node/*/bin/node \"$HOME\"/.local/share/fnm/node-versions/*/installation/bin/node \"$HOME\"/.fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1); [ -z \"$N\" ] && exit 0; d=$(ls -1 \"$HOME\"/.red/redskilled/bundles/redskilled-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); if [ -n \"$d\" ]; then \"$N\" \"$d\" statusline; else echo \"redskilled unreachable — Worker state unknown\"; fi; exit 0'",
+      "command": "sh -c 'N=$(command -v node 2>/dev/null || ls -1 /usr/local/bin/node /opt/homebrew/bin/node /usr/bin/node \"$HOME\"/.volta/bin/node \"$HOME\"/.asdf/shims/node \"$HOME\"/.nodenv/shims/node \"$HOME\"/.nvm/versions/node/*/bin/node \"$HOME\"/.local/share/fnm/node-versions/*/installation/bin/node \"$HOME\"/.fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1); [ -z \"$N\" ] && exit 0; s=$(ls -1 \"$HOME\"/.red/redskilled/bundles/statusline-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); d=$(ls -1 \"$HOME\"/.red/redskilled/bundles/redskilled-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); if [ -n \"$s\" ]; then \"$N\" \"$s\" statusline; elif [ -n \"$d\" ]; then \"$N\" \"$d\" statusline; else echo \"redskilled unreachable — Worker state unknown\"; fi; exit 0'",
       "refreshInterval": 60
     }
   }

--- a/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/packaging/pi/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -65,7 +65,7 @@ This mirrors how Codex itself organizes customization: skills define reusable wo
 {
   "statusLine": {
     "type": "command",
-    "command": "sh -c 'N=$(command -v node 2>/dev/null || ls -1 /usr/local/bin/node /opt/homebrew/bin/node /usr/bin/node \"$HOME\"/.volta/bin/node \"$HOME\"/.asdf/shims/node \"$HOME\"/.nodenv/shims/node \"$HOME\"/.nvm/versions/node/*/bin/node \"$HOME\"/.local/share/fnm/node-versions/*/installation/bin/node \"$HOME\"/.fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1); [ -z \"$N\" ] && exit 0; d=$(ls -1 \"$HOME\"/.red/redskilled/bundles/redskilled-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); if [ -n \"$d\" ]; then \"$N\" \"$d\" statusline; else echo \"redskilled unreachable — Worker state unknown\"; fi; exit 0'",
+    "command": "sh -c 'N=$(command -v node 2>/dev/null || ls -1 /usr/local/bin/node /opt/homebrew/bin/node /usr/bin/node \"$HOME\"/.volta/bin/node \"$HOME\"/.asdf/shims/node \"$HOME\"/.nodenv/shims/node \"$HOME\"/.nvm/versions/node/*/bin/node \"$HOME\"/.local/share/fnm/node-versions/*/installation/bin/node \"$HOME\"/.fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1); [ -z \"$N\" ] && exit 0; s=$(ls -1 \"$HOME\"/.red/redskilled/bundles/statusline-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); d=$(ls -1 \"$HOME\"/.red/redskilled/bundles/redskilled-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); if [ -n \"$s\" ]; then \"$N\" \"$s\" statusline; elif [ -n \"$d\" ]; then \"$N\" \"$d\" statusline; else echo \"redskilled unreachable — Worker state unknown\"; fi; exit 0'",
     "refreshInterval": 60
   }
 }

--- a/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -213,7 +213,7 @@ Decide whether to wire it up for this project:
   {
     "statusLine": {
       "type": "command",
-      "command": "sh -c 'N=$(command -v node 2>/dev/null || ls -1 /usr/local/bin/node /opt/homebrew/bin/node /usr/bin/node \"$HOME\"/.volta/bin/node \"$HOME\"/.asdf/shims/node \"$HOME\"/.nodenv/shims/node \"$HOME\"/.nvm/versions/node/*/bin/node \"$HOME\"/.local/share/fnm/node-versions/*/installation/bin/node \"$HOME\"/.fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1); [ -z \"$N\" ] && exit 0; d=$(ls -1 \"$HOME\"/.red/redskilled/bundles/redskilled-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); if [ -n \"$d\" ]; then \"$N\" \"$d\" statusline; else echo \"redskilled unreachable — Worker state unknown\"; fi; exit 0'",
+      "command": "sh -c 'N=$(command -v node 2>/dev/null || ls -1 /usr/local/bin/node /opt/homebrew/bin/node /usr/bin/node \"$HOME\"/.volta/bin/node \"$HOME\"/.asdf/shims/node \"$HOME\"/.nodenv/shims/node \"$HOME\"/.nvm/versions/node/*/bin/node \"$HOME\"/.local/share/fnm/node-versions/*/installation/bin/node \"$HOME\"/.fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1); [ -z \"$N\" ] && exit 0; s=$(ls -1 \"$HOME\"/.red/redskilled/bundles/statusline-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); d=$(ls -1 \"$HOME\"/.red/redskilled/bundles/redskilled-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); if [ -n \"$s\" ]; then \"$N\" \"$s\" statusline; elif [ -n \"$d\" ]; then \"$N\" \"$d\" statusline; else echo \"redskilled unreachable — Worker state unknown\"; fi; exit 0'",
       "refreshInterval": 60
     }
   }

--- a/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -65,7 +65,7 @@ This mirrors how Codex itself organizes customization: skills define reusable wo
 {
   "statusLine": {
     "type": "command",
-    "command": "sh -c 'N=$(command -v node 2>/dev/null || ls -1 /usr/local/bin/node /opt/homebrew/bin/node /usr/bin/node \"$HOME\"/.volta/bin/node \"$HOME\"/.asdf/shims/node \"$HOME\"/.nodenv/shims/node \"$HOME\"/.nvm/versions/node/*/bin/node \"$HOME\"/.local/share/fnm/node-versions/*/installation/bin/node \"$HOME\"/.fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1); [ -z \"$N\" ] && exit 0; d=$(ls -1 \"$HOME\"/.red/redskilled/bundles/redskilled-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); if [ -n \"$d\" ]; then \"$N\" \"$d\" statusline; else echo \"redskilled unreachable — Worker state unknown\"; fi; exit 0'",
+    "command": "sh -c 'N=$(command -v node 2>/dev/null || ls -1 /usr/local/bin/node /opt/homebrew/bin/node /usr/bin/node \"$HOME\"/.volta/bin/node \"$HOME\"/.asdf/shims/node \"$HOME\"/.nodenv/shims/node \"$HOME\"/.nvm/versions/node/*/bin/node \"$HOME\"/.local/share/fnm/node-versions/*/installation/bin/node \"$HOME\"/.fnm/node-versions/*/installation/bin/node 2>/dev/null | sort -V | tail -1); [ -z \"$N\" ] && exit 0; s=$(ls -1 \"$HOME\"/.red/redskilled/bundles/statusline-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); d=$(ls -1 \"$HOME\"/.red/redskilled/bundles/redskilled-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); if [ -n \"$s\" ]; then \"$N\" \"$s\" statusline; elif [ -n \"$d\" ]; then \"$N\" \"$d\" statusline; else echo \"redskilled unreachable — Worker state unknown\"; fi; exit 0'",
     "refreshInterval": 60
   }
 }

--- a/scripts/test-package-set-contract.sh
+++ b/scripts/test-package-set-contract.sh
@@ -437,6 +437,7 @@ expected_workstation=(
   dist/rsp.bundle.min.mjs
   dist/rsp-core.bundle.min.mjs
   dist/redskilled.bundle.min.mjs
+  dist/statusline.bundle.min.mjs
   dist/herdr-plugin-red-skills.bundle.min.mjs
   dist/vscode-extension-red-skills-9.9.9.vsix
   dist/zellij-dashboard.tgz

--- a/scripts/workstation-package-set.mjs
+++ b/scripts/workstation-package-set.mjs
@@ -70,6 +70,9 @@ export const WORKSTATION_PAYLOADS = [
 
   // The host-scoped daemon (ADR 0130).
   { asset: "dist/redskilled.bundle.min.mjs", kind: "daemon" },
+  // The prompt host's statusline renderer, split out of the daemon bundle so a
+  // per-render invocation does not pay the daemon's import-time initialization.
+  { asset: "dist/statusline.bundle.min.mjs", kind: "daemon" },
 
   // Companion surfaces installed by hand rather than resolved by a launcher, so
   // the release is the only place they can come from (#3060).


### PR DESCRIPTION
Every prompt render invoked the full daemon bundle, and a single-file bundle evaluates everything at import: **~1.2s of module initialization** (CPU-profiled: schema construction and module init dominate; node itself boots in ~70ms) before the first statusline line ran.

The statusline now also ships as `statusline.bundle.min.mjs` — a lean entry over the **same** `statusline-command` module (one command surface, two carriers; the full bundle keeps its `statusline` subcommand). Measured: module evaluation **1.2s → 0.19s**, full render **~1.5s → ~0.5s**, output byte-identical (bedrock + Worker tail + deaths).

- `apps/redskilled` bundle script emits both bundles; `packaging/npm` stages the new asset; the workstation package set and its contract declare it.
- `stabilizeRedskilledEntry` stabilizes the sibling as `statusline-<version>.bundle.min.mjs` — a name deliberately **outside** the `redskilled-*` glob, because `redskilled-statusline-…` would win that glob's `sort -V` and hand the lean renderer to the daemon half.
- The published statusline command (both canonical docs + regenerated pi mirrors) prefers the lean bundle, falling back to the full one on hosts that predate it. The command-doc guard pins the new glob against the daemon's own namer, the preference order, and the non-capture of the lean name by the daemon glob, with a fixture host proving the preference end to end.

Green locally: command-doc guard 28/28, stable-bundle 9/9, package-set contract, npm publish contract, and the 506 repo invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790047535&installation_model_id=20659&pr_number=4304&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4304&signature=7a6aaa382362abcabede23ba8ad40d5a45ad0588455220c6372c52c3d68f3986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->