### PR TITLE
packages/worker local-gate suite is red on main: four tests assume a workspace layout the fixture never creates

### DIFF
--- a/.changeset/harden-worker-local-gate-fixture.md
+++ b/.changeset/harden-worker-local-gate-fixture.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/worker": patch
+---
+
+Harden the worker local gate fixture assertions around the workspace package topology.

--- a/packages/worker/src/acp/local-gate.test.ts
+++ b/packages/worker/src/acp/local-gate.test.ts
@@ -10,29 +10,50 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { gateVerdict } from "../engine/gate-stage-order.js";
-import { runWorkerLocalGate, readWorkspace, workspaceGlobs } from "./local-gate.js";
+import {
+  runWorkerLocalGate,
+  readWorkspace,
+  workspaceGlobs,
+} from "./local-gate.js";
 
 const roots: string[] = [];
+const fixtureApp = "apps/plugin-dev";
+const fixtureSource = `${fixtureApp}/src/index.ts`;
 
 afterEach(async () => {
-  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+  for (const root of roots.splice(0))
+    await rm(root, { recursive: true, force: true });
 });
 
 async function workspace(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "worker-local-gate-"));
   roots.push(root);
-  await writeFile(join(root, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n  - packages/*\n");
-  await writeFile(join(root, "package.json"), JSON.stringify({ name: "root", scripts: { test: "true" } }));
-  await mkdir(join(root, "apps", "plugin-dev"), { recursive: true });
   await writeFile(
-    join(root, "apps", "plugin-dev", "package.json"),
-    JSON.stringify({ name: "@fixture/dev", scripts: { typecheck: "true" }, dependencies: { "@fixture/lib": "workspace:*" } }),
+    join(root, "pnpm-workspace.yaml"),
+    "packages:\n  - apps/*\n  - packages/*\n",
   );
-  await mkdir(join(root, "apps", "plugin-dev", "src"), { recursive: true });
-  await writeFile(join(root, "apps", "plugin-dev", "src", "index.ts"), "export const fixture = true;\n");
+  await writeFile(
+    join(root, "package.json"),
+    JSON.stringify({ name: "root", scripts: { test: "true" } }),
+  );
+  await mkdir(join(root, fixtureApp), { recursive: true });
+  await writeFile(
+    join(root, fixtureApp, "package.json"),
+    JSON.stringify({
+      name: "@fixture/dev",
+      scripts: { typecheck: "true" },
+      dependencies: { "@fixture/lib": "workspace:*" },
+    }),
+  );
+  await mkdir(join(root, fixtureApp, "src"), { recursive: true });
+  await writeFile(join(root, fixtureSource), "export const fixture = true;\n");
   await mkdir(join(root, "packages", "lib"), { recursive: true });
-  await writeFile(join(root, "packages", "lib", "package.json"), JSON.stringify({ name: "@fixture/lib" }));
-  const git = (...args: string[]) => execFileSync("git", args, { cwd: root, stdio: "pipe" });
+  await writeFile(
+    join(root, "packages", "lib", "package.json"),
+    JSON.stringify({ name: "@fixture/lib" }),
+  );
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: root, stdio: "pipe" });
   git("init", "--initial-branch", "main");
   git("config", "user.email", "worker@example.invalid");
   git("config", "user.name", "Worker");
@@ -47,16 +68,26 @@ describe("reading the Worktree's package topology", () => {
     const { layout, graph } = readWorkspace(root);
 
     expect(layout.hasPackage(".")).toBe(true);
-    expect(layout.hasPackage("apps/plugin-dev")).toBe(true);
+    expect(layout.hasPackage(fixtureApp)).toBe(true);
     expect(layout.hasPackage("apps/absent")).toBe(false);
-    expect(layout.hasScript("apps/plugin-dev", "typecheck")).toBe(true);
-    expect(layout.hasScript("apps/plugin-dev", "test")).toBe(false);
-    expect(graph.packages.find((pkg) => pkg.dir === "apps/plugin-dev")?.dependsOn).toEqual(["packages/lib"]);
+    expect(layout.hasScript(fixtureApp, "typecheck")).toBe(true);
+    expect(layout.hasScript(fixtureApp, "test")).toBe(false);
+    expect(graph.packages.map((pkg) => pkg.dir).sort()).toEqual([
+      ".",
+      fixtureApp,
+      "packages/lib",
+    ]);
+    expect(
+      graph.packages.find((pkg) => pkg.dir === fixtureApp)?.dependsOn,
+    ).toEqual(["packages/lib"]);
   });
 
   it("reads the packages list without a YAML decoder", () => {
-    expect(workspaceGlobs("packages:\n  - 'apps/*'\n  - packages/*  # comment\nonlyBuiltDependencies:\n  - esbuild\n"))
-      .toEqual(["apps/*", "packages/*"]);
+    expect(
+      workspaceGlobs(
+        "packages:\n  - 'apps/*'\n  - packages/*  # comment\nonlyBuiltDependencies:\n  - esbuild\n",
+      ),
+    ).toEqual(["apps/*", "packages/*"]);
   });
 });
 
@@ -67,7 +98,7 @@ describe("running the declared stages", () => {
     const result = await runWorkerLocalGate({
       worktree: root,
       base: "main",
-      changedFiles: async () => ["apps/plugin-dev/src/index.ts"],
+      changedFiles: async () => [fixtureSource],
       feedbackExec: async (args) => {
         commands.push(args);
         return { code: 0, stdout: "", stderr: "" };
@@ -76,10 +107,15 @@ describe("running the declared stages", () => {
 
     expect(gateVerdict(result.stages).ok).toBe(true);
     // The cone is the touched package plus nothing else it feeds.
-    expect(commands.map((argv) => argv.slice(1).join(" ")))
-      .toEqual([`-C ${join(root, "apps", "plugin-dev")} typecheck`]);
-    expect(result.stages.find((stage) => stage.stage === "backpressure")?.skipped).toBe(true);
-    expect(result.stages.find((stage) => stage.stage === "review")?.skipped).toBe(true);
+    expect(commands.map((argv) => argv.slice(1).join(" "))).toEqual([
+      `-C ${join(root, fixtureApp)} typecheck`,
+    ]);
+    expect(
+      result.stages.find((stage) => stage.stage === "backpressure")?.skipped,
+    ).toBe(true);
+    expect(
+      result.stages.find((stage) => stage.stage === "review")?.skipped,
+    ).toBe(true);
   });
 
   it("names the failing command in the detail a re-seed carries", async () => {
@@ -87,16 +123,23 @@ describe("running the declared stages", () => {
     const result = await runWorkerLocalGate({
       worktree: root,
       base: "main",
-      changedFiles: async () => ["apps/plugin-dev/src/index.ts"],
-      feedbackExec: async () => ({ code: 2, stdout: "", stderr: "TS2532: Object is possibly undefined" }),
+      changedFiles: async () => [fixtureSource],
+      feedbackExec: async () => ({
+        code: 2,
+        stdout: "",
+        stderr: "TS2532: Object is possibly undefined",
+      }),
     });
 
     const verdict = gateVerdict(result.stages);
     expect(verdict.ok).toBe(false);
     expect(verdict.failedStage).toBe("feedback");
-    expect(result.checks.find((check) => check.status === "failed")?.record.command)
-      .toBe(`pnpm -C ${join(root, "apps", "plugin-dev")} typecheck`);
-    expect(result.detail).toContain(`pnpm -C ${join(root, "apps", "plugin-dev")} typecheck`);
+    expect(
+      result.checks.find((check) => check.status === "failed")?.record.command,
+    ).toBe(`pnpm -C ${join(root, fixtureApp)} typecheck`);
+    expect(result.detail).toContain(
+      `pnpm -C ${join(root, fixtureApp)} typecheck`,
+    );
     expect(result.detail).toContain("TS2532");
   });
 
@@ -107,7 +150,7 @@ describe("running the declared stages", () => {
       worktree: root,
       base: "main",
       backpressureCommands: ["pnpm -C apps/plugin-dev test:invariants"],
-      changedFiles: async () => ["apps/plugin-dev/src/index.ts"],
+      changedFiles: async () => [fixtureSource],
       feedbackExec: async () => ({ code: 1, stdout: "", stderr: "red" }),
       backpressureExec: async ({ command }) => {
         ran.push(command);
@@ -121,7 +164,7 @@ describe("running the declared stages", () => {
       worktree: root,
       base: "main",
       backpressureCommands: ["pnpm -C apps/plugin-dev test:invariants"],
-      changedFiles: async () => ["apps/plugin-dev/src/index.ts"],
+      changedFiles: async () => [fixtureSource],
       feedbackExec: async () => ({ code: 0, stdout: "", stderr: "" }),
       backpressureExec: async ({ command }) => {
         ran.push(command);
@@ -134,8 +177,12 @@ describe("running the declared stages", () => {
 
   it("reads the real diff when the caller names no seam", async () => {
     const root = await workspace();
-    await writeFile(join(root, "apps", "plugin-dev", "added.ts"), "export const added = 1;\n");
-    const git = (...args: string[]) => execFileSync("git", args, { cwd: root, stdio: "pipe" });
+    await writeFile(
+      join(root, fixtureApp, "added.ts"),
+      "export const added = 1;\n",
+    );
+    const git = (...args: string[]) =>
+      execFileSync("git", args, { cwd: root, stdio: "pipe" });
     git("checkout", "-b", "afk/4020");
     git("add", "--", "apps/plugin-dev/added.ts");
     git("commit", "-m", "Refs #4020");
@@ -149,7 +196,8 @@ describe("running the declared stages", () => {
         return { code: 0, stdout: "", stderr: "" };
       },
     });
-    expect(commands.map((argv) => argv.slice(1).join(" ")))
-      .toEqual([`-C ${join(root, "apps", "plugin-dev")} typecheck`]);
+    expect(commands.map((argv) => argv.slice(1).join(" "))).toEqual([
+      `-C ${join(root, fixtureApp)} typecheck`,
+    ]);
   }, 20_000);
 });


### PR DESCRIPTION
Refs reddb-io/redskilled#4

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:d2ef6dcf-735b-4c1c-808a-cf1f9f4f729a:land:a1ae2cb4ef42e8a9e0a6ec2020cdfcba7ba6bb84 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790120793&installation_model_id=20659&pr_number=4327&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4327&signature=a8571c3cc97bf6921de206d92c4c2f9562393647d72913386963efc909af87bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->