### PR TITLE
fix(dev): a declared standing drain registers standing intent and an unregisterable one is loud

### DIFF
--- a/.changeset/standing-drain-registers-standing.md
+++ b/.changeset/standing-drain-registers-standing.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+A drain resolved from a project's `afk.standing` declaration now registers with standing intent, so the registration survives daemon self-upgrade restarts instead of lapsing as a five-minute lease; a declaration that cannot register (no owner/name repository) warns the operator instead of failing silently.

--- a/apps/plugin-dev/src/core/drain-registration-resolve.ts
+++ b/apps/plugin-dev/src/core/drain-registration-resolve.ts
@@ -54,6 +54,11 @@ export function drainRegistrationFor(
     workspacePath: root,
     target,
     version,
+    // The declaration IS the standing intent: a repo that declares
+    // `afk.standing` wants its registration to survive daemon restarts, and
+    // the daemon restarts on every self-upgrade — a non-standing lease from a
+    // declared drain lapsed within one release-train tick.
+    ...(standing == null ? {} : { standing: true }),
     ...(runner == null ? {} : { runner }),
     ...(trunkBranch(root) == null ? {} : { trunkBranch: trunkBranch(root) }),
     ...(declared.length === 0 ? {} : { validationCommands: declared }),

--- a/apps/plugin-dev/src/core/drain-registration.ts
+++ b/apps/plugin-dev/src/core/drain-registration.ts
@@ -35,6 +35,14 @@ export interface DrainRegistrationInput {
   readonly runner?: string | undefined;
   /** The published version whose binary a birth reaches for (ADR 0091). */
   readonly version: string;
+  /**
+   * The project declared this drain as standing policy (`afk.standing`).
+   *
+   * The daemon keeps a standing registration recoverable across its own
+   * restarts — and it restarts on every self-upgrade, so a declared drain
+   * that omitted this lapsed within one release train tick.
+   */
+  readonly standing?: boolean | undefined;
   /** The label that defines "queued"; the executable lane's own by default. */
   readonly readyLabel?: string | undefined;
   /** The operator's declared wall-clock budget for this drain; absent = none. */
@@ -74,6 +82,14 @@ export interface DrainRegistration {
    */
   readonly budget_ms?: number;
   readonly target: number;
+  /**
+   * Standing intent, carried only when the project declared one.
+   *
+   * The daemon's boot recovery keeps a `standing` registration recoverable
+   * indefinitely; without it a registration is a five-minute lease that dies
+   * with the daemon's next self-upgrade restart.
+   */
+  readonly standing?: true;
 }
 
 /**
@@ -136,5 +152,6 @@ export function buildDrainRegistration(input: DrainRegistrationInput): DrainRegi
       : { validation_commands: [...input.validationCommands] }),
     ...(input.budgetMs == null ? {} : { budget_ms: input.budgetMs }),
     target: input.target,
+    ...(input.standing === true ? { standing: true } : {}),
   };
 }

--- a/apps/plugin-dev/src/runtime/standing-drain-start.ts
+++ b/apps/plugin-dev/src/runtime/standing-drain-start.ts
@@ -34,7 +34,7 @@ export type StandingDrainStartOutcome =
   /** The project declared something unusable; the operator was told. */
   | { readonly kind: "incomplete"; readonly detail: string }
   /** The checkout cannot name a repository, so there is no queue to register. */
-  | { readonly kind: "unregisterable" }
+  | { readonly kind: "unregisterable"; readonly detail: string }
   /** The declaration reached the daemon. */
   | { readonly kind: "registered"; readonly runner: string; readonly target: number }
   /** The declaration was read and the daemon refused or did not answer. */
@@ -81,8 +81,16 @@ export async function ensureStandingDrain(
   try {
     const input = (deps.input ?? drainInputFor)(root, deps.version, { runner, target });
     // A registration is what the daemon births from; a drain without one records
-    // an intent nobody polls for. Saying so beats sending it.
-    if (input.registration == null) return { kind: "unregisterable" };
+    // an intent nobody polls for. Saying so beats sending it — and saying it to
+    // the OPERATOR too: this outcome was silent, so a declaration that could
+    // not register looked identical to one that did.
+    if (input.registration == null) {
+      const detail = `redskilled MCP: ${root} declares a standing drain at ${runner} x${target}, ` +
+        "but this checkout names no owner/name repository, so there is no queue to register — " +
+        "the declaration registers nothing";
+      warn(detail);
+      return { kind: "unregisterable", detail };
+    }
     await deps.drain(input);
     return { kind: "registered", runner, target };
   } catch (error) {

--- a/apps/plugin-dev/tests/drain-registration-resolve.test.ts
+++ b/apps/plugin-dev/tests/drain-registration-resolve.test.ts
@@ -103,6 +103,26 @@ describe("what a drain that states nothing resolves", () => {
     expect((input.registration as { argv: readonly string[] }).argv).not.toContain("--child-agent");
   });
 
+  it("a drain completed from afk.standing carries standing intent to the daemon", () => {
+    const input = drainInputFor(checkout(DECLARED), "4.0.1", {}, identity);
+
+    expect((input.registration as { standing?: boolean }).standing).toBe(true);
+  });
+
+  it("an explicit drain in a repo that declares afk.standing also registers standing", () => {
+    // The declaration IS the standing intent: the repo said its drain should
+    // survive daemon restarts, and the daemon restarts on every self-upgrade.
+    const input = drainInputFor(checkout(DECLARED), "4.0.1", { runner: "codex", target: 1 }, identity);
+
+    expect((input.registration as { standing?: boolean }).standing).toBe(true);
+  });
+
+  it("a drain in a repo with no standing declaration carries none", () => {
+    const input = drainInputFor(checkout(null), "4.0.1", {}, identity);
+
+    expect(input.registration).not.toHaveProperty("standing");
+  });
+
   it("keeps an incomplete declaration inert — it registers the governed default, not a guess", () => {
     const input = drainInputFor(
       checkout("    afk:\n      standing:\n        runner: claude-code\n"),

--- a/apps/plugin-dev/tests/standing-drain-start.test.ts
+++ b/apps/plugin-dev/tests/standing-drain-start.test.ts
@@ -119,21 +119,29 @@ describe("what the seam refuses to do", () => {
     expect(warn.mock.calls[0]![0]).toContain("afk.standing.target");
   });
 
-  it("sends nothing when the checkout cannot name a repository", async () => {
+  it("sends nothing when the checkout cannot name a repository, and says so to the operator", async () => {
     const drain = drainSpy();
+    const warn = warnSpy();
 
     await expect(ensureStandingDrain({
       version: "4.1.27",
       root: () => "/repo",
       drain,
-      warn: warnSpy(),
+      warn,
       reading: () => DECLARED,
       // The shape `drainRegistrationFor` returns for a directory with no
       // `owner/name`: no registration, so there is no queue to register.
       input: (_root, _version, stated) => ({ ...stated }),
-    })).resolves.toEqual({ kind: "unregisterable" });
+    })).resolves.toEqual({
+      kind: "unregisterable",
+      detail: expect.stringContaining("the declaration registers nothing"),
+    });
 
     expect(drain).not.toHaveBeenCalled();
+    // This outcome was silent: a declaration that could not register looked
+    // identical to one that did.
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]![0]).toContain("no owner/name repository");
   });
 
   it("never rejects when the daemon refuses — the tool surface outlives the daemon", async () => {


### PR DESCRIPTION
## What

Phase 2 slice 3 of the E2E-flow repair. `buildDrainRegistration` never emitted `standing`, so the registration a declared `afk.standing` drain carried was a plain 5-minute lease. The daemon restarts on every self-upgrade (release-train cadence: several per day), and boot recovery only keeps `standing === true` registrations recoverable — so the declared drain lapsed within one tick and `registrations: []` was the steady state.

- `DrainRegistration` gains `standing?: true`; `drainRegistrationFor` sets it whenever the repo declares `afk.standing` (the declaration IS the standing intent — an explicit `/afk` drain in such a repo also registers standing).
- `ensureStandingDrain`'s `unregisterable` branch now warns the operator with the reason (it was the one silent outcome) and carries `detail`.
- Deliberately NOT sending `renew_within_ms` — lease-length policy is a separate decision.

## Tests

Extended `drain-registration-resolve.test.ts` (declared → `standing: true`, explicit args in declared repo → still standing, undeclared → absent) and `standing-drain-start.test.ts` (unregisterable warns and names the reason). 24/24; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790197857&installation_model_id=20659&pr_number=4370&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4370&signature=356243d648ae5a7d6bb9990826246868cffd68242f25f5cdd77639add6db00a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->