### PR TITLE
fix(release): snapshot releases before FIFO scan

### DIFF
--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -86,6 +86,24 @@ jobs:
             printf 'v%s\n' "${version%%.*}"
           }
 
+          # Snapshot the Release collection once. The FIFO walk below may span
+          # hundreds of historical tags; asking GitHub once per tag made a
+          # no-op resolver spend minutes on serial REST round trips. `gh api`
+          # follows pagination in one invocation and the remaining membership
+          # checks are local.
+          published_release_tags="$(
+            gh api --paginate 'repos/{owner}/{repo}/releases?per_page=100' --jq '.[].tag_name'
+          )"
+          declare -A published_releases=()
+          while IFS= read -r published_tag; do
+            [ -n "$published_tag" ] && published_releases["$published_tag"]=1
+          done <<< "$published_release_tags"
+
+          release_exists() {
+            local candidate="$1"
+            [ "${published_releases[$candidate]+known}" = known ]
+          }
+
           # A GitHub Release is not the whole completion marker: the workflow
           # creates it before moving vX, and a failure in that final push must
           # remain retryable. A major ref at this release OR a newer release in
@@ -104,7 +122,7 @@ jobs:
 
           release_complete() {
             local candidate="$1"
-            gh release view "$candidate" >/dev/null 2>&1 && major_reaches "$candidate"
+            release_exists "$candidate" && major_reaches "$candidate"
           }
 
           major_is_ahead() {

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -426,6 +426,11 @@ git -C "$resolver_fixture/repo" tag v3.11.0
 
 cat > "$resolver_fixture/bin/gh" <<'EOF'
 #!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_CALL_LOG"
+if [ "${1:-}" = "api" ] && [[ " $* " == *" --paginate "* ]]; then
+  printf '%s\n' v2.88.0 v3.1.2 v3.10.1 v3.11.0
+  exit 0
+fi
 if [ "${1:-}" = "release" ] && [ "${2:-}" = "view" ]; then
   case "${3:-}" in
     v2.88.0 | v3.1.2 | v3.10.1 | v3.11.0) exit 0 ;;
@@ -445,6 +450,7 @@ awk '
 if (
   cd "$resolver_fixture/repo"
   PATH="$resolver_fixture/bin:$PATH" \
+    GH_CALL_LOG="$resolver_fixture/gh-calls" \
     EVENT_NAME=workflow_dispatch \
     REF_NAME= \
     INPUT_TAG=v3.11.0 \
@@ -452,10 +458,13 @@ if (
     bash "$resolver_fixture/resolve-release-tag.sh"
 ) > "$resolver_fixture/stdout" 2>&1 &&
    grep -q '^publish=true$' "$resolver_fixture/github-output" &&
-   grep -q '^tag=v3.11.0$' "$resolver_fixture/github-output"; then
-  pass "a moving major ref may carry a descendant hotfix without reopening its release line"
+   grep -q '^tag=v3.11.0$' "$resolver_fixture/github-output" &&
+   [ "$(grep -c '^api ' "$resolver_fixture/gh-calls" || true)" -eq 1 ] &&
+   grep -q -- '--paginate' "$resolver_fixture/gh-calls" &&
+   ! grep -q '^release view ' "$resolver_fixture/gh-calls"; then
+  pass "the FIFO resolver snapshots releases once and handles a descendant major-ref hotfix locally"
 else
-  fail "a descendant hotfix on a moving major ref must not block the next release"
+  fail "the FIFO resolver must use one paginated release snapshot, never one request per tag"
 fi
 
 # One Release, one owner. The release engine creates it and re-reads the body it


### PR DESCRIPTION
Root cause: the FIFO resolver ran one serial GitHub Release lookup per historical semver tag. With 720 tags, the resolve step spent roughly four minutes on network round trips.

This snapshots the paginated Release collection once, keeps release membership local, and preserves the existing oldest-incomplete plus major-ref reconciliation semantics.

Validation:
- regression contract failed before the fix and now forbids per-tag release view calls
- real repository snapshot: 717 releases in 11.34 seconds
- release contract green
- repo invariants: 507/507

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790118659&installation_model_id=20659&pr_number=4325&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4325&signature=0844013c940c535e91e9899efe139ee849189044fc5b7e2275f41d542356c53a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->