### PR TITLE
fix(redskilled): the ACP session journal applies its own retention

### DIFF
--- a/.changeset/acp-session-journal-retention.md
+++ b/.changeset/acp-session-journal-retention.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The durable ACP session journal prunes connect-only sessions past a 24-hour window and caps itself at the 200 newest records — applied by its own writer at load and on every session creation — instead of growing without bound while full-snapshot-rewriting on every append.

--- a/apps/redskilled/src/acp-session-journal.ts
+++ b/apps/redskilled/src/acp-session-journal.ts
@@ -48,6 +48,41 @@ export interface AcpSessionJournalRecord {
   readonly entries: readonly AcpSessionJournalEntry[];
   /** Provider-native artifacts are retained beside, never inside, public history. */
   readonly session_evidence: readonly AcpSessionEvidenceReference[];
+  /** Absent on legacy rows, which retention treats as the oldest. */
+  readonly created_at?: string;
+  readonly updated_at?: string;
+}
+
+/** How long a connect-only session (no entries, no evidence) is kept. */
+export const ACP_SESSION_EMPTY_TTL_MS = 24 * 60 * 60 * 1000;
+/** The most sessions the journal retains; the newest survive. */
+export const ACP_SESSION_JOURNAL_CAP = 200;
+
+/**
+ * The journal's own retention, applied by its writer.
+ *
+ * Every MCP surface and every self-healing re-dial opens a session, so about
+ * half of the journal's rows were connect-and-never-prompt records that grew
+ * without bound — and each append rewrites the WHOLE snapshot, so an unbounded
+ * map made cumulative write cost quadratic. Empty rows past their TTL are
+ * dropped, and the map is capped at the newest records; a legacy row without
+ * timestamps counts as the oldest. PURE.
+ */
+export function compactAcpSessions(
+  records: readonly AcpSessionJournalRecord[],
+  nowMs: number,
+): AcpSessionJournalRecord[] {
+  const stampOf = (record: AcpSessionJournalRecord): number => {
+    const stamp = Date.parse(record.updated_at ?? record.created_at ?? "");
+    return Number.isFinite(stamp) ? stamp : 0;
+  };
+  const kept = records.filter((record) =>
+    record.entries.length > 0 || record.session_evidence.length > 0 ||
+    nowMs - stampOf(record) <= ACP_SESSION_EMPTY_TTL_MS);
+  return kept
+    .sort((left, right) => stampOf(right) - stampOf(left))
+    .slice(0, ACP_SESSION_JOURNAL_CAP)
+    .sort((left, right) => left.public_session_id.localeCompare(right.public_session_id));
 }
 
 export type AcpSessionEvidenceAvailability = "available" | "absent" | "inaccessible";
@@ -105,8 +140,17 @@ export function acpSessionJournalPath(registrationIntentPath: string): string {
   return join(dirname(registrationIntentPath), "redskilled.acp-sessions.toon");
 }
 
