### PR TITLE
fix(redskilled): run through package set symlinks

### DIFF
--- a/.changeset/brave-entries-rest.md
+++ b/.changeset/brave-entries-rest.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+Run the daemon CLI when an active package-set symlink invokes its published
+bundle, including the short `redskilled link` launcher installed by red-dev.

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -8,9 +8,11 @@
  * bundle versions. A path it needs is a path it was given.
  */
 import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { defaultLaunchProbe } from "./launch-probe.js";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { encode as encodeToon } from "@reddb-io/toon";
 import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
 import { parseFlags, routeCommand } from "@reddb-io/shared/args.js";
@@ -913,7 +915,7 @@ function servePaths(values: {
 }
 
 const invokedDirectly = process.argv[1] != null &&
-  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+  realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
 
 if (invokedDirectly) {
   const argv = process.argv.slice(2);

--- a/apps/redskilled/tests/shipped-artifact.test.ts
+++ b/apps/redskilled/tests/shipped-artifact.test.ts
@@ -9,10 +9,9 @@
 // off the artifact's name still names it, and the EXECUTABLE half builds the
 // bundle and starts a daemon from it, because a present artifact that throws on
 // load is the same outage as an absent one.
-import { spawn, type ChildProcess } from "node:child_process";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -39,8 +38,9 @@ describe("redskilled ships as a bundled artifact", () => {
     const pkg = JSON.parse(readFileSync(join(APP, "package.json"), "utf8")) as {
       scripts?: Record<string, string>;
     };
-    const bundle = pkg.scripts?.bundle;
-    expect(bundle, "apps/redskilled must declare a `bundle` script — without it `pnpm bundle` skips the app entirely").toBeTruthy();
+    const aggregate = pkg.scripts?.bundle;
+    const bundle = pkg.scripts?.["bundle:daemon"];
+    expect(aggregate, "apps/redskilled must declare a `bundle` script — without it `pnpm bundle` skips the app entirely").toContain("bundle:daemon");
     expect(bundle).toContain("--entry src/cli.ts");
     expect(bundle).toContain(`--outfile ../../dist/${REDSKILLED_BUNDLE_ASSET}`);
     expect(bundle).toContain(`--asset ${REDSKILLED_BUNDLE_ASSET}`);
@@ -57,6 +57,30 @@ describe("redskilled ships as a bundled artifact", () => {
     expect(existsSync(SHIM)).toBe(true);
     expect(readFileSync(SHIM, "utf8")).toContain(REDSKILLED_BUNDLE_ASSET);
   });
+
+  it("runs when the active package set reaches the bundle through a symlink", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-current-entry-"));
+    roots.push(root);
+    const real = join(root, "sets", "4.2.8", "dist", REDSKILLED_BUNDLE_ASSET);
+    await mkdir(join(root, "sets", "4.2.8", "dist"), { recursive: true });
+    execFileSync(process.execPath, [
+      join(ROOT, "scripts", "bundle-app.mjs"),
+      "--entry", join(APP, "src", "cli.ts"),
+      "--outfile", real,
+      "--asset", REDSKILLED_BUNDLE_ASSET,
+      "--minify",
+      "--reddb-from-package",
+    ], { cwd: APP, stdio: "pipe" });
+    const current = join(root, "current");
+    await symlink(join(root, "sets", "4.2.8"), current, "dir");
+
+    const invoked = spawnSync(process.execPath, [join(current, "dist", REDSKILLED_BUNDLE_ASSET), "--version"], {
+      encoding: "utf8",
+    });
+
+    expect(invoked.status).toBe(0);
+    expect(invoked.stdout).toContain("redskilled 4.2.8");
+  }, 30_000);
 
   it("names the bundle as the daemon entry a spawn invokes, never the caller's own file", () => {
     const lookup = { execPath: "/usr/bin/node", execArgv: [], env: {}, listDir: () => [] };


### PR DESCRIPTION
## Summary
- realpath the daemon CLI entry guard so `~/.red/skills/current` invokes the bundle
- cover the exact active-package-set symlink boundary with a black-box bundle test
- align the existing shipped-artifact assertion with the split daemon/statusline bundle scripts

## Validation
- shipped artifact suite: 5/5
- redskilled typecheck
- focused oxlint
- changeset validation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790191957&installation_model_id=20659&pr_number=4363&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4363&signature=8f57cd1efe328cf29e55a50083d6324b6947ff5100fcc6ad162bbc1a01d32bf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->