### PR TITLE
fix(mcp): prefer red-dev current package set

### DIFF
--- a/.changeset/bright-mcps-prefer-current.md
+++ b/.changeset/bright-mcps-prefer-current.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/red-skills": patch
+---
+
+Start `rs_dev`, `rs_memory`, and `rs_brain` from red-dev's verified current package set before consulting a source checkout or plugin cache.

--- a/apps/plugin-dev/tests/mcp-installed-set-precedence.test.ts
+++ b/apps/plugin-dev/tests/mcp-installed-set-precedence.test.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+const PLUGINS = ["dev", "memory", "brain"] as const;
+
+async function writeLauncher(root: string, plugin: (typeof PLUGINS)[number], identity: string): Promise<void> {
+  if (plugin === "dev") {
+    await mkdir(join(root, "hooks"), { recursive: true });
+    await writeFile(join(root, "hooks/redskilled-mcp.sh"), `#!/usr/bin/env bash\nprintf '${identity}\\n'\n`);
+    return;
+  }
+
+  await mkdir(join(root, ".claude-plugin"), { recursive: true });
+  await mkdir(join(root, "scripts"), { recursive: true });
+  await writeFile(join(root, ".claude-plugin/plugin.json"), '{"version":"test"}\n');
+  await writeFile(join(root, "scripts/bootstrap.mjs"), `process.stdout.write("${identity}\\n");\n`);
+}
+
+describe("Plugin MCP launchers prefer red-dev's verified current package set", () => {
+  for (const plugin of PLUGINS) {
+    it(`does not let a stale ${plugin} source checkout shadow the installed set`, async () => {
+      const sandbox = await mkdtemp(join(tmpdir(), `rs-${plugin}-installed-set-`));
+      const home = join(sandbox, "home");
+      const cwd = join(sandbox, "stale-checkout");
+      const installed = join(home, ".red/skills/current/plugins", plugin);
+      const stale = join(cwd, "plugins", plugin);
+      await writeLauncher(installed, plugin, `current-${plugin}`);
+      await writeLauncher(stale, plugin, `stale-${plugin}`);
+
+      const manifest = JSON.parse(
+        await readFile(join(ROOT, "plugins", plugin, ".mcp.json"), "utf8"),
+      ) as { mcpServers: Record<string, { command: string; args: string[] }> };
+      const declaration = Object.values(manifest.mcpServers)[0];
+      const launched = spawnSync(declaration.command, declaration.args, {
+        cwd,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CLAUDE_PLUGIN_ROOT: "",
+          CODEX_PLUGIN_ROOT: "",
+          HOME: home,
+        },
+      });
+      await rm(sandbox, { force: true, recursive: true });
+
+      expect(launched.status, launched.stderr).toBe(0);
+      expect(launched.stdout).toBe(`current-${plugin}\n`);
+    });
+  }
+});

--- a/packaging/pi/brain/.mcp.json
+++ b/packaging/pi/brain/.mcp.json
@@ -4,7 +4,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/brain\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/brain\" \"$HOME/.codex/plugins/cache/red-skills/brain\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'rs_brain: could not locate brain plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; installed=\"$HOME/.red/skills/current/plugins/brain\"; if [ -f \"$installed/.claude-plugin/plugin.json\" ]; then root=\"$installed\"; elif [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/brain\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/brain\" \"$HOME/.codex/plugins/cache/red-skills/brain\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'rs_brain: could not locate brain plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
       ]
     }
   }

--- a/packaging/pi/dev/.mcp.json
+++ b/packaging/pi/dev/.mcp.json
@@ -4,7 +4,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; for launcher in \"$root/hooks/redskilled-mcp.sh\" \"$PWD/plugins/dev/hooks/redskilled-mcp.sh\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/dev/hooks/redskilled-mcp.sh\"; do if [ -f \"$launcher\" ]; then exec bash \"$launcher\"; fi; done; printf 'rs_dev: could not locate the rs_dev MCP launcher\\n' >&2; exit 1"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; for launcher in \"$HOME/.red/skills/current/plugins/dev/hooks/redskilled-mcp.sh\" \"$root/hooks/redskilled-mcp.sh\" \"$PWD/plugins/dev/hooks/redskilled-mcp.sh\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/dev/hooks/redskilled-mcp.sh\"; do if [ -f \"$launcher\" ]; then exec bash \"$launcher\"; fi; done; printf 'rs_dev: could not locate the rs_dev MCP launcher\\n' >&2; exit 1"
       ]
     }
   }

