### PR TITLE
fix(mobile): attach signed APK releases

### DIFF
--- a/.changeset/attach-signed-mobile-apk.md
+++ b/.changeset/attach-signed-mobile-apk.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-mobile": patch
+---
+
+Attach signed Android APKs to their GitHub Release from checkout-free jobs without relying on secret-tainted workflow outputs.

--- a/.github/workflows/red-mobile-apk.yml
+++ b/.github/workflows/red-mobile-apk.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    outputs:
-      apk-name: ${{ steps.artifact.outputs.name }}
     env:
       REDDB_SKIP_POSTINSTALL: '1'
     steps:
@@ -101,7 +99,6 @@ jobs:
           build_tools=$(find "$ANDROID_HOME/build-tools" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)
           "$build_tools/apksigner" verify --verbose --print-certs "dist-apk/$name"
           sha256sum "dist-apk/$name" > "dist-apk/$name.sha256"
-          echo "name=$name" >> "$GITHUB_OUTPUT"
       - name: Upload workflow artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -125,6 +122,7 @@ jobs:
       - name: Wait for the matching GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
         run: |
           for attempt in $(seq 1 18); do
@@ -138,9 +136,16 @@ jobs:
       - name: Attach APK to the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
-          APK_NAME: ${{ needs.build-apk.outputs.apk-name }}
         run: |
+          mapfile -t apks < <(find dist-apk -maxdepth 1 -type f -name '*.apk' -printf '%f\n' | sort)
+          if [ "${#apks[@]}" -ne 1 ]; then
+            echo "Expected exactly one downloaded APK, found ${#apks[@]}" >&2
+            exit 1
+          fi
+          APK_NAME="${apks[0]}"
+          test -f "dist-apk/$APK_NAME.sha256"
           existing=$(gh release view "$TAG" --json assets --jq '.assets[].name')
           if grep -Fxq "$APK_NAME" <<< "$existing" || grep -Fxq "$APK_NAME.sha256" <<< "$existing"; then
             echo "Release already contains a Redskilled APK asset; refusing to replace it" >&2

--- a/apps/redskilled-mobile/tests/release-signing-plugin.test.ts
+++ b/apps/redskilled-mobile/tests/release-signing-plugin.test.ts
@@ -1,4 +1,6 @@
 import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -46,5 +48,22 @@ describe("Android release signing plugin", () => {
     expect(patchBuildGradle(patched)).toBe(patched);
     expect(() => patchBuildGradle("android {}"))
       .toThrow(/signing block changed/);
+  });
+});
+
+describe("Android release workflow", () => {
+  const workflow = readFileSync(
+    fileURLToPath(new URL("../../../.github/workflows/red-mobile-apk.yml", import.meta.url)),
+    "utf8",
+  );
+
+  it("attaches the downloaded APK without depending on a secret-tainted job output", () => {
+    expect(workflow).not.toContain("needs.build-apk.outputs.apk-name");
+    expect(workflow).not.toMatch(/^    outputs:\n      apk-name:/m);
+    expect(workflow).toContain("find dist-apk -maxdepth 1 -type f -name '*.apk'");
+  });
+
+  it("addresses GitHub explicitly from the checkout-free release job", () => {
+    expect(workflow.match(/GH_REPO: \$\{\{ github\.repository \}\}/g)).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

- give checkout-free release jobs explicit GitHub repository context
- derive the APK name from the downloaded artifact instead of a secret-tainted job output
- lock both failure modes into the mobile release workflow contract

## Root cause

The tag build signed and verified the APK, but `attach-release` ran outside a checkout without `GH_REPO`, so `gh release view` could not resolve a repository. GitHub also suppressed the `apk-name` job output after the secret-backed signing job, leaving the attachment name empty.

## Validation

- live repro: `gh release view` outside a checkout fails without `GH_REPO` and succeeds with it
- mobile tests: 17/17
- mobile typecheck
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790141284&installation_model_id=20659&pr_number=4346&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4346&signature=2670f0d05a737cea8b4421910c3a20fbf53122f3b59fd197af1e6be1b73f4c99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->