### PR TITLE
feat(redskilled): reclaim --projects sweeps local workspaces whose seeding checkout is gone

### DIFF
--- a/.changeset/reclaim-local-project-orphans.md
+++ b/.changeset/reclaim-local-project-orphans.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+`redskilled reclaim --projects` sweeps `local-*` project workspaces whose seeding checkout no longer exists — evidence-judged (the seed clone's origin is the original path), grace-windowed, and refusing to touch github/remote projects or anything holding live drain intent.

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -57,6 +57,9 @@ import {
   reclaimRedskilledRuntimeDirs,
   type RedskilledReclaimOptions,
 } from "./reclaim.js";
+import { sweepOrphanedLocalProjects } from "./project-workspace-gc.js";
+import { createProjectControlStore, projectControlStorePath } from "./project-control.js";
+import { projectDirectoryName } from "./project-workspace.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "./paths.js";
 import { installStatuslineNativeFront } from "./statusline-native.js";
 import { RESOURCE_INCIDENTS_USAGE, runResourceIncidents } from "./resource-incidents-command.js";
@@ -228,12 +231,14 @@ evacuation. A socket nobody answers on is a success with a stated reason.
   --detail <why>  the operator's own words, recorded on the event lane so a
                   successor can tell a planned handover from a crash
 `,
-  reclaim: `Usage: redskilled reclaim [--dry-run] [--grace-ms <n>]
+  reclaim: `Usage: redskilled reclaim [--dry-run] [--grace-ms <n>] [--projects]
 
 Reports every session runtime dir it looked at and why it kept or removed it.
 
   --dry-run        the same report with nothing removed
   --grace-ms <n>   how long a dir must be idle before it is reclaimed
+  --projects       sweep local-* project workspaces whose seeding checkout is
+                   gone, instead of the session runtime dirs
 `,
   reap: `Usage: redskilled reap [--report]
 
@@ -846,6 +851,7 @@ export async function runUnit(
 const RECLAIM_FLAGS = {
   "dry-run": { kind: "boolean" },
   "grace-ms": { kind: "value", coerce: (raw: string) => Number(raw) },
+  projects: { kind: "boolean" },
 } as const;
 
 const REAP_FLAGS = {
@@ -893,6 +899,32 @@ export async function runReclaim(
 ): Promise<number> {
   const write = io.write ?? ((text: string) => process.stdout.write(text));
   const { values } = parseFlags(args, RECLAIM_FLAGS);
+  if (values.projects === true) {
+    const paths = resolveRedskilledPaths();
+    // A project holding live drain intent is kept whatever its origin says:
+    // the control record is the operator's word that this project matters.
+    const controls = await createProjectControlStore(
+      projectControlStorePath(paths.registrationIntentPath),
+    ).read().catch(() => new Map<string, never>());
+    const live = new Set(
+      [...controls.entries()]
+        .filter(([, state]) => (state as { drainIntent?: string }).drainIntent === "draining")
+        .map(([projectId]) => projectDirectoryName(projectId)),
+    );
+    const swept = await sweepOrphanedLocalProjects(paths.projectWorkspaceRoot, {
+      dryRun: values["dry-run"] === true,
+      liveProjectDirNames: live,
+      ...(Number.isFinite(values["grace-ms"]) ? { graceMs: values["grace-ms"] as number } : {}),
+    });
+    write(`${encodeToon({
+      root: swept.root,
+      scanned: swept.scanned,
+      reclaimed: swept.reclaimed,
+      dry_run: swept.dryRun,
+      entries: swept.entries.map((entry) => ({ dir: entry.dir, verdict: entry.verdict, reason: entry.reason })),
+    })}\n`);
+    return swept.entries.some((entry) => entry.verdict === "failed") ? 1 : 0;
+  }
   const report = await reclaimRedskilledRuntimeDirs({
     ...(io.options ?? {}),
     dryRun: values["dry-run"] === true,

--- a/apps/redskilled/src/project-workspace-gc.ts
+++ b/apps/redskilled/src/project-workspace-gc.ts
@@ -1,0 +1,130 @@
+// project-workspace-gc — reclaim `local-*` project workspaces whose seeding
+// checkout no longer exists.
+//
+// Every ACP bind of a repository-less directory mints a `local:<pathhash>`
+// project and clones the directory into the daemon home — and nothing ever
+// swept those clones: a test suite driving the real daemon from throwaway
+// `/tmp` fixtures left ~38 permanent orphans pointing at deleted paths. The
+// sweep follows reclaim's philosophy: report-first (dry-run by default), judge
+// by evidence (the seed clone's origin IS the original checkout path), and
+// never touch what still might be wanted — `github-*`/`remote-*` directories
+// are not its business, a young directory may be mid-seed, and a project with
+// live drain intent is kept whatever its origin says.
+import { execFile } from "node:child_process";
+import { readdir, rm, stat } from "node:fs/promises";
+import { isAbsolute, join } from "node:path";
+
+const GIT_TIMEOUT_MS = 10_000;
+
+/** A local workspace younger than this may still be mid-seed; kept. */
+export const LOCAL_PROJECT_GC_GRACE_MS = 60 * 60_000;
+
+export type LocalProjectGcVerdict = "reclaimed" | "kept" | "young" | "failed";
+
+export interface LocalProjectGcEntry {
+  readonly dir: string;
+  readonly verdict: LocalProjectGcVerdict;
+  readonly reason: string;
+}
+
+export interface LocalProjectGcReport {
+  readonly root: string;
+  readonly scanned: number;
+  readonly reclaimed: number;
+  readonly dryRun: boolean;
+  readonly entries: readonly LocalProjectGcEntry[];
+}
+
+export interface SweepOrphanedLocalProjectsOptions {
+  readonly dryRun?: boolean;
+  readonly graceMs?: number;
+  readonly now?: () => number;
+  /** Project ids holding live control intent; their workspaces are kept. */
+  readonly liveProjectDirNames?: ReadonlySet<string>;
+}
+
+/** Sweep `local-*` workspaces whose seeding checkout is gone. Never throws. */
+export async function sweepOrphanedLocalProjects(
+  workspaceRoot: string,
+  options: SweepOrphanedLocalProjectsOptions = {},
+): Promise<LocalProjectGcReport> {
+  const dryRun = options.dryRun ?? true;
+  const graceMs = options.graceMs ?? LOCAL_PROJECT_GC_GRACE_MS;
+  const now = options.now?.() ?? Date.now();
+  const entries: LocalProjectGcEntry[] = [];
+  let names: string[] = [];
+  try {
+    names = (await readdir(workspaceRoot)).filter((name) => name.startsWith("local-"));
+  } catch {
+    return { root: workspaceRoot, scanned: 0, reclaimed: 0, dryRun, entries: [] };
+  }
+  for (const name of names.sort()) {
+    const dir = join(workspaceRoot, name);
+    try {
+      if (options.liveProjectDirNames?.has(name)) {
+        entries.push({ dir, verdict: "kept", reason: "this project holds live control intent" });
+        continue;
+      }
+      const age = now - (await stat(dir)).mtimeMs;
+      if (age < graceMs) {
+        entries.push({ dir, verdict: "young", reason: "younger than the grace window; may be mid-seed" });
+        continue;
+      }
+      const origin = await gitOriginOf(join(dir, "workspace"));
+      if (origin == null) {
+        entries.push({ dir, verdict: "kept", reason: "no readable seed origin; evidence decides, absence keeps" });
+        continue;
+      }
+      if (!isAbsolute(origin)) {
+        entries.push({ dir, verdict: "kept", reason: `seeded from a non-local origin (${origin})` });
+        continue;
+      }
+      if (await exists(origin)) {
+        entries.push({ dir, verdict: "kept", reason: `its seeding checkout still exists at ${origin}` });
+        continue;
+      }
+      if (!dryRun) await rm(dir, { recursive: true, force: true });
+      entries.push({
+        dir,
+        verdict: "reclaimed",
+        reason: `its seeding checkout at ${origin} no longer exists`,
+      });
+    } catch (error) {
+      entries.push({
+        dir,
+        verdict: "failed",
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return {
+    root: workspaceRoot,
+    scanned: names.length,
+    reclaimed: entries.filter((entry) => entry.verdict === "reclaimed").length,
+    dryRun,
+    entries,
+  };
+}
+
+async function gitOriginOf(workspacePath: string): Promise<string | undefined> {
+  return await new Promise((resolve) => {
+    execFile(
+      "git",
+      ["-C", workspacePath, "remote", "get-url", "origin"],
+      { timeout: GIT_TIMEOUT_MS },
+      (error, stdout) => {
+        const value = stdout?.trim();
+        resolve(error != null || value === "" ? undefined : value);
+      },
+    );
+  });
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/redskilled/tests/project-workspace-gc.test.ts
+++ b/apps/redskilled/tests/project-workspace-gc.test.ts
@@ -1,0 +1,99 @@
+// Every ACP bind of a repository-less directory mints a `local:<pathhash>`
+// project and clones it into the daemon home — and nothing ever swept those
+// clones: a test suite driving the real daemon from throwaway /tmp fixtures
+// left ~38 permanent orphans pointing at deleted paths. The sweep judges by
+// the one piece of evidence a seed clone carries — its origin IS the original
+// checkout path — and keeps everything it cannot prove orphaned.
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { sweepOrphanedLocalProjects } from "../src/project-workspace-gc.js";
+
+const run = promisify(execFile);
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function scratch(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-project-gc-"));
+  roots.push(root);
+  return root;
+}
+
+async function localProject(root: string, name: string, origin: string): Promise<string> {
+  const dir = join(root, name);
+  const workspace = join(dir, "workspace");
+  await mkdir(workspace, { recursive: true });
+  await run("git", ["-C", workspace, "init", "--quiet"]);
+  await run("git", ["-C", workspace, "remote", "add", "origin", origin]);
+  // Old enough to be past the mid-seed grace window.
+  const old = new Date(Date.now() - 2 * 60 * 60_000);
+  await utimes(dir, old, old);
+  return dir;
+}
+
+describe("sweeping orphaned local project workspaces", () => {
+  it("reclaims a local project whose seeding checkout is gone, and only for real off dry-run", async () => {
+    const root = await scratch();
+    const goneCheckout = join(root, "was-a-fixture");
+    const dir = await localProject(root, "local-aaaa1111-bbbb2222", goneCheckout);
+
+    const dry = await sweepOrphanedLocalProjects(root, { dryRun: true });
+    expect(dry.entries).toEqual([
+      { dir, verdict: "reclaimed", reason: expect.stringContaining("no longer exists") },
+    ]);
+    expect(existsSync(dir)).toBe(true);
+
+    const real = await sweepOrphanedLocalProjects(root, { dryRun: false });
+    expect(real.reclaimed).toBe(1);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it("keeps a project whose checkout still exists, a remote-seeded one, and a live one", async () => {
+    const root = await scratch();
+    const livingCheckout = join(root, "still-here");
+    await mkdir(livingCheckout, { recursive: true });
+    await localProject(root, "local-cccc3333-dddd4444", livingCheckout);
+    await localProject(root, "local-eeee5555-ffff6666", "https://github.com/reddb-io/red-skills.git");
+    const claimed = await localProject(root, "local-9999aaaa-bbbbcccc", join(root, "gone"));
+
+    const report = await sweepOrphanedLocalProjects(root, {
+      dryRun: false,
+      liveProjectDirNames: new Set(["local-9999aaaa-bbbbcccc"]),
+    });
+
+    expect(report.reclaimed).toBe(0);
+    expect(report.entries.map((entry) => entry.verdict)).toEqual(["kept", "kept", "kept"]);
+    expect(existsSync(claimed)).toBe(true);
+  });
+
+  it("never touches github or remote project directories, and keeps the young and the unreadable", async () => {
+    const root = await scratch();
+    await mkdir(join(root, "github-1240684599-268fd370", "workspace"), { recursive: true });
+    await mkdir(join(root, "remote-reddb-io-red-skills-25a3bfdc", "workspace"), { recursive: true });
+    const young = join(root, "local-1234abcd-5678efgh");
+    await mkdir(join(young, "workspace"), { recursive: true });
+    const originless = join(root, "local-aaaabbbb-ccccdddd");
+    await mkdir(originless, { recursive: true });
+    await writeFile(join(originless, "note"), "no workspace at all");
+    const old = new Date(Date.now() - 2 * 60 * 60_000);
+    await utimes(originless, old, old);
+
+    const report = await sweepOrphanedLocalProjects(root, { dryRun: false });
+
+    expect(report.scanned).toBe(2);
+    expect(report.entries.map((entry) => [entry.dir.split("/").pop(), entry.verdict])).toEqual([
+      ["local-1234abcd-5678efgh", "young"],
+      ["local-aaaabbbb-ccccdddd", "kept"],
+    ]);
+    expect(existsSync(join(root, "github-1240684599-268fd370"))).toBe(true);
+    expect(existsSync(join(root, "remote-reddb-io-red-skills-25a3bfdc"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Wave 4 slice 3 of the E2E-flow repair. `~/.red/redskilled/projects/` on the maintainer's host holds ~38 `local-*` orphan clones minted by the redcode test suite's throwaway `/tmp/opencode-test-*` fixtures (origins long deleted); `reclaim.ts` only ever swept runtime socket dirs.

- New `project-workspace-gc.ts`: `sweepOrphanedLocalProjects(workspaceRoot, {dryRun, graceMs, liveProjectDirNames})` — for each `local-*` dir, the seed clone's `origin` (which IS the original checkout path) decides: local absolute path that no longer exists → reclaimed; still exists / non-local / unreadable → kept; younger than 1h → young (may be mid-seed); live drain intent → kept. Never throws; report-first.
- Wired as `redskilled reclaim --projects` (same `--dry-run`/`--grace-ms`, TOON report, exit 1 on `failed` entries); live-intent set derived from the project-control store via `projectDirectoryName`.

## Tests

`project-workspace-gc.test.ts`: dry-run reports without deleting and real run deletes; existing-checkout / remote-origin / live-intent all kept; `github-`/`remote-` untouched; young and originless kept. 15/15 with the reclaim suite; typecheck clean; `cli.ts` at 996 lines (baseline 1036).

## Live verification

`redskilled reclaim --projects --dry-run` lists the ~38 orphans; without `--dry-run` removes them; `ls ~/.red/redskilled/projects | grep -c local-` drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790200564&installation_model_id=20659&pr_number=4383&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4383&signature=f55ec88fb01b2a34e191875c61cb514f67d22d76e42c50676e6f3974d9f65c02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->