### PR TITLE
fix(redskilled): the serving daemon stabilizes its own bundle and heals a pinned npx drop-in onto it

### DIFF
--- a/.changeset/stabilize-running-bundle.md
+++ b/.changeset/stabilize-running-bundle.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The serving daemon files its own running bundle (and the statusline sibling) into the stable lane at boot, and a supervised boot rewrites a pinned npx ExecStart onto that stable copy — the lane tracks the served version again instead of freezing at the last file-resolved release, and the next boot needs neither the npm cache nor the network.

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -74,6 +74,7 @@ import {
 } from "./supervision.js";
 import { awaitRedskilledTakeoverCommit, isRedskilledSupervised } from "./self-replace.js";
 import { startGithubCustodyTender } from "./github-custody-tender.js";
+import { stabilizeRunningRedskilledEntry } from "./stable-bundle.js";
 import { runRedskillsAcpAdapter } from "./acp-control-plane.js";
 import { runAcpWorkerCommand } from "@reddb-io/worker/acp";
 import { resolveRedskilledClientEndpoint } from "./client-rendezvous.js";
@@ -586,6 +587,15 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       deaths.uninstall();
       return 0;
     }
+    // The serving daemon files its OWN bundle into the stable lane. The
+    // pinned-dispatch replacement path resolves no bundle file and therefore
+    // never stabilizes, which froze the lane — and the statusline, which
+    // resolves its renderer there, kept running the last file-resolved
+    // release while the daemon marched on. Best-effort: a decline costs only
+    // durability, never the boot.
+    stabilizeRunningRedskilledEntry({
+      version: values["daemon-version"] ?? readBuildInfo("redskilled").version,
+    });
     // A supervised boot proves the running invocation works — the one moment a
     // drop-in poisoned with a relative ExecStart command (#3554) can be
     // converged to this process's own absolute invocation. Best-effort by

--- a/apps/redskilled/src/stable-bundle.ts
+++ b/apps/redskilled/src/stable-bundle.ts
@@ -149,6 +149,33 @@ export function stabilizeRedskilledEntry<T extends StabilizableRedskilledEntry>(
 }
 
 /**
+ * File THIS process's own bundle (and its statusline sibling) into the lane.
+ *
+ * The pinned-dispatch replacement path resolves no bundle FILE, so it never
+ * stabilized — one such takeover and every later release also rode the pin,
+ * and the stable lane froze while the daemon marched on: the statusline kept
+ * rendering the last file-resolved version. The serving daemon closes that
+ * loop by filing the entry it is running, under the version it reports.
+ *
+ * Best-effort like the underlying copy: a local build, a missing home, or any
+ * filesystem refusal declines and the answer is `undefined` — never a throw,
+ * because this runs on the boot that is about to serve clients.
+ */
+export function stabilizeRunningRedskilledEntry(options: {
+  readonly version: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly entryPath?: string;
+}): string | undefined {
+  const entry = options.entryPath ?? process.argv[1];
+  if (entry == null || entry === "") return undefined;
+  const stabilized = stabilizeRedskilledEntry(
+    { command: process.execPath, args: [entry], entry },
+    { version: options.version, homeDir: stableBundleHomeOf(options.env ?? process.env) },
+  );
+  return stabilized.entry === entry ? undefined : stabilized.entry;
+}
+
+/**
  * The operator home an env describes — and ONLY what it describes.
  *
  * Deliberately no `homedir()` fallback: resolution scoped by an injected env

--- a/apps/redskilled/src/supervision.ts
+++ b/apps/redskilled/src/supervision.ts
@@ -37,7 +37,12 @@ import {
   type RedskilledServeTarget,
 } from "./daemon-entry.js";
 import type { RedskilledPaths } from "./paths.js";
-import { stabilizeRedskilledEntry, stableBundleHomeOf } from "./stable-bundle.js";
+import {
+  redskilledStableBundleDir,
+  redskilledStableBundleName,
+  stabilizeRedskilledEntry,
+  stableBundleHomeOf,
+} from "./stable-bundle.js";
 
 /** The unit's name — one per machine, matching the daemon's own scope. */
 export const REDSKILLED_UNIT_NAME = "redskilled.service";
@@ -227,10 +232,13 @@ export interface RedskilledUnitHealReport {
   /**
    * `absent` — no drop-in to heal; `absolute` — already healthy, untouched;
    * `healed` — relative command rewritten to this process's own absolute
-   * invocation; `unparsed` — no readable ExecStart, left alone; `foreign` —
-   * the drop-in serves some other session's socket, never ours to rewrite.
+   * invocation; `stabilized` — a pinned npx dispatch rewritten onto the stable
+   * copy of the running version, so the next boot needs neither the npm cache
+   * nor the network; `unparsed` — no readable ExecStart, left alone;
+   * `foreign` — the drop-in serves some other session's socket, never ours to
+   * rewrite.
    */
-  readonly status: "absent" | "absolute" | "healed" | "unparsed" | "foreign";
+  readonly status: "absent" | "absolute" | "healed" | "stabilized" | "unparsed" | "foreign";
   /** The ExecStart command the drop-in carried, when one was readable. */
   readonly command?: string;
 }
