### PR TITLE
fix(redskilled): a supervised replacement proves its successor before repointing the unit

### DIFF
--- a/.changeset/supervised-takeover-viability.md
+++ b/.changeset/supervised-takeover-viability.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+A supervised self-replacement now proves the successor entry answers `--version` with the target version before the unit is repointed — an unrunnable successor costs one refused upgrade retried on the next takeover window, instead of five systemd restarts and a dead unit.

--- a/apps/redskilled/src/daemon/takeover.ts
+++ b/apps/redskilled/src/daemon/takeover.ts
@@ -4,6 +4,7 @@ import type { RedskilledPaths } from "../paths.js";
 import {
   completeRedskilledReplacement,
   prepareRedskilledReplacement,
+  RedskilledReplacementEntryError,
   stageRedskilledReplacementSuccessor,
   type RedskilledReplacementDecision,
   type RedskilledReplacementIO,
@@ -26,7 +27,28 @@ export interface ReplaceWithViableSuccessorInput {
 export async function replaceWithViableSuccessor(
   input: ReplaceWithViableSuccessorInput,
 ): Promise<boolean> {
-  const prepared = prepareRedskilledReplacement(input.decision, input.io, input.paths);
+  let prepared;
+  try {
+    // Preparation carries the supervised path's viability proof (the successor
+    // must answer `--version` with the target version before the unit is
+    // repointed) — so a failed proof is a refused upgrade, recorded and
+    // retried on the next takeover window, never a stopped incumbent.
+    prepared = await prepareRedskilledReplacement(input.decision, input.io, input.paths);
+  } catch (error) {
+    // An unreachable ENTRY keeps its established contract and propagates; the
+    // held-and-retried outcome is for a resolved entry that failed its proof.
+    if (error instanceof RedskilledReplacementEntryError) throw error;
+    await input.eventLane.recordDaemonTakeoverFailed({
+      ts: input.clock(),
+      pid: input.incumbentPid,
+      socketPath: input.paths.socketPath,
+      detail:
+        `redskilled ${input.decision.to} failed its pre-repoint viability proof: ` +
+        `${error instanceof Error ? error.message : String(error)}; ` +
+        `incumbent ${input.incumbentVersion} remains live`,
+    });
+    return false;
+  }
   const options = { io: input.io };
   let successor;
   try {

--- a/apps/redskilled/src/self-replace.ts
+++ b/apps/redskilled/src/self-replace.ts
@@ -38,6 +38,7 @@
  * PURE apart from the injected spawn, exit and existence lookups.
  */
 import { spawn } from "node:child_process";
+import { proveRedskilledSuccessorEntry } from "./successor-proof.js";
 import { randomUUID } from "node:crypto";
 import { existsSync, readdirSync, rmSync } from "node:fs";
 import { createConnection, createServer, type Socket } from "node:net";
@@ -418,6 +419,11 @@ export interface RedskilledReplacementIO {
   ) => void;
   /** Ends this process so its supervisor revives it; `process.exit` by default. */
   readonly exit?: (code: number) => void;
+  /** Proves a supervised successor runs the target version; a real spawn by default. */
+  readonly proveSuccessor?: (
+    entry: ResolvedRedskilledReplacementEntry,
+    expectedVersion: string,
+  ) => Promise<void>;
   readonly env?: NodeJS.ProcessEnv;
 }
 
@@ -449,11 +455,11 @@ export interface RedskilledSuccessorControl {
  * only then discovered it had nothing to hand over to would have turned a version
  * skew into an outage.
  */
-export function prepareRedskilledReplacement(
+export async function prepareRedskilledReplacement(
   decision: Extract<RedskilledReplacementDecision, { act: "replace" }>,
   io: RedskilledReplacementIO = {},
   target?: RedskilledServeTarget,
-): PreparedRedskilledReplacement {
+): Promise<PreparedRedskilledReplacement> {
   const resolve = io.resolveEntry ??
     ((version: string) => requireRedskilledReplacementEntry(version, io.env == null ? {} : { env: io.env }));
   const entry = resolve(decision.to);
@@ -461,10 +467,19 @@ export function prepareRedskilledReplacement(
     const repoint = io.repointSupervisor ?? ((resolved: ResolvedRedskilledReplacementEntry, serve: RedskilledServeTarget) =>
       repointRedskilledUnitForReplacement(resolved, serve, io.env == null ? {} : { env: io.env }));
     if (target == null) throw new Error("a supervised redskilled replacement needs its serve target before exit");
+    // Proved BEFORE the repoint: the supervised path has no boot handshake —
+    // the incumbent exits and systemd is the only backstop, so an entry that
+    // cannot even answer `--version` with the target version would cost five
+    // failed restarts and a dead unit (#3554's shape) instead of one refused
+    // upgrade the next takeover window retries.
+    await (io.proveSuccessor ?? proveRedskilledSuccessorEntry)(entry, decision.to);
     repoint(entry, target);
   }
   return { via: decision.via, to: decision.to, entry };
 }
+
+export { DEFAULT_REDSKILLED_SUCCESSOR_PROOF_MS } from "./successor-proof.js";
+export { proveRedskilledSuccessorEntry };
 
 /**
  * Start the successor while the incumbent still owns the live session.

--- a/apps/redskilled/src/successor-proof.ts
+++ b/apps/redskilled/src/successor-proof.ts
@@ -1,0 +1,59 @@
+// successor-proof — the supervised takeover's pre-repoint viability check.
+//
+// The self-spawn path stages its successor at a boot handshake; the supervised
+// path has none — the incumbent exits and systemd is the only backstop, so an
+// entry that cannot run costs five failed restarts and a dead unit (#3554's
+// shape) unless it is refused BEFORE the unit is repointed.
+import { spawn } from "node:child_process";
+
+/** How long a cold successor gets to answer `--version` before the proof fails. */
+export const DEFAULT_REDSKILLED_SUCCESSOR_PROOF_MS = 60_000;
+
+/**
+ * Prove a resolved entry actually runs the target version.
+ *
+ * `--version` is the one question every shipped binary answers without a
+ * working machine, so it is the cheapest possible viability proof — and after
+ * the running bundle is stabilized into the daemon home, the entry is a local
+ * file and the proof costs about a second. A cold npx materialization is the
+ * slow case, which is why the deadline is generous: warming that cache is
+ * itself half the proof's value.
+ */
+export async function proveRedskilledSuccessorEntry(
+  entry: { readonly command: string; readonly args: readonly string[] },
+  expectedVersion: string,
+  io: { readonly timeoutMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = io.timeoutMs ?? DEFAULT_REDSKILLED_SUCCESSOR_PROOF_MS;
+  const child = spawn(entry.command, [...entry.args, "--version"], { stdio: ["ignore", "pipe", "ignore"] });
+  let stdout = "";
+  child.stdout?.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString("utf8");
+  });
+  const exitCode = await new Promise<number | null>((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      rejectPromise(new Error(
+        `the ${expectedVersion} successor did not answer --version within ${timeoutMs}ms`,
+      ));
+    }, timeoutMs);
+    timer.unref?.();
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      rejectPromise(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timer);
+      resolvePromise(code);
+    });
+  });
+  if (exitCode !== 0) {
+    throw new Error(`the ${expectedVersion} successor exited ${exitCode ?? "by signal"} answering --version`);
+  }
+  if (!stdout.includes(expectedVersion)) {
+    throw new Error(
+      `the successor answered --version with ${JSON.stringify(stdout.trim().slice(0, 120))}, ` +
+        `not the expected ${expectedVersion}`,
+    );
+  }
+}

