### PR TITLE
fix(render): the global dashboard header answers for the host, and only the host

### DIFF
--- a/.changeset/dashboard-global-scope.md
+++ b/.changeset/dashboard-global-scope.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-render": patch
+---
+
+The global dashboard header answers for the host, and only the host: identity reads `host` instead of the cwd's project, the directory's registration verdict (`!unregistered`/`!lapsed`) stays off the host line, remote counters are no longer borrowed from the cwd's project, and the worker count renders flat (`wrk=N`) instead of the always-1 ratio.

--- a/packages/redskilled-render/dashboard.ts
+++ b/packages/redskilled-render/dashboard.ts
@@ -441,10 +441,18 @@ function buildHeader(
   selected: readonly RedskilledRenderWorker[],
   match: RedskilledStatuslineProjectMatch,
 ): RedskilledDashboardHeader {
+  // **The global header answers for the HOST, and only the host.** It used to
+  // mix scopes on one line: identity and remote counters from the CWD's
+  // project, worker totals from the host, and a `!unregistered` verdict about
+  // the directory beside host-wide numbers — so one line described two
+  // subjects and read as one. In global mode the cwd's project keeps its facts
+  // on its own project ROW; the header keeps the host's.
+  const global = options.mode === "global";
+  const headerProject = global ? null : options.project;
   const activity = (payload.repository_activity?.projects ?? []).find(
-    (project) => project.project_label === options.project,
+    (project) => project.project_label === headerProject,
   );
-  const counts = dashboardCounts(payload, options.project);
+  const counts = dashboardCounts(payload, headerProject);
   const windows: RedskilledDashboardWindows = {
     memory_used_fraction: payload.host.ceiling_used_fraction,
     memory_used_bytes: payload.host.consumption.memory_bytes,
@@ -454,7 +462,7 @@ function buildHeader(
     interactive_reservation: payload.host.ceiling.interactive_reservation ?? 0,
   };
   const model = firstPublishedModel(selected);
-  const repo = activity?.repository ?? options.project;
+  const repo = global ? "host" : activity?.repository ?? options.project;
 
   const engine = payload.engine ?? null;
   const version = engine?.running_version ?? payload.daemon.daemon_version;
@@ -469,8 +477,10 @@ function buildHeader(
     version,
     engine != null && engine.current === false ? ENGINE_BEHIND_MARK : "",
   )];
-  if (match === "unregistered" || match === "name-only") parts.push(UNREGISTERED_MARK);
-  if (match === "lapsed") parts.push(LAPSED_MARK);
+  // A registration verdict is about the DIRECTORY, so in global mode it
+  // belongs on that project's row, never on the host header.
+  if (!global && (match === "unregistered" || match === "name-only")) parts.push(UNREGISTERED_MARK);
+  if (!global && match === "lapsed") parts.push(LAPSED_MARK);
   const liveRates = metrics?.history_48h == null ? null : hourlyHeadline(metrics.history_48h);
   if (liveRates != null) parts.push(colourKeyValues(liveRates));
   const repairing = payload.workers.filter(isRepairWorker).length;
@@ -479,6 +489,10 @@ function buildHeader(
     parts.push(
       `${colourKeyValues(`workers=${coding} coding +`)} ${MODEL_BG}${PAPER}${repairing} repairing${NOBG}${SOFT}`,
     );
+  } else if (global) {
+    // In global mode `selected` IS the host's Worker set, so the old
+    // `wrk=N/N` ratio was always 1 — a precise-looking non-fact.
+    parts.push(colourKeyValues(`wrk=${payload.host.worker_count}`));
   } else {
     parts.push(colourKeyValues(`wrk=${selected.length}/${payload.host.worker_count}`));
   }
@@ -490,12 +504,12 @@ function buildHeader(
   if (model != null) parts.push(`${MODEL_BG}${PAPER}${model}${NOBG}${SOFT}`);
   // The counters come from the ONE builder both densities share, so the table
   // and the line can never date the same poll differently.
-  for (const token of remoteCounterTokens(payload, options.project)) parts.push(colourKeyValues(token));
+  for (const token of remoteCounterTokens(payload, headerProject)) parts.push(colourKeyValues(token));
   // The blanket marker is what a daemon WITHOUT the dated block can say. Once
   // each counter carries its own age, repeating it would warn a second time
   // about the numbers that already said so and warn at all about the ones that
   // are fresh.
-  if (counts.stale && !hasDatedCounters(payload, options.project)) parts.push("!counts stale");
+  if (counts.stale && !hasDatedCounters(payload, headerProject)) parts.push("!counts stale");
   // The rates go here, where a status bar still reads them, and they are the
   // FIRST thing dropped when the line does not fit — see below. Everything
   // before them answers "is this machine healthy"; the rates answer "how fast is

--- a/packages/redskilled-render/tests/render.test.ts
+++ b/packages/redskilled-render/tests/render.test.ts
@@ -749,3 +749,40 @@ describe("withheld is not unmeasured", () => {
     expect(rendered.line).toContain("!unmeasured");
   });
 });
