### PR TITLE
packages/worker local-gate suite is red on main: four tests assume a workspace layout the fixture never creates

### DIFF
--- a/.changeset/local-gate-fixture-command.md
+++ b/.changeset/local-gate-fixture-command.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/worker": patch
+---
+
+Keep Worker local-gate fixture command assertions tied to the package path they exercise.

--- a/packages/worker/src/acp/local-gate.test.ts
+++ b/packages/worker/src/acp/local-gate.test.ts
@@ -22,6 +22,14 @@ const fixtureSource = `${fixtureApp}/src/index.ts`;
 const fixtureAddedSource = `${fixtureApp}/added.ts`;
 const fixtureBackpressureCommand = `pnpm -C ${fixtureApp} test:invariants`;
 
+function fixtureFeedbackArgs(root: string): string[] {
+  return ["pnpm", "-C", join(root, fixtureApp), "typecheck"];
+}
+
+function fixtureFeedbackCommand(root: string): string {
+  return fixtureFeedbackArgs(root).join(" ");
+}
+
 afterEach(async () => {
   for (const root of roots.splice(0))
     await rm(root, { recursive: true, force: true });
@@ -109,9 +117,7 @@ describe("running the declared stages", () => {
 
     expect(gateVerdict(result.stages).ok).toBe(true);
     // The cone is the touched package plus nothing else it feeds.
-    expect(commands.map((argv) => argv.slice(1).join(" "))).toEqual([
-      `-C ${join(root, fixtureApp)} typecheck`,
-    ]);
+    expect(commands).toEqual([fixtureFeedbackArgs(root)]);
     expect(
       result.stages.find((stage) => stage.stage === "backpressure")?.skipped,
     ).toBe(true);
@@ -122,7 +128,7 @@ describe("running the declared stages", () => {
 
   it("names the failing command in the detail a re-seed carries", async () => {
     const root = await workspace();
-    const failingCommand = `pnpm -C ${join(root, fixtureApp)} typecheck`;
+    const failingCommand = fixtureFeedbackCommand(root);
     const invokedCommands: string[] = [];
     const result = await runWorkerLocalGate({
       worktree: root,
@@ -203,9 +209,7 @@ describe("running the declared stages", () => {
         return { code: 0, stdout: "", stderr: "" };
       },
     });
-    expect(commands.map((argv) => argv.slice(1).join(" "))).toEqual([
-      `-C ${join(root, fixtureApp)} typecheck`,
-    ]);
+    expect(commands).toEqual([fixtureFeedbackArgs(root)]);
   }, 20_000);
 });
 


### PR DESCRIPTION
Refs reddb-io/redskilled#4

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:bdb88fad-7794-49cd-9d4f-5819457607b6:land:786a1d8912e163bf6eb2184d0390c89445bd88db -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790139105&installation_model_id=20659&pr_number=4343&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4343&signature=cc319a86bccc7ce1a2fc1c7d30d8b69ff1f6e874327cc593f45380637693ee38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->