### PR TITLE
feat(dev): worker_dispatch serves demand dispatches through the daemon's go-dispatch method

### DIFF
--- a/.changeset/serve-worker-dispatch.md
+++ b/.changeset/serve-worker-dispatch.md
@@ -1,0 +1,6 @@
+---
+"@reddb-io/dev": patch
+"@reddb-io/redskilled": patch
+---
+
+worker_dispatch now serves demand-form dispatches through the daemon's `_redskills/go_dispatch` — the first slice-2 landing on the rs_dev routing table (#4113): the daemon mints the disposable lane:go Ticket, admits the Worker, and answers with its id; issue-form dispatches, mode, and runner refuse by name because the wire deliberately carries the demand alone.

--- a/apps/plugin-dev/src/core/mcp-tool-routing.ts
+++ b/apps/plugin-dev/src/core/mcp-tool-routing.ts
@@ -35,7 +35,7 @@
  * `unserved` list is **shrink-only** — {@link UNSERVED_MCP_TOOL_BASELINE} may
  * only go down, because a number that can go up is a budget, not a ratchet.
  */
-import type { RedskillsAcpMethod } from "@reddb-io/protocol-acp";
+import { REDSKILLS_ACP_METHODS, type RedskillsAcpMethod } from "@reddb-io/protocol-acp";
 
 /** The operations the daemon's Project control surface accepts. */
 export type McpToolControlOperation = "drain" | "stop" | "status";
