### PR TITLE
fix(redskilled): a stale-published heartbeat string is dated instead of frozen

### DIFF
--- a/.changeset/worker-row-age.md
+++ b/.changeset/worker-row-age.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+A Worker row's published heartbeat string is dated once its publication goes stale — `hb=3s (published 9m0s ago)` — so a wedged Worker no longer renders identically to a working one; a fresh publication stays untouched.

--- a/apps/redskilled/src/worker-display.ts
+++ b/apps/redskilled/src/worker-display.ts
@@ -302,15 +302,34 @@ export function isRedskilledWorkerDisplay(value: unknown): value is RedskilledWo
  * `published_at` IS its last sign of life; deriving at payload-build time keeps
  * the wire shape and every renderer untouched while `hb=?` becomes an honest age.
  */
+/** How old a display publication may be before its heartbeat string is dated. */
+export const WORKER_DISPLAY_STALE_PUBLICATION_MS = 30_000;
+
 export function displayWithDerivedHeartbeat(
   record: RedskilledWorkerDisplayRecord | undefined,
   nowMs: number | null,
 ): RedskilledWorkerDisplay | null {
   if (record == null) return null;
-  if (record.display.heartbeat != null || nowMs == null) return record.display;
+  if (nowMs == null) return record.display;
   const at = Date.parse(record.published_at);
   if (!Number.isFinite(at)) return record.display;
-  const seconds = Math.max(0, Math.round((nowMs - at) / 1000));
-  const heartbeat = seconds < 60 ? `${seconds}s` : `${Math.floor(seconds / 60)}m${seconds % 60}s`;
-  return { ...record.display, heartbeat };
+  const ageMs = Math.max(0, nowMs - at);
+  if (record.display.heartbeat == null) {
+    return { ...record.display, heartbeat: formatDisplayAge(ageMs) };
+  }
+  // A published heartbeat string used to render FOREVER: a project that said
+  // "3s" and then stopped publishing showed hb=3s indefinitely, so a wedged
+  // Worker rendered identically to a working one. The string is the project's
+  // own vocabulary and stays — but once its PUBLICATION is stale, the row says
+  // how old the claim itself is.
+  if (ageMs <= WORKER_DISPLAY_STALE_PUBLICATION_MS) return record.display;
+  return {
+    ...record.display,
+    heartbeat: `${record.display.heartbeat} (published ${formatDisplayAge(ageMs)} ago)`,
+  };
+}
+
+function formatDisplayAge(ageMs: number): string {
+  const seconds = Math.max(0, Math.round(ageMs / 1000));
+  return seconds < 60 ? `${seconds}s` : `${Math.floor(seconds / 60)}m${seconds % 60}s`;
 }

--- a/apps/redskilled/tests/worker-pulse.test.ts
+++ b/apps/redskilled/tests/worker-pulse.test.ts
@@ -132,13 +132,26 @@ describe("a display that published no heartbeat gets the age of its last pulse",
     expect(derived?.heartbeat).toBe("7m5s");
   });
 
-  it("never overrides a heartbeat the publisher stated", () => {
+  it("keeps a freshly published heartbeat untouched", () => {
+    const published = coerceWorkerDisplay({ heartbeat: "3s" })!;
+    const derived = displayWithDerivedHeartbeat(
+      { display: published, published_at: "2026-08-20T17:00:00.000Z" },
+      Date.parse("2026-08-20T17:00:12.000Z"),
+    );
+    expect(derived?.heartbeat).toBe("3s");
+  });
+
+  it("dates a published heartbeat whose publication went stale", () => {
+    // A project that said "3s" and then stopped publishing showed hb=3s
+    // FOREVER — a wedged Worker rendered identically to a working one. The
+    // string is the project's vocabulary and stays, but the row now says how
+    // old the claim itself is.
     const published = coerceWorkerDisplay({ heartbeat: "3s" })!;
     const derived = displayWithDerivedHeartbeat(
       { display: published, published_at: "2026-08-20T17:00:00.000Z" },
       Date.parse("2026-08-20T17:09:00.000Z"),
     );
-    expect(derived?.heartbeat).toBe("3s");
+    expect(derived?.heartbeat).toBe("3s (published 9m0s ago)");
   });
 
   it("stays honest with no record and no clock", () => {


### PR DESCRIPTION
## What

Wave 6 slice 5 of the E2E-flow repair. `displayWithDerivedHeartbeat` early-returned on any published `heartbeat` string — a project that published `"3s"` and then stopped showed `hb=3s` forever, so a wedged Worker rendered identically to a working one on every surface (the global `staleness` block measures the RSS sampler, not display publication).

- The publication age is derived always: within `WORKER_DISPLAY_STALE_PUBLICATION_MS` (30s) the project's own string is untouched; past it the row renders `3s (published 9m0s ago)`. String-level and additive — every renderer inherits via the payload with no wire change.

## Tests

`worker-pulse.test.ts`: fresh publication untouched; stale publication dated; existing derived-from-published_at cases unchanged. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790202495&installation_model_id=20659&pr_number=4391&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4391&signature=ef307210ece328db1c7d4c6121f40ecd07c6a5e483e562cd54a1a646e2f8b274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->