### PR TITLE
fix(dev): start rs_dev from the installed package set

### DIFF
--- a/.changeset/calm-ravens-start-local.md
+++ b/.changeset/calm-ravens-start-local.md
@@ -1,0 +1,4 @@
+---
+"@reddb-io/dev": patch
+---
+Start `rs_dev` from the verified red-dev package set without an npm lookup, resolving the atomic `current` symlink so the MCP bundle enters its server main and answers Codex initialization.

--- a/.red/adr/0142-redskilled-is-the-public-mcp-name.md
+++ b/.red/adr/0142-redskilled-is-the-public-mcp-name.md
@@ -77,3 +77,18 @@ host service; it is no longer the name of a server a session mounts.
 
 - Host-prefixed tools are `mcp__plugin_dev_rs_dev__<tool>`.
 - Prompts are `rs_dev:<intent>`.
+
+## Amendment — 2026-08-23 (`rs_dev` starts from the installed package set)
+
+The delivery precedence above is superseded for a workstation provisioned by
+`red-dev`. The verified package set already carries
+`dist/redskilled-mcp.bundle.min.mjs`, and `red-dev` moves
+`~/.red/skills/current` only after the complete set verifies and expands. The
+MCP launcher therefore executes that resident bundle first. It does not put an
+npm registry resolution on every Codex or Claude handshake.
+
+An identifiable source checkout remains the development fallback. The pinned
+`npx -y -p @reddb-io/red-skills@<version>` command remains the final fallback
+for a standalone plugin installation that has no `red-dev` package set. Hosts
+still share one artifact and one launcher; the amendment changes only which
+already-published copy is preferred.

--- a/apps/plugin-dev/tests/mcp-launcher-reachability.test.ts
+++ b/apps/plugin-dev/tests/mcp-launcher-reachability.test.ts
@@ -10,7 +10,9 @@
 // in every repo but this one. The difference was invisible because each server's
 // chain reads plausibly on its own. Two of the three left with ADR 0147 §4; the
 // contract outlives them, because the next server declared here inherits it.
