### PR TITLE
fix(dev): the rs_dev drain enriches from the session's project root, not the launcher's cwd

### DIFF
--- a/.changeset/drain-enrich-session-root.md
+++ b/.changeset/drain-enrich-session-root.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+The rs_dev drain builds its registration from the session's resolved project root instead of the MCP launcher's working directory, and refuses loudly when that root cannot be resolved — a drain without a registration would record intent nothing acts on.

--- a/apps/plugin-dev/src/mcp-server.ts
+++ b/apps/plugin-dev/src/mcp-server.ts
@@ -26,7 +26,7 @@ import { createRsGithubMcpServer, RS_GITHUB_REQUEST_METHOD } from "./mcp-github/
 const buildInfo = readBuildInfo("redskilled-mcp");
 
 export function createRedskilledMcpServer(
-  root = process.cwd(),
+  root: string | (() => string | Promise<string>) = process.cwd(),
   acpInvoke?: (method: string, input: Record<string, unknown>) => Promise<unknown>,
 ): McpServer {
   const server = new McpServer({ name: RS_DEV_MCP_SERVER_NAME, version: buildInfo.version });
@@ -56,10 +56,24 @@ export function createRedskilledMcpServer(
   // Since #4293 the same seam also completes an UNDERSPECIFIED drain from the
   // project's `afk.standing` declaration, so `drain` with no runner argument
   // runs the executor the repository declared rather than the governed default.
-  const enrich = (tool: string, input: Record<string, unknown>): Record<string, unknown> =>
-    tool === "drain" && input.registration == null
-      ? drainInputFor(root, buildInfo.version, input)
-      : input;
+  // The root may be a SUPPLIER: the ACP session binds to the resolved project
+  // root, and a registration built from this process's launch cwd instead names
+  // the wrong checkout — `repositoryOf` then fails and the drain silently
+  // records intent without a registration (#4101's shape, reopened live).
+  const resolveRoot = async (): Promise<string> => (typeof root === "string" ? root : await root());
+  const enrich = async (tool: string, input: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    if (tool !== "drain" || input.registration != null) return input;
+    let resolved: string;
+    try {
+      resolved = await resolveRoot();
+    } catch (error) {
+      throw new Error(
+        `rs_dev drain cannot build its registration: the session's project root did not resolve (${
+          error instanceof Error ? error.message : String(error)}); a drain without a registration would record intent nothing acts on, so it is refused instead`,
+      );
+    }
+    return drainInputFor(resolved, buildInfo.version, input);
+  };
   for (const tool of createCastleMcpTools(dependencies)) {
     registerTool(
       tool.name,
@@ -73,7 +87,7 @@ export function createRedskilledMcpServer(
           {
             type: "text" as const,
             text: encodeRedskilledMcpToon(
-              await invoke(tool.name, enrich(tool.name, input)),
+              await invoke(tool.name, await enrich(tool.name, input)),
             ),
           },
         ],
@@ -235,7 +249,7 @@ async function run(): Promise<void> {
       }));
     return projectPromise;
   };
-  server = createRedskilledMcpServer(fallbackRoot, async (method, input) =>
+  server = createRedskilledMcpServer(projectRoot, async (method, input) =>
     invokeProjectMcp(await project(), method, input));
   const close = () => {
     void server.close();

--- a/apps/plugin-dev/tests/drain-enrich-root.test.ts
+++ b/apps/plugin-dev/tests/drain-enrich-root.test.ts
@@ -1,0 +1,57 @@
+// A drain that carries no registration records intent nothing acts on (#4101),
+// and the registration is built from a ROOT. The dead end this closes: the MCP
+// server enriched from its own launch cwd while the ACP session bound to the
+// resolved project root, so a coder CLI launched from anywhere built the
+// registration against the wrong checkout, `repositoryOf` failed, and the
+// drain silently degraded to orphan intent.
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRedskilledMcpServer } from "../src/mcp-server.js";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+describe("drain enrichment resolves the session's project root", () => {
+  const close: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.all(close.splice(0).map((shutdown) => shutdown()));
+  });
+
+  async function serve(root: string | (() => string | Promise<string>)) {
+    const acpInvoke = vi.fn(async (method: string, input: Record<string, unknown>) => ({ method, input }));
+    const server = createRedskilledMcpServer(root, acpInvoke);
+    const client = new Client({ name: "drain-enrich-root-test", version: "1" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    close.push(() => client.close(), () => server.close());
+    return { client, acpInvoke };
+  }
+
+  it("builds the registration from the supplied session root, not the launcher's cwd", async () => {
+    const supplier = vi.fn(async () => ROOT);
+    const { client, acpInvoke } = await serve(supplier);
+
+    await client.callTool({ name: "drain", arguments: {} });
+
+    expect(supplier).toHaveBeenCalled();
+    const [, input] = acpInvoke.mock.calls[0] as [string, Record<string, unknown>];
+    const registration = input.registration as { workspace_path?: string } | undefined;
+    expect(registration?.workspace_path).toBe(ROOT);
+    expect(registration?.workspace_path).not.toBe(process.cwd());
+  });
+
+  it("a root supplier that rejects refuses the drain loudly instead of enriching from cwd", async () => {
+    const { client, acpInvoke } = await serve(() => {
+      throw new Error("no ACP session root");
+    });
+
+    const result = await client.callTool({ name: "drain", arguments: {} });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain("the session's project root did not resolve");
+    expect(acpInvoke).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Phase 2 slice 1 of the E2E-flow repair (root cause of the live `registrations: []` + `drainIntent: draining` state on the maintainer's host): the drain registration was built from the MCP process's launch cwd while the ACP session binds to the resolved project root. Launched from anywhere but the checkout, `repositoryOf` failed and `drainInputFor` silently returned the input without a registration — orphan intent the demand loop never acts on.

- `createRedskilledMcpServer` accepts `root` as a value or supplier; `run()` passes the same `projectRoot` resolver the ACP session uses.
- A supplier that rejects refuses the drain by name ("the session's project root did not resolve … so it is refused instead") instead of degrading to orphan intent.

## Tests

`apps/plugin-dev/tests/drain-enrich-root.test.ts`: the registration's `workspace_path` is the supplier's root (≠ `process.cwd()`); a rejecting supplier surfaces as a loud tool error and never reaches ACP. Typecheck clean; mcp-proxy-boundary / mcp-tool-surface / mcp-prompts suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790197509&installation_model_id=20659&pr_number=4368&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4368&signature=37a6d0499dfa4c0d85aa28eaa5c1937d49c42d61010bb84c5c8866791e89a6b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->