### PR TITLE
fix(link): stabilize published companion entry

### DIFF
--- a/.changeset/quiet-links-rest.md
+++ b/.changeset/quiet-links-rest.md
@@ -1,0 +1,6 @@
+---
+"@reddb-io/redskilled-mobile": patch
+---
+Fix the published Remote link command when package sets or npm invoke its
+companion through a symlink, and keep the supervised companion outside temporary
+npm caches.

--- a/apps/redskilled-link/src/cli.ts
+++ b/apps/redskilled-link/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { pathToFileURL } from "node:url";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { createRedskillsOperatorAcpClient } from "@reddb-io/redskilled/acp-operator-client";
 import { encodeInvitation, encodeInvitationUri } from "@reddb-io/red-skills-link-protocol/crypto";
@@ -69,7 +70,8 @@ function value(args: readonly string[], name: string): string | undefined {
   return at < 0 ? undefined : args[at + 1];
 }
 
-const invokedDirectly = process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href;
+const invokedDirectly = process.argv[1] != null &&
+  realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
 if (invokedDirectly) {
   runRedskilledLinkCli(process.argv.slice(2)).then(
     (code) => { process.exitCode = code; },

--- a/apps/redskilled-link/src/supervision.ts
+++ b/apps/redskilled-link/src/supervision.ts
@@ -1,13 +1,30 @@
 import { spawnSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
+
+import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
 
 export const REDSKILLED_LINK_UNIT_NAME = "redskilled-link.service";
 
 export interface RedskilledLinkEntry {
   readonly command: string;
   readonly args: readonly string[];
+}
+
+export interface CurrentRedskilledLinkEntryOptions {
+  readonly scriptPath?: string;
+  readonly execPath?: string;
+  readonly execArgv?: readonly string[];
+  readonly homeDir?: string;
 }
 
 export interface RedskilledLinkUnitPlan {
@@ -38,13 +55,50 @@ export function redskilledLinkUnitPath(env: NodeJS.ProcessEnv = process.env): st
   return join(configHome, "systemd", "user", REDSKILLED_LINK_UNIT_NAME);
 }
 
-export function currentRedskilledLinkEntry(): RedskilledLinkEntry {
-  const script = process.argv[1];
+export function currentRedskilledLinkEntry(
+  options: CurrentRedskilledLinkEntryOptions = {},
+): RedskilledLinkEntry {
+  const script = options.scriptPath ?? process.argv[1];
   if (!script) throw new Error("redskilled-link cannot supervise an entry with no script path");
+  const resolvedScript = resolve(script);
   return {
-    command: process.execPath,
-    args: [...process.execArgv, resolve(script)],
+    command: options.execPath ?? process.execPath,
+    args: [
+      ...(options.execArgv ?? process.execArgv),
+      resolvedScript.endsWith(".bundle.min.mjs")
+        ? stabilizePublishedBundle(resolvedScript, options.homeDir ?? homedir())
+        : resolvedScript,
+    ],
   };
+}
+
+function stabilizePublishedBundle(source: string, homeDir: string): string {
+  const bytes = readFileSync(source);
+  const digest = createHash("sha256").update(bytes).digest("hex").slice(0, 16);
+  const binDir = join(redskilledHomeDir(homeDir), "bin");
+  const stable = join(binDir, `redskilled-link-${digest}.bundle.min.mjs`);
+  mkdirSync(binDir, { recursive: true, mode: 0o700 });
+
+  const existing = readFileIfPresent(stable);
+  if (existing && createHash("sha256").update(existing).digest("hex").startsWith(digest)) return stable;
+
+  const temporary = `${stable}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporary, bytes, { flag: "wx", mode: 0o600 });
+    renameSync(temporary, stable);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+  return stable;
+}
+
+function readFileIfPresent(path: string): Buffer | undefined {
+  try {
+    return readFileSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
 }
 
 export function planRedskilledLinkUnit(options: {

--- a/apps/redskilled-link/tests/onboarding.test.ts
+++ b/apps/redskilled-link/tests/onboarding.test.ts
@@ -1,11 +1,11 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { decodeInvitation } from "@reddb-io/red-skills-link-protocol/crypto";
 import { runRedskilledLinkOnboarding } from "../src/onboarding.js";
-import { planRedskilledLinkUnit } from "../src/supervision.js";
+import { currentRedskilledLinkEntry, planRedskilledLinkUnit } from "../src/supervision.js";
 
 const roots: string[] = [];
 afterEach(async () => {
@@ -75,6 +75,26 @@ describe("redskilled link onboarding", () => {
 });
 
 describe("redskilled-link user unit", () => {
+  it("copies a cache-resident companion to the durable daemon bin before supervising it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-link-stable-entry-"));
+    roots.push(root);
+    const cacheEntry = join(root, "temporary-npx-cache", "redskilled-link.bundle.min.mjs");
+    await mkdir(join(root, "temporary-npx-cache"), { recursive: true });
+    await writeFile(cacheEntry, "export const bundle = 'one';");
+
+    const entry = currentRedskilledLinkEntry({
+      scriptPath: cacheEntry,
+      execPath: "/usr/bin/node",
+      execArgv: [],
+      homeDir: root,
+    });
+
+    expect(entry.command).toBe("/usr/bin/node");
+    expect(entry.args).toHaveLength(1);
+    expect(entry.args[0]).toMatch(new RegExp(`^${root}/\\.red/redskilled/bin/redskilled-link-[a-f0-9]{16}\\.bundle\\.min\\.mjs$`));
+    await expect(readFile(entry.args[0]!, "utf8")).resolves.toBe("export const bundle = 'one';");
+  });
+
   it("keeps the companion alive without putting relay credentials in ExecStart", () => {
     const plan = planRedskilledLinkUnit({
       entry: { command: "/usr/bin/node", args: ["/opt/redskilled-link.bundle.min.mjs"] },

--- a/apps/redskilled-link/tests/published-entry.test.ts
+++ b/apps/redskilled-link/tests/published-entry.test.ts
@@ -1,0 +1,40 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const appRoot = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const repoRoot = resolve(appRoot, "..", "..");
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("the published redskilled-link entry", () => {
+  it("routes the CLI when invoked through an installed-current symlink", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-link-entry-"));
+    roots.push(root);
+    const real = join(root, "sets", "4.2.7", "dist", "redskilled-link.bundle.min.mjs");
+    await mkdir(dirname(real), { recursive: true });
+    execFileSync(process.execPath, [
+      join(repoRoot, "scripts", "bundle-app.mjs"),
+      "--entry", join(appRoot, "src", "cli.ts"),
+      "--outfile", real,
+      "--asset", "redskilled-link.bundle.min.mjs",
+      "--minify",
+    ], { cwd: appRoot, stdio: "pipe" });
+    const current = join(root, "current");
+    await symlink(join(root, "sets", "4.2.7"), current, "dir");
+
+    const invoked = spawnSync(process.execPath, [
+      join(current, "dist", "redskilled-link.bundle.min.mjs"),
+      "onboard", "--transport", "wireguard",
+    ], { encoding: "utf8" });
+
+    expect(invoked.status).toBe(2);
+    expect(invoked.stdout).toContain("WireGuard transport is not available in this build");
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary
- route the published Link companion correctly through npm/package-set symlinks
- copy the supervised bundle into the durable redskilled bin instead of retaining an ephemeral npm cache path
- cover both boundaries with black-box regressions

## Validation
- `pnpm --filter @reddb-io/redskilled-link test` (11/11)
- `pnpm --filter @reddb-io/redskilled-link run build`
- `pnpm --filter @reddb-io/redskilled run bundle`
- focused oxlint and workspace changeset validation
- `toon-json-guard.test.ts` (10/10)
- generated daemon bundle: `link --transport wireguard` exits 2 with the expected diagnostic

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790190159&installation_model_id=20659&pr_number=4361&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4361&signature=b9a502eeb5a71a44b359d5c5f671bc09ca9034f3eaaea6d79138e46b11cf86e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->