### PR TITLE
feat(link): project a non-sensitive public pairing status beside the private state

### DIFF
--- a/.changeset/link-public-status-projection.md
+++ b/.changeset/link-public-status-projection.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-link": patch
+---
+
+The link Host projects a non-sensitive `status.json` (schema version and active paired-device count only) beside its private state, so host-side surfaces can show pairing presence without reading secrets; the private state loader now validates every invitation and device record instead of only the top-level shape.

--- a/apps/redskilled-link/src/state.ts
+++ b/apps/redskilled-link/src/state.ts
@@ -17,6 +17,11 @@ export interface LinkDeviceRecord {
   readonly nonces: readonly string[];
 }
 
+export interface RedskilledLinkPublicStatus {
+  readonly version: 1;
+  readonly active_paired_device_count: number;
+}
+
 interface LinkInvitationRecord extends RedskilledLinkInvitation {
   readonly used_at?: string;
 }
@@ -44,13 +49,19 @@ export function defaultLinkStatePath(homeDir = homedir()): string {
   return join(redskilledHomeDir(homeDir), "link", "state.toon");
 }
 
+export function defaultLinkStatusPath(homeDir = homedir()): string {
+  return join(redskilledHomeDir(homeDir), "link", "status.json");
+}
+
 export function createRedskilledLinkStateStore(options: {
   readonly path?: string;
+  readonly statusPath?: string;
   readonly relayUrl?: string;
   readonly hostName?: string;
   readonly now?: () => Date;
 }): RedskilledLinkStateStore {
   const path = options.path ?? defaultLinkStatePath();
+  const statusPath = options.statusPath ?? join(dirname(path), "status.json");
   const now = options.now ?? (() => new Date());
   const initial = (): LinkState => {
     const relayUrl = options.relayUrl?.trim();
@@ -74,7 +85,10 @@ export function createRedskilledLinkStateStore(options: {
       return initial();
     }
   };
-  const mutate = async <T>(operation: (state: LinkState) => readonly [LinkState, T]): Promise<T> => {
+  const mutate = async <T>(
+    operation: (state: LinkState) => readonly [LinkState, T],
+    publishStatus = false,
+  ): Promise<T> => {
     await mkdir(dirname(path), { recursive: true, mode: 0o700 });
     const lock = `${path}.lock`;
     let held;
@@ -93,6 +107,9 @@ export function createRedskilledLinkStateStore(options: {
       const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
       await writeFile(temporary, encodeWireFrame(next, "toon"), { mode: 0o600 });
       await rename(temporary, path);
+      // This projection is advisory. A failed public-status write must never
+      // turn an already-committed pairing into a client-visible error.
+      if (publishStatus) await writePublicStatus(statusPath, next).catch(() => undefined);
       return answer;
     } finally {
       await held.close();
@@ -101,7 +118,7 @@ export function createRedskilledLinkStateStore(options: {
   };
   return {
     async identity() {
-      const state = await mutate((current) => [current, current]);
+      const state = await mutate((current) => [current, current], true);
       return { host_id: state.host_id, host_name: state.host_name, relay_url: state.relay_url };
     },
     async configure(config) {
@@ -125,7 +142,7 @@ export function createRedskilledLinkStateStore(options: {
           expires_at: new Date(now().getTime() + ttlMs).toISOString(),
         };
         return [{ ...state, invitations: [...state.invitations, invitation] }, invitation];
-      });
+      }, true);
     },
     async invitation(inviteId) {
       const state = await read();
@@ -150,7 +167,7 @@ export function createRedskilledLinkStateStore(options: {
             : invite),
           devices: [...state.devices.filter((entry) => entry.device_id !== device.device_id), paired],
         }, undefined];
-      });
+      }, true);
     },
     async device(deviceId) {
       return (await read()).devices.find((device) => device.device_id === deviceId && !device.revoked);
@@ -170,9 +187,45 @@ export function createRedskilledLinkStateStore(options: {
   };
 }
 
+async function writePublicStatus(path: string, state: LinkState): Promise<void> {
+  const status: RedskilledLinkPublicStatus = {
+    version: 1,
+    active_paired_device_count: state.devices.filter((device) => !device.revoked).length,
+  };
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, `${JSON.stringify(status)}\n`, { mode: 0o600 });
+    await rename(temporary, path);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}
+
 function isLinkState(value: unknown): value is LinkState {
   if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
   const state = value as Record<string, unknown>;
   return state.version === 1 && typeof state.host_id === "string" && typeof state.host_name === "string" &&
-    typeof state.relay_url === "string" && Array.isArray(state.invitations) && Array.isArray(state.devices);
+    typeof state.relay_url === "string" && Array.isArray(state.invitations) &&
+    state.invitations.every(isLinkInvitationRecord) && Array.isArray(state.devices) &&
+    state.devices.every(isLinkDeviceRecord);
+}
+
+function isLinkInvitationRecord(value: unknown): value is LinkInvitationRecord {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const invitation = value as Record<string, unknown>;
+  return invitation.version === 1 && typeof invitation.relay_url === "string" &&
+    typeof invitation.host_id === "string" && typeof invitation.host_name === "string" &&
+    typeof invitation.invite_id === "string" && typeof invitation.secret === "string" &&
+    typeof invitation.expires_at === "string" &&
+    (invitation.used_at === undefined || typeof invitation.used_at === "string");
+}
+
+function isLinkDeviceRecord(value: unknown): value is LinkDeviceRecord {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const device = value as Record<string, unknown>;
+  return typeof device.device_id === "string" && typeof device.device_name === "string" &&
+    typeof device.secret === "string" && typeof device.paired_at === "string" &&
+    typeof device.revoked === "boolean" && Array.isArray(device.nonces) &&
+    device.nonces.every((nonce) => typeof nonce === "string");
 }

