### PR TITLE
packages/worker local-gate suite is red on main: four tests assume a workspace layout the fixture never creates

### DIFF
--- a/.changeset/firm-worker-local-gate-fixture.md
+++ b/.changeset/firm-worker-local-gate-fixture.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/worker": patch
+---
+
+Keep Worker local-gate fixture command assertions pinned to the full command line they exercise.

--- a/packages/worker/src/acp/local-gate.test.ts
+++ b/packages/worker/src/acp/local-gate.test.ts
@@ -109,8 +109,8 @@ describe("running the declared stages", () => {
 
     expect(gateVerdict(result.stages).ok).toBe(true);
     // The cone is the touched package plus nothing else it feeds.
-    expect(commands.map((argv) => argv.slice(1).join(" "))).toEqual([
-      `-C ${join(root, fixtureApp)} typecheck`,
+    expect(commands.map((argv) => argv.join(" "))).toEqual([
+      `pnpm -C ${join(root, fixtureApp)} typecheck`,
     ]);
     expect(
       result.stages.find((stage) => stage.stage === "backpressure")?.skipped,
@@ -203,8 +203,8 @@ describe("running the declared stages", () => {
         return { code: 0, stdout: "", stderr: "" };
       },
     });
-    expect(commands.map((argv) => argv.slice(1).join(" "))).toEqual([
-      `-C ${join(root, fixtureApp)} typecheck`,
+    expect(commands.map((argv) => argv.join(" "))).toEqual([
+      `pnpm -C ${join(root, fixtureApp)} typecheck`,
     ]);
   }, 20_000);
 });


### PR DESCRIPTION
Refs reddb-io/redskilled#4

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:130bf5a3-48d1-498d-b405-10a8f6aaf585:land:1aad4cff38c49fdf9f523abd26bbae1ad140eb03 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790138759&installation_model_id=20659&pr_number=4342&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4342&signature=de1f20596b5febd0023dc1df3521a00d3422e48e41b4fa835277a6d683108763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->