### PR TITLE
fix(redskilled): a v2 prompt drain registers, releases, and warns like the tool path

### DIFF
--- a/.changeset/v2-prompt-drain-parity.md
+++ b/.changeset/v2-prompt-drain-parity.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+A prompt-shaped project control turn on ACP v2 now rides the same bound control surface as the tool path: a drain registers before its intent is written, a stop releases the registration, the unregistered-drain warning fires, and a registration authored in the prompt's brace args reaches the daemon.

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -506,7 +506,7 @@ async function servePublicConnection(
           return invocation == null
             ? runV2PublicTurn(options, sessionJournal, sessions, active, params, upstream, () => attached)
             : runV2ProjectControlTurn(
-              sessions, params, upstream, invocation, projectControls, persistProjectControls, readProjectStatus,
+              sessions, params, upstream, invocation, { mutate: mutateProjectControl, read: readProjectStatus },
             );
         })
         .catch(() => {})

--- a/apps/redskilled/src/project-control.ts
+++ b/apps/redskilled/src/project-control.ts
@@ -328,6 +328,8 @@ export interface ProjectControlInvocation {
   readonly operation: ProjectControlCommand;
   readonly target?: number;
   readonly runner?: string;
+  /** A registration the caller authored with its drain; never invented here. */
+  readonly registration?: Readonly<Record<string, unknown>>;
 }
 
 const CONTROL_VERB: ReadonlyMap<string, ProjectControlCommand> = new Map([
@@ -357,10 +359,12 @@ export function coreProjectInvocation(prompt: unknown): ProjectControlInvocation
     ? args.target
     : undefined;
   const runner = typeof args.runner === "string" && args.runner.length > 0 ? args.runner : undefined;
+  const registration = record(args.registration);
   return {
     operation,
     ...(target == null ? {} : { target }),
     ...(runner == null ? {} : { runner }),
+    ...(registration == null ? {} : { registration }),
   };
 }
 
@@ -451,18 +455,27 @@ export async function runV2ProjectControlTurn(
   params: acpV2.PromptRequest,
   upstream: acpV2.AgentContext,
   invocation: ProjectControlInvocation,
-  projectControls: Map<string, ProjectControlState>,
-  persist: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>,
-  readStatus: (project: AcpProjectWorkspace) => Promise<ReturnType<typeof projectStatusSnapshot>>,
+  // The BOUND control surface, exactly as the v1 twin and the tool path get
+  // it. This turn briefly called `applyProjectControl` directly, so a v2
+  // prompt drain never registered, a stop never released, and the
+  // unregistered warning never fired — a fully silent revision bump (#4101).
+  control: {
+    readonly mutate: (
+      operation: ProjectControlOperation,
+      request: ProjectControlRequest,
+    ) => Promise<unknown>;
+    readonly read: (project: AcpProjectWorkspace) => Promise<ReturnType<typeof projectStatusSnapshot>>;
+  },
 ): Promise<void> {
   const session = sessions.get(params.sessionId);
   if (session == null) return;
   const operation = invocation.operation;
-  const control = operation === "status"
-    ? await readStatus(session.project)
-    : await applyProjectControl(session.project, operation, projectControls, persist, {
+  const answer = operation === "status"
+    ? await control.read(session.project)
+    : await control.mutate(operation, {
         target: invocation.target,
         runner: invocation.runner,
+        registration: invocation.registration,
       });
   await upstream.notify(acpV2.methods.client.session.update, {
     sessionId: params.sessionId,
@@ -484,7 +497,7 @@ export async function runV2ProjectControlTurn(
   await upstream.notify(acpV2.methods.client.session.update, {
     sessionId: params.sessionId,
     update: { sessionUpdate: "state_update", state: "idle", stopReason: "end_turn" },
-    _meta: { redskills: { authority: "redskilled", projectControl: control } },
+    _meta: { redskills: { authority: "redskilled", projectControl: answer } },
   });
 }
 

--- a/apps/redskilled/tests/unregistered-drain.test.ts
+++ b/apps/redskilled/tests/unregistered-drain.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   bindProjectControl,
+  coreProjectInvocation,
   projectIsRegistered,
   projectStatusSnapshot,
+  runV2ProjectControlTurn,
   UNREGISTERED_DRAIN_WARNING,
   type ProjectControlState,
 } from "../src/project-control.js";
@@ -219,5 +221,83 @@ describe("a drain says the same thing twice without failing", () => {
 
     await expect(mutateProjectControl("drain", { registration: { selector: "" } }))
       .rejects.toThrow(/the selector was empty/);
+  });
+});
+
+describe("a v2 prompt-shaped drain rides the same bound control surface", () => {
+  const upstream = () => {
+    const notifications: { method: unknown; params: Record<string, unknown> }[] = [];
+    return {
+      notifications,
+      context: {
+        notify: async (method: unknown, params: Record<string, unknown>) => {
+          notifications.push({ method, params });
+        },
+      } as never,
+    };
+  };
+
+  it("registers before the intent is written and answers with the same warning the tool path answers with", async () => {
+    const registered: Record<string, unknown>[] = [];
+    const controls = new Map<string, ProjectControlState>();
+    const { mutateProjectControl, readProjectStatus } = bindProjectControl({
+      scopedProject: () => project,
+      projectControls: controls,
+      persistProjectControls: async () => {},
+      hostState: () => hostState(false),
+      clock: () => "2026-08-19T20:00:00.000Z",
+      readGithubCustody: async () => null,
+      registerProject: (request) => registered.push({ ...request }),
+    });
+    const wire = upstream();
+
+    await runV2ProjectControlTurn(
+      new Map([["session-1", { project } as never]]),
+      { sessionId: "session-1", prompt: [] } as never,
+      wire.context,
+      { operation: "drain", target: 2, registration: { selector: "is:issue" } },
+      { mutate: mutateProjectControl, read: readProjectStatus },
+    );
+
+    expect(registered).toEqual([{ selector: "is:issue", project_label: "reddb-io/red-skills" }]);
+    const terminal = wire.notifications.at(-1)?.params as {
+      _meta?: { redskills?: { projectControl?: { warning?: string } } };
+    };
+    expect(terminal._meta?.redskills?.projectControl?.warning).toBe(UNREGISTERED_DRAIN_WARNING);
+  });
+
+  it("a v2 prompt stop releases the registration", async () => {
+    const released: string[] = [];
+    const { mutateProjectControl, readProjectStatus } = bindProjectControl({
+      scopedProject: () => project,
+      projectControls: new Map<string, ProjectControlState>(),
+      persistProjectControls: async () => {},
+      hostState: () => hostState(true),
+      clock: () => "2026-08-19T20:00:00.000Z",
+      readGithubCustody: async () => null,
+      releaseProject: (label) => released.push(label),
+    });
+    const wire = upstream();
+
+    await runV2ProjectControlTurn(
+      new Map([["session-1", { project } as never]]),
+      { sessionId: "session-1", prompt: [] } as never,
+      wire.context,
+      { operation: "stop" },
+      { mutate: mutateProjectControl, read: readProjectStatus },
+    );
+
+    expect(released).toEqual(["reddb-io/red-skills"]);
+  });
+
+  it("coreProjectInvocation lifts a registration out of the prompt's brace args", () => {
+    const invocation = coreProjectInvocation([
+      { type: "text", text: '/drain {"target": 1, "registration": {"selector": "is:issue"}}' },
+    ]);
+    expect(invocation).toEqual({
+      operation: "drain",
+      target: 1,
+      registration: { selector: "is:issue" },
+    });
   });
 });


### PR DESCRIPTION
## What

Phase 2 slice 2 of the E2E-flow repair. `runV2ProjectControlTurn` bypassed `bindProjectControl`'s `mutateProjectControl` and called `applyProjectControl` directly, so a prompt-shaped `/drain` on ACP v2: never registered (no Worker would ever be born), never released on stop, and never carried the `UNREGISTERED_DRAIN_WARNING` — a fully silent revision bump.

- The turn now receives the same bound `{mutate, read}` surface the v1 twin (`runV1ProjectControlTurn`) and the tool path use — register-before-intent, stop-releases, and the warning all come along for free.
- `coreProjectInvocation` lifts a caller-authored `registration` out of the prompt's brace args (`ProjectControlInvocation.registration`), so an ACP client that can author one is no longer silently stripped.

## Tests

Extended `apps/redskilled/tests/unregistered-drain.test.ts`: a v2 prompt drain registers before intent and answers with the same warning the tool path answers with (read from the terminal update's `_meta`); a v2 prompt stop releases the registration; `coreProjectInvocation` round-trips the registration. 24/24 across the three touched suites; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790197680&installation_model_id=20659&pr_number=4369&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4369&signature=9520a905f54937fa80e8d38a350a41d109c914fcdf61260d295c812cb127bec6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->