### PR TITLE
fix(redskilled): project identity rides a durable cache and the daemon's own credential

### DIFF
--- a/.changeset/project-identity-offline.md
+++ b/.changeset/project-identity-offline.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Project identity resolution rides a durable per-remote cache and the daemon's own personal credential, so a rate-limited or offline GitHub API no longer silently demotes a known repository to a second `remote:<slug>` identity; a demotion that does happen is recorded on the host event lane instead of vanishing.

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -67,7 +67,9 @@ import {
   resolveAcpProjectIdentity,
   type AcpProjectIdentity,
   type AcpProjectWorkspace,
+  type ResolveAcpProjectIdentityOptions,
 } from "./project-workspace.js";
+import { createProjectIdentityStore, projectIdentityStorePath } from "./project-identity-store.js";
 import {
   bindTargetedDispatch,
   createAcpSessionJournal as createAcpDispatchJournal,
@@ -109,6 +111,8 @@ export { ACP_V2_DRAFT_REVISION, REDSKILLS_WIRE_MAJOR } from "@reddb-io/protocol-
 interface StoreHolders {
   readonly brainStore: HostBrainStore;
   readonly memoryStore: ProjectMemoryStore;
+  /** The endpoint's one identity resolution policy; every bind rides it. */
+  readonly identityOptions?: ResolveAcpProjectIdentityOptions;
 }
 
 /** Bind the daemon-owned public ACP endpoint. */
@@ -122,6 +126,21 @@ export async function startRedskillsAcpControlPlane(
   // Closing the client therefore drops observation only; drain intent remains
   // until the shared reducer receives an explicit stop.
   const projectControlStore = createProjectControlStore(projectControlStorePath(paths.registrationIntentPath));
+  // One identity resolution policy for every bind on this endpoint: the durable
+  // slug cache answers first, the daemon's own personal credential authenticates
+  // a miss, and a demotion to `remote:<slug>` is recorded instead of silent —
+  // identity deciding differently per bind is how one repository became two
+  // projects with split control state.
+  const identityOptions: ResolveAcpProjectIdentityOptions = {
+    identityCache: createProjectIdentityStore(projectIdentityStorePath(paths.registrationIntentPath)),
+    resolveToken: async () =>
+      (await options.githubGateway?.credentialForProfile?.("personal"))?.secret ?? null,
+    onIdentityDemotion: (slug, reason) => options.recordAcpFailure?.({
+      projectLabel: slug,
+      detail: `project identity fell back to remote:${slug} — ${reason}`,
+      surface: "connection",
+    }),
+  };
   const projectControls = await projectControlStore.read();
   const persistProjectControls = projectControlStore.replace.bind(projectControlStore);
   const sessionJournal = await createDurableAcpSessionJournal(acpSessionJournalPath(paths.registrationIntentPath));
@@ -162,7 +181,7 @@ export async function startRedskillsAcpControlPlane(
     socket.once("close", () => sockets.delete(socket));
     void servePublicConnection(
       socket,
-      { ...connectionOptions, brainStore, memoryStore },
+      { ...connectionOptions, brainStore, memoryStore, identityOptions },
       workspaceFor,
       projectControls,
       persistProjectControls,
@@ -182,7 +201,7 @@ export async function startRedskillsAcpControlPlane(
   // The demand loop holds a label and a path, never a bound Project: resolving
   // here keeps the one workspace resolver in the one place that owns it.
   const runDemandTurn = async (request: DemandBirthTurn): Promise<DemandTurnResult> => runTurn({
-    project: await workspaceFor(await resolveAcpProjectIdentity(request.workspacePath)),
+    project: await workspaceFor(await resolveAcpProjectIdentity(request.workspacePath, identityOptions)),
     prompt: request.prompt,
     ...(request.workItem == null ? {} : { workItem: request.workItem }),
     ...(request.runner == null || !(ACP_AGENT_IDS as readonly string[]).includes(request.runner)
@@ -226,7 +245,7 @@ async function servePublicConnection(
   let attached = true;
 
   const bindProject = async (cwd: string, incompatible: () => Error): Promise<AcpProjectWorkspace> => {
-    const identity = await resolveAcpProjectIdentity(cwd);
+    const identity = await resolveAcpProjectIdentity(cwd, options.identityOptions);
     if (connectionProject != null && connectionProject.projectId !== identity.projectId) throw incompatible();
     connectionProject ??= await workspaceFor(identity);
     return connectionProject;

--- a/apps/redskilled/src/project-identity-store.ts
+++ b/apps/redskilled/src/project-identity-store.ts
@@ -1,0 +1,108 @@
+// project-identity-store — the durable answer to "which GitHub repository is
+// this remote slug?".
+//
+// **Identity must not depend on a live network call.** Project identity was
+// decided per bind by an (often unauthenticated) GitHub read: past the rate
+// limit, offline, or against a private repository the resolution silently
+// demoted `github:<id>` to `remote:<slug>` — and every store keyed by project
+// id (control state, workspaces, memory roots) split in two. A GitHub numeric
+// id is immutable across renames, so one successful resolution is
+// authoritative forever; this store files it beside the other host-state
+// snapshots and answers every later bind without the network.
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+
+export interface ProjectIdentityRecord {
+  /** The normalized `owner/repo` slug the checkout's remote names. */
+  readonly slug: string;
+  readonly github_id: string;
+  readonly full_name: string;
+  readonly first_resolved_at: string;
+  readonly last_confirmed_at: string;
+}
+
+export interface ProjectIdentityStore {
+  read(slug: string): Promise<ProjectIdentityRecord | undefined>;
+  remember(entry: { slug: string; githubId: string; fullName: string }): Promise<void>;
+}
+
+/** The snapshot lives beside the other durable host-state files. */
+export function projectIdentityStorePath(registrationIntentPath: string): string {
+  return join(dirname(registrationIntentPath), "redskilled.project-identities.toon");
+}
+
+export function createProjectIdentityStore(
+  path: string,
+  clock: () => string = () => new Date().toISOString(),
+): ProjectIdentityStore {
+  let tail: Promise<unknown> = Promise.resolve();
+  const load = async (): Promise<ProjectIdentityRecord[]> => {
+    let raw: string;
+    try {
+      raw = await readFile(path, "utf8");
+    } catch {
+      return [];
+    }
+    let parsed: unknown;
+    try {
+      parsed = decode(raw.trim());
+    } catch {
+      return [];
+    }
+    const snapshot = parsed as { identities?: unknown };
+    if (!Array.isArray(snapshot?.identities)) return [];
+    return snapshot.identities.filter(isProjectIdentityRecord);
+  };
+  return {
+    async read(slug) {
+      const normalized = normalizeSlug(slug);
+      return (await load()).find((record) => record.slug === normalized);
+    },
+    async remember(entry) {
+      const write = tail.then(async () => {
+        const normalized = normalizeSlug(entry.slug);
+        const now = clock();
+        const held = await load();
+        const existing = held.find((record) => record.slug === normalized);
+        const next: ProjectIdentityRecord = {
+          slug: normalized,
+          github_id: entry.githubId,
+          full_name: entry.fullName,
+          first_resolved_at: existing?.first_resolved_at ?? now,
+          last_confirmed_at: now,
+        };
+        const records = [...held.filter((record) => record.slug !== normalized), next]
+          .sort((left, right) => left.slug.localeCompare(right.slug));
+        await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+        const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+        try {
+          await writeFile(
+            temporary,
+            `${encode({ version: 1, identities: records } as unknown as JsonValue)}\n`,
+            { mode: 0o600 },
+          );
+          await rename(temporary, path);
+        } finally {
+          await rm(temporary, { force: true });
+        }
+      });
+      tail = write.catch(() => undefined);
+      await write;
+    },
+  };
+}
+
+function normalizeSlug(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
+function isProjectIdentityRecord(value: unknown): value is ProjectIdentityRecord {
+  const record = value as Record<string, unknown> | null;
+  return record != null && typeof record === "object" &&
+    typeof record.slug === "string" && typeof record.github_id === "string" &&
+    typeof record.full_name === "string" && typeof record.first_resolved_at === "string" &&
+    typeof record.last_confirmed_at === "string";
+}

--- a/apps/redskilled/src/project-workspace.ts
+++ b/apps/redskilled/src/project-workspace.ts
@@ -36,6 +36,23 @@ export interface AcpProjectWorkspace extends AcpProjectIdentity {
 export interface ResolveAcpProjectIdentityOptions {
   readonly env?: NodeJS.ProcessEnv;
   readonly fetchImpl?: typeof fetch;
+  /** The daemon's own credential; env vars remain the fallback. */
+  readonly resolveToken?: () => string | null | Promise<string | null>;
+  /**
+   * Durable slug → GitHub identity answers. A hit is authoritative and costs
+   * no network: a GitHub numeric id is immutable across renames, and identity
+   * deciding differently per bind is exactly the split this closes.
+   */
+  readonly identityCache?: {
+    read(slug: string): Promise<{ github_id: string; full_name: string } | undefined>;
+    remember(entry: { slug: string; githubId: string; fullName: string }): Promise<void>;
+  };
+  /**
+   * Told when a GitHub-remoted checkout could not resolve its `github:<id>`
+   * and fell back to `remote:<slug>` — the silent demotion that used to split
+   * one repository into two project identities.
+   */
+  readonly onIdentityDemotion?: (slug: string, reason: string) => void;
 }
 
 /** Resolve identity without creating Project state, so authority can be checked first. */
@@ -47,10 +64,33 @@ export async function resolveAcpProjectIdentity(
   const gitCommonDir = await gitOutput(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
   const remoteUrl = await gitOutput(cwd, ["remote", "get-url", "origin"]);
   const remoteSlug = repoSlugFromRemoteUrl(remoteUrl);
+  // The cache answers first, with no network: one successful resolution is
+  // authoritative forever (GitHub ids survive renames), so a rate-limited or
+  // offline bind can no longer demote a known repository to a second identity.
+  const cached = remoteSlug == null
+    ? undefined
+    : await options.identityCache?.read(remoteSlug).catch(() => undefined);
+  if (cached != null) {
+    return {
+      projectId: `github:${cached.github_id}`,
+      projectLabel: cached.full_name,
+      checkoutRoot,
+      ...(remoteUrl == null ? {} : { remoteUrl }),
+    };
+  }
+  let demotionReason = "the GitHub repository read answered without an identity";
   const github = remoteSlug == null
     ? undefined
-    : await readGithubRepository(remoteSlug, remoteUrl, options).catch(() => undefined);
+    : await readGithubRepository(remoteSlug, remoteUrl, options).catch((error) => {
+        demotionReason = error instanceof Error ? error.message : String(error);
+        return undefined;
+      });
   if (github != null) {
+    await options.identityCache?.remember({
+      slug: remoteSlug as string,
+      githubId: github.id,
+      fullName: github.fullName,
+    }).catch(() => undefined);
     return {
       projectId: `github:${github.id}`,
       projectLabel: github.fullName,
@@ -58,6 +98,7 @@ export async function resolveAcpProjectIdentity(
       ...(remoteUrl == null ? {} : { remoteUrl }),
     };
   }
+  if (remoteSlug != null) options.onIdentityDemotion?.(remoteSlug, demotionReason);
 
   // Non-GitHub directories remain usable by generic ACP clients. This fallback
   // is deliberately named as local/remote evidence; it never masquerades as an
@@ -158,7 +199,11 @@ async function readGithubRepository(
   const env = options.env ?? process.env;
   const configuredOrigin = env.GITHUB_API_URL?.trim();
   const isGithubRemote = /(^|[.@/:])github\.com(?=[:/])/i.test(remoteUrl ?? "");
-  const token = (env.REDSKILLED_HOST_TOKEN ?? env.GITHUB_TOKEN ?? env.GH_TOKEN ?? "").trim();
+  // The daemon's own credential first: an unauthenticated read runs against a
+  // 60/hour/IP budget, and exhausting it mid-day is what flipped identity per
+  // bind. Env vars stay as the fallback for embeddings without a gateway.
+  const resolved = options.resolveToken == null ? null : await options.resolveToken();
+  const token = (resolved ?? env.REDSKILLED_HOST_TOKEN ?? env.GITHUB_TOKEN ?? env.GH_TOKEN ?? "").trim();
   if (!configuredOrigin && !isGithubRemote && token === "") return undefined;
 
   const origin = (configuredOrigin || "https://api.github.com").replace(/\/+$/, "");

--- a/apps/redskilled/tests/project-identity-store.test.ts
+++ b/apps/redskilled/tests/project-identity-store.test.ts
@@ -1,0 +1,146 @@
+// Project identity used to be decided per bind by a live (often
+// unauthenticated) GitHub read: past the 60/hour anonymous budget the same
+// repository silently became `remote:<slug>` beside its `github:<id>` twin,
+// splitting every store keyed by project id. A GitHub numeric id is immutable
+// across renames, so one successful resolution is authoritative forever —
+// these tests pin the durable cache and the credentialed, reported resolution
+// path that make identity stop depending on the network.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createProjectIdentityStore,
+  projectIdentityStorePath,
+} from "../src/project-identity-store.js";
+import { resolveAcpProjectIdentity } from "../src/project-workspace.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function scratchStore() {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-identity-store-"));
+  roots.push(root);
+  const path = projectIdentityStorePath(join(root, "redskilled.registrations.toon"));
+  return { root, path };
+}
+
+describe("the durable project identity store", () => {
+  it("remembers a resolution and answers it back, case-insensitively, across instances", async () => {
+    const { path } = await scratchStore();
+    const store = createProjectIdentityStore(path, () => "2026-08-24T20:00:00.000Z");
+
+    await store.remember({ slug: "RedDB-io/Red-Skills", githubId: "1240684599", fullName: "reddb-io/red-skills" });
+
+    // A fresh instance reads the same file — the answer survives a daemon restart.
+    const reborn = createProjectIdentityStore(path);
+    await expect(reborn.read("reddb-io/red-skills")).resolves.toMatchObject({
+      github_id: "1240684599",
+      full_name: "reddb-io/red-skills",
+      first_resolved_at: "2026-08-24T20:00:00.000Z",
+    });
+  });
+
+  it("a re-confirmation updates the name and keeps the first resolution instant", async () => {
+    const { path } = await scratchStore();
+    let now = "2026-08-24T20:00:00.000Z";
+    const store = createProjectIdentityStore(path, () => now);
+
+    await store.remember({ slug: "a/b", githubId: "7", fullName: "a/b" });
+    now = "2026-08-25T09:00:00.000Z";
+    await store.remember({ slug: "a/b", githubId: "7", fullName: "a/b-renamed" });
+
+    await expect(store.read("a/b")).resolves.toMatchObject({
+      full_name: "a/b-renamed",
+      first_resolved_at: "2026-08-24T20:00:00.000Z",
+      last_confirmed_at: "2026-08-25T09:00:00.000Z",
+    });
+  });
+
+  it("an absent or unreadable snapshot answers nothing rather than throwing", async () => {
+    const store = createProjectIdentityStore("/nowhere/identities.toon");
+    await expect(store.read("a/b")).resolves.toBeUndefined();
+  });
+});
+
+describe("identity resolution rides the cache, the daemon credential, and the demotion report", () => {
+  async function gitCheckout(remote: string): Promise<string> {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const run = promisify(execFile);
+    const root = await mkdtemp(join(tmpdir(), "redskilled-identity-checkout-"));
+    roots.push(root);
+    await run("git", ["-C", root, "init", "--quiet"]);
+    await run("git", ["-C", root, "remote", "add", "origin", remote]);
+    return root;
+  }
+
+  it("resolves a cached github identity without any network call", async () => {
+    const cwd = await gitCheckout("https://github.com/reddb-io/red-skills.git");
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("the network must not be asked");
+    });
+
+    const identity = await resolveAcpProjectIdentity(cwd, {
+      env: {},
+      fetchImpl: fetchImpl as never,
+      identityCache: {
+        read: async () => ({ github_id: "1240684599", full_name: "reddb-io/red-skills" }),
+        remember: async () => {},
+      },
+    });
+
+    expect(identity.projectId).toBe("github:1240684599");
+    expect(identity.projectLabel).toBe("reddb-io/red-skills");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("threads the daemon credential into the read and remembers the answer", async () => {
+    const cwd = await gitCheckout("https://github.com/reddb-io/red-skills.git");
+    const remembered: unknown[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: { headers: Record<string, string> }) => {
+      expect(init.headers.authorization).toBe("Bearer the-daemon-token");
+      return {
+        ok: true,
+        json: async () => ({ id: 1240684599, full_name: "reddb-io/red-skills" }),
+      } as never;
+    });
+
+    const identity = await resolveAcpProjectIdentity(cwd, {
+      env: {},
+      fetchImpl: fetchImpl as never,
+      resolveToken: async () => "the-daemon-token",
+      identityCache: {
+        read: async () => undefined,
+        remember: async (entry) => void remembered.push(entry),
+      },
+    });
+
+    expect(identity.projectId).toBe("github:1240684599");
+    expect(remembered).toEqual([{
+      slug: "reddb-io/red-skills",
+      githubId: "1240684599",
+      fullName: "reddb-io/red-skills",
+    }]);
+  });
+
+  it("reports the demotion when resolution fails instead of splitting silently", async () => {
+    const cwd = await gitCheckout("https://github.com/reddb-io/red-skills.git");
+    const demotions: string[] = [];
+
+    const identity = await resolveAcpProjectIdentity(cwd, {
+      env: {},
+      fetchImpl: (async () => {
+        throw new Error("rate limit exhausted");
+      }) as never,
+      onIdentityDemotion: (slug, reason) => demotions.push(`${slug}: ${reason}`),
+    });
+
+    expect(identity.projectId).toBe("remote:reddb-io/red-skills");
+    expect(demotions).toEqual(["reddb-io/red-skills: rate limit exhausted"]);
+  });
+});


### PR DESCRIPTION
## What

Wave 4 slice 1 of the E2E-flow repair (root cause of the `github:1240684599` / `remote:reddb-io/red-skills` split-brain: 611 vs 561 sessions on one repo, double clones, drain intent invisible across the spellings).

- New `project-identity-store.ts`: durable TOON snapshot `redskilled.project-identities.toon` beside the other host-state files, keyed by normalized remote slug — `{slug, github_id, full_name, first_resolved_at, last_confirmed_at}`. A hit is authoritative and costs no network (GitHub ids survive renames); `remember` is serialized and atomic.
- `resolveAcpProjectIdentity` resolution order: git evidence → **cache** → network **with the daemon's personal credential** (`resolveToken`, from the gateway registration; env vars stay the fallback) → `remote:`/`local:` fallback **reporting the demotion** via `onIdentityDemotion`.
- The control plane builds one `identityOptions` policy for every bind: cache at `projectIdentityStorePath(paths.registrationIntentPath)`, token via `githubGateway.credentialForProfile("personal")`, demotions recorded as `acp-failure` events (the Wave 1 lane). No `lifecycle.ts` touch.

## Tests

`project-identity-store.test.ts`: store round-trip across instances (case-insensitive slug, restart-survival), re-confirmation keeps `first_resolved_at`, absent snapshot answers nothing; resolution: cached identity with zero network, credential threaded + answer remembered, failed resolution reports the demotion. 12/12 with adjacent suites; typecheck clean.

Follow-up (w4b): canonicalize the existing `remote:*` state on this host onto the cached `github:` identities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790200250&installation_model_id=20659&pr_number=4381&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4381&signature=1e244d4dafe90a60c52709b84990d5ab1a75a0d4d03ce7748df3f072e473fc96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->