### PR TITLE
packages/worker local-gate suite is red on main: four tests assume a workspace layout the fixture never creates

### DIFF
--- a/.changeset/quiet-worker-local-gate.md
+++ b/.changeset/quiet-worker-local-gate.md
@@ -2,4 +2,4 @@
 "@reddb-io/worker": patch
 ---
 
-Keep the Worker local-gate fixture paths consistent with its assertions.
+Keep the Worker local-gate fixture paths and failing-command assertion consistent with the suite's subject.

--- a/packages/worker/src/acp/local-gate.test.ts
+++ b/packages/worker/src/acp/local-gate.test.ts
@@ -121,21 +121,26 @@ describe("running the declared stages", () => {
 
   it("names the failing command in the detail a re-seed carries", async () => {
     const root = await workspace();
+    const failingCommand = `pnpm -C ${join(root, fixtureApp)} typecheck`;
+    const invokedCommands: string[] = [];
     const result = await runWorkerLocalGate({
       worktree: root,
       base: "main",
       changedFiles: async () => [fixtureSource],
-      feedbackExec: async () => ({
-        code: 2,
-        stdout: "",
-        stderr: "TS2532: Object is possibly undefined",
-      }),
+      feedbackExec: async (args) => {
+        invokedCommands.push(args.join(" "));
+        return {
+          code: 2,
+          stdout: "",
+          stderr: "TS2532: Object is possibly undefined",
+        };
+      },
     });
 
     const verdict = gateVerdict(result.stages);
-    const failingCommand = `pnpm -C ${join(root, fixtureApp)} typecheck`;
     expect(verdict.ok).toBe(false);
     expect(verdict.failedStage).toBe("feedback");
+    expect(invokedCommands).toEqual([failingCommand]);
     expect(
       result.checks.find((check) => check.status === "failed")?.record.command,
     ).toBe(failingCommand);


### PR DESCRIPTION
Refs reddb-io/redskilled#4

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:826dfcde-932c-4363-a5c1-7f35bd79fce3:land:b0475e9852e1ba993a103cdb441394a4381abf94 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790133438&installation_model_id=20659&pr_number=4339&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4339&signature=5bb3947a09bf1c0b8958a2930f8a29009fd5b1128903cf6e1237fcf1fe8a1e64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->