### PR TITLE
feat(mobile): operator state answer v2 — host block and published Worker facts

### DIFF
--- a/.changeset/mobile-operator-payload-v2.md
+++ b/.changeset/mobile-operator-payload-v2.md
@@ -1,0 +1,7 @@
+---
+"@reddb-io/protocol-acp": minor
+"@reddb-io/redskilled": minor
+"@reddb-io/red-skills-link-protocol": minor
+---
+
+Mobile operator state answer v2 (additive): a `host` block (daemon_version, started_at, worker_ceiling, honest staleness mirrored from the statusline read, generated_at) and per-Worker `phase`, `heartbeat_age_ms`, `repository`, `ticket` — sourced from the one statusline document, never a second read; deliberately no vitals and no log lines (ADR 0166).

--- a/apps/redskilled-link/tests/link-e2e.test.ts
+++ b/apps/redskilled-link/tests/link-e2e.test.ts
@@ -37,7 +37,18 @@ describe("app <> relay <> Host <> redskilled", () => {
     });
     const invitation = await state.createInvitation();
     const operator = {
-      state: vi.fn(async () => ({ version: 1 as const, daemon_version: "4.2.0", workers: [] })),
+      state: vi.fn(async () => ({
+        version: 2 as const,
+        daemon_version: "4.2.0",
+        workers: [],
+        host: {
+          daemon_version: "4.2.0",
+          started_at: "2026-08-23T08:00:00.000Z",
+          worker_ceiling: 4,
+          staleness: null,
+          generated_at: "2026-08-23T12:10:00.000Z",
+        },
+      })),
       dispatch: vi.fn(async () => ({
         version: 1 as const,
         repository: "reddb-io/red-skills",
@@ -110,7 +121,18 @@ describe("app <> relay <> Host <> redskilled", () => {
     const host = runRedskilledLinkHost({
       state,
       operator: {
-        state: async () => ({ version: 1, daemon_version: "test", workers: [] }),
+        state: async () => ({
+          version: 2,
+          daemon_version: "test",
+          workers: [],
+          host: {
+            daemon_version: "test",
+            started_at: "2026-08-23T08:00:00.000Z",
+            worker_ceiling: null,
+            staleness: null,
+            generated_at: "2026-08-23T12:10:00.000Z",
+          },
+        }),
         dispatch: async () => { throw new Error("not reached"); },
         stop: async () => { throw new Error("not reached"); },
       },

--- a/apps/redskilled/src/acp-connection-methods.ts
+++ b/apps/redskilled/src/acp-connection-methods.ts
@@ -47,6 +47,7 @@ import type { HostBrainStore } from "./brain-store.js";
 import type { ProjectMemoryStore } from "./memory-store.js";
 import type { RedskilledGithubGatewayRegistration } from "./github-gateway.js";
 import type { RedskilledHostState } from "./host-state.js";
+import type { RedskilledStatuslinePayload } from "./statusline-payload.js";
 import type { RedskilledPaths } from "./paths.js";
 import {
   projectControlMethodDomain,
@@ -73,6 +74,9 @@ export interface ConnectionMethodDeps {
   readonly mobileWorkerStop: (
     params: MobileWorkerStopParams,
   ) => Promise<MobileWorkerStopAnswer>;
+  /** The statusline read the Mobile v2 answer dates itself by; null when none. */
+  readonly statuslinePayload?: () => RedskilledStatuslinePayload | null;
+  readonly clock?: () => string;
   /**
    * The host's ONE brain store holder (ADR 0152).
    *
@@ -141,6 +145,8 @@ export function connectionMethodTables(deps: ConnectionMethodDeps): ConnectionMe
     mobileOperatorMethodDomain({
       hostAdministration: deps.hostAdministration,
       hostState: deps.hostState,
+      ...(deps.statuslinePayload == null ? {} : { statuslinePayload: deps.statuslinePayload }),
+      ...(deps.clock == null ? {} : { clock: deps.clock }),
       dispatch: deps.mobileTicketDispatch,
       stop: deps.mobileWorkerStop,
     }),

--- a/apps/redskilled/src/acp-control-plane-contract.ts
+++ b/apps/redskilled/src/acp-control-plane-contract.ts
@@ -16,6 +16,7 @@ import type { RedskilledPaths } from "./paths.js";
 import type { AcpProjectWorkspace } from "./project-workspace.js";
 import type { RedskilledProjectRegistrationRequest } from "./project-registration.js";
 import type { StandingOrdersStore } from "./standing-orders.js";
+import type { RedskilledStatuslinePayload } from "./statusline-payload.js";
 import type { LaunchedWorker, RedskilledWorkerSpec } from "./worker-launch.js";
 
 export interface PublicSession {
@@ -52,6 +53,8 @@ export interface StartRedskillsAcpControlPlaneOptions {
   readonly mobileWorkerStop?: (
     params: MobileWorkerStopParams,
   ) => Promise<MobileWorkerStopAnswer>;
+  /** The statusline document the Mobile v2 answer dates itself by; optional. */
+  readonly statuslinePayload?: () => RedskilledStatuslinePayload | null;
   readonly evidenceRoot?: string;
   readonly evidenceTtlMs?: number;
   readonly clock?: () => string;

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -334,6 +334,8 @@ async function servePublicConnection(
     scopedState,
     scopedProject,
     hostState: options.hostState,
+    ...(options.statuslinePayload == null ? {} : { statuslinePayload: options.statuslinePayload }),
+    ...(options.clock == null ? {} : { clock: options.clock }),
     mutateProjectControl,
     readProjectStatus: () => readProjectStatus(scopedProject()),
     onGithubReader: (reader) => {

--- a/apps/redskilled/src/acp-mobile-operator.ts
+++ b/apps/redskilled/src/acp-mobile-operator.ts
@@ -23,10 +23,19 @@ import {
   type RedskillsAcpMethodDomain,
 } from "./acp-method-registry.js";
 import type { RedskilledHostState } from "./host-state.js";
+import type { RedskilledStatuslinePayload } from "./statusline-payload.js";
 
 export interface AcpMobileOperatorDeps {
   readonly hostAdministration: boolean;
   readonly hostState: () => RedskilledHostState;
+  /**
+   * The statusline document composed beside the answer, when the daemon has one.
+   *
+   * Optional so thin embeddings and tests run on host state alone; when absent
+   * the v2 host block says so (`staleness: null`) instead of inventing a verdict.
+   */
+  readonly statuslinePayload?: () => RedskilledStatuslinePayload | null;
+  readonly clock?: () => string;
   readonly dispatch: (params: MobileTicketDispatchParams) => Promise<MobileTicketDispatchAnswer>;
   readonly stop: (params: MobileWorkerStopParams) => Promise<MobileWorkerStopAnswer>;
 }
@@ -45,7 +54,10 @@ export function mobileOperatorMethodDomain(deps: AcpMobileOperatorDeps): Redskil
         mobileOperatorStateParams,
         () => {
           requireAuthority();
-          return projectOperatorState(deps.hostState());
+          return projectOperatorState(deps.hostState(), {
+            statusline: deps.statuslinePayload?.() ?? null,
+            now: deps.clock?.() ?? new Date().toISOString(),
+          });
         },
       ),
       redskillsAcpMethod(
@@ -76,14 +88,70 @@ export function mobileOperatorMethodDomain(deps: AcpMobileOperatorDeps): Redskil
   };
 }
 
-export function projectOperatorState(state: RedskilledHostState): MobileOperatorStateAnswer {
+export interface MobileOperatorStateSources {
+  /** The one statusline read this answer dates itself and its Workers by. */
+  readonly statusline?: RedskilledStatuslinePayload | null;
+  /** The answer's own instant; falls back to the statusline's when absent. */
+  readonly now?: string;
+}
+
+/**
+ * Project the v2 app state: host facts plus what each project PUBLISHED.
+ *
+ * Everything per-Worker beyond the v1 identity comes from the statusline
+ * document rather than a second read, so the phone and the terminal describe
+ * the same instant — and a Worker the document does not cover renders its
+ * extras as `null`, never as a guess. Paths, pids, credentials, vitals and log
+ * lines deliberately never cross this wire (ADR 0166).
+ */
+export function projectOperatorState(
+  state: RedskilledHostState,
+  sources: MobileOperatorStateSources = {},
+): MobileOperatorStateAnswer {
+  const statusline = sources.statusline ?? null;
+  const generatedAt = statusline?.generated_at ?? sources.now ?? state.started_at;
+  const generatedMs = Date.parse(generatedAt);
+  const published = new Map(
+    (statusline?.workers ?? []).map((worker) => [worker.worker_id, worker]),
+  );
+  const repositories = new Map(
+    (statusline?.repository_activity?.projects ?? []).map(
+      (project) => [project.project_label, project.repository],
+    ),
+  );
   return {
-    version: 1,
+    version: 2,
     daemon_version: state.daemon_version,
-    workers: state.workers.map((worker) => ({
-      worker_id: worker.worker_id,
-      project_label: worker.project_label,
-      started_at: worker.started_at,
-    })),
+    workers: state.workers.map((worker) => {
+      const row = published.get(worker.worker_id);
+      const publishedAt = row?.log.published_at ?? null;
+      const publishedMs = publishedAt == null ? Number.NaN : Date.parse(publishedAt);
+      return {
+        worker_id: worker.worker_id,
+        project_label: worker.project_label,
+        started_at: worker.started_at,
+        phase: row?.display?.phase ?? null,
+        heartbeat_age_ms:
+          Number.isNaN(publishedMs) || Number.isNaN(generatedMs)
+            ? null
+            : Math.max(0, generatedMs - publishedMs),
+        repository: repositories.get(worker.project_label) ?? null,
+        ticket: row?.display?.issue ?? null,
+      };
+    }),
+    host: {
+      daemon_version: state.daemon_version,
+      started_at: state.started_at,
+      worker_ceiling: state.ceiling?.worker_count ?? null,
+      staleness: statusline == null
+        ? null
+        : {
+          stale: statusline.staleness.stale,
+          age_ms: statusline.staleness.age_ms,
+          threshold_ms: statusline.staleness.threshold_ms,
+          reason: statusline.staleness.reason,
+        },
+      generated_at: generatedAt,
+    },
   };
 }

--- a/apps/redskilled/src/daemon/lifecycle.ts
+++ b/apps/redskilled/src/daemon/lifecycle.ts
@@ -2397,7 +2397,7 @@ export async function startRedskilledDaemon(options: RedskilledDaemonOptions): P
     acpControlPlane = await startRedskillsAcpControlPlane({
       paths,
       startWorker,
-      hostState,
+      hostState, statuslinePayload: () => statuslinePayload(),
       hostAdministration: true,
       mobileWorkerStop: createMobileWorkerStop(runWorkerCommand),
       ...(options.githubGateway == null ? {} : { githubGateway: options.githubGateway }),

--- a/apps/redskilled/tests/acp-mobile-operator.test.ts
+++ b/apps/redskilled/tests/acp-mobile-operator.test.ts
@@ -9,6 +9,8 @@ import {
 function hostState() {
   return {
     daemon_version: "4.2.0",
+    started_at: "2026-08-23T08:00:00.000Z",
+    ceiling: { worker_count: 4 },
     workers: [{
       worker_id: "W1",
       project_label: "reddb-io/red-skills",
@@ -18,6 +20,29 @@ function hostState() {
       isolated: true,
       warnings: [],
     }],
+  } as never;
+}
+
+function statusline() {
+  return {
+    generated_at: "2026-08-23T12:10:00.000Z",
+    staleness: {
+      stale: false,
+      age_ms: 5_000,
+      threshold_ms: 30_000,
+      reason: "measured 5s ago",
+    },
+    workers: [{
+      worker_id: "W1",
+      log: {
+        last_line: "coding: touched /secret/worktree/src/index.ts",
+        published_at: "2026-08-23T12:09:30.000Z",
+      },
+      display: { phase: "coding", issue: "4321" },
+    }],
+    repository_activity: {
+      projects: [{ project_label: "reddb-io/red-skills", repository: "reddb-io/red-skills" }],
+    },
   } as never;
 }
 
@@ -37,7 +62,7 @@ describe("the Mobile operator ACP domain", () => {
     ]);
     expect(domain.capability).toEqual({
       mobileOperator: {
-        version: 1,
+        version: 2,
         methods: [
           REDSKILLS_ACP_METHODS.operatorState,
           REDSKILLS_ACP_METHODS.ticketDispatch,
@@ -64,15 +89,54 @@ describe("the Mobile operator ACP domain", () => {
     }
   });
 
-  it("projects no host path, pid, credential or policy into the app state", () => {
-    expect(projectOperatorState(hostState())).toEqual({
-      version: 1,
+  it("projects no host path, pid, credential, vitals or log line into the app state", () => {
+    const answer = projectOperatorState(hostState(), { statusline: statusline() });
+
+    expect(JSON.stringify(answer)).not.toContain("/secret/worktree");
+    expect(JSON.stringify(answer)).not.toContain("pid");
+    expect(answer).toEqual({
+      version: 2,
       daemon_version: "4.2.0",
       workers: [{
         worker_id: "W1",
         project_label: "reddb-io/red-skills",
         started_at: "2026-08-23T12:00:00.000Z",
+        phase: "coding",
+        heartbeat_age_ms: 30_000,
+        repository: "reddb-io/red-skills",
+        ticket: "4321",
       }],
+      host: {
+        daemon_version: "4.2.0",
+        started_at: "2026-08-23T08:00:00.000Z",
+        worker_ceiling: 4,
+        staleness: { stale: false, age_ms: 5_000, threshold_ms: 30_000, reason: "measured 5s ago" },
+        generated_at: "2026-08-23T12:10:00.000Z",
+      },
     });
+  });
+
+  it("a Worker the statusline read does not cover renders null extras, never a guess", () => {
+    const answer = projectOperatorState(hostState(), {
+      statusline: { ...(statusline() as object), workers: [], repository_activity: { projects: [] } } as never,
+    });
+
+    expect(answer.workers[0]).toEqual({
+      worker_id: "W1",
+      project_label: "reddb-io/red-skills",
+      started_at: "2026-08-23T12:00:00.000Z",
+      phase: null,
+      heartbeat_age_ms: null,
+      repository: null,
+      ticket: null,
+    });
+  });
+
+  it("without a statusline read beside it the host block says so instead of inventing a verdict", () => {
+    const answer = projectOperatorState(hostState(), { now: "2026-08-23T12:11:00.000Z" });
+
+    expect(answer.host.staleness).toBeNull();
+    expect(answer.host.generated_at).toBe("2026-08-23T12:11:00.000Z");
+    expect(answer.workers[0]?.phase).toBeNull();
   });
 });

--- a/packages/protocol-acp/mobile-operator.ts
+++ b/packages/protocol-acp/mobile-operator.ts
@@ -34,16 +34,57 @@ export interface MobileOperatorWorker {
   readonly worker_id: string;
   readonly project_label: string;
   readonly started_at: string;
+  /** The phase the Worker's project last published; `null` when it published none. */
+  readonly phase?: string | null;
+  /** Age of the last published heartbeat at `generated_at`; `null` when unpublished. */
+  readonly heartbeat_age_ms?: number | null;
+  /** The repository the activity poll attributes to this project; `null` unpolled. */
+  readonly repository?: string | null;
+  /** The Issue the project says this Worker is on; `null` when it named none. */
+  readonly ticket?: string | null;
 }
 
+/**
+ * Whether the numbers in this answer are current, on the daemon's own clock.
+ *
+ * Mirrors the statusline document's verdict rather than re-deriving one, so the
+ * phone and the terminal can never date the same read two different ways.
+ */
+export interface MobileOperatorStaleness {
+  readonly stale: boolean;
+  readonly age_ms: number | null;
+  readonly threshold_ms: number;
+  readonly reason: string;
+}
+
+/** The host block of the v2 answer — facts about the machine, not one Worker. */
+export interface MobileOperatorHost {
+  readonly daemon_version: string;
+  readonly started_at: string;
+  /** `null` is an unlimited host, never an unknown one. */
+  readonly worker_ceiling: number | null;
+  /** `null` when the daemon composed no statusline read beside this answer. */
+  readonly staleness: MobileOperatorStaleness | null;
+  readonly generated_at: string;
+}
+
+/**
+ * Version 2 is ADDITIVE: the v1 fields keep their exact meaning and position,
+ * `host` and the per-Worker extras ride beside them. Deliberately no vitals and
+ * no log lines — remote exposure stays capability-scoped (ADR 0166), and a
+ * phone that needs the receipts opens the host, not a wider wire.
+ */
 export interface MobileOperatorStateAnswer {
-  readonly version: 1;
+  readonly version: 2;
   readonly daemon_version: string;
   readonly workers: readonly MobileOperatorWorker[];
+  readonly host: MobileOperatorHost;
 }
 
+// Version 2 = the additive state answer above; the method set is unchanged, so
+// a v1 client keeps calling the same three names and reads the same v1 fields.
 export const MOBILE_OPERATOR_SCHEMA = {
-  version: 1,
+  version: 2,
   methods: [
     REDSKILLS_ACP_METHODS.operatorState,
     REDSKILLS_ACP_METHODS.ticketDispatch,

--- a/packages/red-skills-link-protocol/protocol.ts
+++ b/packages/red-skills-link-protocol/protocol.ts
@@ -25,14 +25,35 @@ export type RedskilledLinkOperation =
   | { readonly operation: "worker_stop"; readonly params: { readonly worker_id: string } };
 
 export type RedskilledLinkOperationAnswer =
+  // The state answer mirrors `MobileOperatorStateAnswer` v2 (protocol-acp);
+  // spelled out here because this package is the one surface the phone builds
+  // against and it deliberately imports no daemon wiring. v2 is ADDITIVE over
+  // v1: the identity fields keep their meaning, `host` and the per-Worker
+  // extras ride beside them.
   | {
-      readonly version: 1;
+      readonly version: 2;
       readonly daemon_version: string;
       readonly workers: readonly {
         readonly worker_id: string;
         readonly project_label: string;
         readonly started_at: string;
+        readonly phase?: string | null;
+        readonly heartbeat_age_ms?: number | null;
+        readonly repository?: string | null;
+        readonly ticket?: string | null;
       }[];
+      readonly host: {
+        readonly daemon_version: string;
+        readonly started_at: string;
+        readonly worker_ceiling: number | null;
+        readonly staleness: {
+          readonly stale: boolean;
+          readonly age_ms: number | null;
+          readonly threshold_ms: number;
+          readonly reason: string;
+        } | null;
+        readonly generated_at: string;
+      };
     }
   | {
       readonly version: 1;


### PR DESCRIPTION
## What

Wave 7 slice 1 (w7a) of the E2E-flow repair. The mobile app showed a bare worker list against a hardcoded "online" because the operator wire carried nothing to be honest with. `MobileOperatorStateAnswer` v2 is **additive**:

- **host block**: `daemon_version`, `started_at`, `worker_ceiling` (`null` = unlimited, never unknown), `staleness` mirrored from the statusline document (`null` when no read was composed beside the answer — stated, not invented), `generated_at`;
- **per Worker**: `phase`, `heartbeat_age_ms` (age of the last published heartbeat at `generated_at`), `repository` (from the activity poll), `ticket` — every extra sourced from the **one** statusline read, so the phone and the terminal can never date the same instant two different ways. A Worker the document does not cover renders `null` extras, never a guess.
- Deliberately **no vitals and no log lines** — remote exposure stays capability-scoped (ADR 0166), and the projection test asserts no path/pid crosses the wire.

Wiring: `AcpMobileOperatorDeps` gains an optional `statuslinePayload` supplier, threaded through the connection method tables and the control-plane contract; `daemon/lifecycle.ts` passes its existing `statuslinePayload()` and stays at its pinned 2476 lines. `MOBILE_OPERATOR_SCHEMA.version` advertises 2 (method set unchanged). The link protocol's state arm mirrors the same v2 shape — that package is the one surface the phone builds against.

Consumers compile unchanged (`redskilled-link` host relays opaquely; the typed operator client is generic). The mobile app's honest status derivation is the next slice (w7b).

## Tests

- `apps/redskilled/tests/acp-mobile-operator.test.ts`: v2 projection (exact answer, null-extras arm, no-statusline arm, no path/pid leak), capability v2.
- `apps/redskilled-link` suite green; typecheck green across `protocol-acp`, `redskilled`, `red-skills-link-protocol`, `redskilled-link`, `redskilled-mobile`.
- Full local `apps/redskilled` run: the only failures are the pre-existing main failures (verified identical on a clean main worktree: acp-conformance identity naming, telemetry authority, control-plane 700-line headroom at 767 on main, statusline-string/worker-birth/conditional-polling env failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790205095&installation_model_id=20659&pr_number=4398&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4398&signature=2e15091ad02f0d510c02e881fbd8024a87b1cf0221646acec83f9d9800ba2ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->