### PR TITLE
fix(redskilled): an idle host's staleness derives from the daemon's own beat

### DIFF
--- a/.changeset/idle-staleness-honesty.md
+++ b/.changeset/idle-staleness-honesty.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The payload's staleness on a zero-Worker host now derives from the daemon's own request-health beat instead of a hardcoded `false` — an idle-but-broken daemon can no longer wear a green "live" badge on any consumer; a daemon reporting no beat keeps the old calm answer.

--- a/apps/redskilled/src/statusline-payload.ts
+++ b/apps/redskilled/src/statusline-payload.ts
@@ -104,6 +104,12 @@ export {
 /** What a Worker is doing, as the daemon knows it. */
 export type RedskilledWorkerState = "running" | "reattached";
 
+/** An ISO instant in milliseconds, or `null` when it is not one. PURE. */
+function instant(value: string): number | null {
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
 /**
  * One Worker's measured consumption, or the honest absence of it.
  *
@@ -225,16 +231,17 @@ export interface RedskilledStatuslineHost {
 }
 
 /** How current this answer is, decided by the daemon and rendered by the consumer. */
-export interface RedskilledStatuslineStaleness {
-  readonly sampled_at: string | null;
-  readonly age_ms: number | null;
-  readonly threshold_ms: number;
-  readonly stale: boolean;
-  readonly measured_worker_count: number;
-  /** Live Workers the last sample did not measure, by id. */
-  readonly unmeasured_workers: readonly string[];
-  readonly reason: string;
-}
+// The freshness verdict's own judgements — the Worker-sample window, and the
+// daemon-beat aging that replaces it on a zero-Worker host — live in
+// `./statusline-staleness.js`. Re-exported because this module's payload
+// interface NAMES the type, so a consumer typing a payload reaches it from
+// the module it already imports.
+export {
+  buildStatuslineStaleness,
+  type RedskilledStatuslineStaleness,
+} from "./statusline-staleness.js";
+import { buildStatuslineStaleness } from "./statusline-staleness.js";
+import type { RedskilledStatuslineStaleness } from "./statusline-staleness.js";
 
 /** Which daemon answered, so two answers can be told apart rather than averaged. */
 export interface RedskilledStatuslineDaemon {
@@ -528,13 +535,15 @@ export function buildStatuslinePayload(input: BuildStatuslinePayloadInput): Reds
       machine_id_hash: input.hostState.machine_id_hash,
       session_key_hash: input.hostState.session_key_hash,
     },
-    staleness: buildStaleness({
+    staleness: buildStatuslineStaleness({
       sampledAt: input.sampledAt,
       ageMs,
       threshold,
       workerCount: workers.length,
       measuredCount,
       unmeasured,
+      now: input.now,
+      health: input.hostState.request_health,
     }),
     host: {
       worker_count: workers.length,
@@ -738,56 +747,6 @@ function buildProjects(workers: readonly RedskilledStatuslineWorker[]): readonly
     .sort((a, b) => a.project_label.localeCompare(b.project_label));
 }
 
-/**
- * Date the answer, in a sentence a surface can render unchanged.
- *
- * A host holding no Workers is never stale: there is nothing to measure, and
- * calling that state old would put a warning on every idle machine.
- */
-function buildStaleness(input: {
-  readonly sampledAt: string | null;
-  readonly ageMs: number | null;
-  readonly threshold: number;
-  readonly workerCount: number;
-  readonly measuredCount: number;
-  readonly unmeasured: readonly string[];
-}): RedskilledStatuslineStaleness {
-  const common = {
-    sampled_at: input.sampledAt,
-    age_ms: input.ageMs,
-    threshold_ms: input.threshold,
-    measured_worker_count: input.measuredCount,
-    unmeasured_workers: input.unmeasured,
-  };
-  if (input.workerCount === 0) {
-    return { ...common, stale: false, reason: "the host holds no Workers, so there is nothing to measure and nothing to age" };
-  }
-  if (input.sampledAt == null || input.ageMs == null) {
-    return {
-      ...common,
-      stale: true,
-      reason: `this answer is stale: the daemon has taken no measurement of its ${input.workerCount} live Worker(s) yet`,
-    };
-  }
-  if (input.ageMs > input.threshold) {
-    return {
-      ...common,
-      stale: true,
-      reason: `this answer is stale: its measurement is ${input.ageMs}ms old, past the ${input.threshold}ms staleness window`,
-    };
-  }
-  return {
-    ...common,
-    stale: false,
-    reason: `measured ${input.ageMs}ms ago, within the ${input.threshold}ms staleness window`,
-  };
-}
-
-/** An ISO instant in milliseconds, or `null` when it is not one. PURE. */
-function instant(value: string): number | null {
-  const ms = Date.parse(value);
-  return Number.isFinite(ms) ? ms : null;
-}
 
 // The fail-closed shape check moved to its own module (see the note there);
 // re-exported so every consumer keeps the import it already had.

--- a/apps/redskilled/src/statusline-staleness.ts
+++ b/apps/redskilled/src/statusline-staleness.ts
@@ -1,0 +1,101 @@
+// statusline-staleness — the payload's one freshness verdict.
+//
+// **Staleness travels inside the payload** (see `./statusline-payload.js`),
+// and this module owns HOW it is judged: against the Worker sample while
+// Workers exist, and against the daemon's own request-health beat when none
+// do. The zero-worker arm exists because a hardcoded `stale: false` there made
+// the one global freshness bit unusable exactly when it mattered — an
+// idle-but-broken daemon rendered a green "live" badge on every consumer.
+import type { RedskilledRequestHealth } from "./host-state.js";
+
+export interface RedskilledStatuslineStaleness {
+  readonly sampled_at: string | null;
+  readonly age_ms: number | null;
+  readonly threshold_ms: number;
+  readonly stale: boolean;
+  readonly measured_worker_count: number;
+  /** Live Workers the last sample did not measure, by id. */
+  readonly unmeasured_workers: readonly string[];
+  readonly reason: string;
+}
+
+export interface BuildStatuslineStalenessInput {
+  readonly sampledAt: string | null;
+  readonly ageMs: number | null;
+  readonly threshold: number;
+  readonly workerCount: number;
+  readonly measuredCount: number;
+  readonly unmeasured: readonly string[];
+  readonly now?: string;
+  readonly health?: RedskilledRequestHealth;
+}
+
+/** Judge one payload's freshness. PURE. */
+export function buildStatuslineStaleness(
+  input: BuildStatuslineStalenessInput,
+): RedskilledStatuslineStaleness {
+  const common = {
+    sampled_at: input.sampledAt,
+    age_ms: input.ageMs,
+    threshold_ms: input.threshold,
+    measured_worker_count: input.measuredCount,
+    unmeasured_workers: input.unmeasured,
+  };
+  if (input.workerCount === 0) {
+    // With zero Workers the daemon's own beat is the only thing left to age,
+    // so it is what this arm ages. A daemon reporting no beat at all keeps the
+    // old calm answer — older hosts must not cry wolf.
+    const health = input.health;
+    if (health == null) {
+      return { ...common, stale: false, reason: "the host holds no Workers, so there is nothing to measure and nothing to age" };
+    }
+    const beatAge = input.now == null || health.last_success_at == null
+      ? null
+      : beatAgeBetween(input.now, health.last_success_at);
+    if (health.status === "degraded") {
+      return {
+        ...common,
+        stale: true,
+        reason: `this answer is stale: the host holds no Workers and the daemon's own beat is degraded — ${health.detail}`,
+      };
+    }
+    if (beatAge == null) {
+      return {
+        ...common,
+        stale: true,
+        reason: "this answer is stale: the host holds no Workers and the daemon's own beat is unproven",
+      };
+    }
+    return {
+      ...common,
+      stale: false,
+      reason: `the host holds no Workers; the daemon's own beat is ${beatAge}ms old and healthy`,
+    };
+  }
+  if (input.sampledAt == null || input.ageMs == null) {
+    return {
+      ...common,
+      stale: true,
+      reason: `this answer is stale: the daemon has taken no measurement of its ${input.workerCount} live Worker(s) yet`,
+    };
+  }
+  if (input.ageMs > input.threshold) {
+    return {
+      ...common,
+      stale: true,
+      reason: `this answer is stale: its measurement is ${input.ageMs}ms old, past the ${input.threshold}ms staleness window`,
+    };
+  }
+  return {
+    ...common,
+    stale: false,
+    reason: `measured ${input.ageMs}ms ago, within the ${input.threshold}ms staleness window`,
+  };
+}
+
+/** Non-negative age between two instants, or `null` when either is not one. PURE. */
+function beatAgeBetween(now: string, then: string): number | null {
+  const nowMs = Date.parse(now);
+  const thenMs = Date.parse(then);
+  return Number.isFinite(nowMs) && Number.isFinite(thenMs) ? Math.max(0, nowMs - thenMs) : null;
+}

--- a/apps/redskilled/tests/statusline-idle-staleness.test.ts
+++ b/apps/redskilled/tests/statusline-idle-staleness.test.ts
@@ -1,0 +1,77 @@
+// `staleness.stale` was hardcoded `false` whenever the host held zero Workers
+// — so the one global freshness bit was unusable exactly when it mattered, and
+// every consumer of the payload (herdr's "● live" badge included) rendered an
+// idle-but-broken daemon as green. With no Workers the daemon's own beat is
+// the only thing left to age, so it is what the zero-worker arm now ages.
+import { describe, expect, it } from "vitest";
+
+import { buildHostState, type RedskilledRequestHealth } from "../src/host-state.js";
+import { buildStatuslinePayload } from "../src/statusline-payload.js";
+import { UNBOUNDED_HOST_CEILING } from "../src/admission.js";
+
+function idlePayload(health?: RedskilledRequestHealth) {
+  return buildStatuslinePayload({
+    hostState: buildHostState({
+      daemonVersion: "9.9.9",
+      machineIdHash: "mach",
+      sessionKeyHash: "sess",
+      pid: 99,
+      startedAt: "2026-08-24T00:00:00.000Z",
+      workers: [],
+      registrations: [],
+      ...(health == null ? {} : { requestHealth: health }),
+    }),
+    ceiling: UNBOUNDED_HOST_CEILING,
+    rss: {},
+    sampledAt: null,
+    now: "2026-08-24T12:00:00.000Z",
+  });
+}
+
+const beat = (overrides: Partial<RedskilledRequestHealth>): RedskilledRequestHealth => ({
+  status: "healthy",
+  consecutive_misses: 0,
+  miss_threshold: 3,
+  last_probe_at: "2026-08-24T11:59:58.000Z",
+  last_success_at: "2026-08-24T11:59:58.000Z",
+  last_failure_at: null,
+  detail: "the daemon answered its own socket",
+  ...overrides,
+});
+
+describe("an idle host's staleness derives from the daemon's own beat", () => {
+  it("stays fresh with a healthy beat, and says why", () => {
+    const staleness = idlePayload(beat({})).staleness;
+
+    expect(staleness.stale).toBe(false);
+    expect(staleness.reason).toContain("the daemon's own beat is 2000ms old and healthy");
+  });
+
+  it("is stale, not calm, when the daemon's own beat is degraded", () => {
+    const staleness = idlePayload(beat({
+      status: "degraded",
+      consecutive_misses: 4,
+      detail: "the daemon has missed 4 probes of its own socket",
+    })).staleness;
+
+    expect(staleness.stale).toBe(true);
+    expect(staleness.reason).toContain("degraded");
+    expect(staleness.reason).toContain("missed 4 probes");
+  });
+
+  it("is stale when the beat exists but never succeeded", () => {
+    const staleness = idlePayload(beat({ last_success_at: null })).staleness;
+
+    expect(staleness.stale).toBe(true);
+    expect(staleness.reason).toContain("unproven");
+  });
+
+  it("keeps the old calm answer when the daemon reports no beat at all", () => {
+    // A daemon from before request health existed still serves this payload;
+    // inventing staleness for it would cry wolf on every older host.
+    const staleness = idlePayload().staleness;
+
+    expect(staleness.stale).toBe(false);
+    expect(staleness.reason).toContain("nothing to measure");
+  });
+});


### PR DESCRIPTION
## What

Wave 6 slice 2 of the E2E-flow repair. `buildStaleness` hardcoded `stale: false` at zero Workers (`statusline-payload.ts`) — the one global freshness bit was unusable exactly when the daemon had quietly stopped doing work, and herdr's `● live` header badge reads exactly this bit.

- The zero-worker arm now ages the daemon's own `request_health` beat: healthy → `stale: false` with "the daemon's own beat is Nms old and healthy"; degraded or never-succeeded → `stale: true` carrying the daemon's own detail; **no beat reported → the old calm answer** (older daemons must not cry wolf).
- herdr and every other consumer become honest for free — they already render this bit.

## Tests

`statusline-idle-staleness.test.ts`: four cases (healthy/degraded/unproven/absent beat) through the real payload builder. 10/10 with the local-project render suite; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790202050&installation_model_id=20659&pr_number=4389&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4389&signature=8d2c7298577d59bb083fd8d6d5bcd71e2e11a9a4c3e560e8eb122ce1654afde4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->