### PR TITLE
fix(mcp): the danger posture guards the live ACP invoke path

### DIFF
--- a/.changeset/mcp-wrapper-honesty.md
+++ b/.changeset/mcp-wrapper-honesty.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/dev": patch
+---
+
+The danger posture now guards the path that runs: the stdio MCP adapter rebuilds the tool surface with the ACP invoke as each tool's body and wraps THAT with `applyDangerPosture("confirm")`, so a MUTATING tool (`gate_run`, `land_branch`) refuses without `confirmation: true` and the published schema carries the `confirmation` argument. The gate previously wrapped tool bodies the adapter never executed.

--- a/apps/plugin-dev/src/mcp-server.ts
+++ b/apps/plugin-dev/src/mcp-server.ts
@@ -12,6 +12,7 @@ import {
   RS_DEV_MCP_SERVER_NAME,
   type CastleMcpDependencies,
 } from "./mcp-tools/index.js";
+import { applyDangerPosture, type DangerPosture } from "./mcp-tools/posture.js";
 import { encodeRedskilledMcpToon } from "./mcp-toon.js";
 import { invokeProjectMcp } from "./project-acp-adapter.js";
 import { drainInputFor } from "./core/drain-registration-resolve.js";
@@ -24,6 +25,15 @@ import { createAcpLaneFollower } from "./acp-lane-follower.js";
 import { createRsGithubMcpServer, RS_GITHUB_REQUEST_METHOD } from "./mcp-github/index.js";
 
 const buildInfo = readBuildInfo("redskilled-mcp");
+
+/**
+ * The posture the LIVE adapter serves under: a MUTATING tool asks first.
+ *
+ * A constant rather than config on purpose — the gate exists so `gate_run` and
+ * `land_branch` cannot fire off one mis-tabbed tool call, and a knob that could
+ * relax it per-checkout would be the mis-tab with a longer fuse.
+ */
+export const RS_DEV_DANGER_POSTURE: DangerPosture = "confirm";
 
 export function createRedskilledMcpServer(
   root: string | (() => string | Promise<string>) = process.cwd(),
@@ -74,7 +84,22 @@ export function createRedskilledMcpServer(
     }
     return drainInputFor(resolved, buildInfo.version, input);
   };
