### PR TITLE
fix(pi): avoid treating bucket README files as skills

### DIFF
--- a/.changeset/pi-skill-manifest-files.md
+++ b/.changeset/pi-skill-manifest-files.md
@@ -1,0 +1,8 @@
+---
+"@reddb-io/red-skills-brain": patch
+"@reddb-io/red-skills-dev": patch
+"@reddb-io/red-skills-internal": patch
+"@reddb-io/red-skills-memory": patch
+---
+
+Declare concrete `SKILL.md` files in Pi manifests so Pi 0.84.x does not validate bucket README files as skills.

--- a/.changeset/pi-skill-manifest-files.md
+++ b/.changeset/pi-skill-manifest-files.md
@@ -1,8 +1,7 @@
 ---
-"@reddb-io/red-skills-brain": patch
-"@reddb-io/red-skills-dev": patch
-"@reddb-io/red-skills-internal": patch
-"@reddb-io/red-skills-memory": patch
+"@reddb-io/brain": patch
+"@reddb-io/dev": patch
+"@reddb-io/memory": patch
 ---
 
 Declare concrete `SKILL.md` files in Pi manifests so Pi 0.84.x does not validate bucket README files as skills.

--- a/.changeset/pi-skill-manifest-files.md
+++ b/.changeset/pi-skill-manifest-files.md
@@ -1,7 +1,5 @@
 ---
-"@reddb-io/brain": patch
-"@reddb-io/dev": patch
-"@reddb-io/memory": patch
+"@reddb-io/red-skills": patch
 ---
 
 Declare concrete `SKILL.md` files in Pi manifests so Pi 0.84.x does not validate bucket README files as skills.

