### PR TITLE
fix(release): build the redskilled-link asset

### DIFF
--- a/.changeset/build-redskilled-link-release-asset.md
+++ b/.changeset/build-redskilled-link-release-asset.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Build the redskilled-link companion before constructing the signed workstation package set so releases include the declared Remote-link asset.

--- a/.github/workflows/red-publish.yml
+++ b/.github/workflows/red-publish.yml
@@ -652,6 +652,21 @@ jobs:
           set -euo pipefail
           pnpm bundle
 
+      # The Remote-link Host/Relay companion is a signed workstation payload,
+      # so it must exist before the package-set manifest enumerates and hashes
+      # every declared asset. It is private workspace source, not an npm bin;
+      # the release bundle is the artifact operators install.
+      - name: Build redskilled-link companion bundle
+        if: steps.target.outputs.publish == 'true'
+        working-directory: apps/redskilled-link
+        env:
+          RED_BUILD_VERSION: ${{ steps.target.outputs.tag }}
+          RED_BUILD_GIT_SHA: ${{ steps.target.outputs.sha }}
+          RED_BUILD_TIME: ${{ steps.target.outputs.built_at }}
+        run: |
+          set -euo pipefail
+          pnpm bundle
+
       # The release engine ships as dist/release.bundle.min.mjs behind the
       # packaged `red-skills-release` bin. Every prior publish staged the bin
       # and skipped the bundle ("release.bundle.min.mjs not built; skipping"),

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -43,6 +43,7 @@ assert_before() {
 verify_line="$(line_of_step "Verify the tag matches the tree")"
 pack_line="$(line_of_step "Pack npm package + producer/consumer contract check")"
 release_bundle_line="$(line_of_step "Build release engine bundle" || true)"
+link_bundle_line="$(line_of_step "Build redskilled-link companion bundle" || true)"
 publish_line="$(line_of_step "Publish to npm")"
 smoke_line="$(line_of_step "Smoke published npm package from registry")"
 release_line="$(line_of_step "GitHub Release")"
@@ -67,6 +68,17 @@ assert_before "release engine bundle build" "$release_bundle_line" "pack/contrac
 grep -qF 'working-directory: apps/release' "$WORKFLOW" ||
   fail "release engine bundle must be built from apps/release so pnpm bundle emits dist/release.bundle.min.mjs"
 pass "release engine bundle is built before the pack"
+
+# A workstation payload is part of the signed identity even when it is not in
+# the npm tarball. Enumerating the companion without producing it made v4.2.0
+# fail at package-set construction before npm publish.
+[ -n "$link_bundle_line" ] || fail "release workflow must build the redskilled-link companion bundle"
+assert_before "redskilled-link companion bundle build" "$link_bundle_line" "pack/contract check" "$pack_line"
+if grep -qF 'working-directory: apps/redskilled-link' "$WORKFLOW"; then
+  pass "redskilled-link companion bundle is produced for the signed workstation set"
+else
+  fail "redskilled-link companion must build from apps/redskilled-link"
+fi
 
 # That the version surfaces agree with EACH OTHER is the version-train
 # invariant, run on every PR by the release engine's own gate. What this


### PR DESCRIPTION
## Root cause

The v4.2.0 publish correctly enumerated `dist/redskilled-link.bundle.min.mjs` in the signed workstation package set, but `red-publish.yml` had no producer step for that new asset. Package-set construction therefore failed with `ENOENT` before npm publish.

## Fix

- build `apps/redskilled-link` with its own stamped `pnpm bundle` step before package-set construction
- pin the producer and its ordering ahead of the pack in the release contract
- add a patch changeset so the complete release converges as 4.2.1

## Validation

- `bash scripts/test-red-release-npm-publish-contract.sh`
- `bash scripts/test-package-set-contract.sh`
- `node scripts/validate-changesets.mjs`
- `git diff --check`

The failed v4.2.0 run stopped before the npm pack/publish steps, so no partial registry state needs repair.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790127156&installation_model_id=20659&pr_number=4332&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4332&signature=58d33e03c272ddc32a69292f6083df2f37fc6b071e1d3056233178c2177a7268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->