-  for (const tool of createCastleMcpTools(dependencies)) {
+  // **The posture gate guards the path that runs.** `createCastleMcpTools`
+  // wires the danger posture around each tool's OWN invoke, but this adapter
+  // replaces every invocation with the ACP call — so the gate it shipped with
+  // guarded a body that never executes. Rebuild the surface with the ACP call
+  // as the body and wrap THAT: a `dangerClass` tool now refuses without
+  // `confirmation: true`, and the augmented schema is what the SDK publishes —
+  // an argument absent from the schema never reaches the handler. Output
+  // contracts stay off this path for now: the daemon's refusal envelopes are
+  // deliberately not the tools' declared payloads, and a validator that turned
+  // an honest refusal into a thrown error would be the second dishonesty.
+  const acpTools = createCastleMcpTools(dependencies).map((tool) => ({
+    ...tool,
+    invoke: async (input: Record<string, unknown>) =>
+      invoke(tool.name, await enrich(tool.name, input)),
+  }));
+  for (const tool of applyDangerPosture(acpTools, RS_DEV_DANGER_POSTURE)) {
     registerTool(
       tool.name,
       {
@@ -86,9 +111,7 @@ export function createRedskilledMcpServer(
         content: [
           {
             type: "text" as const,
-            text: encodeRedskilledMcpToon(
-              await invoke(tool.name, await enrich(tool.name, input)),
-            ),
+            text: encodeRedskilledMcpToon(await tool.invoke(input)),
           },
         ],
       }),

--- a/apps/plugin-dev/tests/mcp-posture-live.test.ts
+++ b/apps/plugin-dev/tests/mcp-posture-live.test.ts
@@ -1,0 +1,70 @@
+// The danger posture guards the path that RUNS. `createCastleMcpTools` wired
+// `applyDangerPosture` around each tool's own invoke, but the stdio adapter
+// replaces every invocation with the ACP call — so a MUTATING `gate_run` or
+// `land_branch` executed on the daemon with no confirmation asked, while the
+// gate guarded a body that never ran. These tests drive the REAL server over
+// the SDK's linked transport, because the schema augmentation is part of the
+// claim: an argument absent from the published schema never reaches a handler.
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRedskilledMcpServer, RS_DEV_DANGER_POSTURE } from "../src/mcp-server.js";
+
+describe("the danger posture wraps the live ACP invoke", () => {
+  const close: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.all(close.splice(0).map((shutdown) => shutdown()));
+  });
+
+  async function serve() {
+    const acpInvoke = vi.fn(async (method: string, input: Record<string, unknown>) => ({ method, input }));
+    const server = createRedskilledMcpServer(process.cwd(), acpInvoke);
+    const client = new Client({ name: "mcp-posture-live-test", version: "1" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    close.push(() => client.close(), () => server.close());
+    return { client, acpInvoke };
+  }
+
+  it("the adapter serves the confirm posture, not the allow default", () => {
+    expect(RS_DEV_DANGER_POSTURE).toBe("confirm");
+  });
+
+  it("a MUTATING tool without confirmation is refused before the daemon hears of it", async () => {
+    const { client, acpInvoke } = await serve();
+
+    const result = await client.callTool({ name: "gate_run", arguments: { branch: "fix/x" } });
+
+    const text = JSON.stringify(result.content);
+    expect(text).toContain("refused");
+    expect(text).toContain("confirmation");
+    expect(acpInvoke).not.toHaveBeenCalled();
+  });
+
+  it("confirmation reaches the handler through the published schema and is stripped before ACP", async () => {
+    const { client, acpInvoke } = await serve();
+
+    await client.callTool({
+      name: "land_branch",
+      arguments: { issue: 42, branch: "fix/x", confirmation: true },
+    });
+
+    expect(acpInvoke).toHaveBeenCalledTimes(1);
+    const [method, input] = acpInvoke.mock.calls[0] as [string, Record<string, unknown>];
+    expect(method).toBe("land_branch");
+    expect(input.branch).toBe("fix/x");
+    expect(input).not.toHaveProperty("confirmation");
+  });
+
+  it("a tool with no dangerClass rides the ACP path unwrapped", async () => {
+    const { client, acpInvoke } = await serve();
+
+    await client.callTool({ name: "status", arguments: { scope: "project" } });
+
+    expect(acpInvoke).toHaveBeenCalledTimes(1);
+    const [method] = acpInvoke.mock.calls[0] as [string, Record<string, unknown>];
+    expect(method).toBe("status");
+  });
+});


### PR DESCRIPTION
## What

Wave 5 slice (w5c) of the E2E-flow repair. `createCastleMcpTools` wires `applyDangerPosture` around each tool's **own** invoke, but the stdio adapter replaces every invocation with the ACP call — so the posture gate (and its confirmation demand for MUTATING `gate_run`/`land_branch`) guarded a body that never executed, and the live surface served everything at `allow`.

The adapter now rebuilds the surface with the ACP call as each tool's body and wraps **that** at the new exported `RS_DEV_DANGER_POSTURE` (`"confirm"`, a constant on purpose — a per-checkout knob that could relax it would be the mis-tab with a longer fuse):

- a `dangerClass` tool refuses with a structured repair unless `confirmation: true` is passed;
- the published inputSchema carries the `confirmation` argument (the MCP SDK strips arguments absent from the schema, so the augmentation is load-bearing);
- the flag is stripped before the daemon hears the call;
- non-dangerous tools ride the ACP path unchanged.

Output contracts stay off the ACP path deliberately: the daemon's refusal envelopes are not the tools' declared payloads, and a validator that turned an honest refusal into a thrown error would be the second dishonesty — that rewire is its own follow-up.

## Tests

`apps/plugin-dev/tests/mcp-posture-live.test.ts` drives the real server over the SDK's linked transport: refusal before ACP without confirmation, confirmation passes through the published schema and is stripped, undangered tools unwrapped. Plus mcp-tool-surface, routing-guard, complexity/file-size guards, typecheck — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790203845&installation_model_id=20659&pr_number=4397&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4397&signature=1ae2fa61fccc63dbe16ba9fd660ad05e1f7bad6569ffde6dd356402a7fbf88d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->