--- a/apps/plugin-dev/tests/manifest-parity.test.ts
+++ b/apps/plugin-dev/tests/manifest-parity.test.ts
@@ -84,7 +84,7 @@ describe("dev plugin manifest + frontmatter hygiene", () => {
       .map((s) => s.replace(/^\.\/skills\//, "").replace(/\/$/, ""))
       .sort();
     const piBuckets = pi.pi.skills
-      .map((s) => s.replace(/^\.\/skills\//, "").replace(/\/$/, ""))
+      .map((s) => s.replace(/^\.\/skills\//, "").replace(/\/\*\/SKILL\.md$/, ""))
       .sort();
     expect(piBuckets).toEqual(codexBuckets);
     expect(piBuckets).not.toContain("in-progress");

--- a/apps/plugin-dev/tests/pi-manifest-generator.test.ts
+++ b/apps/plugin-dev/tests/pi-manifest-generator.test.ts
@@ -76,7 +76,7 @@ describe("Pi manifest generator", () => {
       license: "Apache-2.0",
       keywords: ["pi-package", "reddb-io", "red-skills"],
       pi: {
-        skills: ["./skills/engineering/", "./skills/knowledge/"],
+        skills: ["./skills/engineering/*/SKILL.md", "./skills/knowledge/*/SKILL.md"],
       },
     });
 
@@ -90,7 +90,32 @@ describe("Pi manifest generator", () => {
     const internalPackage = JSON.parse(
       await readFile(join(root, "plugins/internal/package.json"), "utf8"),
     );
-    expect(internalPackage.pi.skills).toEqual(["./skills/core/"]);
+    expect(internalPackage.pi.skills).toEqual(["./skills/core/*/SKILL.md"]);
+  });
+
+  it("declares only SKILL.md files so Pi does not validate bucket README files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "red-skills-pi-manifests-skill-files-"));
+
+    await mkdir(join(root, ".claude-plugin"), { recursive: true });
+    await mkdir(join(root, "plugins/brain/.claude-plugin"), { recursive: true });
+    await writeJson(join(root, ".claude-plugin/marketplace.json"), {
+      name: "red-skills",
+      plugins: [{ name: "brain", source: "./plugins/brain", description: "Brain." }],
+    });
+    await writeJson(join(root, "plugins/brain/.claude-plugin/plugin.json"), {
+      name: "brain",
+      version: "9.9.9",
+      description: "Brain.",
+      skills: ["./skills/core/capture", "./skills/core/search"],
+    });
+
+    await execFileAsync("node", [generator, "--root", root]);
+
+    const brainPackage = JSON.parse(
+      await readFile(join(root, "plugins/brain/package.json"), "utf8"),
+    );
+    expect(brainPackage.pi.skills).toEqual(["./skills/core/*/SKILL.md"]);
+    expect(brainPackage.pi.skills.every((entry: string) => entry.endsWith("/SKILL.md"))).toBe(true);
   });
 
   it("fails --check when a committed Pi manifest drifts from the generator", async () => {

--- a/apps/plugin-dev/tests/pi-package-builder.test.ts
+++ b/apps/plugin-dev/tests/pi-package-builder.test.ts
@@ -196,7 +196,10 @@ description: Test init skill.
     // package must be publishable. Verifying via negation: there is no
     // truthy `private` key.
     expect(devPkg.private).not.toBe(true);
-    expect(devPkg.pi.skills).toEqual(["./skills/engineering/", "./skills/knowledge/"]);
+    expect(devPkg.pi.skills).toEqual([
+      "./skills/engineering/*/SKILL.md",
+      "./skills/knowledge/*/SKILL.md",
+    ]);
 
     // Skills copied + in-progress/ excluded
     const afk = await readFile(
@@ -220,7 +223,7 @@ description: Test init skill.
     const memoryPkg = JSON.parse(
       await readFile(join(root, "packaging/pi/memory/package.json"), "utf8"),
     );
-    expect(memoryPkg.pi.skills).toEqual(["./skills/core/"]);
+    expect(memoryPkg.pi.skills).toEqual(["./skills/core/*/SKILL.md"]);
     expect(await readFile(join(root, "packaging/pi/memory/dist/memory.bundle.min.mjs"), "utf8"))
       .toBe("// memory runtime\n");
     expect(await readFile(join(root, "packaging/pi/memory/dist/memory-tokenizer.asset.cjs"), "utf8"))

--- a/packaging/pi/brain/package.json
+++ b/packaging/pi/brain/package.json
@@ -15,7 +15,7 @@
   ],
   "pi": {
     "skills": [
-      "./skills/core/"
+      "./skills/core/*/SKILL.md"
     ]
   },
   "publishConfig": {

--- a/packaging/pi/dev/package.json
+++ b/packaging/pi/dev/package.json
@@ -15,10 +15,10 @@
   ],
   "pi": {
     "skills": [
-      "./skills/engineering/",
-      "./skills/knowledge/",
-      "./skills/productivity/",
-      "./skills/misc/"
+      "./skills/engineering/*/SKILL.md",
+      "./skills/knowledge/*/SKILL.md",
+      "./skills/productivity/*/SKILL.md",
+      "./skills/misc/*/SKILL.md"
     ]
   },
   "publishConfig": {

--- a/packaging/pi/internal/package.json
+++ b/packaging/pi/internal/package.json
@@ -15,7 +15,7 @@
   ],
   "pi": {
     "skills": [
-      "./skills/maintainer/"
+      "./skills/maintainer/*/SKILL.md"
     ]
   },
   "publishConfig": {

--- a/packaging/pi/memory/package.json
+++ b/packaging/pi/memory/package.json
@@ -16,7 +16,7 @@
   ],
   "pi": {
     "skills": [
-      "./skills/core/"
+      "./skills/core/*/SKILL.md"
     ]
   },
   "publishConfig": {

--- a/plugins/brain/package.json
+++ b/plugins/brain/package.json
@@ -16,7 +16,7 @@
   ],
   "pi": {
     "skills": [
-      "./skills/core/"
+      "./skills/core/*/SKILL.md"
     ]
   }
 }

--- a/plugins/dev/package.json
+++ b/plugins/dev/package.json
@@ -16,10 +16,10 @@
   ],
   "pi": {
     "skills": [
-      "./skills/engineering/",
-      "./skills/knowledge/",
-      "./skills/productivity/",
-      "./skills/misc/"
+      "./skills/engineering/*/SKILL.md",
+      "./skills/knowledge/*/SKILL.md",
+      "./skills/productivity/*/SKILL.md",
+      "./skills/misc/*/SKILL.md"
     ]
   }
 }

--- a/plugins/internal/package.json
+++ b/plugins/internal/package.json
@@ -16,7 +16,7 @@
   ],
   "pi": {
     "skills": [
-      "./skills/maintainer/"
+      "./skills/maintainer/*/SKILL.md"
     ]
   }
 }

--- a/plugins/memory/package.json
+++ b/plugins/memory/package.json
@@ -17,7 +17,7 @@
   ],
   "pi": {
     "skills": [
-      "./skills/core/"
+      "./skills/core/*/SKILL.md"
     ]
   }
 }

--- a/scripts/generate-pi-manifests.mjs
+++ b/scripts/generate-pi-manifests.mjs
@@ -4,7 +4,9 @@
 //
 // Pi packages are installed via `pi install <local-path>` and need a
 // package.json with a `pi-package` keyword plus a `pi.skills` array pointing at
-// the same skill buckets the Claude/Codex manifests expose. This script keeps
+// the same skill buckets the Claude/Codex manifests expose. Pi 0.84.2 treats
+// every root Markdown file under a declared directory as a skill, so entries
+// must name only the actual `SKILL.md` files. This script keeps
 // the per-plugin package.json files under `plugins/<name>/package.json` in
 // sync with the source-of-truth Claude manifests; run `pnpm pi:manifests` to
 // regenerate, `pnpm pi:manifests:check` to fail on drift.
@@ -15,7 +17,7 @@
 // Skills exposed here are the same bucket paths the Codex manifest lists, so
 // a `pi install ./plugins/dev` install gives the agent every published dev
 // skill (engineering/knowledge/productivity/misc) without the in-progress
-// drafts.
+// drafts or bucket README files being interpreted as skills.
 
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -60,9 +62,10 @@ function deriveSkillRoots(skills) {
 
   // The Pi package manifest sits at plugins/<name>/package.json, so paths are
   // rooted there and must include the shared `./skills/` prefix the Claude and
-  // Codex manifests also use. Pi auto-discovers SKILL.md files recursively
-  // beneath each listed directory.
-  return orderedRoots.map((root) => `./skills/${root}/`);
+  // Codex manifests also use. Keep the glob one directory above SKILL.md:
+  // Pi 0.84.2 scans root Markdown files in a declared directory and reports a
+  // bucket README as a malformed skill.
+  return orderedRoots.map((root) => `./skills/${root}/*/SKILL.md`);
 }
 
 export function buildPiPackage(claudePlugin) {

--- a/scripts/validate-install-metadata.sh
+++ b/scripts/validate-install-metadata.sh
@@ -144,8 +144,8 @@ validate_plugin() {
     || fail "$plugin: Claude marketplace must expose ./$dir"
 
   # Pi package manifest: must exist, declare the pi-package keyword, carry the
-  # same version as the Claude/Codex manifests, and enumerate only buckets
-  # that exist on disk under ./skills/.
+  # same version as the Claude/Codex manifests, and enumerate only concrete
+  # SKILL.md globs that resolve on disk under ./skills/.
   local pi_pkg="$dir/package.json"
   [ -f "$pi_pkg" ] \
     || fail "$plugin: Pi package.json missing: $pi_pkg"
@@ -159,12 +159,12 @@ validate_plugin() {
     || fail "$plugin: $pi_pkg version must match Claude/Codex manifests"
   jq -e '.pi.skills | type == "array" and length > 0' "$pi_pkg" >/dev/null \
     || fail "$plugin: $pi_pkg pi.skills must be a non-empty array"
-  local bucket
-  while IFS= read -r bucket; do
-    [[ "$bucket" == ./skills/* ]] \
-      || fail "$plugin: Pi skill bucket must start with ./skills/: $bucket"
-    [[ -d "$dir/${bucket#./}" ]] \
-      || fail "$plugin: Pi skill bucket not found on disk: $bucket"
+  local skill_glob
+  while IFS= read -r skill_glob; do
+    [[ "$skill_glob" == ./skills/*/SKILL.md ]] \
+      || fail "$plugin: Pi skill entry must be a SKILL.md glob: $skill_glob"
+    compgen -G "$dir/${skill_glob#./}" >/dev/null \
+      || fail "$plugin: Pi skill glob matched no files on disk: $skill_glob"
   done < <(jq -r '.pi.skills[]' "$pi_pkg")
 
   # Staged npm package (ADR 0110): packaging/pi/<name>/package.json must mirror


### PR DESCRIPTION
Fixes #4306

## Problem
Pi 0.84.2 validates root Markdown files in each declared skill directory. The published manifests declared bucket directories, so `skills/core/README.md` was reported as a malformed skill (`description is required`).

## Fix
- Generate `./skills/<bucket>/*/SKILL.md` entries for all Pi manifests.
- Regenerate source manifests and packaging mirrors.
- Add generator, package-builder, and manifest-parity regression coverage.
- Add a patch changeset for all four published plugin packages.

The repro was run against Pi 0.84.2 with red-skills 4.1.34: broad bucket entries reproduced the warning; explicit SKILL.md entries produced no diagnostics.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790104158&installation_model_id=20659&pr_number=4317&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4317&signature=483ef165639891121af6004a4ede2602f7902bdb76b26a4228700d9d9fe219e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->