### PR TITLE
packages/worker local-gate suite is red on main: four tests assume a workspace layout the fixture never creates

### DIFF
--- a/.changeset/pin-worker-local-gate-argv.md
+++ b/.changeset/pin-worker-local-gate-argv.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/worker": patch
+---
+
+Pin the worker local-gate fixture assertions to the exact feedback command argv.

--- a/packages/worker/src/acp/local-gate.test.ts
+++ b/packages/worker/src/acp/local-gate.test.ts
@@ -107,8 +107,8 @@ describe("running the declared stages", () => {
 
     expect(gateVerdict(result.stages).ok).toBe(true);
     // The cone is the touched package plus nothing else it feeds.
-    expect(commands.map((argv) => argv.slice(1).join(" "))).toEqual([
-      `-C ${join(root, fixtureApp)} typecheck`,
+    expect(commands).toEqual([
+      ["pnpm", "-C", join(root, fixtureApp), "typecheck"],
     ]);
     expect(
       result.stages.find((stage) => stage.stage === "backpressure")?.skipped,
@@ -138,7 +138,9 @@ describe("running the declared stages", () => {
     expect(
       result.checks.find((check) => check.status === "failed")?.record.command,
     ).toBe(failingCommand);
-    expect(result.detail).toMatch(new RegExp(`^${escapeRegExp(failingCommand)}:`));
+    expect(result.detail).toMatch(
+      new RegExp(`^${escapeRegExp(failingCommand)}:`),
+    );
     expect(result.detail).toContain("TS2532");
   });
 
@@ -195,8 +197,8 @@ describe("running the declared stages", () => {
         return { code: 0, stdout: "", stderr: "" };
       },
     });
-    expect(commands.map((argv) => argv.slice(1).join(" "))).toEqual([
-      `-C ${join(root, fixtureApp)} typecheck`,
+    expect(commands).toEqual([
+      ["pnpm", "-C", join(root, fixtureApp), "typecheck"],
     ]);
   }, 20_000);
 });


### PR DESCRIPTION
Refs reddb-io/redskilled#4

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:d2b15b88-e2cc-4278-bd3c-0e72a1d57f4b:land:66bce1032c4575360d114ed55cf7c3de492c1305 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790126747&installation_model_id=20659&pr_number=4330&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4330&signature=be67925f031935a1de2462a62e6e47c601900ce5183093fa5cae17849f7e32c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->