### PR TITLE
fix(redskilled): a handler failure on a parsed request never reads as a dialect downgrade proof

### DIFF
--- a/.changeset/unintelligible-proof-ambiguity.md
+++ b/.changeset/unintelligible-proof-ambiguity.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+A daemon error on a request it did parse now echoes that request's id (or answers `id: null` when it carried none) instead of minting a fresh one — a fresh id is reserved as the dialect-downgrade proof for frames that were never parsed, so an ordinary handler failure can no longer silently downgrade a healthy TOON client to JSON.

--- a/apps/redskilled/src/daemon/socket.ts
+++ b/apps/redskilled/src/daemon/socket.ts
@@ -89,7 +89,13 @@ export function handleSocket(
     (request, respond) => handler(request, respond as (response: RedskilledResponse) => void),
     (err, request, respond) => {
       respond({
-        id: request?.id ?? randomUUID(),
+        // A FRESH id is the rule-3 downgrade proof: "this frame was never
+        // parsed, so there is no id to echo". A failure on a request the
+        // daemon DID parse must echo that request's id — or answer `id: null`
+        // when it carried none — because a fresh id here made every ordinary
+        // handler error read as "this peer cannot speak TOON" and silently
+        // downgraded healthy TOON clients to JSON for the process lifetime.
+        id: request == null ? randomUUID() : typeof request.id === "string" ? request.id : null,
         ok: false,
         error: err instanceof Error ? err.message : String(err),
       } satisfies RedskilledResponse);

--- a/apps/redskilled/src/protocol.ts
+++ b/apps/redskilled/src/protocol.ts
@@ -233,7 +233,11 @@ export type RedskilledRequest =
 
 export type RedskilledResponse =
   | { id: string; ok: true; value: unknown }
-  | { id: string; ok: false; error: string };
+  // `id: null` is the one failure shape a PARSED request without a usable id
+  // may wear: a fresh string id is reserved as the rule-3 proof that the frame
+  // was never parsed at all (`isUnintelligibleResponse`), and an ordinary
+  // handler failure must never be able to counterfeit it.
+  | { id: string | null; ok: false; error: string };
 
 export interface RedskilledResourceLeaseReleased {
   readonly version: 1;

--- a/apps/redskilled/tests/wire-dialect.test.ts
+++ b/apps/redskilled/tests/wire-dialect.test.ts
@@ -8,7 +8,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { decodeWireFrame, takeWireFrame } from "@reddb-io/shared/resident-wire.js";
+import { decodeWireFrame, isUnintelligibleResponse, takeWireFrame } from "@reddb-io/shared/resident-wire.js";
 import { afterEach, describe, expect, it } from "vitest";
 import { startRedskilledDaemon, type RedskilledDaemon } from "../src/daemon.js";
 import { isRedskilledPong, sendRedskilledRequest } from "../src/protocol.js";
@@ -101,5 +101,56 @@ describe("redskilled socket dialect", () => {
     expect(raw.startsWith("{")).toBe(true);
     expect(parsed).toMatchObject({ id: "json-1", ok: true });
     expect(isRedskilledPong((parsed as { value: unknown }).value)).toBe(true);
+  });
+});
+
+describe("a handler failure never masquerades as the downgrade proof", () => {
+  async function rawExchange(socketPath: string, payload: string): Promise<Record<string, unknown>> {
+    return await new Promise((resolve, reject) => {
+      const socket = createConnection(socketPath);
+      let buffer = "";
+      socket.on("connect", () => socket.write(payload));
+      socket.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
+        const framed = takeWireFrame(buffer);
+        if (framed == null) return;
+        try {
+          resolve(decodeWireFrame(framed.frame) as Record<string, unknown>);
+        } catch (err) {
+          reject(err as Error);
+        }
+        socket.end();
+      });
+      socket.on("error", reject);
+    });
+  }
+
+  it("a failure on a request the daemon did parse echoes that request's id", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({ paths });
+    running.push(daemon);
+
+    const id = randomUUID();
+    const parsed = await rawExchange(paths.socketPath, `${JSON.stringify({ id, op: "no-such-op" })}\n`);
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.id).toBe(id);
+    // The rule-3 reader agrees: this is an ordinary refusal, not a dialect
+    // downgrade proof — a TOON client keeps speaking TOON after it.
+    expect(isUnintelligibleResponse({ id, op: "no-such-op" }, parsed)).toBe(false);
+  });
+
+  it("a frame the daemon cannot parse still answers with a fresh id — the real proof", async () => {
+    const paths = await sessionPaths();
+    const daemon = await startRedskilledDaemon({ paths });
+    running.push(daemon);
+
+    const id = randomUUID();
+    const parsed = await rawExchange(paths.socketPath, "{{{{\n");
+
+    expect(parsed.ok).toBe(false);
+    expect(typeof parsed.id).toBe("string");
+    expect(parsed.id).not.toBe(id);
+    expect(isUnintelligibleResponse({ id }, parsed)).toBe(true);
   });
 });


### PR DESCRIPTION
## What

Wave 3 slice 2 of the E2E-flow repair, and the second half of ADR 0170's slice-2 precondition. The op socket answered every failure with `id: request?.id ?? randomUUID()`. A fresh string id on an `ok:false` response is byte-identical to the rule-3 proof that the frame was never parsed (`isUnintelligibleResponse`), so an ordinary handler error made TOON clients `rememberJsonOnlyPeer` and silently downgrade the socket path to JSON for the process lifetime.

- A parsed request's failure now echoes the request's id, or answers `id: null` when it carried no usable one (`RedskilledResponse`'s failure arm widens to `id: string | null` — the one shape that can never counterfeit the proof).
- The fresh uuid remains exclusively on genuine pre-parse failures — the only place the proof is true.

## Tests

`wire-dialect.test.ts` against the real daemon: an unknown-op failure echoes the id and reads as an ordinary refusal to `isUnintelligibleResponse`; an unparseable frame still answers a fresh id and reads as the proof. 5/5; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790199939&installation_model_id=20659&pr_number=4380&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4380&signature=2063f77de0d26e89ba4b8dbb9229878ea4e0cb952ae34e9d65d623f2d25ddaf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->