--- a/apps/redskilled/tests/self-replacement.test.ts
+++ b/apps/redskilled/tests/self-replacement.test.ts
@@ -39,10 +39,12 @@ import {
   localRedskilledPublishedEvidence,
   planRedskilledMajorHold,
   planRedskilledReplacement,
+  proveRedskilledSuccessorEntry,
   REDSKILLED_REPLACE_EXIT_CODE,
   RedskilledReplacementEntryError,
   requireRedskilledReplacementEntry,
 } from "../src/self-replace.js";
+import { replaceWithViableSuccessor } from "../src/daemon/takeover.js";
 
 const require_ = createRequire(import.meta.url);
 const tsxLoader = require_.resolve("tsx");
@@ -558,6 +560,9 @@ describe("a daemon that has observed a newer published version", () => {
         repointSupervisor: (entry) => repoints.push(entry.version),
         exit: (code) => exits.push(code),
         spawnSuccessor: (entry) => spawns.push(entry.command),
+        // This test pins the handover choreography; the viability proof has
+        // its own suite below.
+        proveSuccessor: async () => {},
       },
     });
     running.push(daemon);
@@ -917,5 +922,126 @@ describe("a read the registry never answers", () => {
     // an unreachable registry must never be the reason a major is crossed.
     expect(evidence.version).toBe(PUBLISHED_VERSION);
     expect(evidence.newest).toBe("2.0.0");
+  });
+});
+
+describe("the supervised path proves its successor before repointing", () => {
+  const target = {
+    socketPath: "/run/test/redskilled.sock",
+    leasePath: "/run/test/redskilled.lease.toon",
+    eventLanePath: "/tmp/test/redskilled.log.toonl",
+    sessionKeyHash: "abc",
+    machineIdHash: "def",
+    machineClaimPath: "/tmp/test/claim.toon",
+  } as never;
+  const decision = { act: "replace", to: "9.9.9", via: "supervisor-exit" } as const;
+  const entry = { command: "/usr/bin/node", args: ["/opt/redskilled-9.9.9.bundle.min.mjs"], source: "stable-home" } as never;
+
+  function takeoverFailures() {
+    const failures: string[] = [];
+    return {
+      failures,
+      eventLane: {
+        recordDaemonTakeoverFailed: async (input: { detail: string }) => {
+          failures.push(input.detail);
+          return {} as never;
+        },
+        flush: async () => {},
+      } as never,
+    };
+  }
+
+  it("a successor that cannot prove its version costs the upgrade and leaves the drop-in untouched", async () => {
+    const repointed: unknown[] = [];
+    const { failures, eventLane } = takeoverFailures();
+    let stopped = false;
+
+    const replaced = await replaceWithViableSuccessor({
+      decision,
+      io: {
+        resolveEntry: () => entry,
+        repointSupervisor: (resolved) => void repointed.push(resolved),
+        proveSuccessor: async () => {
+          throw new Error("the 9.9.9 successor did not answer --version within 60000ms");
+        },
+      },
+      paths: target,
+      incumbentVersion: "9.9.8",
+      incumbentPid: 4242,
+      clock: () => "2026-08-24T21:00:00.000Z",
+      eventLane,
+      flushRegistration: async () => {},
+      stop: async () => {
+        stopped = true;
+      },
+      onViable: () => {},
+    });
+
+    expect(replaced).toBe(false);
+    expect(stopped).toBe(false);
+    expect(repointed).toEqual([]);
+    expect(failures).toEqual([expect.stringContaining("failed its pre-repoint viability proof")]);
+    expect(failures[0]).toContain("incumbent 9.9.8 remains live");
+  });
+
+  it("a proved successor repoints the unit and the handover proceeds", async () => {
+    const repointed: unknown[] = [];
+    const { failures, eventLane } = takeoverFailures();
+    let stopped = false;
+
+    const replaced = await replaceWithViableSuccessor({
+      decision,
+      io: {
+        resolveEntry: () => entry,
+        repointSupervisor: (resolved) => void repointed.push(resolved),
+        proveSuccessor: async () => {},
+        exit: () => {},
+      },
+      paths: target,
+      incumbentVersion: "9.9.8",
+      incumbentPid: 4242,
+      clock: () => "2026-08-24T21:00:00.000Z",
+      eventLane,
+      flushRegistration: async () => {},
+      stop: async () => {
+        stopped = true;
+      },
+      onViable: () => {},
+    });
+
+    expect(replaced).toBe(true);
+    expect(stopped).toBe(true);
+    expect(repointed).toEqual([entry]);
+    expect(failures).toEqual([]);
+  });
+});
+
+describe("proveRedskilledSuccessorEntry", () => {
+  // A script FILE, not `-e`: node consumes a trailing `--version` for itself
+  // when the program comes from -e, which is exactly the false positive a
+  // proof must not be built on.
+  async function scriptEntry(body: string): Promise<{ command: string; args: string[] }> {
+    const dir = await mkdtemp(join(tmpdir(), "redskilled-successor-proof-"));
+    roots.push(dir);
+    const file = join(dir, "successor.mjs");
+    await writeFile(file, body);
+    return { command: process.execPath, args: [file] };
+  }
+
+  it("accepts an entry whose --version answer carries the target version", async () => {
+    const entry = await scriptEntry("console.log('redskilled 9.9.9+test');\n");
+    await expect(proveRedskilledSuccessorEntry(entry as never, "9.9.9")).resolves.toBeUndefined();
+  });
+
+  it("refuses an entry that answers with some other version", async () => {
+    const entry = await scriptEntry("console.log('redskilled 1.0.0');\n");
+    await expect(proveRedskilledSuccessorEntry(entry as never, "9.9.9"))
+      .rejects.toThrow(/answered --version with/);
+  });
+
+  it("refuses an entry that cannot run at all", async () => {
+    const entry = await scriptEntry("process.exit(3);\n");
+    await expect(proveRedskilledSuccessorEntry(entry as never, "9.9.9"))
+      .rejects.toThrow(/exited 3/);
   });
 });


