### PR TITLE
fix(redskilled): a daemon boot resumes stranded merge-custody obligations

### DIFF
--- a/.changeset/merge-custody-tender.md
+++ b/.changeset/merge-custody-tender.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+A daemon boot resumes every active merge-custody obligation from the durable snapshot and keeps re-tendering on a slow interval — a restart no longer strands handed-off PRs on `repair-custodian` until a client happens to ask.

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -73,6 +73,7 @@ import {
   type RedskilledUnitIO,
 } from "./supervision.js";
 import { awaitRedskilledTakeoverCommit, isRedskilledSupervised } from "./self-replace.js";
+import { startGithubCustodyTender } from "./github-custody-tender.js";
 import { runRedskillsAcpAdapter } from "./acp-control-plane.js";
 import { runAcpWorkerCommand } from "@reddb-io/worker/acp";
 import { resolveRedskilledClientEndpoint } from "./client-rendezvous.js";
@@ -613,7 +614,22 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       // read every kill as a planned handover (#2919).
       process.once(signal, () => void daemon.stop({ reason: "signal", signal }).catch(() => undefined));
     }
+    // Resume the durable merge-custody obligations the previous daemon's death
+    // stranded: the custodian's timers are in-memory and were re-armed only by
+    // a client's handoff/status call, so every restart parked active records on
+    // `repair-custodian` until someone happened to ask. Wired here in the CLI —
+    // the lifecycle file is baseline-pinned — and stopped with the daemon.
+    const custodyTender = startGithubCustodyTender({
+      custodyPath: join(redskilledHomeDir(homedir()), "state", "github", "custody.toon"),
+      registration: githubGateway,
+      onReport: (report) => {
+        if (report.resumed === 0 && report.unresolved.length === 0) return;
+        process.stderr.write(`merge-custody tender: resumed ${report.resumed} execution(s)${
+          report.unresolved.length === 0 ? "" : `; no credential for ${report.unresolved.join(", ")}`}\n`);
+      },
+    });
     await daemon.closed;
+    custodyTender.stop();
     deaths.phase("closed");
     return 0;
   }

