### PR TITLE
fix(link): classify the public status.json projection as external JSON

### DIFF
--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -167,6 +167,11 @@
       "moveKey": "24cdd7f5b667"
     },
     {
+      "id": "apps/redskilled-link/src/state.ts#json-stringify-file-write#0f89e1a2aec2",
+      "classification": "external",
+      "reason": "The public link status.json is read by non-TOON surfaces (mobile app, shell probes) as ecosystem JSON by design."
+    },
+    {
       "id": "apps/release/src/cli.ts#json-parse-file-read#06f60309d571",
       "classification": "external",
       "reason": "npm package.json manifests are an external JSON format the release engine must read as-is"


### PR DESCRIPTION
#4365 landed a deliberately-JSON public projection (`~/.red/redskilled/link/status.json` — schema version + active device count, read by non-TOON surfaces) without classifying the write site in `.red/contracts/toon-json-file-io-allowlist.json`. #4365's own cone never ran the toon-json guard, so the red only surfaced on the next PR whose cone includes the plugin-dev invariants (#4371). This classifies the one site as `external`; the private link state stays TOON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790198543&installation_model_id=20659&pr_number=4375&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4375&signature=8d1b78111e0387ef0bd929f111f9b0c6970e060dbe52b263063ebaa838d1e04f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->