### PR TITLE
fix(redskilled): merge remote: twins onto their github: identity everywhere state is keyed

### DIFF
--- a/.changeset/project-identity-canonicalize.md
+++ b/.changeset/project-identity-canonicalize.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+Projects previously split between `remote:<slug>` and `github:<id>` identities are merged onto the github identity — control rows re-keyed with drain intent merged restrictively, duplicate workspace clones removed, displaced memory roots set aside as `.superseded`, and journal sessions re-keyed — once at boot for every cached alias and again the moment a new one is learned.

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -70,6 +70,7 @@ import {
   type ResolveAcpProjectIdentityOptions,
 } from "./project-workspace.js";
 import { createProjectIdentityStore, projectIdentityStorePath } from "./project-identity-store.js";
+import { memoryRootBesideWorkspaces, migrateProjectIdentity } from "./project-identity-migration.js";
 import {
   bindTargetedDispatch,
   createAcpSessionJournal as createAcpDispatchJournal,
@@ -131,8 +132,45 @@ export async function startRedskillsAcpControlPlane(
   // a miss, and a demotion to `remote:<slug>` is recorded instead of silent —
   // identity deciding differently per bind is how one repository became two
   // projects with split control state.
+  const identityStore = createProjectIdentityStore(projectIdentityStorePath(paths.registrationIntentPath));
+  const projectControls = await projectControlStore.read();
+  const persistProjectControls = projectControlStore.replace.bind(projectControlStore);
+  // Every resolved alias also REPAIRS history: the `remote:` twin's control
+  // row, workspace clone, memory root and journal sessions are merged onto the
+  // canonical `github:` identity — once at boot for everything already known,
+  // and again the moment a new alias is learned. Idempotent, so a clean pass
+  // costs a few stats and reports nothing.
+  const migrationDeps = {
+    registrationIntentPath: paths.registrationIntentPath,
+    projectWorkspaceRoot: paths.projectWorkspaceRoot,
+    memoryRoot: memoryRootBesideWorkspaces(paths.projectWorkspaceRoot),
+    projectControls,
+    persistProjectControls,
+  };
+  const migrateAlias = (alias: { slug: string; githubId: string; fullName: string }): void => {
+    void migrateProjectIdentity(alias, migrationDeps)
+      .then((report) => {
+        for (const action of report.actions) {
+          process.stderr.write(`project identity migration: ${action}\n`);
+        }
+      })
+      .catch(() => undefined);
+  };
+  void identityStore.all()
+    .then((records) => {
+      for (const record of records) {
+        migrateAlias({ slug: record.slug, githubId: record.github_id, fullName: record.full_name });
+      }
+    })
+    .catch(() => undefined);
   const identityOptions: ResolveAcpProjectIdentityOptions = {
-    identityCache: createProjectIdentityStore(projectIdentityStorePath(paths.registrationIntentPath)),
+    identityCache: {
+      read: (slug) => identityStore.read(slug),
+      remember: async (entry) => {
+        await identityStore.remember(entry);
+        migrateAlias(entry);
+      },
+    },
     resolveToken: async () =>
       (await options.githubGateway?.credentialForProfile?.("personal"))?.secret ?? null,
     onIdentityDemotion: (slug, reason) => options.recordAcpFailure?.({
@@ -141,8 +179,6 @@ export async function startRedskillsAcpControlPlane(
       surface: "connection",
     }),
   };
-  const projectControls = await projectControlStore.read();
-  const persistProjectControls = projectControlStore.replace.bind(projectControlStore);
   const sessionJournal = await createDurableAcpSessionJournal(acpSessionJournalPath(paths.registrationIntentPath));
   const runTurn = demandTurnRunnerFor(options, sessionJournal);
   const connectionOptions = {

--- a/apps/redskilled/src/project-identity-migration.ts
+++ b/apps/redskilled/src/project-identity-migration.ts
@@ -1,0 +1,181 @@
+// project-identity-migration — merge a `remote:<slug>` project into its
+// `github:<id>` identity, everywhere the daemon keyed state by project id.
+//
+// The identity coin-flip (an unauthenticated per-bind GitHub read) left one
+// repository standing as TWO projects: two full clones, two control rows —
+// with drain intent recorded on one spelling invisible to a connection bound
+// under the other — and two memory roots. The durable identity cache stops NEW
+// twins from forming; this migration repairs the history, one alias pair at a
+// time, idempotently, under the daemon's single-writer ownership of the files
+// it touches.
+//
+// Merge rules, decided with the maintainer:
+// - **Control rows**: the `github:` row wins field-wise; drain intent merges
+//   restrictively (a drain issued against either identity must survive, so
+//   `draining` on either side is `draining` on the merged row); revision takes
+//   the max so no consumer sees it move backwards.
+// - **Workspaces**: never keep both clones. The `github:` workspace wins; a
+//   lone `remote:` workspace is renamed onto the canonical name.
+// - **Memory roots**: merging two live stores is not mechanical, so the
+//   `github:` root wins and a coexisting `remote:` root is set aside as
+//   `<name>.superseded` — documented, recoverable, never silently dropped.
+// - **Session journal**: rows re-keyed to the canonical id, so retake and
+//   recovery stop splitting on the spelling.
+import { readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import type { ProjectControlState } from "./project-control.js";
+import { acpSessionJournalPath } from "./acp-session-journal.js";
+import { projectDirectoryName } from "./project-workspace.js";
+
+export interface ProjectIdentityAlias {
+  readonly slug: string;
+  readonly githubId: string;
+  readonly fullName: string;
+}
+
+export interface MigrateProjectIdentityDeps {
+  readonly registrationIntentPath: string;
+  readonly projectWorkspaceRoot: string;
+  /** The `~/.red/memory` parent; absent skips the memory step. */
+  readonly memoryRoot?: string;
+  /**
+   * The LIVE control map and its persist path, handed in by the one process
+   * that owns them. The control plane holds this map in memory and persists it
+   * whole, so a migration that re-keyed only the file would be silently undone
+   * by the next control write.
+   */
+  readonly projectControls: Map<string, ProjectControlState>;
+  readonly persistProjectControls: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>;
+}
+
+export interface ProjectIdentityMigrationReport {
+  readonly from: string;
+  readonly to: string;
+  /** What happened, one operator-readable sentence per touched surface. */
+  readonly actions: readonly string[];
+}
+
+/** Merge one alias pair everywhere. Idempotent; a clean pass reports nothing. */
+export async function migrateProjectIdentity(
+  alias: ProjectIdentityAlias,
+  deps: MigrateProjectIdentityDeps,
+): Promise<ProjectIdentityMigrationReport> {
+  const from = `remote:${alias.slug}`;
+  const to = `github:${alias.githubId}`;
+  const actions: string[] = [];
+
+  // 1. Control rows: re-key or merge, so drain intent recorded under either
+  //    spelling drives the one surviving project. The LIVE map is mutated —
+  //    the control plane persists that map whole, so a file-only rewrite
+  //    would be silently undone by its next write.
+  const controls = deps.projectControls;
+  const held = controls.get(from);
+  if (held != null) {
+    const canonical = controls.get(to);
+    const merged: ProjectControlState = canonical == null ? held : {
+      ...canonical,
+      drainIntent: held.drainIntent === "draining" || canonical.drainIntent === "draining"
+        ? "draining"
+        : canonical.drainIntent,
+      revision: Math.max(held.revision, canonical.revision),
+      ...((canonical.target ?? held.target) == null ? {} : { target: (canonical.target ?? held.target) as number }),
+      ...((canonical.runner ?? held.runner) == null ? {} : { runner: (canonical.runner ?? held.runner) as string }),
+    };
+    controls.delete(from);
+    controls.set(to, merged);
+    await deps.persistProjectControls(controls);
+    actions.push(canonical == null
+      ? `re-keyed the ${from} control row to ${to}`
+      : `merged the ${from} control row into ${to} (drain intent ${merged.drainIntent})`);
+  }
+
+  // 2. Workspaces: one clone per repository.
+  const fromDir = join(deps.projectWorkspaceRoot, projectDirectoryName(from));
+  const toDir = join(deps.projectWorkspaceRoot, projectDirectoryName(to));
+  if (await exists(fromDir)) {
+    if (await exists(toDir)) {
+      await rm(fromDir, { recursive: true, force: true });
+      actions.push(`removed the duplicate ${from} workspace clone (the ${to} clone stands)`);
+    } else {
+      await rename(fromDir, toDir);
+      actions.push(`renamed the ${from} workspace onto its canonical ${to} name`);
+    }
+  }
+
+  // 3. Memory roots: the canonical root wins; a displaced one is set aside.
+  if (deps.memoryRoot != null) {
+    const fromMemory = join(deps.memoryRoot, projectDirectoryName(from));
+    const toMemory = join(deps.memoryRoot, projectDirectoryName(to));
+    if (await exists(fromMemory)) {
+      if (await exists(toMemory)) {
+        await rename(fromMemory, `${fromMemory}.superseded`);
+        actions.push(`set the ${from} memory root aside as .superseded (the ${to} root stands)`);
+      } else {
+        await rename(fromMemory, toMemory);
+        actions.push(`renamed the ${from} memory root onto its canonical ${to} name`);
+      }
+    }
+  }
+
+  // 4. Session journal: rows follow the surviving identity.
+  const journalPath = acpSessionJournalPath(deps.registrationIntentPath);
+  const rekeyed = await rekeySessionJournal(journalPath, from, to, alias.fullName);
+  if (rekeyed > 0) actions.push(`re-keyed ${rekeyed} journal session(s) from ${from} to ${to}`);
+
+  return { from, to, actions };
+}
+
+async function rekeySessionJournal(
+  path: string,
+  from: string,
+  to: string,
+  fullName: string,
+): Promise<number> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return 0;
+  }
+  let parsed: unknown;
+  try {
+    parsed = decode(raw.trim());
+  } catch {
+    return 0;
+  }
+  const snapshot = parsed as { version?: unknown; sessions?: unknown };
+  if (snapshot?.version !== 1 || !Array.isArray(snapshot.sessions)) return 0;
+  let touched = 0;
+  const sessions = snapshot.sessions.map((value) => {
+    const record = value as Record<string, unknown> | null;
+    if (record == null || typeof record !== "object" || record.project_id !== from) return value;
+    touched += 1;
+    return { ...record, project_id: to, project_label: fullName };
+  });
+  if (touched === 0) return 0;
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, `${encode({ ...snapshot, sessions } as unknown as JsonValue)}\n`, { mode: 0o600 });
+    await rename(temporary, path);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+  return touched;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The `~/.red/memory` parent derived from the daemon's own workspace root. */
+export function memoryRootBesideWorkspaces(projectWorkspaceRoot: string): string {
+  return join(dirname(dirname(projectWorkspaceRoot)), "memory");
+}

--- a/apps/redskilled/src/project-identity-store.ts
+++ b/apps/redskilled/src/project-identity-store.ts
@@ -27,6 +27,8 @@ export interface ProjectIdentityRecord {
 export interface ProjectIdentityStore {
   read(slug: string): Promise<ProjectIdentityRecord | undefined>;
   remember(entry: { slug: string; githubId: string; fullName: string }): Promise<void>;
+  /** Every remembered identity — the migration's worklist at boot. */
+  all(): Promise<readonly ProjectIdentityRecord[]>;
 }
 
 /** The snapshot lives beside the other durable host-state files. */
@@ -60,6 +62,9 @@ export function createProjectIdentityStore(
     async read(slug) {
       const normalized = normalizeSlug(slug);
       return (await load()).find((record) => record.slug === normalized);
+    },
+    async all() {
+      return await load();
     },
     async remember(entry) {
       const write = tail.then(async () => {

--- a/apps/redskilled/tests/project-identity-migration.test.ts
+++ b/apps/redskilled/tests/project-identity-migration.test.ts
@@ -1,0 +1,139 @@
+// The identity coin-flip left one repository standing as TWO projects: two
+// full clones, two control rows (drain intent on one spelling invisible to
+// the other), two memory roots, and journal sessions split across both. The
+// durable cache stops new twins; this migration repairs the history — and
+// these tests pin its merge rules and its idempotence.
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  memoryRootBesideWorkspaces,
+  migrateProjectIdentity,
+} from "../src/project-identity-migration.js";
+import { acpSessionJournalPath } from "../src/acp-session-journal.js";
+import { projectDirectoryName } from "../src/project-workspace.js";
+import type { ProjectControlState } from "../src/project-control.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+const ALIAS = { slug: "reddb-io/red-skills", githubId: "1240684599", fullName: "reddb-io/red-skills" };
+const FROM = "remote:reddb-io/red-skills";
+const TO = "github:1240684599";
+
+async function host() {
+  const root = await mkdtemp(join(tmpdir(), "redskilled-identity-migration-"));
+  roots.push(root);
+  const registrationIntentPath = join(root, ".red", "redskilled", "redskilled.registrations.toon");
+  const projectWorkspaceRoot = join(root, ".red", "redskilled", "projects");
+  await mkdir(projectWorkspaceRoot, { recursive: true });
+  const persisted: unknown[] = [];
+  const projectControls = new Map<string, ProjectControlState>();
+  return {
+    root,
+    persisted,
+    deps: {
+      registrationIntentPath,
+      projectWorkspaceRoot,
+      memoryRoot: memoryRootBesideWorkspaces(projectWorkspaceRoot),
+      projectControls,
+      persistProjectControls: async (projects: ReadonlyMap<string, ProjectControlState>) => {
+        persisted.push(new Map(projects));
+      },
+    },
+  };
+}
+
+const state = (overrides: Partial<ProjectControlState>): ProjectControlState => ({
+  drainIntent: "stopped",
+  revision: 1,
+  updates: [],
+  ...overrides,
+});
+
+describe("migrating a remote: project onto its github: identity", () => {
+  it("re-keys a lone remote control row and renames its workspace and memory root", async () => {
+    const { deps } = await host();
+    deps.projectControls.set(FROM, state({ drainIntent: "draining", revision: 8, target: 1 }));
+    const fromWorkspace = join(deps.projectWorkspaceRoot, projectDirectoryName(FROM));
+    await mkdir(join(fromWorkspace, "workspace"), { recursive: true });
+    const fromMemory = join(deps.memoryRoot, projectDirectoryName(FROM));
+    await mkdir(fromMemory, { recursive: true });
+
+    const report = await migrateProjectIdentity(ALIAS, deps);
+
+    expect(deps.projectControls.has(FROM)).toBe(false);
+    expect(deps.projectControls.get(TO)).toMatchObject({ drainIntent: "draining", target: 1 });
+    expect(existsSync(join(deps.projectWorkspaceRoot, projectDirectoryName(TO), "workspace"))).toBe(true);
+    expect(existsSync(fromWorkspace)).toBe(false);
+    expect(existsSync(join(deps.memoryRoot, projectDirectoryName(TO)))).toBe(true);
+    expect(report.actions).toHaveLength(3);
+  });
+
+  it("merges drain intent restrictively when both rows exist, and drops the duplicate clone", async () => {
+    const { deps } = await host();
+    deps.projectControls.set(FROM, state({ drainIntent: "draining", revision: 23, runner: "codex" }));
+    deps.projectControls.set(TO, state({ drainIntent: "stopped", revision: 8, target: 2 }));
+    await mkdir(join(deps.projectWorkspaceRoot, projectDirectoryName(FROM), "workspace"), { recursive: true });
+    await mkdir(join(deps.projectWorkspaceRoot, projectDirectoryName(TO), "workspace"), { recursive: true });
+    const fromMemory = join(deps.memoryRoot, projectDirectoryName(FROM));
+    await mkdir(fromMemory, { recursive: true });
+    await mkdir(join(deps.memoryRoot, projectDirectoryName(TO)), { recursive: true });
+
+    await migrateProjectIdentity(ALIAS, deps);
+
+    // A drain issued against either identity survives the merge.
+    expect(deps.projectControls.get(TO)).toMatchObject({
+      drainIntent: "draining",
+      revision: 23,
+      target: 2,
+      runner: "codex",
+    });
+    expect(existsSync(join(deps.projectWorkspaceRoot, projectDirectoryName(FROM)))).toBe(false);
+    // Two live memory stores never merge mechanically: the displaced one is
+    // set aside, recoverable, never silently dropped.
+    expect(existsSync(`${fromMemory}.superseded`)).toBe(true);
+  });
+
+  it("re-keys journal sessions to the canonical identity", async () => {
+    const { deps } = await host();
+    const journalPath = acpSessionJournalPath(deps.registrationIntentPath);
+    await mkdir(join(deps.registrationIntentPath, ".."), { recursive: true });
+    await writeFile(journalPath, `${encode({
+      version: 1,
+      sessions: [
+        { public_session_id: "s1", project_id: FROM, project_label: "reddb-io/red-skills", workspace_path: "/x", entries: [], session_evidence: [] },
+        { public_session_id: "s2", project_id: "github:7", project_label: "a/b", workspace_path: "/y", entries: [], session_evidence: [] },
+      ],
+    } as unknown as JsonValue)}\n`);
+
+    const report = await migrateProjectIdentity(ALIAS, deps);
+
+    const rewritten = decode((await readFile(journalPath, "utf8")).trim()) as {
+      sessions: { public_session_id: string; project_id: string }[];
+    };
+    expect(rewritten.sessions.find((s) => s.public_session_id === "s1")?.project_id).toBe(TO);
+    expect(rewritten.sessions.find((s) => s.public_session_id === "s2")?.project_id).toBe("github:7");
+    expect(report.actions).toEqual([expect.stringContaining("re-keyed 1 journal session")]);
+  });
+
+  it("is idempotent — a second pass finds nothing to do", async () => {
+    const { deps, persisted } = await host();
+    deps.projectControls.set(FROM, state({ drainIntent: "draining" }));
+    await mkdir(join(deps.projectWorkspaceRoot, projectDirectoryName(FROM), "workspace"), { recursive: true });
+
+    await migrateProjectIdentity(ALIAS, deps);
+    const persistsAfterFirst = persisted.length;
+    const second = await migrateProjectIdentity(ALIAS, deps);
+
+    expect(second.actions).toEqual([]);
+    expect(persisted.length).toBe(persistsAfterFirst);
+  });
+});


### PR DESCRIPTION
## What

Wave 4 slice 4 (last) of the E2E-flow repair — the history repair behind #4381's cache. On the maintainer's host one repo stands as `remote:reddb-io/red-skills` + `github:1240684599`: doubled clones, split control rows (a drain on one spelling invisible to the other), split memory roots, split journal sessions.

- New `project-identity-migration.ts`: `migrateProjectIdentity(alias, deps)`, idempotent per `remote:<slug>` → `github:<id>` pair. Merge rules (maintainer-approved): control row re-keyed, or merged with **github winning field-wise and drain intent merging restrictively** (draining on either side survives; revision takes the max); **never two clones** (github workspace wins, lone remote renamed); memory roots never merged mechanically (displaced one set aside as `.superseded`, recoverable); journal sessions re-keyed. One operator-readable action line per touched surface.
- The control plane runs the migration at boot for every cached alias and on each newly learned one — **mutating the LIVE `projectControls` map** it holds in memory, because a file-only rewrite would be silently undone by the plane's next whole-map persist. `ProjectIdentityStore` gains `all()` as the boot worklist.

## Tests

`project-identity-migration.test.ts`: lone-row re-key + workspace/memory rename; both-rows merge (draining survives, target/runner union, duplicate clone dropped, memory set aside); journal re-key leaves other projects alone; second pass reports nothing and persists nothing. 11/11 with adjacent suites; typecheck clean.

## Live verification (after deploy + one bind of red-skills)

Daemon stderr prints the migration actions; `redskilled.project-control.toon` holds ONE row for red-skills with `drainIntent` preserved; `ls ~/.red/redskilled/projects` shows no `remote-reddb-io-*` twins; `du -sh` drops ~1.4 GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790200848&installation_model_id=20659&pr_number=4384&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4384&signature=a21ed9ca606e229e41258a3d4284ca7b7851f41bba0cc07364e9fc2b6c69da96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->