### PR TITLE
fix(dev): status honors its scope — host answers from host_state, worker refuses by name

### DIFF
--- a/.changeset/status-scope-host.md
+++ b/.changeset/status-scope-host.md
@@ -1,0 +1,6 @@
+---
+"@reddb-io/dev": patch
+"@reddb-io/redskilled": patch
+---
+
+`status { scope: "host" }` now answers from the daemon's host_state instead of silently returning project status, and `scope: "worker"` refuses by name until a daemon method serves it — a scope silently substituted was a wrong answer wearing a healthy face.

--- a/apps/plugin-dev/src/project-acp-adapter.ts
+++ b/apps/plugin-dev/src/project-acp-adapter.ts
@@ -69,7 +69,20 @@ export async function invokeProjectMcp(
         `the Project control surface cannot express ${JSON.stringify(unsupported.sort())} for ${JSON.stringify(tool)}`,
       );
     }
-    if (operation === "status") return await session.control("status");
+    if (operation === "status") {
+      // The tool declares three scopes and used to answer PROJECT for all of
+      // them — a wrong answer wearing a healthy face. Host is served by the
+      // daemon's own host_state; worker refuses by name until a method serves
+      // it, because a scope silently substituted is worse than one refused.
+      if (input.scope === "host") return await session.hostState();
+      if (input.scope === "worker") {
+        throw new Error(
+          'status { scope: "worker" } is not served: worker vitals live in no daemon method yet; ' +
+            'read scope "host" and filter its workers, or use scope "project"',
+        );
+      }
+      return await session.control("status");
+    }
     return await session.control(operation, controlRequest(input));
   }
   const declared = mcpToolRoute(tool);

--- a/apps/plugin-dev/tests/status-scope.test.ts
+++ b/apps/plugin-dev/tests/status-scope.test.ts
@@ -1,0 +1,51 @@
+// `status` declares worker | project | host and used to answer PROJECT status
+// for every one of them — the same healthy-looking-wrong-answer class #4113
+// was raised about, still live after the refusal fix. The host scope has been
+// fillable all along (`_redskills/host_state` is served); the worker scope
+// refuses by name until a method serves it, because a scope silently
+// substituted is worse than one refused.
+import { describe, expect, it, vi } from "vitest";
+
+import { invokeProjectMcp } from "../src/project-acp-adapter.js";
+import type { RedskillsProjectAcpSession } from "@reddb-io/redskilled/acp-client";
+
+function session() {
+  const control = vi.fn(async () => ({ version: 1, project_id: "github:1" }));
+  const hostState = vi.fn(async () => ({ workers: [], daemon_version: "9.9.9" }));
+  return {
+    spy: { control, hostState },
+    client: { control, hostState } as never as RedskillsProjectAcpSession,
+  };
+}
+
+describe("status honors its scope", () => {
+  it("scope host reaches the daemon's host_state, not the project control surface", async () => {
+    const { spy, client } = session();
+
+    const answer = await invokeProjectMcp(client, "status", { scope: "host" });
+
+    expect(spy.hostState).toHaveBeenCalledOnce();
+    expect(spy.control).not.toHaveBeenCalled();
+    expect(answer).toMatchObject({ daemon_version: "9.9.9" });
+  });
+
+  it("scope worker refuses by name instead of silently answering project status", async () => {
+    const { spy, client } = session();
+
+    await expect(invokeProjectMcp(client, "status", { scope: "worker" }))
+      .rejects.toThrow(/scope "worker" .* is not served|status \{ scope: "worker" \} is not served/);
+    expect(spy.control).not.toHaveBeenCalled();
+    expect(spy.hostState).not.toHaveBeenCalled();
+  });
+
+  it("scope project — and an unstated scope — still reach the control surface", async () => {
+    const { spy, client } = session();
+
+    await invokeProjectMcp(client, "status", { scope: "project" });
+    await invokeProjectMcp(client, "status", {});
+
+    expect(spy.control).toHaveBeenCalledTimes(2);
+    expect(spy.control).toHaveBeenCalledWith("status");
+    expect(spy.hostState).not.toHaveBeenCalled();
+  });
+});

--- a/apps/redskilled/src/acp-client.ts
+++ b/apps/redskilled/src/acp-client.ts
@@ -92,6 +92,11 @@ export interface RedskillsProjectAcpSession {
    */
   goDispatch(demand: string): Promise<GoDispatchAnswer>;
   /**
+   * The daemon's whole host document: every Worker, every registration, the
+   * daemon's own health. The read `status { scope: host }` answers from.
+   */
+  hostState(): Promise<unknown>;
+  /**
    * Forward one brain tool call to the store the daemon holds for this host.
    *
    * The client names a tool and its arguments and nothing else: WHERE the brain
@@ -235,6 +240,10 @@ export async function connectRedskillsProjectAcp(
         REDSKILLS_ACP_METHODS.goDispatch,
         { demand },
       );
+    },
+    async hostState() {
+      const held = await ensureLive();
+      return await held.connection.agent.request<unknown>(REDSKILLS_ACP_METHODS.hostState, {});
     },
     async brain(call) {
       const held = await ensureLive();


### PR DESCRIPTION
## What

Wave 5 slice 2 of the E2E-flow repair. `status` declares `worker | project | host` and `project-acp-adapter.ts` dropped the input entirely — `{scope: host}` and `{scope: worker}` silently returned **project** status: a wrong answer wearing a healthy face (the exact class reddb-io/redskilled#3 named).

- `acp-client.ts`: new `hostState()` session method over `_redskills/host_state` (served by the daemon all along).
- Adapter: `scope: "host"` → `session.hostState()`; `scope: "worker"` → refuses by name ("read scope host and filter its workers, or use scope project") until a daemon method serves worker vitals; `project`/unstated unchanged. The routing-table row stays `control` — the scope split is the adapter's translation.

## Tests

`status-scope.test.ts`: host reaches `hostState` and never the control surface; worker refuses without touching either; project/unstated keep the control path. 23/23 with the routing guard; typecheck clean both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790201336&installation_model_id=20659&pr_number=4386&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4386&signature=8f4ae3b735b1bcf9379616fe7108622e6fb5f3bc9dc8c670e13878380e649811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->