--- a/apps/redskilled-link/tests/link-status.test.ts
+++ b/apps/redskilled-link/tests/link-status.test.ts
@@ -1,0 +1,106 @@
+// The private link state carries host and device secrets; the public status
+// file exists so host-side surfaces can show "is anything paired?" without
+// ever being handed that state. These tests close the dead end where the
+// projection leaks private material or where a broken projection path breaks
+// pairing itself.
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createRedskilledLinkStateStore,
+  defaultLinkStatusPath,
+  type RedskilledLinkPublicStatus,
+} from "../src/state.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("public link status", () => {
+  it("uses the public status path beside the default private state", () => {
+    expect(defaultLinkStatusPath("/home/tester")).toBe("/home/tester/.red/redskilled/link/status.json");
+  });
+
+  it("atomically projects only the active paired-device count with owner-only permissions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-link-status-"));
+    roots.push(root);
+    const statePath = join(root, "private-state.toon");
+    const statusPath = join(root, "status.json");
+    const state = createRedskilledLinkStateStore({
+      path: statePath,
+      relayUrl: "wss://relay.example/private",
+      hostName: "Sensitive Host Name",
+    });
+
+    await state.identity();
+    const initial: RedskilledLinkPublicStatus = JSON.parse(await readFile(statusPath, "utf8"));
+    expect(initial).toEqual({ version: 1, active_paired_device_count: 0 });
+    expect((await stat(statusPath)).mode & 0o777).toBe(0o600);
+
+    const invitation = await state.createInvitation();
+    await state.pair(invitation.invite_id, {
+      device_id: "private-device-id",
+      device_name: "Private Phone Name",
+      secret: "private-device-secret",
+    });
+
+    const rendered = await readFile(statusPath, "utf8");
+    expect(JSON.parse(rendered)).toEqual({ version: 1, active_paired_device_count: 1 });
+    expect(rendered).not.toContain("private");
+    expect(Object.keys(JSON.parse(rendered))).toEqual(["version", "active_paired_device_count"]);
+
+    const statusStat = await stat(statusPath);
+    await state.acceptNonce("private-device-id", "nonce-1");
+    const statusAfterNonce = await stat(statusPath);
+    expect(statusAfterNonce.ino).toBe(statusStat.ino);
+    expect(statusAfterNonce.mtimeMs).toBe(statusStat.mtimeMs);
+  });
+
+  it("replaces malformed private state with a non-sensitive initial snapshot", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-link-malformed-status-"));
+    roots.push(root);
+    const statePath = join(root, "state.toon");
+    await writeFile(statePath, JSON.stringify({
+      version: 1,
+      host_id: "private-host-id",
+      host_name: "Private Host",
+      relay_url: "wss://private.example",
+      invitations: [],
+      devices: [{ revoked: false, secret: "malformed private secret material" }],
+    }), { mode: 0o600 });
+    const state = createRedskilledLinkStateStore({
+      path: statePath,
+      relayUrl: "wss://replacement.example",
+      hostName: "Replacement Host",
+    });
+
+    await state.identity();
+    const rendered = await readFile(join(root, "status.json"), "utf8");
+    expect(JSON.parse(rendered)).toEqual({ version: 1, active_paired_device_count: 0 });
+    expect(rendered).not.toContain("secret");
+  });
+
+  it("does not let an unavailable status path break pairing state", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-link-status-failure-"));
+    roots.push(root);
+    const blocked = join(root, "not-a-directory");
+    await writeFile(blocked, "blocked");
+    const state = createRedskilledLinkStateStore({
+      path: join(root, "state.toon"),
+      statusPath: join(blocked, "status.json"),
+      relayUrl: "wss://relay.example",
+    });
+
+    const invitation = await state.createInvitation();
+    await expect(state.pair(invitation.invite_id, {
+      device_id: "device-id",
+      device_name: "Phone",
+      secret: "device-secret",
+    })).resolves.toBeUndefined();
+    await expect(state.device("device-id")).resolves.toMatchObject({ revoked: false });
+  });
+});


### PR DESCRIPTION
## What

Ports the surviving pieces of the maintainer's uncommitted QR-pairing draft onto the landed onboarding flow (#4359 already shipped the scanner, the terminal QR, and `invite --qr`; this PR carries what that landing dropped):

- **Public status projection**: the link Host writes `~/.red/redskilled/link/status.json` — schema version and active paired-device count only — atomically (temp+rename), `0600`, on every mutation that can change it (`identity`, `createInvitation`, `pair`). The write is advisory: a failed projection never turns a committed pairing into a client-visible error. A reader lands with the mobile/link observability wave.
- **Strict state validation**: `isLinkState` now validates every invitation and device record, so a malformed private snapshot is replaced with a fresh one instead of being half-trusted.

## Tests

`apps/redskilled-link/tests/link-status.test.ts` — 4 cases: default path shape; projection carries only the two public fields with owner-only permissions and no private material; malformed private state re-initializes without leaking; an unavailable status path cannot break pairing. Full `redskilled-link` suite: 15/15, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790196733&installation_model_id=20659&pr_number=4365&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4365&signature=42a1cebc8c2ebe4f76f4897ccf151929403c1879c7c8d9afb5168e5e3c6b3259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->