-export async function createAcpSessionJournal(path: string): Promise<AcpSessionJournal> {
-  const sessions = await readSnapshot(path);
+export async function createAcpSessionJournal(
+  path: string,
+  clock: () => string = () => new Date().toISOString(),
+): Promise<AcpSessionJournal> {
+  const loaded = await readSnapshot(path);
+  // Retention runs where the writer runs: a journal loaded by a fresh daemon
+  // sheds its expired connect-only rows before the first append rewrites it.
+  const sessions = new Map(
+    compactAcpSessions([...loaded.values()], Date.parse(clock()))
+      .map((record) => [record.public_session_id, record] as const),
+  );
   let tail: Promise<void> = Promise.resolve();
 
   const persist = (): Promise<void> => {
@@ -120,6 +164,7 @@ export async function createAcpSessionJournal(path: string): Promise<AcpSessionJ
     if (held == null) throw new Error("unknown durable RedSkills ACP session");
     sessions.set(publicSessionId, {
       ...held,
+      updated_at: clock(),
       entries: [...held.entries, { ...entry, sequence: held.entries.length + 1 } as AcpSessionJournalEntry],
     });
     return persist();
@@ -127,6 +172,12 @@ export async function createAcpSessionJournal(path: string): Promise<AcpSessionJ
 
   return {
     create(publicSessionId, project) {
+      // Opportunistic retention: every new session sheds whatever expired
+      // since boot, so a long-lived daemon's journal stays bounded too.
+      const now = clock();
+      const compacted = compactAcpSessions([...sessions.values()], Date.parse(now));
+      sessions.clear();
+      for (const record of compacted) sessions.set(record.public_session_id, record);
       sessions.set(publicSessionId, {
         public_session_id: publicSessionId,
         project_id: project.projectId,
@@ -134,6 +185,8 @@ export async function createAcpSessionJournal(path: string): Promise<AcpSessionJ
         workspace_path: project.workspacePath,
         entries: [],
         session_evidence: [],
+        created_at: now,
+        updated_at: now,
       });
       return persist();
     },
@@ -160,6 +213,7 @@ export async function createAcpSessionJournal(path: string): Promise<AcpSessionJ
       if (held == null) throw new Error("unknown durable RedSkills ACP session");
       sessions.set(publicSessionId, {
         ...held,
+        updated_at: clock(),
         session_evidence: [
           ...held.session_evidence,
           { worker_id: workerId, ...report, retention: "evidence" },

--- a/apps/redskilled/tests/acp-session-journal-retention.test.ts
+++ b/apps/redskilled/tests/acp-session-journal-retention.test.ts
@@ -1,0 +1,113 @@
+// The durable session journal rewrites its WHOLE snapshot on every append, and
+// every MCP surface and self-healing re-dial opens a session — so about half
+// of a live host's rows were connect-and-never-prompt records and cumulative
+// write cost grew quadratically (1612 rows, ~1 MB per write). Retention runs
+// where the writer runs: empty rows past their TTL are shed at load and on
+// every create, and the map is capped at the newest records.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  ACP_SESSION_EMPTY_TTL_MS,
+  ACP_SESSION_JOURNAL_CAP,
+  compactAcpSessions,
+  createAcpSessionJournal,
+  type AcpSessionJournalRecord,
+} from "../src/acp-session-journal.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+const project = {
+  projectId: "github:1",
+  projectLabel: "reddb-io/red-skills",
+  workspacePath: "/tmp/workspace",
+} as never;
+
+function row(overrides: Partial<AcpSessionJournalRecord>): AcpSessionJournalRecord {
+  return {
+    public_session_id: "session",
+    project_id: "github:1",
+    project_label: "reddb-io/red-skills",
+    workspace_path: "/tmp/workspace",
+    entries: [],
+    session_evidence: [],
+    ...overrides,
+  } as AcpSessionJournalRecord;
+}
+
+describe("compactAcpSessions", () => {
+  const now = Date.parse("2026-08-24T20:00:00.000Z");
+
+  it("drops connect-only sessions past the retention window and keeps fresh ones", () => {
+    const kept = compactAcpSessions([
+      row({ public_session_id: "stale-empty", updated_at: "2026-08-22T00:00:00.000Z" }),
+      row({ public_session_id: "fresh-empty", updated_at: "2026-08-24T19:30:00.000Z" }),
+      row({ public_session_id: "legacy-empty" }),
+    ], now);
+
+    expect(kept.map((record) => record.public_session_id)).toEqual(["fresh-empty"]);
+  });
+
+  it("keeps sessions with entries or evidence regardless of age", () => {
+    const kept = compactAcpSessions([
+      row({
+        public_session_id: "old-but-worked",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        entries: [{ kind: "prompt", sequence: 1 } as never],
+      }),
+      row({
+        public_session_id: "old-with-evidence",
+        session_evidence: [{ worker_id: "w" } as never],
+      }),
+    ], now);
+
+    expect(kept.map((record) => record.public_session_id).sort()).toEqual([
+      "old-but-worked",
+      "old-with-evidence",
+    ]);
+  });
+
+  it("caps the journal at the newest records", () => {
+    const crowd = Array.from({ length: ACP_SESSION_JOURNAL_CAP + 25 }, (_, index) =>
+      row({
+        public_session_id: `session-${String(index).padStart(4, "0")}`,
+        entries: [{ kind: "prompt", sequence: 1 } as never],
+        updated_at: new Date(now - index * 1000).toISOString(),
+      }));
+
+    const kept = compactAcpSessions(crowd, now);
+
+    expect(kept).toHaveLength(ACP_SESSION_JOURNAL_CAP);
+    // The newest survive; the 25 oldest are shed.
+    expect(kept.some((record) => record.public_session_id === "session-0000")).toBe(true);
+    expect(kept.some((record) => record.public_session_id === `session-${ACP_SESSION_JOURNAL_CAP + 24}`)).toBe(false);
+  });
+});
+
+describe("the journal applies its own retention", () => {
+  it("stamps created_at on new sessions and sheds expired empties on load", async () => {
+    const root = await mkdtemp(join(tmpdir(), "redskilled-journal-retention-"));
+    roots.push(root);
+    const path = join(root, "redskilled.acp-sessions.toon");
+    let now = "2026-08-24T20:00:00.000Z";
+    const clock = () => now;
+
+    const journal = await createAcpSessionJournal(path, clock);
+    await journal.create("connect-only", project);
+    await journal.create("worked", project);
+    await journal.prompt("worked", [{ type: "text", text: "do things" }] as never);
+
+    // A day later, a fresh daemon loads the journal: the connect-only row is
+    // past its window and gone; the worked session survives with its history.
+    now = new Date(Date.parse(now) + ACP_SESSION_EMPTY_TTL_MS + 60_000).toISOString();
+    const reborn = await createAcpSessionJournal(path, clock);
+    expect(() => reborn.recovery("connect-only")).toThrow(/unknown durable/);
+    expect(reborn.recovery("worked").entries).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

Wave 4 slice 2 of the E2E-flow repair. `redskilled.acp-sessions.toon` had no delete/TTL/compaction anywhere: every MCP surface and every self-healing re-dial creates a session, each was journaled forever, and `persist()` rewrites the whole snapshot per event — live host: 1612 records, ~796 with `entries: []`, 1.0 MB per write, ~850 MB cumulative I/O (O(N²)).

- `AcpSessionJournalRecord` gains optional `created_at`/`updated_at` (legacy rows = oldest); `create` stamps, `append`/`evidence` bump.
- New pure `compactAcpSessions`: connect-only rows (no entries, no evidence) past `ACP_SESSION_EMPTY_TTL_MS` (24h) are shed; the map is capped at `ACP_SESSION_JOURNAL_CAP` (200) newest. Sessions with content are never age-pruned.
- Retention is applied **by the writer**: at load (a fresh daemon sheds before its first rewrite) and opportunistically on every `create`.
- The full-snapshot rewrite stays — bounded by the cap, an append-log redesign is not worth its complexity.

## Tests

`acp-session-journal-retention.test.ts`: TTL prune keeps fresh empties and drops legacy/stale ones; content is never age-pruned; the cap keeps the newest; a day-later reload sheds the connect-only row while the worked session's history survives. Adjacent `acp-session-evidence` + `acp-local-transport` suites green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790200411&installation_model_id=20659&pr_number=4382&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4382&signature=5bd004137f4e4eb07ed267c4f4d3f63c4aa528799e6bd3a9f2d0868e00707b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->