### PR DESCRIPTION
## What

Wave 2 slice 3 of the E2E-flow repair. The self-spawn takeover path proves its successor at a 30s handshake; the supervised path (`via: supervisor-exit`) repointed the drop-in and exited 75 on faith — `StartLimitBurst=5/60s` was the only backstop, and five failed starts leave a dead unit with no daemon alive to heal it.

- New `proveRedskilledSuccessorEntry(entry, expectedVersion, {timeoutMs})`: spawns `entry --version` (the one question every shipped binary answers without a working machine), bounded at 60s (generous because a cold npx materialization is the slow case — and warming that cache is half the proof's value; after #4374 the entry usually resolves to a local stable-lane file and the proof costs ~1s).
- `prepareRedskilledReplacement` is now async and proves BEFORE `repoint` on the supervised arm; injectable via `RedskilledReplacementIO.proveSuccessor`.
- `replaceWithViableSuccessor` records `daemon-takeover-failed` ("failed its pre-repoint viability proof … incumbent X remains live") and returns false on a failed proof — retried on the next takeover window. An unreachable ENTRY keeps its established propagating contract (`RedskilledReplacementEntryError`).

## Tests

`self-replacement.test.ts`: failed proof → no repoint, no stop, recorded refusal; proved successor → handover proceeds; `proveRedskilledSuccessorEntry` accepted/wrong-version/cannot-run cases via real script files (deliberately not `-e`, whose trailing `--version` node consumes itself). 35/35; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790199217&installation_model_id=20659&pr_number=4378&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4378&signature=fbbbc7e1e6c9b4a453a160409c37b2ceafdf39942538ef8108375b19aa5ba41e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->