### PR TITLE
chore(vscode): delete the dashboard view's unreachable dead branch

### DIFF
--- a/.changeset/vscode-dead-branch.md
+++ b/.changeset/vscode-dead-branch.md
@@ -1,0 +1,5 @@
+---
+"vscode-extension-red-skills": patch
+---
+
+The dashboard view's unreachable dead branch ("this daemon does not serve statusline-dashboard" — false by construction since the dashboard is rendered locally from the same payload read) is deleted, and HostSnapshot becomes a discriminated union so the state is unrepresentable.

--- a/apps/vscode-extension-redskilled/src/model/dashboard-view.ts
+++ b/apps/vscode-extension-redskilled/src/model/dashboard-view.ts
@@ -1,13 +1,14 @@
 /**
  * dashboard-view — what the status bar says and what the panel shows. PURE.
  *
- * **Every fact here was computed by the daemon.** The header line, the Worker
- * rows, the pipeline bars and the counts arrive finished from
- * `statusline-dashboard`; this module decides only where the text goes and how it
- * is escaped for a webview. That is the rule the statusline pair was built on
- * (ADR 0130 rule 10): an editor panel and a herdr pane each doing their own
- * Worker math would be two dashboards lying in two different ways about the same
- * instant.
+ * **Every fact here originates from the daemon's one payload read.** The header
+ * line, the Worker rows, the pipeline bars and the counts are drawn by the
+ * shared `renderRedskilledDashboard` (in `./snapshot.ts`, from the payload the
+ * daemon served — one read, one render, ADR 0132 decisions 1 and 9); this
+ * module decides only where the finished text goes and how it is escaped for a
+ * webview. That is the rule the statusline pair was built on (ADR 0130 rule
+ * 10): an editor panel and a herdr pane each doing their own Worker math would
+ * be two dashboards lying in two different ways about the same instant.
  *
  * Editor-free on purpose, so the whole of what a reader SEES is asserted by a
  * test that never opens a window. `views/status-bar.ts` and
@@ -46,14 +47,6 @@ export function statusBarView(snapshot: HostSnapshot): StatusBarView {
         snapshot.error?.message ?? "no reason given"
       }`,
       warning: true,
-    };
-  }
-  if (snapshot.dashboard === null) {
-    return {
-      text: "$(server) redskilled",
-      tooltip:
-        "This daemon does not serve statusline-dashboard. It answers the Worker set, and the dashboard is rendered by the daemon rather than here, so there is nothing to draw until it does.",
-      warning: false,
     };
   }
   const header = snapshot.dashboard.header;
@@ -127,15 +120,6 @@ function dashboardBody(snapshot: HostSnapshot): string {
     ].join("\n");
   }
   const dashboard = snapshot.dashboard;
-  if (dashboard === null) {
-    return [
-      '<p class="absence">',
-      escapeHtml(
-        "This daemon does not serve statusline-dashboard. The dashboard is rendered by the daemon rather than here, so there is nothing to draw until it does.",
-      ),
-      "</p>",
-    ].join("\n");
-  }
   return [
     `<pre class="header">${escapeHtml(stripAnsi(dashboard.header.line))}</pre>`,
     ...(dashboard.rows.length === 0

--- a/apps/vscode-extension-redskilled/src/model/snapshot.ts
+++ b/apps/vscode-extension-redskilled/src/model/snapshot.ts
@@ -23,32 +23,45 @@ export interface SnapshotFailure {
   readonly message: string;
 }
 
-export interface HostSnapshot {
-  readonly reachable: boolean;
+/**
+ * A discriminated union, so the type system itself removes the dead branch: a
+ * reachable snapshot ALWAYS carries a payload and its locally-drawn dashboard
+ * (they are read and rendered together), and only an unreachable one is null.
+ * The view briefly carried a reachable-but-no-dashboard rendering whose message
+ * ("this daemon does not serve statusline-dashboard") was false by
+ * construction — no such state can be built.
+ */
+export type HostSnapshot = ReachableHostSnapshot | UnreachableHostSnapshot;
+
+export interface ReachableHostSnapshot extends HostSnapshotCommon {
+  readonly reachable: true;
+  readonly payload: RedskilledStatuslinePayload;
+  readonly dashboard: RedskilledDashboard;
+  readonly error: null;
+}
+
+export interface UnreachableHostSnapshot extends HostSnapshotCommon {
+  readonly reachable: false;
+  readonly payload: null;
+  readonly dashboard: null;
+  readonly error: SnapshotFailure;
+}
+
+export interface HostSnapshotCommon {
   readonly socketPath: string;
   /** How the socket path was decided — carried for the unreachable case. */
   readonly source: string;
-  readonly payload: RedskilledStatuslinePayload | null;
   /**
    * The host document, or `null`.
    *
    * Null does NOT imply unreachable: `host-state` is read best-effort beside the
    * payload, so a daemon that serves one and refuses the other still yields a
-   * usable frame instead of an outage.
+   * usable frame instead of an outage. The dashboard, by contrast, is drawn
+   * HERE from the payload beside it (**one read, one render** — ADR 0132
+   * decisions 1 and 9), so it exists exactly when the payload does.
    */
   readonly hostState: RedskilledHostState | null;
-  /**
-   * The table for this frame, drawn HERE from the payload beside it.
-   *
-   * **One read, one render** (ADR 0132 decisions 1 and 9): it used to be a second
-   * socket call, which spent a round trip per frame to receive text this process
-   * could compute from bytes it already held. It is `null` exactly when the
-   * payload is — an unreachable daemon — and never because a daemon was too old
-   * to lay a table out, because no daemon lays one out any more.
-   */
-  readonly dashboard: RedskilledDashboard | null;
   readonly lane: EventLaneRead;
-  readonly error: SnapshotFailure | null;
   readonly readAt: string;
 }
 