@@ -267,6 +275,7 @@ export function healRedskilledUnitDropIn(
     readonly version?: string;
     readonly readFile?: (path: string) => string;
     readonly run?: (argv: readonly string[]) => RedskilledUnitRunResult;
+    readonly exists?: (path: string) => boolean;
   } = {},
 ): RedskilledUnitHealReport {
   const path = redskilledReplacementDropInPath(options.env ?? process.env);
@@ -279,7 +288,29 @@ export function healRedskilledUnitDropIn(
   const words = execStartWordsOf(text);
   const command = words?.[0];
   if (words == null || command == null) return { path, status: "unparsed" };
-  if (isAbsolute(command)) return { path, status: "absolute", command };
+  if (isAbsolute(command)) {
+    // An absolute PINNED NPX dispatch is healthy but not durable: it resolves
+    // through the npm cache (which npm may GC) and, because it names no bundle
+    // FILE, the replacement path never stabilizes it — so the stable lane
+    // froze at the last file-resolved release while the daemon marched on.
+    // Once the running version's stable copy exists, the drop-in is rewritten
+    // onto it. The foreign-socket guard runs first, exactly as for the
+    // relative heal: another session's drop-in is never ours to rewrite.
+    const pinned = pinnedNpxDispatchOf(words);
+    if (pinned == null) return { path, status: "absolute", command };
+    if (options.socketPath == null || !words.includes(options.socketPath)) {
+      return { path, status: "foreign", command };
+    }
+    if (options.version == null || pinned.version !== options.version) {
+      return { path, status: "absolute", command };
+    }
+    const homeDir = stableBundleHomeOf(options.env ?? process.env);
+    if (homeDir == null) return { path, status: "absolute", command };
+    const stable = join(redskilledStableBundleDir(homeDir), redskilledStableBundleName(pinned.version));
+    if (!(options.exists ?? existsSync)(stable)) return { path, status: "absolute", command };
+    writeHealedDropIn(path, [options.execPath ?? process.execPath, stable, ...pinned.tail], options.run);
+    return { path, status: "stabilized", command };
+  }
   if (options.socketPath == null || !words.includes(options.socketPath)) {
     return { path, status: "foreign", command };
   }
@@ -295,7 +326,16 @@ export function healRedskilledUnitDropIn(
       ...(options.version == null ? {} : { version: options.version }),
     },
   );
-  const argv = [execPath, ...(stabilized?.args ?? tail)];
+  writeHealedDropIn(path, [execPath, ...(stabilized?.args ?? tail)], options.run);
+  return { path, status: "healed", command };
+}
+
+/** Rewrite the drop-in's ExecStart atomically and ask systemd to re-read it. */
+function writeHealedDropIn(
+  path: string,
+  argv: readonly string[],
+  run?: (argv: readonly string[]) => RedskilledUnitRunResult,
+): void {
   const healed = [
     "[Service]",
     "ExecStart=",
@@ -307,8 +347,24 @@ export function healRedskilledUnitDropIn(
   renameSync(temporary, path);
   // A failed reload is not undone: the file on disk is already correct, and
   // systemd reads it on its own next reload or login — later beats never.
-  (options.run ?? defaultRun)(["systemctl", "--user", "daemon-reload"]);
-  return { path, status: "healed", command };
+  (run ?? defaultRun)(["systemctl", "--user", "daemon-reload"]);
+}
+
+/**
+ * The pinned npx dispatch an ExecStart carries, when it is one.
+ *
+ * The shape ADR 0091 pins: `<npx> -y -p @reddb-io/red-skills@<version>
+ * red-skills-redskilled <args…>`. The answer is the version and everything
+ * after the binary name — the serve flags a rewrite must carry verbatim.
+ */
+function pinnedNpxDispatchOf(
+  words: readonly string[],
+): { readonly version: string; readonly tail: readonly string[] } | undefined {
+  const binary = words.indexOf("red-skills-redskilled");
+  if (binary <= 0) return undefined;
+  const pin = words.slice(0, binary).map((word) => /^@reddb-io\/red-skills@(.+)$/.exec(word)?.[1])
+    .find((version) => version != null);
+  return pin == null ? undefined : { version: pin, tail: words.slice(binary + 1) };
 }
 
 /** The words of the LAST non-empty `ExecStart=` line, unquoted. */

--- a/apps/redskilled/tests/self-supervision.test.ts
+++ b/apps/redskilled/tests/self-supervision.test.ts
@@ -50,6 +50,7 @@ import {
   uninstallRedskilledUnit,
   type RedskilledUnitRunResult,
 } from "../src/supervision.js";
+import { redskilledStableBundleDir, redskilledStableBundleName } from "../src/stable-bundle.js";
 
 const require_ = createRequire(import.meta.url);
 const tsxLoader = require_.resolve("tsx");
@@ -468,5 +469,76 @@ describe("an installed user unit", () => {
     expect(status.findings).toEqual([
       expect.objectContaining({ code: "enabled-but-inactive" }),
     ]);
+  });
+});
+
+describe("stabilizing a pinned npx drop-in", () => {
+  it("rewrites a pinned npx ExecStart onto the stable copy of the running version", async () => {
+    const { paths } = await host();
+    const env = { HOME: paths.runtimeDir };
+    const dropIn = redskilledReplacementDropInPath(env);
+    await mkdir(resolve(dropIn, ".."), { recursive: true });
+    await writeFile(
+      dropIn,
+      `[Service]\nExecStart=\nExecStart=/usr/local/bin/npx -y -p @reddb-io/red-skills@4.2.9 red-skills-redskilled serve --socket ${paths.socketPath}\n`,
+    );
+    const stableDir = redskilledStableBundleDir(paths.runtimeDir);
+    const stable = join(stableDir, redskilledStableBundleName("4.2.9"));
+    await mkdir(stableDir, { recursive: true });
+    await writeFile(stable, "the filed bytes");
+    const reload = recordingRun();
+
+    const report = healRedskilledUnitDropIn({
+      env,
+      socketPath: paths.socketPath,
+      execPath: "/fake/toolchain/node-lts/bin/node",
+      version: "4.2.9",
+      run: reload.run,
+    });
+
+    expect(report).toEqual({ path: dropIn, status: "stabilized", command: "/usr/local/bin/npx" });
+    expect(readFileSync(dropIn, "utf8")).toContain(
+      `ExecStart=/fake/toolchain/node-lts/bin/node ${stable} serve --socket ${paths.socketPath}`,
+    );
+    expect(reload.calls).toEqual([["systemctl", "--user", "daemon-reload"]]);
+  });
+
+  it("leaves a pinned npx ExecStart untouched when the stable copy is absent or the version differs", async () => {
+    const { paths } = await host();
+    const env = { HOME: paths.runtimeDir };
+    const dropIn = redskilledReplacementDropInPath(env);
+    const pinned =
+      `[Service]\nExecStart=\nExecStart=/usr/local/bin/npx -y -p @reddb-io/red-skills@4.2.9 red-skills-redskilled serve --socket ${paths.socketPath}\n`;
+    await mkdir(resolve(dropIn, ".."), { recursive: true });
+    await writeFile(dropIn, pinned);
+    const reload = recordingRun();
+
+    // No stable copy on disk: healthy but not rewritable.
+    expect(healRedskilledUnitDropIn({ env, socketPath: paths.socketPath, version: "4.2.9", run: reload.run }))
+      .toEqual({ path: dropIn, status: "absolute", command: "/usr/local/bin/npx" });
+    // A different running version has no claim on this pin.
+    const stableDir = redskilledStableBundleDir(paths.runtimeDir);
+    await mkdir(stableDir, { recursive: true });
+    await writeFile(join(stableDir, redskilledStableBundleName("4.3.0")), "newer bytes");
+    expect(healRedskilledUnitDropIn({ env, socketPath: paths.socketPath, version: "4.3.0", run: reload.run }))
+      .toEqual({ path: dropIn, status: "absolute", command: "/usr/local/bin/npx" });
+    expect(readFileSync(dropIn, "utf8")).toBe(pinned);
+    expect(reload.calls).toEqual([]);
+  });
+
+  it("a pinned npx drop-in serving another session's socket is foreign, never rewritten", async () => {
+    const { paths } = await host();
+    const env = { HOME: paths.runtimeDir };
+    const dropIn = redskilledReplacementDropInPath(env);
+    const pinned =
+      "[Service]\nExecStart=\nExecStart=/usr/local/bin/npx -y -p @reddb-io/red-skills@4.2.9 red-skills-redskilled serve --socket /run/someone-else.sock\n";
+    await mkdir(resolve(dropIn, ".."), { recursive: true });
+    await writeFile(dropIn, pinned);
+    const reload = recordingRun();
+
+    expect(healRedskilledUnitDropIn({ env, socketPath: paths.socketPath, version: "4.2.9", run: reload.run }))
+      .toEqual({ path: dropIn, status: "foreign", command: "/usr/local/bin/npx" });
+    expect(readFileSync(dropIn, "utf8")).toBe(pinned);
+    expect(reload.calls).toEqual([]);
   });
 });

