### PR TITLE
fix(redskilled): the unreachable statusline names the last daemon death

### DIFF
--- a/.changeset/absence-reads-deaths.md
+++ b/.changeset/absence-reads-deaths.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+An unreachable statusline now carries the dead daemon's own evidence as a second line — the newest daemon death from the on-disk death lane, dated, with its exit path, phase, and detail — instead of only a generic "unreachable".

--- a/apps/redskilled/src/statusline-command.ts
+++ b/apps/redskilled/src/statusline-command.ts
@@ -30,6 +30,8 @@ import {
 } from "./client.js";
 import { probeRedskilledStatuslinePayload } from "./statusline-probe.js";
 import { resolveRedskilledPaths, type RedskilledPaths } from "./paths.js";
+import { homedir } from "node:os";
+import { daemonDeathLanePath, readLastDaemonDeathHeadline } from "./statusline-last-evidence.js";
 import {
   parseRedskilledStatuslineFlags,
   resolveRedskilledStatuslineOptions,
@@ -101,6 +103,8 @@ export async function runStatusline(
     readonly client?: RedskilledClientConfig;
     /** The clock, for the one instant no daemon supplies: an absence's own. */
     readonly now?: () => string;
+    /** The operator home the daemon's death lane hangs off; tests inject it. */
+    readonly homeDir?: string;
     /** The bedrock's own seams — the host payload, local git, the build stamp. */
     readonly bedrock?: StatuslineBedrockIO;
   } = {},
@@ -127,10 +131,25 @@ export async function runStatusline(
     });
   } catch (err) {
     warn(`redskilled statusline: ${err instanceof Error ? err.message : String(err)}\n`);
+    const generatedAt = (io.now ?? (() => new Date().toISOString()))();
     render = renderRedskilledStatuslineAbsence({
       options: resolved.options,
-      generated_at: (io.now ?? (() => new Date().toISOString()))(),
+      generated_at: generatedAt,
     });
+    // The dead daemon's own evidence, read directly: "unreachable" alone reads
+    // the same on a machine mid-upgrade and one that has been down for a day,
+    // and the death lane on disk has known which the whole time.
+    try {
+      const headline = readLastDaemonDeathHeadline(
+        daemonDeathLanePath(io.homeDir ?? homedir()),
+        Date.parse(generatedAt),
+      );
+      if (headline != null) {
+        render = { ...render, lines: [...render.lines, headline] };
+      }
+    } catch {
+      // The absence line stands on its own; evidence is a bonus, never a cost.
+    }
   }
   // Every line the shared render produced, in order — one write, whatever the
   // taste. With `--verbose` that is the Worker line plus a second line per

