### PR TITLE
fix(dev): re-pin worker_dispatch consumers to the served demand route

### DIFF
--- a/.changeset/serve-dispatch-followups.md
+++ b/.changeset/serve-dispatch-followups.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+Consumer pins of worker_dispatch follow its served demand route: the engine-floor contract asserts the served path and the new by-name refusals, and the working-mode doc contract declares ask-red's worker_dispatch binding.

--- a/apps/plugin-dev/src/core/working-mode-doc-contract.ts
+++ b/apps/plugin-dev/src/core/working-mode-doc-contract.ts
@@ -121,6 +121,8 @@ export const WORKING_MODE_DOC_CONTRACT: readonly SkillToolBinding[] = [
       "runner_list",
       "standing_orders_append",
       "standing_orders_show",
+      // The router now names the served demand-dispatch route (#4385).
+      "worker_dispatch",
     ],
     why: "the router names the tool each destination is reached by, so a route is callable rather than descriptive",
   },

--- a/apps/plugin-dev/tests/engine-floor.test.ts
+++ b/apps/plugin-dev/tests/engine-floor.test.ts
@@ -290,27 +290,48 @@ describe("the dispatch-time reading", () => {
 });
 
 describe("worker_dispatch crosses only the public ACP Project surface", () => {
-  it.each([
-    [{ issue: 3031 }],
-    [{ demand: "fix it" }],
-  ])("refuses %o by name rather than narrate it at a Worker (#4113)", async (input) => {
-    // This assertion used to read the other way: the adapter handed
-    // `/worker_dispatch {"issue":3031}` to `session.prompt`, and the test
-    // called that "crossing the public surface". It crossed nothing — the
-    // Worker had no ticket handoff for the text, narrated one line and ended
-    // the turn, and the caller read an empty envelope as success. **A
-    // fallthrough is only a degradation when something exists to degrade to.**
+  // These assertions have read two other ways: first the adapter handed
+  // `/worker_dispatch {...}` to `session.prompt` (which crossed nothing — the
+  // Worker had no ticket handoff, narrated one line, and the caller read an
+  // empty envelope as success), then it refused everything pending #4113.
+  // Since #4385 the demand form is SERVED through the daemon's go-dispatch
+  // method, and only what the one-field wire cannot express refuses by name.
+  function dispatchSession() {
     const prompt = vi.fn(async () => ({ stopReason: "end_turn", updates: [] }));
+    const goDispatch = vi.fn(async (demand: string) => ({
+      version: 1,
+      worker_id: "worker-go",
+      ticket: 1,
+      lane: "lane:go",
+      demand,
+    }));
     const session = {
       prompt,
+      goDispatch,
       control: vi.fn(),
       cancel: vi.fn(),
       permission: vi.fn(),
       close: vi.fn(),
     } as unknown as RedskillsProjectAcpSession;
+    return { session, prompt, goDispatch };
+  }
 
-    await expect(invokeProjectMcp(session, "worker_dispatch", input))
-      .rejects.toThrow(/rs_dev tool "worker_dispatch" is not served/);
+  it("refuses { issue: 3031 } by name rather than narrate it at a Worker", async () => {
+    const { session, prompt, goDispatch } = dispatchSession();
+
+    await expect(invokeProjectMcp(session, "worker_dispatch", { issue: 3031 }))
+      .rejects.toThrow(/a tracked-issue dispatch rides the registered drain/);
+    expect(prompt).not.toHaveBeenCalled();
+    expect(goDispatch).not.toHaveBeenCalled();
+  });
+
+  it("serves { demand: 'fix it' } through the daemon's go-dispatch method, never a prompt", async () => {
+    const { session, prompt, goDispatch } = dispatchSession();
+
+    const answer = await invokeProjectMcp(session, "worker_dispatch", { demand: "fix it" });
+
+    expect(goDispatch).toHaveBeenCalledWith("fix it");
+    expect(answer).toMatchObject({ lane: "lane:go" });
     expect(prompt).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Repairs the red #4385 left on main (my process fault: a CI waiter's failure count was printed but not gated on before merging — the merge ran with 3 failures). Both are consumer pins of the old behavior, not defects in the served route:

- `engine-floor.test.ts`: the two `worker_dispatch` cases asserted the pre-serve blanket refusal. The demand form now pins the served path (reaches `session.goDispatch`, never a prompt) and the issue form pins the new by-name refusal.
- `working-mode-doc-contract.ts`: `ask-red` legitimately names `worker_dispatch` since #4385's rule-8 update — declared in the contract so the binding is checked against the live tool surface.

40/40 across engine-floor + working-mode-doc-contract + worker-dispatch-route; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790201562&installation_model_id=20659&pr_number=4387&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4387&signature=94ffd4c1b3fe4b48d8c5113d4704b03ab07af8aeac7811e6daaf5b9e8696fb31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->