### PR TITLE
fix(redskilled): the native statusline front labels a stale cached render with its age

### DIFF
--- a/.changeset/statusline-native-staleness.md
+++ b/.changeset/statusline-native-staleness.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The native statusline front dates its cached render: a cache older than 15 minutes prints with a `!stale <N>m` mark instead of a frozen line wearing a live face — a background renderer that stops rewriting the cache is now visible at the prompt.

--- a/apps/redskilled/src/statusline-native-source.ts
+++ b/apps/redskilled/src/statusline-native-source.ts
@@ -19,14 +19,30 @@ export const STATUSLINE_NATIVE_SOURCE = `// statusline-fast — native statuslin
 // daemon tail stays at most one render old. The cache is PER PROJECT (the
 // prompt host runs this with cwd = the repo), so one project's render never
 // appears inside another project's session.
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, statSync } from "node:fs";
 
 const cachePath = ".red/state/statusline/last-render.txt";
+// ADR 0157 promises "at most one render old". A render happens per prompt, so
+// a cache this stale means the background renderer stopped rewriting it — and
+// the one thing worse than an old line is an old line wearing a live face.
+const staleAfterMs = 900000;
 
 if (existsSync(cachePath)) {
   const cached = readFileSync(cachePath, "utf8");
   if (cached.trim() !== "") {
-    process.stdout.write(cached.endsWith("\\n") ? cached : cached + "\\n");
+    let suffix = "";
+    let ageMs = 0;
+    try {
+      ageMs = Date.now() - statSync(cachePath).mtimeMs;
+    } catch {
+      ageMs = 0;
+    }
+    if (ageMs > staleAfterMs) {
+      const minutes = Math.floor(ageMs / 60000);
+      suffix = " !stale " + minutes + "m";
+    }
+    const body = cached.endsWith("\\n") ? cached.slice(0, cached.length - 1) : cached;
+    process.stdout.write(body + suffix + "\\n");
     process.exit(0);
   }
 }

--- a/apps/redskilled/tests/statusline-native.test.ts
+++ b/apps/redskilled/tests/statusline-native.test.ts
@@ -67,3 +67,43 @@ describe("installing the native statusline front", () => {
     expect(result.detail).toContain("SC2020");
   });
 });
+
+describe("the native front dates its cached render", () => {
+  async function runNativeSource(cwd: string, stdin = ""): Promise<string> {
+    const { execFile } = await import("node:child_process");
+    const { promisify } = await import("node:util");
+    const { createRequire } = await import("node:module");
+    const { pathToFileURL } = await import("node:url");
+    const { STATUSLINE_NATIVE_SOURCE } = await import("../src/statusline-native-source.js");
+    const run = promisify(execFile);
+    const program = join(cwd, "statusline-fast.ts");
+    await writeFile(program, STATUSLINE_NATIVE_SOURCE);
+    const tsx = pathToFileURL(createRequire(import.meta.url).resolve("tsx")).href;
+    const { stdout } = await run(process.execPath, ["--import", tsx, program], {
+      cwd,
+      ...(stdin === "" ? {} : {}),
+    });
+    return stdout;
+  }
+
+  it("prints a fresh cached render verbatim, and labels a stale one with its age", async () => {
+    const { utimes } = await import("node:fs/promises");
+    const root = await mkdtemp(join(tmpdir(), "redskilled-native-stale-"));
+    roots.push(root);
+    const cache = join(root, ".red", "state", "statusline");
+    await mkdir(cache, { recursive: true });
+    await writeFile(join(cache, "last-render.txt"), "rskld 4.2.9 · main · 0w idle\n");
+
+    // Fresh: verbatim, no mark.
+    expect(await runNativeSource(root)).toBe("rskld 4.2.9 · main · 0w idle\n");
+
+    // An hour stale: the same truth, labeled old — the background renderer
+    // stopped rewriting the cache, and the old truth labeled old beats a
+    // frozen line wearing a live face.
+    const old = new Date(Date.now() - 60 * 60_000);
+    await utimes(join(cache, "last-render.txt"), old, old);
+    const stale = await runNativeSource(root);
+    expect(stale).toContain("rskld 4.2.9 · main · 0w idle");
+    expect(stale).toMatch(/!stale (5\d|6\d)m\n$/);
+  });
+});


### PR DESCRIPTION
## What

Wave 6 slice 1 of the E2E-flow repair (the headline statusline-confusion source from the diagnosis). The native front (`statusline-fast`) printed `.red/state/statusline/last-render.txt` verbatim — no mtime check, no TTL — so a dead background renderer left the last healthy line on screen indefinitely, wearing a live face. ADR 0157 promises "at most one render old" with no mechanism enforcing it.

- The embedded source now stats the cache: older than 15 min → the same line prints with ` !stale <N>m` appended (the `marks.ts` vocabulary). Fresh renders are byte-identical to before; the writer one-liner in `.claude/settings.json` stays untouched (its `&&`-guarded `mv` failure mode is now harmless).
- Stays inside scriptc's static subset — `statSync`/`Date.now`/`Math.floor` all lower; **verified by compiling with the pinned scriptc locally and running the binary**: fresh → verbatim, hour-stale → `!stale 60m`, empty → warming-up line.

## Tests

`statusline-native.test.ts` gains a behavioral case running the embedded source via tsx against a fixture cache: fresh verbatim, hour-old labeled with its age. 4/4; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790201837&installation_model_id=20659&pr_number=4388&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4388&signature=30d1270c4e62d94f88079065d12926d461bca05f4afd425153e91e3b3099b880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->