--- a/apps/redskilled/src/statusline-last-evidence.ts
+++ b/apps/redskilled/src/statusline-last-evidence.ts
@@ -1,0 +1,63 @@
+// statusline-last-evidence — what the DEAD daemon left behind, read directly.
+//
+// While the daemon is down every surface degrades to a generic "unreachable",
+// yet the evidence for WHY sits on disk the whole time: the death lane the
+// daemon's own recorder writes (`~/.red/redskilled/state/deaths/`). That lane
+// was only ever read by the reaper and by the daemon that replaces the dead
+// one — so the one reader who needed it (the operator staring at an
+// unreachable statusline) never saw it. This module is the absence arm's
+// second line: the newest daemon death, dated, with the record's own facts.
+//
+// No freshness cutoff, deliberately: a daemon down for three days IS explained
+// by a death three days old, and the age in the sentence is the honesty.
+import { join } from "node:path";
+
+import { readProcessDeathLane, type ProcessDeathRecord } from "@reddb-io/shared/death-record.js";
+import { deathLaneFileIn } from "@reddb-io/shared/red-paths.js";
+import { redskilledHomeDir } from "@reddb-io/shared/redskilled-home.js";
+
+/** The daemon's own death lane, under the host-scoped home. */
+export function daemonDeathLanePath(homeDir: string): string {
+  return deathLaneFileIn(join(redskilledHomeDir(homeDir), "state"));
+}
+
+/**
+ * One operator-readable line naming the newest daemon death, or `null`.
+ *
+ * Never throws: an unreadable lane answers nothing, exactly like an empty one
+ * — this runs on the absence path, where everything else already failed.
+ */
+export function readLastDaemonDeathHeadline(lanePath: string, nowMs: number): string | null {
+  let records: ProcessDeathRecord[];
+  try {
+    records = readProcessDeathLane(lanePath);
+  } catch {
+    return null;
+  }
+  const daemon = records
+    .filter((record) => record.kind === "daemon")
+    .sort((left, right) => Date.parse(right.ts) - Date.parse(left.ts))[0];
+  if (daemon == null) return null;
+  const diedAt = Date.parse(daemon.ts);
+  if (!Number.isFinite(diedAt)) return null;
+  const how = daemon.signal != null
+    ? `by ${daemon.signal}`
+    : daemon.exit_code != null
+      ? `exit ${daemon.exit_code}`
+      : daemon.exit_path;
+  const detail = daemon.detail == null || daemon.detail.trim() === ""
+    ? ""
+    : ` — ${daemon.detail.replace(/\s+/g, " ").trim().slice(0, 160)}`;
+  return `last daemon death ${formatEvidenceAge(Math.max(0, nowMs - diedAt))} ago ` +
+    `(${how}, phase ${daemon.last_phase})${detail}`;
+}
+
+function formatEvidenceAge(ageMs: number): string {
+  const seconds = Math.round(ageMs / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h${minutes % 60}m`;
+  return `${Math.floor(hours / 24)}d`;
+}

--- a/apps/redskilled/tests/statusline-last-evidence.test.ts
+++ b/apps/redskilled/tests/statusline-last-evidence.test.ts
@@ -1,0 +1,87 @@
+// While the daemon is down every surface says a generic "unreachable" — and
+// the evidence for WHY sits on disk the whole time, in the death lane the
+// daemon's own recorder writes. These tests pin the absence arm's second line:
+// the newest daemon death, dated, with the record's own facts.
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { appendProcessDeathRecord, buildProcessDeathRecord } from "@reddb-io/shared/death-record.js";
+import {
+  daemonDeathLanePath,
+  readLastDaemonDeathHeadline,
+} from "../src/statusline-last-evidence.js";
+import { runStatusline } from "../src/statusline-command.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function laneWith(records: { ts: string; kind: "daemon" | "worker"; signal?: string | null; detail?: string }[]) {
+  const home = await mkdtemp(join(tmpdir(), "redskilled-last-evidence-"));
+  roots.push(home);
+  const lane = daemonDeathLanePath(home);
+  await mkdir(dirname(lane), { recursive: true });
+  for (const record of records) {
+    appendProcessDeathRecord(lane, buildProcessDeathRecord({
+      kind: record.kind,
+      id: `${record.kind}:99`,
+      pid: 99,
+      exit_path: record.signal == null ? "exit" : "signal",
+      signal: record.signal ?? null,
+      exit_code: record.signal == null ? 0 : null,
+      last_phase: "serving",
+      detail: record.detail ?? null,
+      ts: record.ts,
+    } as never, {} as never));
+  }
+  return { home, lane };
+}
+
+describe("the absence line names the last daemon death", () => {
+  it("reads the newest daemon record with its age, path, and detail", async () => {
+    const { lane } = await laneWith([
+      { ts: "2026-08-24T10:00:00.000Z", kind: "daemon", signal: "SIGTERM" },
+      { ts: "2026-08-24T18:00:00.000Z", kind: "worker", signal: "SIGKILL" },
+      { ts: "2026-08-24T19:00:00.000Z", kind: "daemon", detail: "a newer published bundle is taking the session over" },
+    ]);
+
+    const headline = readLastDaemonDeathHeadline(lane, Date.parse("2026-08-24T20:30:00.000Z"));
+
+    expect(headline).toContain("last daemon death 1h30m ago");
+    expect(headline).toContain("exit 0");
+    expect(headline).toContain("phase serving");
+    expect(headline).toContain("a newer published bundle is taking the session over");
+  });
+
+  it("answers nothing for an absent lane or one holding only worker deaths", async () => {
+    expect(readLastDaemonDeathHeadline("/nowhere/deaths.toonl", Date.now())).toBeNull();
+    const { lane } = await laneWith([{ ts: "2026-08-24T10:00:00.000Z", kind: "worker", signal: "SIGKILL" }]);
+    expect(readLastDaemonDeathHeadline(lane, Date.now())).toBeNull();
+  });
+
+  it("the unreachable statusline carries the evidence as its second line", async () => {
+    const { home } = await laneWith([
+      { ts: "2026-08-24T19:00:00.000Z", kind: "daemon", signal: "SIGTERM" },
+    ]);
+    const lines: string[] = [];
+
+    await runStatusline([], {
+      cwd: home,
+      homeDir: home,
+      now: () => "2026-08-24T19:45:00.000Z",
+      write: (line) => void lines.push(line),
+      warn: () => {},
+      // A client that poses as a dead host: every read refuses.
+      client: { request: async () => { throw new Error("connection refused"); } } as never,
+      paths: { socketPath: join(home, "no.sock"), acpSocketPath: join(home, "no-acp.sock") } as never,
+    });
+
+    const output = lines.join("");
+    expect(output).toContain("last daemon death 45m ago");
+    expect(output).toContain("SIGTERM");
+  });
+});


### PR DESCRIPTION
## What

Wave 6 slice 7 of the E2E-flow repair. `~/.red/redskilled/state/deaths/deaths.toonl` is read only by the reaper and the daemon that replaces the dead one — while the daemon is down, no surface reads it, and every UI degrades to a generic "unreachable" though the evidence sits on disk.

- New `statusline-last-evidence.ts`: `readLastDaemonDeathHeadline(lanePath, nowMs)` — the newest `kind: daemon` record, rendered as `last daemon death 1h30m ago (by SIGTERM, phase serving) — <detail>`. No freshness cutoff (the age in the sentence is the honesty); never throws.
- The statusline's absence arm appends it as a second line, wrapped so evidence can never cost the absence line itself. `runStatusline` gains an injectable `homeDir` for tests.
- Incidents-lane surfacing is a stated follow-up — one concern per PR.

## Tests

`statusline-last-evidence.test.ts`: newest-daemon-record selection with age/path/detail; absent lane and worker-only lane answer nothing; end-to-end `runStatusline` against a refused client shows the evidence line. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790202866&installation_model_id=20659&pr_number=4393&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4393&signature=dc2d636a1348c5a3743dde1e0c3a60d4bbf96cf650ab90f24a6c1096cb0b9793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->