+
+describe("the global dashboard header answers for the host, and only the host", () => {
+  // One payload, one difference: the mode. The session sits in an UNREGISTERED
+  // acme/widgets checkout, which is exactly the shape that used to leak a
+  // directory verdict onto a host-wide line.
+  const doc = () => payload({ known_projects: [], registered_projects: [] });
+
+  it("names the host, drops the directory's registration verdict, and counts workers flat", () => {
+    const global = renderRedskilledDashboard(doc(), {
+      ...REDSKILLED_DASHBOARD_DEFAULTS,
+      mode: "global",
+      project: "acme/widgets",
+      maxWidth: 400,
+    });
+    const head = stripAnsi(global.header.line);
+    expect(head).toContain("host");
+    // The cwd's project keeps its facts on its own project row, never here.
+    expect(head).not.toContain("acme/widgets");
+    expect(head).not.toContain("!unregistered");
+    // `selected` IS the host set in global mode, so a ratio was always 1.
+    expect(head).toContain("wrk=1 ");
+    expect(head).not.toContain("wrk=1/1");
+  });
+
+  it("keeps the cwd identity, its verdict and the ratio on the local header", () => {
+    const local = renderRedskilledDashboard(doc(), {
+      ...REDSKILLED_DASHBOARD_DEFAULTS,
+      mode: "local",
+      project: "acme/widgets",
+      maxWidth: 400,
+    });
+    const head = stripAnsi(local.header.line);
+    expect(head).toContain("acme/widgets");
+    expect(head).toContain("!unregistered");
+    expect(head).toContain("wrk=1/1");
+  });
+});


### PR DESCRIPTION
## What

Wave 6 slice (w6d) of the E2E-flow repair: the dashboard's **global** header used to mix scopes on one line — identity and remote counters from the CWD's project, worker totals from the host, and a `!unregistered` verdict about the directory beside host-wide numbers — so one line described two subjects while reading as one.

In global mode the header now answers for the host, and only the host:

- identity reads `host` (the cwd's project keeps its identity on its own project row);
- the directory registration verdicts (`!unregistered`, `!lapsed`) never reach the host line;
- remote counters and the `!counts stale` blanket are no longer borrowed from the cwd's project;
- the worker count renders flat `wrk=N` — the old `wrk=N/N` ratio was always 1 in global mode, because `selected` IS the host's Worker set: a precise-looking non-fact.

Local mode is byte-identical to before (pinned by test).

## Tests

- `packages/redskilled-render/tests/render.test.ts`: two new tests — the global header names the host, drops the verdict and counts flat; the local header keeps identity, verdict and ratio. Suite 110/110.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790203510&installation_model_id=20659&pr_number=4396&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4396&signature=c8edb5ed842bda51036c09592a27847f9f389d411e2c649f82962221c712a375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->