--- a/apps/vscode-extension-redskilled/tests/dashboard.test.ts
+++ b/apps/vscode-extension-redskilled/tests/dashboard.test.ts
@@ -109,7 +109,7 @@ function snapshotOf(overrides: Partial<HostSnapshot> = {}): HostSnapshot {
     error: null,
     readAt: "2026-08-01T10:00:00.000Z",
     ...overrides,
-  };
+  } as HostSnapshot;
 }
 
 describe("the status bar shows the daemon's own summary", () => {
@@ -143,11 +143,14 @@ describe("the status bar shows the daemon's own summary", () => {
     expect(view.tooltip).toContain("not reachable");
   });
 
-  it("says a daemon predating the op has nothing to draw, rather than drawing zeros", () => {
-    const view = statusBarView(snapshotOf({ dashboard: null }));
-    expect(view.warning).toBe(false);
-    expect(view.text).not.toContain("wrk=");
-    expect(view.tooltip).toContain("statusline-dashboard");
+  it("a reachable snapshot always carries a dashboard — the snapshot type forbids the old dead branch", () => {
+    // The view once carried a reachable-but-no-dashboard rendering whose
+    // message ("this daemon does not serve statusline-dashboard") was false by
+    // construction: the dashboard is rendered locally from the payload read in
+    // the same frame, so it exists exactly when the payload does. The
+    // discriminated HostSnapshot union now makes that state unrepresentable.
+    const view = statusBarView(snapshotOf());
+    expect(view.text).toContain("wrk=");
   });
 });
 

--- a/apps/vscode-extension-redskilled/tests/signals.test.ts
+++ b/apps/vscode-extension-redskilled/tests/signals.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../src/watch/signals.js";
 import type { HostSnapshot } from "../src/model/snapshot.js";
 import type { RedskilledHostEvent } from "../src/redskilled/event-lane.js";
-import { hostState, statuslinePayload, worker } from "./fixtures.js";
+import { dashboard, hostState, statuslinePayload, worker } from "./fixtures.js";
 
 const PREFERENCES: NotificationPreferences = { ...DEFAULT_NOTIFICATION_PREFERENCES, workerBirth: true };
 
@@ -19,12 +19,12 @@ function snapshotOf(overrides: Partial<HostSnapshot> = {}): HostSnapshot {
     source: "a test",
     payload: statuslinePayload(),
     hostState: hostState(),
-    dashboard: null,
+    dashboard: dashboard(),
     lane: { path: "/tmp/rsk/lane.toonl", exists: true, truncated: false, events: [] },
     error: null,
     readAt: "2026-08-01T10:00:00.000Z",
     ...overrides,
-  };
+  } as HostSnapshot;
 }
 
 function event(overrides: Partial<RedskilledHostEvent>): RedskilledHostEvent {

--- a/apps/vscode-extension-redskilled/tests/views.test.ts
+++ b/apps/vscode-extension-redskilled/tests/views.test.ts
@@ -11,6 +11,7 @@ import { readSettings, MIN_POLL_INTERVAL_MS } from "../src/config.js";
 import type { HostSnapshot } from "../src/model/snapshot.js";
 import type { RedskilledHostEvent } from "../src/redskilled/event-lane.js";
 import { statuslinePayload, hostState, worker } from "./fixtures.js";
+import { dashboard } from "./fixtures.js";
 
 function snapshotOf(overrides: Partial<HostSnapshot> = {}): HostSnapshot {
   return {
@@ -19,12 +20,12 @@ function snapshotOf(overrides: Partial<HostSnapshot> = {}): HostSnapshot {
     source: "derived from XDG_RUNTIME_DIR",
     payload: statuslinePayload(),
     hostState: hostState(),
-    dashboard: null,
+    dashboard: dashboard(),
     lane: { path: "/tmp/rsk/lane.toonl", exists: true, truncated: false, events: [] },
     error: null,
     readAt: "2026-08-01T10:00:00.000Z",
     ...overrides,
-  };
+  } as HostSnapshot;
 }
 
 function labels(nodes: readonly ViewNode[]): string[] {


### PR DESCRIPTION
## What

Wave 6 slice 8 (last) of the E2E-flow repair. `snapshot.ts` only nulls `dashboard` together with `reachable: false`, so `dashboard-view.ts`'s two reachable-but-no-dashboard renderings were unreachable — and their message ("this daemon does not serve statusline-dashboard") was false by construction: the dashboard is drawn locally from the same payload read (one read, one render, ADR 0132 d1/d9).

- `HostSnapshot` becomes a discriminated union (`ReachableHostSnapshot` | `UnreachableHostSnapshot`) — the dead state is now unrepresentable, not merely unvisited; both branches deleted whole (no-legacy rule); the module doc-comment stops teaching the pre-ADR-0132 "arrives finished from statusline-dashboard" architecture.
- Test fixtures follow the union; the test that pinned the dead rendering becomes a type-level pin that a reachable snapshot always carries a dashboard.

## Tests

83/83; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790203111&installation_model_id=20659&pr_number=4395&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4395&signature=280d0bd626c242338e0f360477cd4dafdf0281f31e149fa75eaad09b6e671a21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->