--- a/packaging/pi/memory/.mcp.json
+++ b/packaging/pi/memory/.mcp.json
@@ -4,7 +4,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/memory\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/memory\" \"$HOME/.codex/plugins/cache/red-skills/memory\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'rs_memory: could not locate memory plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; installed=\"$HOME/.red/skills/current/plugins/memory\"; if [ -f \"$installed/.claude-plugin/plugin.json\" ]; then root=\"$installed\"; elif [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/memory\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/memory\" \"$HOME/.codex/plugins/cache/red-skills/memory\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'rs_memory: could not locate memory plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
       ]
     }
   }

--- a/plugins/brain/.mcp.json
+++ b/plugins/brain/.mcp.json
@@ -4,7 +4,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/brain\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/brain\" \"$HOME/.codex/plugins/cache/red-skills/brain\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'rs_brain: could not locate brain plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; installed=\"$HOME/.red/skills/current/plugins/brain\"; if [ -f \"$installed/.claude-plugin/plugin.json\" ]; then root=\"$installed\"; elif [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/brain\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/brain\" \"$HOME/.codex/plugins/cache/red-skills/brain\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'rs_brain: could not locate brain plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
       ]
     }
   }

--- a/plugins/dev/.mcp.json
+++ b/plugins/dev/.mcp.json
@@ -4,7 +4,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; for launcher in \"$root/hooks/redskilled-mcp.sh\" \"$PWD/plugins/dev/hooks/redskilled-mcp.sh\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/dev/hooks/redskilled-mcp.sh\"; do if [ -f \"$launcher\" ]; then exec bash \"$launcher\"; fi; done; printf 'rs_dev: could not locate the rs_dev MCP launcher\\n' >&2; exit 1"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; for launcher in \"$HOME/.red/skills/current/plugins/dev/hooks/redskilled-mcp.sh\" \"$root/hooks/redskilled-mcp.sh\" \"$PWD/plugins/dev/hooks/redskilled-mcp.sh\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/dev/hooks/redskilled-mcp.sh\"; do if [ -f \"$launcher\" ]; then exec bash \"$launcher\"; fi; done; printf 'rs_dev: could not locate the rs_dev MCP launcher\\n' >&2; exit 1"
       ]
     }
   }

--- a/plugins/memory/.mcp.json
+++ b/plugins/memory/.mcp.json
@@ -4,7 +4,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; if [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/memory\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/memory\" \"$HOME/.codex/plugins/cache/red-skills/memory\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'rs_memory: could not locate memory plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
+        "root=\"${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-}}\"; installed=\"$HOME/.red/skills/current/plugins/memory\"; if [ -f \"$installed/.claude-plugin/plugin.json\" ]; then root=\"$installed\"; elif [ -z \"$root\" ]; then for candidate in \"$PWD/plugins/memory\" \"$HOME/.codex/.tmp/marketplaces/red-skills/plugins/memory\" \"$HOME/.codex/plugins/cache/red-skills/memory\"/*; do if [ -f \"$candidate/.claude-plugin/plugin.json\" ]; then root=\"$candidate\"; break; fi; done; fi; if [ -z \"$root\" ] || [ ! -f \"$root/scripts/bootstrap.mjs\" ]; then printf 'rs_memory: could not locate memory plugin root; install or rebuild the plugin first\\n' >&2; exit 1; fi; exec node \"$root/scripts/bootstrap.mjs\" mcp"
       ]
     }
   }


### PR DESCRIPTION
## Summary

- prefer `~/.red/skills/current` before a source checkout for `rs_dev`, `rs_memory`, and `rs_brain`
- keep plugin-root, checkout, cache, and standalone fallbacks intact when no red-dev package set exists
- regenerate the Pi package mirrors
- add a regression harness for an old checkout shadowing a newer installed set

## Root cause

Codex does not always export `CODEX_PLUGIN_ROOT`. In a RedSkills checkout the manifest then selected `$PWD/plugins/<plugin>` first, so a stale primary checkout started 3.22.0 even though red-dev had verified and activated 4.2.3.

## Validation

- `pnpm --filter @reddb-io/dev test` — 474 files / 6102 tests
- `pnpm --filter @reddb-io/dev typecheck`
- `pnpm lint`
- `pnpm pi:packages:check`
- `bash scripts/validate-install-metadata.sh`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790149314&installation_model_id=20659&pr_number=4354&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4354&signature=dabce6ccebfa69742bb0880564e68b64ce4ed9527979683a1109e7551d8e0e3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->