--- a/apps/redskilled/src/github-custody-tender.ts
+++ b/apps/redskilled/src/github-custody-tender.ts
@@ -1,0 +1,143 @@
+// github-custody-tender — the boot-time (and slow re-tender) resume of durable
+// merge-custody obligations.
+//
+// **A durable record whose driver died is a promise nobody keeps.** The
+// custodian's tick timers live in memory and are re-armed only by `register`,
+// whose only callers are a connection's `handoff`/`status` — so after a daemon
+// restart every active custody record sat inert, publishing
+// `next_action: "repair-custodian"` with its own ready-made repair that no
+// process ever executed. The daemon restarts on every self-upgrade, which made
+// this the steady state, not an edge: nine PRs once waited thirteen hours on a
+// two-minute threshold for a client to happen to ask.
+//
+// The tender resumes obligations from the snapshot the custodian itself
+// persists: each active record already carries its whole project authority and
+// its credential profile, so one `mergeCustodyStatus()` per distinct
+// project/credential pair re-registers the execution and re-arms every tick.
+// A record whose credential cannot be resolved is reported, never retried hot
+// — the interval pass picks it up when a credential appears.
+import { readFile } from "node:fs/promises";
+
+import { decode } from "@reddb-io/toon";
+import type { RedskilledGithubManagedProjectReader } from "./github-gateway.js";
+import { credentialForAcpProject } from "./github-project-credential.js";
+import type { RedskilledGithubGatewayRegistration } from "./github-project-credential.js";
+
+export interface GithubCustodyTenderReport {
+  /** Distinct project/credential executions re-registered this pass. */
+  readonly resumed: number;
+  /** Project ids whose credential profile resolved to nothing, one entry each. */
+  readonly unresolved: readonly string[];
+}
+
+export interface StartGithubCustodyTenderOptions {
+  /** The custodian's own durable snapshot; the tender never writes it. */
+  readonly custodyPath: string;
+  readonly registration: RedskilledGithubGatewayRegistration;
+  /** How often obligations are re-tendered; 5 minutes when unstated. */
+  readonly intervalMs?: number;
+  readonly onReport?: (report: GithubCustodyTenderReport) => void;
+}
+
+interface TenderableRecord {
+  readonly project_id: string;
+  readonly project_label: string;
+  readonly workspace_path: string;
+  readonly credential_profile: string;
+}
+
+/** One resume pass over the snapshot. Never rejects; absence is an empty pass. */
+export async function tendGithubCustody(
+  options: Pick<StartGithubCustodyTenderOptions, "custodyPath" | "registration">,
+): Promise<GithubCustodyTenderReport> {
+  const records = await readActiveCustodyRecords(options.custodyPath);
+  const unresolved: string[] = [];
+  let resumed = 0;
+  const seen = new Set<string>();
+  for (const record of records) {
+    const key = `${record.project_id}\0${record.credential_profile}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    try {
+      const selection = await credentialForAcpProject(options.registration, {
+        projectId: record.project_id,
+        projectLabel: record.project_label,
+        workspacePath: record.workspace_path,
+        credentialProfile: record.credential_profile,
+      });
+      if (selection == null) {
+        unresolved.push(record.project_id);
+        continue;
+      }
+      // `mergeCustodyStatus` runs the custodian's own `register` first, which
+      // re-arms every non-terminal record this project holds — the record's
+      // published repair, executed through the same authority that made it.
+      const reader = options.registration.gateway.forProject({
+        projectId: record.project_id,
+        projectLabel: record.project_label,
+        workspacePath: record.workspace_path,
+        credentialProfile: selection.profile,
+      }, selection.credential) as Partial<RedskilledGithubManagedProjectReader>;
+      // A gateway without the managed surface holds no custodian to re-arm.
+      if (typeof reader.mergeCustodyStatus !== "function") {
+        unresolved.push(record.project_id);
+        continue;
+      }
+      await reader.mergeCustodyStatus();
+      resumed += 1;
+    } catch {
+      unresolved.push(record.project_id);
+    }
+  }
+  return { resumed, unresolved };
+}
+
+/**
+ * Resume now, then keep re-tendering on an interval.
+ *
+ * The interval is deliberately slow and `unref`'d: the first pass does the
+ * repair; later passes exist so a credential that appears after boot still
+ * revives the records it was missing for.
+ */
+export function startGithubCustodyTender(
+  options: StartGithubCustodyTenderOptions,
+): { stop(): void } {
+  const intervalMs = options.intervalMs ?? 300_000;
+  const pass = (): void => {
+    void tendGithubCustody(options)
+      .then((report) => options.onReport?.(report))
+      .catch(() => undefined);
+  };
+  pass();
+  const timer = setInterval(pass, intervalMs);
+  timer.unref?.();
+  return {
+    stop() {
+      clearInterval(timer);
+    },
+  };
+}
+
+async function readActiveCustodyRecords(path: string): Promise<TenderableRecord[]> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = decode(raw.trim());
+  } catch {
+    return [];
+  }
+  const snapshot = parsed as { records?: unknown };
+  if (!Array.isArray(snapshot?.records)) return [];
+  return snapshot.records.filter((value): value is TenderableRecord & { state?: string } => {
+    const record = value as Record<string, unknown> | null;
+    return record != null && typeof record === "object" &&
+      typeof record.project_id === "string" && typeof record.project_label === "string" &&
+      typeof record.workspace_path === "string" && typeof record.credential_profile === "string" &&
+      record.state !== "terminal";
+  });
+}

--- a/apps/redskilled/tests/github-custody-tender.test.ts
+++ b/apps/redskilled/tests/github-custody-tender.test.ts
@@ -1,0 +1,116 @@
+// A durable custody record whose driver died is a promise nobody keeps: the
+// custodian's timers are in-memory and only a client's handoff/status call
+// re-armed them, so every daemon restart parked active records on
+// `repair-custodian` until someone happened to ask (nine PRs once waited
+// thirteen hours on a two-minute threshold). The tender executes the record's
+// own published repair at boot, from the snapshot the custodian persists.
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { encode, type JsonValue } from "@reddb-io/toon";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { startGithubCustodyTender, tendGithubCustody } from "../src/github-custody-tender.js";
+import type { RedskilledGithubGatewayRegistration } from "../src/github-project-credential.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function custodyRecord(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    pull_request: 4319,
+    owner_ticket: 4280,
+    branch: "red/x/4280",
+    base: "main",
+    project_id: "github:1",
+    project_label: "reddb-io/red-skills",
+    workspace_path: "/tmp/workspace",
+    credential_profile: "personal",
+    handed_off_at: "2026-08-24T06:00:00.000Z",
+    state: "active",
+    last_tick_at: null,
+    last_forge_state: "unknown",
+    next_action: "repair-custodian",
+    terminal_outcome: null,
+    ...overrides,
+  };
+}
+
+async function snapshotAt(records: Record<string, unknown>[]): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-custody-tender-"));
+  roots.push(root);
+  const path = join(root, "state", "github", "custody.toon");
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${encode({ version: 1, records } as unknown as JsonValue)}\n`);
+  return path;
+}
+
+function registration(statuses: { project: string; profile: string }[]) {
+  const mergeCustodyStatus = vi.fn(async () => ({ version: 1, records: [] }));
+  const reg: RedskilledGithubGatewayRegistration = {
+    gateway: {
+      forProject: (authority: { projectId: string; credentialProfile: string }) => {
+        statuses.push({ project: authority.projectId, profile: authority.credentialProfile });
+        return { mergeCustodyStatus } as never;
+      },
+    } as never,
+    credentialForProfile: async (profile) =>
+      profile === "personal" ? { secret: "personal-token" } : null,
+    credentialForProject: async () => null,
+  };
+  return { reg, mergeCustodyStatus };
+}
+
+describe("the merge-custody tender", () => {
+  it("tendGithubCustody resumes each active project execution and reports the credential-less ones", async () => {
+    const path = await snapshotAt([
+      custodyRecord({}),
+      custodyRecord({ pull_request: 4321 }),
+      custodyRecord({ pull_request: 4322, state: "terminal", next_action: "none" }),
+      custodyRecord({
+        pull_request: 9,
+        project_id: "github:2",
+        project_label: "reddb-io/other",
+        credential_profile: "an-app-nobody-configured",
+      }),
+    ]);
+    const statuses: { project: string; profile: string }[] = [];
+    const { reg, mergeCustodyStatus } = registration(statuses);
+
+    const report = await tendGithubCustody({ custodyPath: path, registration: reg });
+
+    // One status call per distinct project/credential pair re-arms every
+    // record that project holds — two active records, one resume.
+    expect(report).toEqual({ resumed: 1, unresolved: ["github:2"] });
+    expect(statuses).toEqual([{ project: "github:1", profile: "personal" }]);
+    expect(mergeCustodyStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("an absent or unreadable snapshot is an empty pass, never a throw", async () => {
+    const { reg } = registration([]);
+    await expect(tendGithubCustody({ custodyPath: "/nowhere/custody.toon", registration: reg }))
+      .resolves.toEqual({ resumed: 0, unresolved: [] });
+  });
+
+  it("startGithubCustodyTender runs one pass immediately and hands the report to its sink", async () => {
+    const path = await snapshotAt([custodyRecord({})]);
+    const { reg } = registration([]);
+    const reports: unknown[] = [];
+    const tender = startGithubCustodyTender({
+      custodyPath: path,
+      registration: reg,
+      intervalMs: 60_000,
+      onReport: (report) => reports.push(report),
+    });
+    try {
+      await vi.waitFor(() => {
+        expect(reports).toEqual([{ resumed: 1, unresolved: [] }]);
+      });
+    } finally {
+      tender.stop();
+    }
+  });
+});


### PR DESCRIPTION
## What

Wave 2 slice 2 of the E2E-flow repair. Custody records carry their whole project authority and credential profile, but the custodian's drive timers are in-memory and only a client's `handoff`/`status` re-arms them — so every daemon restart (which happens on every self-upgrade) parked active records on `repair-custodian` until someone happened to ask. Live evidence on the maintainer's host: 9 PRs stuck ~13h on a 2-minute inert threshold.

- New `apps/redskilled/src/github-custody-tender.ts`: `tendGithubCustody` reads the custodian's own durable snapshot (never writes it), resolves each active record's credential via `credentialForAcpProject`, and calls `mergeCustodyStatus()` once per distinct project/credential pair — the custodian's `register` re-arms every non-terminal record for that project. Credential-less records are reported, never retried hot.
- `startGithubCustodyTender` runs one pass at serve boot and re-tenders every 5 min (`unref`'d), wired in `cli.ts` (the lifecycle file is baseline-pinned) and stopped with the daemon.
- No `DECLARED_WAITS` entry: the declared-wait ratchet sweeps `apps/plugin-dev/src` and `packages/worker/src`; this is an `unref`'d interval in `apps/redskilled`, reported through its own sink.

## Tests

`github-custody-tender.test.ts`: distinct-pair resume with terminal records skipped and credential-less projects reported; absent snapshot = empty pass; immediate first pass reaches the report sink. 6/6 with the custody suite; typecheck clean.

## Live verification

After deploy + restart: `~/.red/redskilled/state/github/custody.toon` records show fresh `last_tick_at` within ~30s and `next_action` back to `await-forge`/`none`; the stuck PRs progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790198890&installation_model_id=20659&pr_number=4376&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4376&signature=3bd5f90e66d4134e52d416e5d300dfa2b97b65830b0012c004edcaf829f8b9e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->