### PR TITLE
packages/worker local-gate suite is red on main: four tests assume a workspace layout the fixture never creates

### DIFF
--- a/.changeset/worker-local-gate-fixture.md
+++ b/.changeset/worker-local-gate-fixture.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/worker": patch
+---
+
+Fix the local-gate test fixture workspace layout so the worker gate suite runs green.

--- a/packages/worker/src/acp/local-gate.test.ts
+++ b/packages/worker/src/acp/local-gate.test.ts
@@ -23,9 +23,9 @@ async function workspace(): Promise<string> {
   roots.push(root);
   await writeFile(join(root, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n  - packages/*\n");
   await writeFile(join(root, "package.json"), JSON.stringify({ name: "root", scripts: { test: "true" } }));
-  await mkdir(join(root, "apps", "dev"), { recursive: true });
+  await mkdir(join(root, "apps", "plugin-dev"), { recursive: true });
   await writeFile(
-    join(root, "apps", "dev", "package.json"),
+    join(root, "apps", "plugin-dev", "package.json"),
     JSON.stringify({ name: "@fixture/dev", scripts: { typecheck: "true" }, dependencies: { "@fixture/lib": "workspace:*" } }),
   );
   await mkdir(join(root, "packages", "lib"), { recursive: true });
@@ -75,7 +75,7 @@ describe("running the declared stages", () => {
     expect(gateVerdict(result.stages).ok).toBe(true);
     // The cone is the touched package plus nothing else it feeds.
     expect(commands.map((argv) => argv.slice(1).join(" ")))
-      .toEqual([`-C ${join(root, "apps", "dev")} typecheck`]);
+      .toEqual([`-C ${join(root, "apps", "plugin-dev")} typecheck`]);
     expect(result.stages.find((stage) => stage.stage === "backpressure")?.skipped).toBe(true);
     expect(result.stages.find((stage) => stage.stage === "review")?.skipped).toBe(true);
   });
@@ -92,7 +92,7 @@ describe("running the declared stages", () => {
     const verdict = gateVerdict(result.stages);
     expect(verdict.ok).toBe(false);
     expect(verdict.failedStage).toBe("feedback");
-    expect(result.detail).toContain("typecheck");
+    expect(result.detail).toContain(`pnpm -C ${join(root, "apps", "plugin-dev")} typecheck`);
     expect(result.detail).toContain("TS2532");
   });
 
@@ -130,7 +130,7 @@ describe("running the declared stages", () => {
 
   it("reads the real diff when the caller names no seam", async () => {
     const root = await workspace();
-    await writeFile(join(root, "apps", "dev", "added.ts"), "export const added = 1;\n");
+    await writeFile(join(root, "apps", "plugin-dev", "added.ts"), "export const added = 1;\n");
     const git = (...args: string[]) => execFileSync("git", args, { cwd: root, stdio: "pipe" });
     git("checkout", "-b", "afk/4020");
     git("add", "--", "apps/plugin-dev/added.ts");
@@ -146,6 +146,6 @@ describe("running the declared stages", () => {
       },
     });
     expect(commands.map((argv) => argv.slice(1).join(" ")))
-      .toEqual([`-C ${join(root, "apps", "dev")} typecheck`]);
+      .toEqual([`-C ${join(root, "apps", "plugin-dev")} typecheck`]);
   }, 20_000);
 });


### PR DESCRIPTION
Refs reddb-io/redskilled#4

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:216bced6-4491-43e4-83c0-e126c034bf52:land:1eb9db41a406e0e06a0408638d7ea8d19664bced -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790117800&installation_model_id=20659&pr_number=4324&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4324&signature=b075513fc6862ced7c3742a8825ba0f1020837bfb2ca5c49cba966c969add3e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->