### PR TITLE
packages/worker local-gate suite is red on main: four tests assume a workspace layout the fixture never creates

### DIFF
--- a/.changeset/steady-worker-local-gate-fixture.md
+++ b/.changeset/steady-worker-local-gate-fixture.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/worker": patch
+---
+
+Keep the worker local-gate test fixture aligned with the workspace layout and commands it asserts.

--- a/packages/worker/src/acp/local-gate.test.ts
+++ b/packages/worker/src/acp/local-gate.test.ts
@@ -19,6 +19,8 @@ import {
 const roots: string[] = [];
 const fixtureApp = "apps/plugin-dev";
 const fixtureSource = `${fixtureApp}/src/index.ts`;
+const fixtureAddedSource = `${fixtureApp}/added.ts`;
+const fixtureInvariantCommand = `pnpm -C ${fixtureApp} test:invariants`;
 
 afterEach(async () => {
   for (const root of roots.splice(0))
@@ -41,7 +43,7 @@ async function workspace(): Promise<string> {
     join(root, fixtureApp, "package.json"),
     JSON.stringify({
       name: "@fixture/dev",
-      scripts: { typecheck: "true" },
+      scripts: { typecheck: "true", "test:invariants": "true" },
       dependencies: { "@fixture/lib": "workspace:*" },
     }),
   );
@@ -148,7 +150,7 @@ describe("running the declared stages", () => {
     const blocked = await runWorkerLocalGate({
       worktree: root,
       base: "main",
-      backpressureCommands: ["pnpm -C apps/plugin-dev test:invariants"],
+      backpressureCommands: [fixtureInvariantCommand],
       changedFiles: async () => [fixtureSource],
       feedbackExec: async () => ({ code: 1, stdout: "", stderr: "red" }),
       backpressureExec: async ({ command }) => {
@@ -162,7 +164,7 @@ describe("running the declared stages", () => {
     const green = await runWorkerLocalGate({
       worktree: root,
       base: "main",
-      backpressureCommands: ["pnpm -C apps/plugin-dev test:invariants"],
+      backpressureCommands: [fixtureInvariantCommand],
       changedFiles: async () => [fixtureSource],
       feedbackExec: async () => ({ code: 0, stdout: "", stderr: "" }),
       backpressureExec: async ({ command }) => {
@@ -171,19 +173,19 @@ describe("running the declared stages", () => {
       },
     });
     expect(gateVerdict(green.stages).ok).toBe(true);
-    expect(ran).toEqual(["pnpm -C apps/plugin-dev test:invariants"]);
+    expect(ran).toEqual([fixtureInvariantCommand]);
   });
 
   it("reads the real diff when the caller names no seam", async () => {
     const root = await workspace();
     await writeFile(
-      join(root, fixtureApp, "added.ts"),
+      join(root, fixtureAddedSource),
       "export const added = 1;\n",
     );
     const git = (...args: string[]) =>
       execFileSync("git", args, { cwd: root, stdio: "pipe" });
     git("checkout", "-b", "afk/4020");
-    git("add", "--", "apps/plugin-dev/added.ts");
+    git("add", "--", fixtureAddedSource);
     git("commit", "-m", "Refs #4020");
 
     const commands: string[][] = [];


### PR DESCRIPTION
Refs reddb-io/redskilled#4

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:6dae4dbe-464d-45ea-b1a4-07d354dc3359:land:95ee53d86008d6029e00f7c27ffbf13e67f68c3c -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790128092&installation_model_id=20659&pr_number=4335&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4335&signature=d752f0110cb3bbc7f4ac11feb65eeaaa8a9231d0ffdc230730e0dce2e2e25cc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->