### PR TITLE
fix(render): one unregistered verdict on both surfaces

### DIFF
--- a/.changeset/unregistered-verdict.md
+++ b/.changeset/unregistered-verdict.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-render": patch
+---
+
+An unregistered directory carries the same quiet `!unregistered` mark on the statusline as on the dashboard — the two surfaces no longer render opposite verdicts from one payload.

--- a/apps/redskilled/tests/statusline-local-project.test.ts
+++ b/apps/redskilled/tests/statusline-local-project.test.ts
@@ -203,14 +203,14 @@ describe("`project unknown`", () => {
     expect(render.line).toContain("idle");
   });
 
-  it("renders healthy idleness when the directory's project has no drain registration", () => {
+  it("marks a directory nothing will be born for, on the line as on the dashboard", () => {
     const render = renderRedskilledStatusline(
       payloadOf([worker({ project_label: "acme/other" })]),
       options({ project: "acme/widgets" }),
     );
 
     expect(render.project_match).toBe("unregistered");
-    expect(render.line).toBe("0w idle 0B v0.1.0");
+    expect(render.line).toBe("0w idle !unregistered 0B v0.1.0");
     expect(render.repair).toBeUndefined();
     expect(render.repair_reason).toBeUndefined();
   });

--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -319,6 +319,12 @@ function renderHead(
     if (workers.length === 0) {
       parts.push(idleCell(payload.last_outcome, options.project, payload.generated_at));
     }
+    // One verdict on both surfaces: the dashboard has always marked an
+    // unregistered directory, while this line rendered it as healthy idleness
+    // — the same payload read as opposite states depending on where an
+    // operator looked. A directory nothing will be born for carries the same
+    // quiet mark here.
+    if (match === "unregistered") parts.push(UNREGISTERED_MARK);
   } else if (match === "name-only") {
     // The Workers still count — they are running — but the line says out loud
     // that the host holds no registration, and it never says `idle`: a project
@@ -460,9 +466,11 @@ function compactLoopSpan(spanMs: number): string {
 /**
  * The head for a directory that is not currently matched to a registration. PURE.
  *
- * `unregistered` is ordinary idleness: no drain declared intent, so there is no
- * defect or repair to narrate. Every other branch represents prior intent or an
- * unresolved identity and keeps its explicit reason and actionability.
+ * `unregistered` narrates nothing HERE because the head already carries its
+ * mark (`!unregistered`, the dashboard's verdict, now on both surfaces): no
+ * drain declared intent, so there is no defect or repair to narrate beyond the
+ * mark. Every other branch represents prior intent or an unresolved identity
+ * and keeps its explicit reason and actionability.
  */
 function unmatchedHead(
   payload: RedskilledRenderPayload,

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -471,7 +471,9 @@ describe("an unknown project's registration history (#3191)", () => {
     expect(rendered.project_match).toBe("unregistered");
     expect(rendered.repair).toBeUndefined();
     expect(rendered.repair_reason).toBeUndefined();
-    expect(rendered.line).toBe("0w idle 0B v3.3.11");
+    // One verdict on both surfaces: the dashboard has always marked an
+    // unregistered directory, and the line now carries the same quiet mark.
+    expect(rendered.line).toBe("0w idle !unregistered 0B v3.3.11");
   });
 
   it.each([


### PR DESCRIPTION
## What

Wave 6 slice 3 of the E2E-flow repair. `packages/redskilled-render/line.ts` rendered `unregistered` as healthy idleness (`0w idle`, empty prose) while `dashboard.ts:471` marked the same payload `!unregistered` — the same fact read as opposite states depending on the surface.

- The dashboard's verdict wins (maintainer-adopted default): the statusline head now appends the same quiet `UNREGISTERED_MARK` beside its idle cell; `unmatchedHead`'s empty narration stays (the mark already says it).

## Tests

Both existing pins updated to the unified verdict (`0w idle !unregistered …`); render suite 108/108; statusline-local-project suite green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790202163&installation_model_id=20659&pr_number=4390&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4390&signature=4cfb77d1d713b48321c1db80c98e21129eab36044bade03e3eb2bc8adafb233d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->