@@ -105,7 +105,12 @@ export const MCP_TOOL_ROUTING: readonly McpToolRoute[] = [
   unserved("queue_status", ENGINE_GONE),
   unserved("events_since", ENGINE_GONE),
   unserved("deadend_audit", ENGINE_GONE),
-  unserved("worker_dispatch", DAEMON_OWNED),
+  // The first slice-2 landing: the daemon has served its go-dispatch method
+  // since ADR 0150 §3, with zero callers — the /go skill dispatched through
+  // this tool, which refused. Demand-form dispatches now reach the method;
+  // issue-form and mode/runner arguments refuse by name in the adapter, since
+  // the wire deliberately carries one field (the demand).
+  { tool: "worker_dispatch", kind: "served", method: REDSKILLS_ACP_METHODS.goDispatch },
   unserved("worker_stop", DAEMON_OWNED),
   unserved("worker_recycle", DAEMON_OWNED),
   unserved("runner_list", DAEMON_OWNED),
@@ -155,7 +160,7 @@ export const MCP_TOOL_ROUTING: readonly McpToolRoute[] = [
  * served instead — the whole point of the ratchet is that "we added another
  * verb nothing implements" cannot pass review as a number bump.
  */
-export const UNSERVED_MCP_TOOL_BASELINE = 51;
+export const UNSERVED_MCP_TOOL_BASELINE = 50;
 
 const BY_TOOL: ReadonlyMap<string, McpToolRoute> = new Map(
   MCP_TOOL_ROUTING.map((route) => [route.tool, route]),

--- a/apps/plugin-dev/src/project-acp-adapter.ts
+++ b/apps/plugin-dev/src/project-acp-adapter.ts
@@ -9,6 +9,7 @@ import {
   renderUnservedToolRefusal,
   type McpToolControlOperation,
 } from "./core/mcp-tool-routing.js";
+import { dispatchInput } from "./mcp-tools/worker.js";
 
 /**
  * The control map, DERIVED from the declared routing table (#4113).
@@ -71,13 +72,29 @@ export async function invokeProjectMcp(
     if (operation === "status") return await session.control("status");
     return await session.control(operation, controlRequest(input));
   }
+  const declared = mcpToolRoute(tool);
+  // The first served row: a demand-form dispatch reaches the daemon's own
+  // go-dispatch method. The wire deliberately carries ONE field, so the tool
+  // arguments the wire cannot express refuse by name — an issue-form dispatch
+  // belongs to the registered drain, and mode/runner are the daemon's verdicts
+  // on this lane.
+  if (declared?.kind === "served" && tool === "worker_dispatch") {
+    const parsed = dispatchInput({ ...input });
+    if (parsed.issue !== undefined || parsed.mode !== undefined || parsed.runner !== undefined) {
+      throw new Error(
+        'rs_dev tool "worker_dispatch" serves demand dispatches through the daemon\'s go-dispatch ' +
+          "method; a tracked-issue dispatch rides the registered drain (arm /afk), and mode/runner " +
+          "are not expressible on the go_dispatch wire",
+      );
+    }
+    return await session.goDispatch(parsed.demand as string);
+  }
   // **Refuse by name; never prompt a Worker with the call's own text.** Every
   // remaining published tool is declared `unserved`: the verb lives in no
   // process, so `session.prompt("/queue_status {}")` reached a Worker with no
   // ticket handoff for it, which narrated one line and ended the turn. The
   // caller read a healthy-looking empty envelope and went hunting capacity,
   // sockets and version skew (#4113).
-  const declared = mcpToolRoute(tool);
   if (declared?.kind === "unserved") throw new Error(renderUnservedToolRefusal(declared));
   throw new Error(`unsupported ACP Project capability ${JSON.stringify(tool)}`);
 }

--- a/apps/plugin-dev/tests/mcp-tool-routing-guard.test.ts
+++ b/apps/plugin-dev/tests/mcp-tool-routing-guard.test.ts
@@ -83,8 +83,10 @@ describe("the rs_dev routing table matches the live surfaces (#4113)", () => {
     ]);
   });
 
-  it("serves nothing through a daemon method yet, so slice 2 has a landing pad", () => {
-    expect(MCP_TOOL_ROUTING.filter((route) => route.kind === "served")).toEqual([]);
+  it("serves worker_dispatch through the daemon's go_dispatch method — the first slice-2 landing", () => {
+    expect(MCP_TOOL_ROUTING.filter((route) => route.kind === "served")).toEqual([
+      { tool: "worker_dispatch", kind: "served", method: "_redskills/go_dispatch" },
+    ]);
   });
 
   it("resolves one route by name and misses an undeclared one", () => {
@@ -147,7 +149,7 @@ describe("the audit refuses a table that drifted from a live source", () => {
 });
 
 describe("the adapter refuses an unserved verb instead of prompting a Worker", () => {
-  it.each(["queue_status", "project_activation", "worker_dispatch", "logs"])(
+  it.each(["queue_status", "project_activation", "worker_stop", "logs"])(
     "refuses %s by name, naming what does work, without reaching prompt",
     async (tool) => {
       const client = session();

--- a/apps/plugin-dev/tests/worker-dispatch-route.test.ts
+++ b/apps/plugin-dev/tests/worker-dispatch-route.test.ts
@@ -1,0 +1,72 @@
+// The daemon has served `_redskills/go_dispatch` since ADR 0150 §3 with ZERO
+// callers: the /go skill dispatched through `worker_dispatch`, which was
+// declared unserved and refused before the wire — the whole /go lane was
+// structurally dead. These tests pin the first slice-2 landing: a demand-form
+// dispatch reaches the daemon method, and everything the one-field wire cannot
+// express refuses by name instead of being dropped.
+import { describe, expect, it, vi } from "vitest";
+
+import { invokeProjectMcp } from "../src/project-acp-adapter.js";
+import type { RedskillsProjectAcpSession } from "@reddb-io/redskilled/acp-client";
+
+function sessionWith(goDispatch: (demand: string) => Promise<unknown>): RedskillsProjectAcpSession {
+  return {
+    goDispatch,
+    control: async () => {
+      throw new Error("worker_dispatch must not reach the control surface");
+    },
+    prompt: async () => {
+      throw new Error("worker_dispatch must never degrade to a Worker prompt");
+    },
+  } as never;
+}
+
+describe("worker_dispatch serves the go_dispatch wire", () => {
+  it("a demand dispatch reaches session.goDispatch and returns the daemon's answer", async () => {
+    const goDispatch = vi.fn(async (demand: string) => ({
+      version: 1,
+      worker_id: "worker-go-1",
+      ticket: 4390,
+      lane: "lane:go",
+      demand,
+    }));
+
+    const answer = await invokeProjectMcp(
+      sessionWith(goDispatch),
+      "worker_dispatch",
+      { demand: "touch nothing; reply DONE" },
+    );
+
+    expect(goDispatch).toHaveBeenCalledWith("touch nothing; reply DONE");
+    expect(answer).toMatchObject({ worker_id: "worker-go-1", ticket: 4390, lane: "lane:go" });
+  });
+
+  it("an issue-form dispatch is refused by name, not degraded or dropped", async () => {
+    const goDispatch = vi.fn(async () => ({}));
+
+    await expect(invokeProjectMcp(sessionWith(goDispatch), "worker_dispatch", { issue: 4280 }))
+      .rejects.toThrow(/a tracked-issue dispatch rides the registered drain/);
+    expect(goDispatch).not.toHaveBeenCalled();
+  });
+
+  it("mode and runner are refused by name — the wire carries the demand alone", async () => {
+    const goDispatch = vi.fn(async () => ({}));
+
+    await expect(invokeProjectMcp(
+      sessionWith(goDispatch),
+      "worker_dispatch",
+      { demand: "do it", mode: "scout" },
+    )).rejects.toThrow(/not expressible on the go_dispatch wire/);
+    await expect(invokeProjectMcp(
+      sessionWith(goDispatch),
+      "worker_dispatch",
+      { demand: "do it", runner: "codex" },
+    )).rejects.toThrow(/not expressible on the go_dispatch wire/);
+    expect(goDispatch).not.toHaveBeenCalled();
+  });
+
+  it("a dispatch naming neither issue nor demand keeps the schema's own refusal", async () => {
+    await expect(invokeProjectMcp(sessionWith(async () => ({})), "worker_dispatch", {}))
+      .rejects.toThrow(/exactly one of issue or demand/);
+  });
+});

--- a/apps/redskilled/src/acp-client.ts
+++ b/apps/redskilled/src/acp-client.ts
@@ -18,6 +18,7 @@ import { resolveRedskilledClientEndpoint } from "./client-rendezvous.js";
 import {
   REDSKILLS_ACP_METHODS,
   REDSKILLS_WIRE_MAJOR,
+  type GoDispatchAnswer,
   type RedskilledBrainAnswer,
   type RedskilledBrainCall,
   type RedskilledMemoryAnswer,
@@ -83,6 +84,13 @@ export interface RedskillsProjectAcpSession {
    * mutation is scheduled durably are all decided on the far side of this call.
    */
   github(request: RedskilledGithubRequest): Promise<RedskilledGithubRequestAnswer>;
+  /**
+   * Dispatch one ad-hoc demand through the daemon's own `/go` authority.
+   *
+   * The wire carries exactly the demand (ADR 0150 §3): lane, tracker, Worker
+   * kind, budget and placement are the daemon's verdicts.
+   */
+  goDispatch(demand: string): Promise<GoDispatchAnswer>;
   /**
    * Forward one brain tool call to the store the daemon holds for this host.
    *
@@ -219,6 +227,13 @@ export async function connectRedskillsProjectAcp(
       return await held.connection.agent.request<RedskilledGithubRequestAnswer>(
         REDSKILLS_ACP_METHODS.githubRequest,
         { request },
+      );
+    },
+    async goDispatch(demand) {
+      const held = await ensureLive();
+      return await held.connection.agent.request<GoDispatchAnswer>(
+        REDSKILLS_ACP_METHODS.goDispatch,
+        { demand },
       );
     },
     async brain(call) {

--- a/packaging/pi/dev/skills/engineering/afk/MCP.md
+++ b/packaging/pi/dev/skills/engineering/afk/MCP.md
@@ -196,17 +196,17 @@ holds both halves of that in place.
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `worker_dispatch` | mutating | **REFUSES (#4113).** Run one tracked issue, or mint and run one disposable demand. |
+| `worker_dispatch` | mutating | **Serves demand dispatches** through the daemon's `_redskills/go_dispatch`: mints the disposable `lane:go` Ticket, admits the Worker, and answers `{worker_id, ticket, lane}`. An `issue`-form dispatch, `mode`, or `runner` refuses by name — the wire deliberately carries the demand alone. |
 | `worker_stop` | mutating | **REFUSES (#4113).** Terminate one worker process tree. |
 | `worker_recycle` | mutating | **REFUSES (#4113).** Terminate one fleet worker so its supervisor refills the slot. |
 | `worker_request` | mutating | **REFUSES (#4113).** Dispatch a worker with a special request injected at spawn time. |
 
-`worker_dispatch` takes **exactly one** of `issue` or `demand`; `mode` is valid
-only for a `demand`. Go modes (`no-mistakes` / `direct-PR` / `local-only`) run
-the standard AFK engine and open a PR. The `scout` mode runs a **read-only
-investigation**: it mints a disposable `lane:scout` issue, runs the engine with
-`run_mode=scout` (no push, no PR, no merge), and posts the agent's report as a
-comment before closing the issue. Scout cannot be combined with `issue`.
+`worker_dispatch` takes **exactly one** of `issue` or `demand`, and today only
+the `demand` form is served: the `go_dispatch` wire carries one field, so fold
+the Definition of Done and any verify command into the demand text itself. An
+`issue`-form dispatch belongs to the registered drain (arm `/afk`), and `mode`
+and `runner` are not yet expressible on the wire — the tool refuses each by
+name rather than dropping it.
 
 ### Runner — backends and live steering
 

--- a/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/ask-red/SKILL.md
@@ -95,7 +95,8 @@ back into `/start`, `/to-spec`, `/to-tickets`, `/afk`, or `/hitl`.
   for project workflow truth and `/redskilled` for host process/budget truth.
   `/afk` and `/go` are clients of that canonical interface. The
   tool protocol is `plugins/dev/skills/engineering/afk/MCP.md`, which names the
-  four verbs that answer today and marks every tool that refuses pending #4113. Repo owners tune worker-slot
+  verbs that answer today (the four control verbs plus demand-form
+  `worker_dispatch`) and marks every tool that refuses pending #4113. Repo owners tune worker-slot
   throughput through `/afk` config: `afk.landing.wait` chooses release after
   merge, green CI, or PR-open; route that choice to the AFK config reference.
   A merge-queue ejection, or a clean fleet PR found outside the queue, belongs
@@ -175,11 +176,12 @@ ACP credential-budget observations (Project clients receive only their bound
 profile; explicit host administration receives all configured profiles and
 pools; warning and density policy stays daemon-owned) -> `/redskilled` and
 `apps/redskilled/src/acp-budget.ts`;
-`rs_dev` MCP (the canonical project interface; four verbs answer today —
-`drain`, `status`, `project_status`, `project_stop` — and every other tool,
-`help` and `project_reset` included, refuses by name pending #4113 because no
-`_redskills/*` daemon method serves it; a refusal is the verb being
-unimplemented, never a daemon, socket, capacity or version-skew fault) ->
+`rs_dev` MCP (the canonical project interface; four control verbs answer today —
+`drain`, `status`, `project_status`, `project_stop` — plus `worker_dispatch`,
+which serves demand-form dispatches through the daemon's `_redskills/go_dispatch`;
+every other tool, `help` and `project_reset` included, refuses by name pending
+#4113 because no `_redskills/*` daemon method serves it; a refusal is the verb
+being unimplemented, never a daemon, socket, capacity or version-skew fault) ->
 `plugins/dev/skills/engineering/afk/MCP.md`;
 Worker GitHub publication (credential-free Workers request authenticated fetch,
 push, pull-request, and Issue operations through project-scoped ACP; redskilled

--- a/packaging/pi/dev/skills/engineering/go/SKILL.md
+++ b/packaging/pi/dev/skills/engineering/go/SKILL.md
@@ -41,19 +41,21 @@ mints the disposable Ticket, admits the Worker against the host budget, and retu
 its id — all inside that call. `/go` mints nothing itself, places no workspace, and
 runs no boot phase over the human's checkout.
 
-`worker_dispatch` takes **exactly one** of `demand` or `issue`, and `mode` is valid
-only with `demand` — the schema enforces the `/go`-versus-`/afk` boundary that the
-hard rules below state in prose. The complete surface, host tool-name prefixing,
-and the mutation-mode contract are in [`../afk/MCP.md`](../afk/MCP.md).
+`worker_dispatch` takes **exactly one** of `demand` or `issue`, and today only
+the `demand` form is served — the `go_dispatch` wire deliberately carries one
+field, so the `/go`-versus-`/afk` boundary the hard rules below state in prose
+is also the wire's: an `issue`-form dispatch refuses by name and belongs to the
+registered drain. The complete surface, host tool-name prefixing, and the
+mutation-mode contract are in [`../afk/MCP.md`](../afk/MCP.md).
 
 | Dispatch parameter | Meaning |
 | --- | --- |
-| `demand` | the approved Task, as one string |
-| `dod` | the approved semantic Definition of Done |
-| `mode` | `direct-PR` (default), `no-mistakes`, `local-only`, or `scout` |
-| `runner` | a pinned backend; omitted, the host resolves its own |
-| `verify` | one ephemeral command appended to `post_done` for this dispatch |
-| `tags` | territory `tag:<value>` labels stamped on the minted Ticket |
+| `demand` | the approved Task, as one string — fold the approved Definition of Done and any agreed verify command into this text, under their own headings |
+
+`mode`, `runner`, `verify`, and `tags` are not yet expressible on the
+`go_dispatch` wire; the tool refuses them by name instead of dropping them.
+Widening the wire is a recorded follow-up, decided by the daemon, never smuggled
+through a dispatch argument.
 
 **What `/go` never does by hand.** No `git worktree add`, no branch pushed from
 the human's checkout, no CI watched in a shell loop, no `gh pr merge`: the

--- a/plugins/dev/skills/engineering/afk/MCP.md
+++ b/plugins/dev/skills/engineering/afk/MCP.md
@@ -196,17 +196,17 @@ holds both halves of that in place.
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `worker_dispatch` | mutating | **REFUSES (#4113).** Run one tracked issue, or mint and run one disposable demand. |
+| `worker_dispatch` | mutating | **Serves demand dispatches** through the daemon's `_redskills/go_dispatch`: mints the disposable `lane:go` Ticket, admits the Worker, and answers `{worker_id, ticket, lane}`. An `issue`-form dispatch, `mode`, or `runner` refuses by name — the wire deliberately carries the demand alone. |
 | `worker_stop` | mutating | **REFUSES (#4113).** Terminate one worker process tree. |
 | `worker_recycle` | mutating | **REFUSES (#4113).** Terminate one fleet worker so its supervisor refills the slot. |
 | `worker_request` | mutating | **REFUSES (#4113).** Dispatch a worker with a special request injected at spawn time. |
 
-`worker_dispatch` takes **exactly one** of `issue` or `demand`; `mode` is valid
-only for a `demand`. Go modes (`no-mistakes` / `direct-PR` / `local-only`) run
-the standard AFK engine and open a PR. The `scout` mode runs a **read-only
-investigation**: it mints a disposable `lane:scout` issue, runs the engine with
-`run_mode=scout` (no push, no PR, no merge), and posts the agent's report as a
-comment before closing the issue. Scout cannot be combined with `issue`.
+`worker_dispatch` takes **exactly one** of `issue` or `demand`, and today only
+the `demand` form is served: the `go_dispatch` wire carries one field, so fold
+the Definition of Done and any verify command into the demand text itself. An
+`issue`-form dispatch belongs to the registered drain (arm `/afk`), and `mode`
+and `runner` are not yet expressible on the wire — the tool refuses each by
+name rather than dropping it.
 
 ### Runner — backends and live steering
 

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -95,7 +95,8 @@ back into `/start`, `/to-spec`, `/to-tickets`, `/afk`, or `/hitl`.
   for project workflow truth and `/redskilled` for host process/budget truth.
   `/afk` and `/go` are clients of that canonical interface. The
   tool protocol is `plugins/dev/skills/engineering/afk/MCP.md`, which names the
-  four verbs that answer today and marks every tool that refuses pending #4113. Repo owners tune worker-slot
+  verbs that answer today (the four control verbs plus demand-form
+  `worker_dispatch`) and marks every tool that refuses pending #4113. Repo owners tune worker-slot
   throughput through `/afk` config: `afk.landing.wait` chooses release after
   merge, green CI, or PR-open; route that choice to the AFK config reference.
   A merge-queue ejection, or a clean fleet PR found outside the queue, belongs
@@ -175,11 +176,12 @@ ACP credential-budget observations (Project clients receive only their bound
 profile; explicit host administration receives all configured profiles and
 pools; warning and density policy stays daemon-owned) -> `/redskilled` and
 `apps/redskilled/src/acp-budget.ts`;
-`rs_dev` MCP (the canonical project interface; four verbs answer today —
-`drain`, `status`, `project_status`, `project_stop` — and every other tool,
-`help` and `project_reset` included, refuses by name pending #4113 because no
-`_redskills/*` daemon method serves it; a refusal is the verb being
-unimplemented, never a daemon, socket, capacity or version-skew fault) ->
+`rs_dev` MCP (the canonical project interface; four control verbs answer today —
+`drain`, `status`, `project_status`, `project_stop` — plus `worker_dispatch`,
+which serves demand-form dispatches through the daemon's `_redskills/go_dispatch`;
+every other tool, `help` and `project_reset` included, refuses by name pending
+#4113 because no `_redskills/*` daemon method serves it; a refusal is the verb
+being unimplemented, never a daemon, socket, capacity or version-skew fault) ->
 `plugins/dev/skills/engineering/afk/MCP.md`;
 Worker GitHub publication (credential-free Workers request authenticated fetch,
 push, pull-request, and Issue operations through project-scoped ACP; redskilled

--- a/plugins/dev/skills/engineering/go/SKILL.md
+++ b/plugins/dev/skills/engineering/go/SKILL.md
@@ -41,19 +41,21 @@ mints the disposable Ticket, admits the Worker against the host budget, and retu
 its id — all inside that call. `/go` mints nothing itself, places no workspace, and
 runs no boot phase over the human's checkout.
 
-`worker_dispatch` takes **exactly one** of `demand` or `issue`, and `mode` is valid
-only with `demand` — the schema enforces the `/go`-versus-`/afk` boundary that the
-hard rules below state in prose. The complete surface, host tool-name prefixing,
-and the mutation-mode contract are in [`../afk/MCP.md`](../afk/MCP.md).
+`worker_dispatch` takes **exactly one** of `demand` or `issue`, and today only
+the `demand` form is served — the `go_dispatch` wire deliberately carries one
+field, so the `/go`-versus-`/afk` boundary the hard rules below state in prose
+is also the wire's: an `issue`-form dispatch refuses by name and belongs to the
+registered drain. The complete surface, host tool-name prefixing, and the
+mutation-mode contract are in [`../afk/MCP.md`](../afk/MCP.md).
 
 | Dispatch parameter | Meaning |
 | --- | --- |
-| `demand` | the approved Task, as one string |
-| `dod` | the approved semantic Definition of Done |
-| `mode` | `direct-PR` (default), `no-mistakes`, `local-only`, or `scout` |
-| `runner` | a pinned backend; omitted, the host resolves its own |
-| `verify` | one ephemeral command appended to `post_done` for this dispatch |
-| `tags` | territory `tag:<value>` labels stamped on the minted Ticket |
+| `demand` | the approved Task, as one string — fold the approved Definition of Done and any agreed verify command into this text, under their own headings |
+
+`mode`, `runner`, `verify`, and `tags` are not yet expressible on the
+`go_dispatch` wire; the tool refuses them by name instead of dropping them.
+Widening the wire is a recorded follow-up, decided by the daemon, never smuggled
+through a dispatch argument.
 
 **What `/go` never does by hand.** No `git worktree add`, no branch pushed from
 the human's checkout, no CI watched in a shell loop, no `gh pr merge`: the


### PR DESCRIPTION
## What

Wave 5 slice 1 of the E2E-flow repair — **the /go lane comes back to life**, and the first slice-2 landing on the rs_dev routing table (#4113).

The daemon has served `_redskills/go_dispatch` since ADR 0150 §3 (admission, disposable `lane:go` Ticket mint, Worker birth) with **zero callers**: `/go` dispatched via `worker_dispatch`, which was declared `unserved` and refused before the wire.

- `mcp-tool-routing.ts`: `worker_dispatch` becomes the first `served` row; `UNSERVED_MCP_TOOL_BASELINE` **51 → 50** (the shrink the ratchet exists for). Guard test updated to pin the served set to exactly this row.
- `acp-client.ts`: new `goDispatch(demand)` session method (typed `GoDispatchAnswer`).
- `project-acp-adapter.ts`: served branch validates with the tool's own `dispatchInput` and forwards the demand; `issue`-form, `mode`, and `runner` refuse by name (the wire deliberately carries one field). No prompt degradation possible.
- Skills updated honestly + rule 8: `afk/MCP.md` (worker_dispatch row + form contract), `go/SKILL.md` (parameter table reduced to the wire's truth; DoD/verify fold into the demand text), `ask-red` coverage; `pi:manifests`/`codex:manifests`/`pi:packages:build` regenerated in this PR.

## Tests

New `worker-dispatch-route.test.ts` (demand reaches `goDispatch` and returns the daemon's answer; issue-form/mode/runner refuse by name without touching the wire; neither-form keeps the schema refusal). Routing guard, skill-named-verbs, adapter-ownership, drain-enrich suites: 46/46; typecheck clean both packages.

## Live verification

rs_dev `worker_dispatch {demand: "touch nothing; reply DONE"}` → `{worker_id, ticket, lane: "lane:go"}`; the disposable issue appears on the tracker; the Worker shows in host state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790201230&installation_model_id=20659&pr_number=4385&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4385&signature=e4298ab7101062a616bb3810d2b14ef7963f3135e10192b53d97a1972010a6d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->