### PR TITLE
fix(redskilled): complete supervised handover

### DIFF
--- a/.changeset/close-redskilled-before-handover.md
+++ b/.changeset/close-redskilled-before-handover.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Complete supervised daemon handovers when the final active client socket closes synchronously.

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -2180,13 +2180,13 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     await resourceLeaseStore.flush().catch(() => undefined);
     await acpControlPlane?.close().catch(() => undefined);
     // Ownership records go first while the socket still proves this daemon is
-    // reachable. If either release stalls or fails, the old daemon stays bound
-    // and no successor mistakes a live, socketless pid for the singleton.
+    // reachable. The close callback is registered before active clients are
+    // destroyed, so a synchronous final `close` cannot strand the successor.
     await leaseStore.release(owner);
     await machineClaimStore.release(machineOwner);
-    server.close();
+    const serverClosed = new Promise<void>((resolve) => server.close(() => resolve()));
     for (const socket of activeSockets) socket.destroy();
-    await new Promise<void>((resolve) => server.once("close", () => resolve()));
+    await serverClosed;
     await rm(paths.socketPath, { force: true });
     resolveClosed();
     return await closed;

--- a/apps/redskilled/tests/daemon-stop-ownership-order.test.ts
+++ b/apps/redskilled/tests/daemon-stop-ownership-order.test.ts
@@ -1,8 +1,10 @@
 // A stop must surrender its lease before its socket. The reverse order creates
 // a live, socketless lease holder that refuses every supervised successor.
 import { mkdtemp, rm } from "node:fs/promises";
+import { connect } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { once } from "node:events";
 import { afterEach, describe, expect, it } from "vitest";
 import { socketAnswers, startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import { resolveRedskilledPaths } from "../src/paths.js";
@@ -17,6 +19,27 @@ afterEach(async () => {
 });
 
 describe("redskilled stop ownership order", () => {
+  it("finishes after closing an active client connection", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-stop-connected-"));
+    roots.push(root);
+    const paths = resolveRedskilledPaths({
+      env: { REDSKILLED_SESSION: `test:${root}`, REDSKILLED_MACHINE_DIR: root },
+      runtimeDir: root,
+    });
+    const daemon = await startRedskilledDaemon({ paths });
+    const client = connect(paths.socketPath);
+    await once(client, "connect");
+
+    const stopped = daemon.stop().then(() => "stopped");
+    const outcome = await Promise.race([
+      stopped,
+      new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 250)),
+    ]);
+
+    client.destroy();
+    expect(outcome).toBe("stopped");
+  });
+
   it("keeps the socket bound until the lease is released", async () => {
     const root = await mkdtemp(join(tmpdir(), "redskilled-stop-order-"));
     roots.push(root);


### PR DESCRIPTION
## Outcome

A supervised redskilled upgrade can no longer become socketless when its final active client closes during shutdown.

## Root cause

The daemon registered its `close` listener only after calling `server.close()` and destroying active sockets. Node can emit `close` synchronously while the final socket is destroyed, so the handover awaited an event it had already missed. The incumbent had released its lease and socket but never reached the supervisor exit.

## Fix

Register the close promise before closing the server or clients, preserving the existing lease-before-socket ownership order.

## Proof

- Regression test reproduces an active client during shutdown; it hung before the fix and completes afterward.
- `daemon-stop-ownership-order.test.ts`: 2/2
- `self-replacement.test.ts`: 30/30
- redskilled typecheck
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790144244&installation_model_id=20659&pr_number=4351&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4351&signature=d5c9d1878c0eb673ae8d59fb513f8d2ec4b79c01bb96428e4d4367607b29cb9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->