### PR TITLE
fix(render): withheld renders as withheld, never as a failed measurement

### DIFF
--- a/.changeset/withheld-rendered.md
+++ b/.changeset/withheld-rendered.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-render": patch
+---
+
+A vitals block the reader deliberately did not ask for renders as `·withheld` instead of `!unmeasured` — the payload has distinguished the two facts all along, and no renderer read the field.

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -52,6 +52,7 @@ import {
   DEATH_MARK,
   ENGINE_BEHIND_MARK,
   LAPSED_MARK,
+  missingMeasurementMark,
   UNREGISTERED_MARK,
 } from "./marks.js";
 import {
@@ -518,7 +519,7 @@ function buildHeader(
   }
   if (payload.staleness.stale) {
     const age = payload.staleness.age_ms;
-    parts.push(age == null ? "!unmeasured" : `!stale ${Math.round(age / 1000)}s`);
+    parts.push(age == null ? missingMeasurementMark(payload.withheld) : `!stale ${Math.round(age / 1000)}s`);
   }
 
   // The rates are optional in the literal sense: a header clamped mid-figure

--- a/packages/redskilled-render/line.ts
+++ b/packages/redskilled-render/line.ts
@@ -46,6 +46,7 @@ import {
   DEATH_MARK,
   ENGINE_BEHIND_MARK,
   LOG_LINE_MARK,
+  missingMeasurementMark,
   REDSKILLED_RENDER_ABSENCE,
   UNREGISTERED_MARK,
 } from "./marks.js";
@@ -556,7 +557,7 @@ function memoryFigure(payload: RedskilledRenderPayload, options: RedskilledStatu
 /** How old the answer is, in the shortest sentence that stays honest. */
 function stalenessMark(payload: RedskilledRenderPayload): string {
   const age = payload.staleness.age_ms;
-  return age == null ? "!unmeasured" : `!stale ${Math.round(age / 1000)}s`;
+  return age == null ? missingMeasurementMark(payload.withheld) : `!stale ${Math.round(age / 1000)}s`;
 }
 
 /**

--- a/packages/redskilled-render/marks.ts
+++ b/packages/redskilled-render/marks.ts
@@ -50,3 +50,18 @@ export const LOG_LINE_MARK = "↳";
 
 /** The one sentence an unreachable host renders as, at every density. */
 export const REDSKILLED_RENDER_ABSENCE = "redskilled unreachable — Worker state unknown";
+
+/** A block the reader deliberately did not ask for; never a failed measurement. */
+export const WITHHELD_MARK = "·withheld";
+
+/**
+ * The right mark for a missing measurement: withheld and unmeasured are
+ * opposite facts wearing the same `null` (the payload's own words), and a
+ * surface that rendered both as `!unmeasured` blamed the daemon for an absence
+ * the reader itself requested.
+ */
+export function missingMeasurementMark(
+  withheld: readonly ("logs" | "vitals" | "display")[] | undefined,
+): string {
+  return withheld?.includes("vitals") ? WITHHELD_MARK : "!unmeasured";
+}

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -707,3 +707,45 @@ describe("the worker, phase and progress clocks", () => {
     expect(table.rows[1]!.cells.eta).toBe("");
   });
 });
+
+describe("withheld is not unmeasured", () => {
+  it("a withheld vitals block renders as withheld, never as a failed measurement", () => {
+    const rendered = renderRedskilledStatusline(
+      payload({
+        staleness: {
+          sampled_at: null,
+          age_ms: null,
+          threshold_ms: 30_000,
+          stale: true,
+          measured_worker_count: 0,
+          unmeasured_workers: [],
+          reason: "vitals were withheld from this read",
+        },
+        withheld: ["vitals"],
+      }),
+      { ...LOCAL, maxWidth: 400 },
+    );
+
+    expect(rendered.line).toContain("·withheld");
+    expect(rendered.line).not.toContain("!unmeasured");
+  });
+
+  it("an actually unmeasured payload keeps the unmeasured mark", () => {
+    const rendered = renderRedskilledStatusline(
+      payload({
+        staleness: {
+          sampled_at: null,
+          age_ms: null,
+          threshold_ms: 30_000,
+          stale: true,
+          measured_worker_count: 0,
+          unmeasured_workers: [],
+          reason: "no measurement yet",
+        },
+      }),
+      { ...LOCAL, maxWidth: 400 },
+    );
+
+    expect(rendered.line).toContain("!unmeasured");
+  });
+});


### PR DESCRIPTION
## What

Wave 6 slice 6 of the E2E-flow repair. `payload.withheld` is produced by the daemon precisely so "not asked for" ≠ "not measured" (its own doc comment says the two are opposite facts wearing the same `null`) — and **no renderer read it**: a read that deliberately skipped vitals rendered `!unmeasured`, blaming the daemon for an absence the reader itself requested.

- `marks.ts` gains `WITHHELD_MARK` (`·withheld`) and one shared `missingMeasurementMark(withheld)` judge; the line's `stalenessMark` and the dashboard header's staleness cell both use it.

## Tests

Two new render cases: withheld vitals → `·withheld` and never `!unmeasured`; genuinely unmeasured keeps its mark. 110/110; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790202639&installation_model_id=20659&pr_number=4392&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4392&signature=159f4a5e1d80a15d5173726f8583b2e637f394c02d9537c8c26e8173247d9014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->