### PR TITLE
packages/worker local-gate suite is red on main: four tests assume a workspace layout the fixture never creates

### DIFF
--- a/.changeset/local-gate-fixture-path.md
+++ b/.changeset/local-gate-fixture-path.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/worker": patch
+---
+
+Keep the worker local-gate fixture diff path tied to the workspace package it creates.

--- a/packages/worker/src/acp/local-gate.test.ts
+++ b/packages/worker/src/acp/local-gate.test.ts
@@ -19,6 +19,7 @@ import {
 const roots: string[] = [];
 const fixtureApp = "apps/plugin-dev";
 const fixtureSource = `${fixtureApp}/src/index.ts`;
+const fixtureAdded = `${fixtureApp}/added.ts`;
 
 afterEach(async () => {
   for (const root of roots.splice(0))
@@ -177,13 +178,13 @@ describe("running the declared stages", () => {
   it("reads the real diff when the caller names no seam", async () => {
     const root = await workspace();
     await writeFile(
-      join(root, fixtureApp, "added.ts"),
+      join(root, fixtureAdded),
       "export const added = 1;\n",
     );
     const git = (...args: string[]) =>
       execFileSync("git", args, { cwd: root, stdio: "pipe" });
     git("checkout", "-b", "afk/4020");
-    git("add", "--", "apps/plugin-dev/added.ts");
+    git("add", "--", fixtureAdded);
     git("commit", "-m", "Refs #4020");
 
     const commands: string[][] = [];


### PR DESCRIPTION
Refs reddb-io/redskilled#4

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:4f5b7036-6679-452d-aeba-9ad452b8f0c0:land:63b9b20051f8fa8d4f149cac31898704131f25b1 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790128863&installation_model_id=20659&pr_number=4338&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4338&signature=425b0b85e835ab307448c6d604afbf2dc6f4257b26215245a3503fc13b769b45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->