-import { readdir, readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -60,6 +62,40 @@ async function declarations(): Promise<Declaration[]> {
 }
 
 describe("every MCP server resolves from a directory that is not this repo (#3186-adjacent)", () => {
+  it("starts rs_dev from red-dev's verified current package set before consulting npm", async () => {
+    const home = await mkdtemp(join(tmpdir(), "rs-dev-current-set-"));
+    const bin = join(home, "bin");
+    const set = join(home, ".red/skills/sets/4.1.35-test");
+    const bundle = join(set, "dist/redskilled-mcp.bundle.min.mjs");
+    await mkdir(join(set, "dist"), { recursive: true });
+    await symlink(set, join(home, ".red/skills/current"));
+    await mkdir(bin, { recursive: true });
+    await writeFile(
+      bundle,
+      'import { fileURLToPath } from "node:url";\n' +
+        'import { resolve } from "node:path";\n' +
+        'if (resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) ' +
+        'process.stdout.write("current-package-set\\n");\n',
+    );
+    await writeFile(join(bin, "npx"), '#!/usr/bin/env bash\nprintf "npm-fallback\\n"\n');
+    await chmod(join(bin, "npx"), 0o755);
+
+    const launched = spawnSync("bash", [join(ROOT, "plugins/dev/hooks/redskilled-mcp.sh")], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CODEX_PLUGIN_ROOT: join(ROOT, "plugins/dev"),
+        HOME: home,
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+      },
+    });
+    await rm(home, { force: true, recursive: true });
+
+    expect(launched.status, launched.stderr).toBe(0);
+    expect(launched.stdout).toBe("current-package-set\n");
+  });
+
   it("gives each file-resolving launcher a $HOME-anchored candidate", async () => {
     const all = await declarations();
     expect(all.length, "found no MCP declarations — a walker that reaches nothing is green by accident")

--- a/apps/plugin-dev/tests/shipped-hooks-posix.test.ts
+++ b/apps/plugin-dev/tests/shipped-hooks-posix.test.ts
@@ -191,17 +191,21 @@ describe("shipped hooks run under bash, wrappers stay POSIX", () => {
     expect(offenders).toEqual([]);
   });
 
-  it("launches the redskilled MCP through the same version-pinned npx lane on every host", () => {
+  it("launches the redskilled MCP from the verified package set before the npm fallback", () => {
     const launcher = readFileSync(
       join(ROOT, "plugins/dev/hooks/redskilled-mcp.sh"),
       "utf8",
     );
 
+    const currentSet = '$HOME/.red/skills/current/dist';
+    const npmFallback = 'npx -y -p "@reddb-io/red-skills@$ver" red-skills-redskilled-mcp';
+    expect(launcher).toContain(currentSet);
     expect(launcher).toContain(
-      'npx -y -p "@reddb-io/red-skills@$ver" red-skills-redskilled-mcp',
+      npmFallback,
     );
+    expect(launcher.indexOf(currentSet)).toBeLessThan(launcher.indexOf(npmFallback));
     expect(launcher).not.toMatch(/\b(?:curl|wget)\b|api\.github\.com|gh\s+release/);
-    expect(launcher).toContain("Source-checkout fallback only");
+    expect(launcher).toContain("Source-checkout fallback");
   });
 
   it("never hands a shipped hook to `sh` at an invocation site", () => {

--- a/packaging/pi/dev/hooks/redskilled-mcp.sh
+++ b/packaging/pi/dev/hooks/redskilled-mcp.sh
@@ -31,22 +31,33 @@ if [ -n "$plugin_json" ]; then
   ver="$(node -e "process.stdout.write(require(process.argv[1]).version)" "$plugin_json" 2>/dev/null || true)"
 fi
 
-if [ -n "$ver" ]; then
-  npx -y -p "@reddb-io/red-skills@$ver" red-skills-redskilled-mcp "$@"
-  status=$?
-  if [ "$status" -eq 0 ]; then
-    exit 0
+# red-dev moves this pointer only after it verifies and expands the complete
+# package set. Once present, that resident bundle is the fastest and strongest
+# identity available: no registry resolution belongs on every MCP handshake.
+current_dist="$HOME/.red/skills/current/dist"
+current_bundle="$current_dist/redskilled-mcp.bundle.min.mjs"
+if [ -f "$current_bundle" ]; then
+  # `current` is an atomic symlink. Execute the physical path because the
+  # bundle's direct-entry guard compares argv[1] with its resolved import URL.
+  physical_dist="$(cd "$current_dist" 2>/dev/null && pwd -P)"
+  if [ -n "$physical_dist" ]; then
+    exec node "$physical_dist/redskilled-mcp.bundle.min.mjs" "$@"
   fi
-  printf 'redskilled: npm package launcher failed for %s (exit %s); trying local dist fallback\n' "$ver" "$status" >&2
 fi
 
-# Source-checkout fallback only. Installed Codex and Claude plugins both take
-# the version-pinned npx path above; neither host owns a binary download lane.
+# Source-checkout fallback for development before a workstation set is installed.
 repo="$PWD"
 if [ -f "$repo/pnpm-workspace.yaml" ] && \
    [ -f "$repo/apps/plugin-dev/package.json" ] && \
    [ -f "$repo/dist/redskilled-mcp.bundle.min.mjs" ]; then
   exec node "$repo/dist/redskilled-mcp.bundle.min.mjs" "$@"
+fi
+
+# A standalone plugin installation has no red-dev package set. Preserve the
+# published, version-pinned npm path for that host, but keep it off the resident
+# workstation path above.
+if [ -n "$ver" ]; then
+  exec npx -y -p "@reddb-io/red-skills@$ver" red-skills-redskilled-mcp "$@"
 fi
 
 printf 'redskilled: could not locate the redskilled-mcp bundle\n' >&2

--- a/plugins/dev/hooks/redskilled-mcp.sh
+++ b/plugins/dev/hooks/redskilled-mcp.sh
@@ -31,22 +31,33 @@ if [ -n "$plugin_json" ]; then
   ver="$(node -e "process.stdout.write(require(process.argv[1]).version)" "$plugin_json" 2>/dev/null || true)"
 fi
 
-if [ -n "$ver" ]; then
-  npx -y -p "@reddb-io/red-skills@$ver" red-skills-redskilled-mcp "$@"
-  status=$?
-  if [ "$status" -eq 0 ]; then
-    exit 0
+# red-dev moves this pointer only after it verifies and expands the complete
+# package set. Once present, that resident bundle is the fastest and strongest
+# identity available: no registry resolution belongs on every MCP handshake.
+current_dist="$HOME/.red/skills/current/dist"
+current_bundle="$current_dist/redskilled-mcp.bundle.min.mjs"
+if [ -f "$current_bundle" ]; then
+  # `current` is an atomic symlink. Execute the physical path because the
+  # bundle's direct-entry guard compares argv[1] with its resolved import URL.
+  physical_dist="$(cd "$current_dist" 2>/dev/null && pwd -P)"
+  if [ -n "$physical_dist" ]; then
+    exec node "$physical_dist/redskilled-mcp.bundle.min.mjs" "$@"
   fi
-  printf 'redskilled: npm package launcher failed for %s (exit %s); trying local dist fallback\n' "$ver" "$status" >&2
 fi
 
-# Source-checkout fallback only. Installed Codex and Claude plugins both take
-# the version-pinned npx path above; neither host owns a binary download lane.
+# Source-checkout fallback for development before a workstation set is installed.
 repo="$PWD"
 if [ -f "$repo/pnpm-workspace.yaml" ] && \
    [ -f "$repo/apps/plugin-dev/package.json" ] && \
    [ -f "$repo/dist/redskilled-mcp.bundle.min.mjs" ]; then
   exec node "$repo/dist/redskilled-mcp.bundle.min.mjs" "$@"
+fi
+
+# A standalone plugin installation has no red-dev package set. Preserve the
+# published, version-pinned npm path for that host, but keep it off the resident
+# workstation path above.
+if [ -n "$ver" ]; then
+  exec npx -y -p "@reddb-io/red-skills@$ver" red-skills-redskilled-mcp "$@"
 fi
 
 printf 'redskilled: could not locate the redskilled-mcp bundle\n' >&2


### PR DESCRIPTION
## Outcome

Codex and Claude start `rs_dev` from the verified red-dev package set without consulting npm on every MCP handshake.

## Root cause

The launcher always preferred `npx -p`. The resident bundle already existed under `~/.red/skills/current`, but `current` is an atomic symlink: passing that unresolved path to Node made the bundle's direct-entry guard see an import rather than its executable entrypoint, so it exited 0 without answering `initialize`.

The launcher now resolves the physical `dist` directory before executing the resident bundle. An identifiable source checkout remains next, and pinned npm remains the final fallback for standalone plugin installs without red-dev.

## Evidence

- live MCP `initialize` returned `rs_dev 4.1.35` through the fixed launcher
- dev invariants: 507/507
- focused launcher, Pi, TOON and packaging tests: 41/41
- typecheck and lint green
- Pi package mirror regenerated and checked

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790116648&installation_model_id=20659&pr_number=4318&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4318&signature=dbbb85524f2e7b0fb6dc1c4a06765eb47168f54193ec336479a236c3bb435d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->