### PR TITLE
packages/worker local-gate suite is red on main: four tests assume a workspace layout the fixture never creates

### DIFF
--- a/.changeset/fix-worker-local-gate-fixture.md
+++ b/.changeset/fix-worker-local-gate-fixture.md
@@ -2,4 +2,4 @@
 "@reddb-io/worker": patch
 ---
 
-Fix the local gate test fixture so it creates the workspace package path its assertions exercise.
+Fix the local gate test fixture so it creates the workspace package path and touched source file its assertions exercise.

--- a/packages/worker/src/acp/local-gate.test.ts
+++ b/packages/worker/src/acp/local-gate.test.ts
@@ -28,6 +28,8 @@ async function workspace(): Promise<string> {
     join(root, "apps", "plugin-dev", "package.json"),
     JSON.stringify({ name: "@fixture/dev", scripts: { typecheck: "true" }, dependencies: { "@fixture/lib": "workspace:*" } }),
   );
+  await mkdir(join(root, "apps", "plugin-dev", "src"), { recursive: true });
+  await writeFile(join(root, "apps", "plugin-dev", "src", "index.ts"), "export const fixture = true;\n");
   await mkdir(join(root, "packages", "lib"), { recursive: true });
   await writeFile(join(root, "packages", "lib", "package.json"), JSON.stringify({ name: "@fixture/lib" }));
   const git = (...args: string[]) => execFileSync("git", args, { cwd: root, stdio: "pipe" });


### PR DESCRIPTION
Refs reddb-io/redskilled#4

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:1e424e5d-ef10-4a21-955d-f73d04670010:land:0067c2e3c8e387e978e07270bd3db745168f81cc -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790119937&installation_model_id=20659&pr_number=4326&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4326&signature=8075b3a38cdec6a0c1827b234e9333cbf903e28287147f3ddd4c52120391ca36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->