--- a/apps/redskilled/tests/stable-bundle.test.ts
+++ b/apps/redskilled/tests/stable-bundle.test.ts
@@ -18,6 +18,7 @@ import {
   redskilledStatuslineBundleName,
   STATUSLINE_BUNDLE_ASSET,
   stabilizeRedskilledEntry,
+  stabilizeRunningRedskilledEntry,
 } from "../src/stable-bundle.js";
 import { requireRedskilledReplacementEntry } from "../src/self-replace.js";
 
@@ -178,5 +179,48 @@ describe("the replacement resolver rides the stable home", () => {
     expect(entry.source).toBe("bundle-cache");
     expect(entry.args).toEqual([target]);
     expect(readFileSync(target, "utf8")).toBe("published bytes");
+  });
+});
+
+describe("stabilizing the RUNNING entry", () => {
+  it("stabilizeRunningRedskilledEntry files the unversioned running bundle under the daemon's own version", async () => {
+    const { homeDir, sourceDir } = await scratch();
+    const entry = join(sourceDir, "redskilled.bundle.min.mjs");
+    await writeFile(entry, "the served bytes");
+    await writeFile(join(sourceDir, STATUSLINE_BUNDLE_ASSET), "the lean renderer");
+
+    const stable = stabilizeRunningRedskilledEntry({
+      version: "4.2.9",
+      env: { HOME: homeDir },
+      entryPath: entry,
+    });
+
+    const target = join(redskilledStableBundleDir(homeDir), redskilledStableBundleName("4.2.9"));
+    expect(stable).toBe(target);
+    expect(readFileSync(target, "utf8")).toBe("the served bytes");
+    // The statusline sibling is filed in the same breath: it is the renderer
+    // the published statusline command resolves from this very lane.
+    expect(readFileSync(
+      join(redskilledStableBundleDir(homeDir), redskilledStatuslineBundleName("4.2.9")),
+      "utf8",
+    )).toBe("the lean renderer");
+  });
+
+  it("declines a local build and a home the env does not name", async () => {
+    const { homeDir, sourceDir } = await scratch();
+    const entry = join(sourceDir, "redskilled.bundle.min.mjs");
+    await writeFile(entry, "local bytes");
+
+    expect(stabilizeRunningRedskilledEntry({
+      version: "4.2.9+abcdef",
+      env: { HOME: homeDir },
+      entryPath: entry,
+    })).toBeUndefined();
+    expect(stabilizeRunningRedskilledEntry({
+      version: "4.2.9",
+      env: {},
+      entryPath: entry,
+    })).toBeUndefined();
+    expect(existsSync(join(redskilledStableBundleDir(homeDir), redskilledStableBundleName("4.2.9")))).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Wave 2 slice 1 of the E2E-flow repair (highest leverage for observability: the statusline lane on the maintainer's host froze at 4.1.34 while the daemon serves 4.2.x).

Root cause: `requireRedskilledReplacementEntry` probes only versioned bundle names; the npx package ships an UNVERSIONED `dist/redskilled.bundle.min.mjs`, so every takeover lands on the `pinned-dispatch` rung, which returns **without** stabilizing — self-perpetuating, since `stable-home` then never gains the next version.

- New `stabilizeRunningRedskilledEntry({version, env, entryPath})` in `stable-bundle.ts`: files this process's own (unversioned-basename) bundle under the version it reports, statusline sibling in the same breath; best-effort, declines local builds and unnamed homes. Called on the `serve` path.
- `healRedskilledUnitDropIn` gains status `stabilized`: an absolute **pinned npx** ExecStart serving OUR socket at OUR version is rewritten onto the stable copy once it exists (foreign-socket guard first; version mismatch or missing copy stays `absolute`). Shared `writeHealedDropIn` helper; new `pinnedNpxDispatchOf` parser.

## Tests

`stable-bundle.test.ts`: running-entry stabilization (+ statusline sibling), local-build/no-home declines. `self-supervision.test.ts`: pinned-npx rewrite to `stabilized`, absent-copy/version-mismatch stay `absolute`, foreign socket refused. 27/27; typecheck clean.

## Live verification (after release restarts the daemon)

`ls ~/.red/redskilled/bundles/ | sort -V | tail -3` shows the current version; `systemctl --user cat redskilled.service` drop-in points into `bundles/`; statusline renders the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790198409&installation_model_id=20659&pr_number=4374&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4374&signature=b5e9dd2112fdbdd1b96fd1384acfee8c2156dc96df2f440f6b695801f3383add"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->