### PR TITLE
packages/worker local-gate suite is red on main: four tests assume a workspace layout the fixture never creates

### DIFF
--- a/.changeset/pin-worker-local-gate-detail.md
+++ b/.changeset/pin-worker-local-gate-detail.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/worker": patch
+---
+
+Pin the worker local gate failure-detail regression test to the exact failing command.

--- a/packages/worker/src/acp/local-gate.test.ts
+++ b/packages/worker/src/acp/local-gate.test.ts
@@ -132,14 +132,13 @@ describe("running the declared stages", () => {
     });
 
     const verdict = gateVerdict(result.stages);
+    const failingCommand = `pnpm -C ${join(root, fixtureApp)} typecheck`;
     expect(verdict.ok).toBe(false);
     expect(verdict.failedStage).toBe("feedback");
     expect(
       result.checks.find((check) => check.status === "failed")?.record.command,
-    ).toBe(`pnpm -C ${join(root, fixtureApp)} typecheck`);
-    expect(result.detail).toContain(
-      `pnpm -C ${join(root, fixtureApp)} typecheck`,
-    );
+    ).toBe(failingCommand);
+    expect(result.detail).toMatch(new RegExp(`^${escapeRegExp(failingCommand)}:`));
     expect(result.detail).toContain("TS2532");
   });
 
@@ -201,3 +200,7 @@ describe("running the declared stages", () => {
     ]);
   }, 20_000);
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
Refs reddb-io/redskilled#4

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:8417ab27-3f6d-4d60-9d19-9f3029d81036:land:20c7efe393845bd8a44dcf5e5f5fb64a988fe9e0 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790123278&installation_model_id=20659&pr_number=4328&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4328&signature=d254259b7d99771e2fac7f5ea19227c247d09a907304e303b37459c158f78d3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->