### PR TITLE
fix(redskilled): the native-front compile spells npx canonically

### DIFF
--- a/.changeset/scriptc-canonical-invocation.md
+++ b/.changeset/scriptc-canonical-invocation.md
@@ -1,0 +1,10 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The native-front compile spells npx in ADR 0091's canonical form
+
+`npx -y scriptc@0.0.35 build …` resolved `scriptc@0.0.35` as a COMMAND on the
+first live host and failed with "not found"; the canonical
+`npx -y -p scriptc@<version> scriptc build …` form runs the pinned package's
+binary. Found by the unit-install outcome facts doing exactly their job.

--- a/apps/redskilled/src/statusline-native.ts
+++ b/apps/redskilled/src/statusline-native.ts
@@ -64,9 +64,12 @@ export async function installStatuslineNativeFront(
     await mkdir(binDir, { recursive: true, mode: 0o700 });
     const source = join(binDir, "statusline-fast.source.mts");
     await writeFile(source, STATUSLINE_NATIVE_SOURCE, { mode: 0o644 });
+    // ADR 0091's canonical form: `-p <pkg>@<version> <binary>`. The bare
+    // `npx -y scriptc@<v> build` spelling resolved `scriptc@0.0.35` as a
+    // COMMAND on the first live host and failed with "not found".
     const compiled = await run(
       "npx",
-      ["-y", `scriptc@${SCRIPTC_PINNED_VERSION}`, "build", source, "-o", target],
+      ["-y", "-p", `scriptc@${SCRIPTC_PINNED_VERSION}`, "scriptc", "build", source, "-o", target],
       { timeoutMs: COMPILE_TIMEOUT_MS },
     );
     await rm(source, { force: true });


### PR DESCRIPTION
`npx -y scriptc@0.0.35 build …` resolved the versioned spec as a **command** on the first live host (`sh: scriptc@0.0.35: not found`). ADR 0091's canonical form — `npx -y -p <pkg>@<version> <binary>` — runs the pinned package's bin. Surfaced by the unit-install outcome facts doing exactly their job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RuYndZizsrZnb4sWrH64V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790080679&installation_model_id=20659&pr_number=4309&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4309&signature=4e8e94a60723ebb04b729156bd5faab36c7db97daa2c2363e3f478eb129a5613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->