### PR TITLE
fix(mobile): the host card and Worker rows say what the link proved

### DIFF
--- a/.changeset/mobile-honest-status.md
+++ b/.changeset/mobile-honest-status.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-mobile": patch
+---
+
+The mobile host card derives its status from evidence — the last state read that answered (connecting / online <10s / stale <30s / unreachable) — instead of a hardcoded "online"; failed reads surface their reason; dispatch draws a pending row the Host's own list reconciles away; Worker rows show the published phase and heartbeat age from the v2 snapshot; the preview gateway serves the same v2-shaped snapshot.

--- a/apps/redskilled-mobile/App.tsx
+++ b/apps/redskilled-mobile/App.tsx
@@ -27,8 +27,10 @@ import {
   SectionHeading,
 } from "./src/design-system/components";
 import { colors, density, radii, spacing, type } from "./src/design-system/tokens";
+import { deriveHostStatus } from "./src/domain/host-status";
 import { parseGitHubIssueUrl } from "./src/domain/issue-url";
-import type { MobileWorker, PairedHost } from "./src/domain/ticket-dispatch";
+import type { MobileHostSnapshot, MobileWorker, PairedHost } from "./src/domain/ticket-dispatch";
+import { reconcilePendingWorkers } from "./src/domain/worker-reconcile";
 import { loadPairedHost, savePairedHost } from "./src/transport/paired-host-store";
 import { createRemoteOperatorGateway } from "./src/transport/remote-operator-gateway";
 import { copy } from "./src/ui/copy";
@@ -47,7 +49,10 @@ export default function App() {
   const [issueUrl, setIssueUrl] = useState("");
   const [isDispatching, setIsDispatching] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [workers, setWorkers] = useState<MobileWorker[]>([]);
+  const [workers, setWorkers] = useState<readonly MobileWorker[]>([]);
+  const [snapshot, setSnapshot] = useState<MobileHostSnapshot | null>(null);
+  const [lastAnsweredAt, setLastAnsweredAt] = useState<number | null>(null);
+  const [linkFailure, setLinkFailure] = useState<string | null>(null);
   const gateway = useMemo(
     () => pairedHost == null ? null : createRemoteOperatorGateway(pairedHost),
     [pairedHost],
@@ -64,9 +69,23 @@ export default function App() {
   useEffect(() => {
     if (gateway == null) return;
     let active = true;
-    const refresh = () => void gateway.state().then((state) => {
-      if (active) setWorkers([...state]);
-    }).catch(() => undefined);
+    // Every outcome lands in state: an answered read stamps the instant the
+    // status verdict derives from, and a failed read records WHY instead of
+    // being swallowed — the card then reads stale/unreachable by evidence.
+    const refresh = () => void gateway.state().then((read) => {
+      if (!active) return;
+      setSnapshot(read);
+      setLastAnsweredAt(Date.now());
+      setLinkFailure(null);
+      setWorkers((current) => reconcilePendingWorkers(
+        read.workers,
+        current.filter((worker) => worker.pending === true),
+        Date.now(),
+      ));
+    }).catch((failure: unknown) => {
+      if (!active) return;
+      setLinkFailure(failure instanceof Error ? failure.message : String(failure));
+    });
     refresh();
     const timer = setInterval(refresh, 3_000);
     return () => {
@@ -83,10 +102,11 @@ export default function App() {
     }
   }, [issueUrl]);
 
+  const hostStatus = deriveHostStatus(lastAnsweredAt, Date.now());
   const selectedHost: PairedHost | null = pairedHost == null ? null : {
     id: pairedHost.host_id,
     name: pairedHost.host_name,
-    status: "online",
+    status: hostStatus,
   };
   const canDispatch = selectedHost != null && issue != null && !isDispatching;
 
@@ -105,6 +125,7 @@ export default function App() {
         repository: receipt.repository,
         ticket: receipt.ticket,
         startedAt: new Date().toISOString(),
+        pending: true,
       }, ...current.filter((worker) => worker.workerId !== receipt.workerId)]);
       setIssueUrl("");
     } catch {
@@ -259,10 +280,17 @@ export default function App() {
                   </View>
                   <View style={styles.hostText}>
                     <Text style={styles.hostName}>{selectedHost.name}</Text>
-                    <Text style={styles.metadata}>{copy.host.pairedDescription}</Text>
+                    <Text style={styles.metadata}>
+                      {snapshot?.daemonVersion == null
+                        ? copy.host.pairedDescription
+                        : `${copy.host.pairedDescription} · ${copy.host.daemonVersion(snapshot.daemonVersion)}`}
+                    </Text>
+                    {linkFailure == null || hostStatus === "online" ? null : (
+                      <Text style={styles.metadata}>{copy.errors.state(linkFailure)}</Text>
+                    )}
                   </View>
                 </View>
-                <Pill glyph="◆" label={copy.host.paired} />
+                <Pill glyph="◆" label={copy.host.status[selectedHost.status]} />
               </Card>
             )}
           </View>
@@ -341,7 +369,16 @@ export default function App() {
                         {worker.repository}{worker.ticket == null ? "" : ` #${worker.ticket}`}
                       </Text>
                       <Text numberOfLines={1} style={styles.workerId}>{worker.workerId}</Text>
-                      <Text style={styles.runningText}>{copy.workers.running}</Text>
+                      <Text style={styles.runningText}>
+                        {worker.pending === true
+                          ? copy.workers.pending
+                          : [
+                            (worker.phase ?? copy.workers.running).toUpperCase(),
+                            worker.heartbeatAgeMs == null
+                              ? null
+                              : copy.workers.heartbeat(Math.round(worker.heartbeatAgeMs / 1000)),
+                          ].filter((part) => part != null).join(" · ")}
+                      </Text>
                     </View>
                     <Button
                       label={copy.workers.stop}

--- a/apps/redskilled-mobile/src/domain/host-status.ts
+++ b/apps/redskilled-mobile/src/domain/host-status.ts
@@ -1,0 +1,27 @@
+/**
+ * host-status — the link's verdict about the Host, derived from evidence.
+ *
+ * The card used to say "online" the moment a Host was PAIRED, which is a fact
+ * about the past (a pairing succeeded once) presented as a fact about now. The
+ * only honest input is the last state read that actually answered: fresh means
+ * online, aging means stale, silent means unreachable — and before the first
+ * answer the app says it is still connecting rather than guessing either way.
+ */
+export type HostLinkStatus = "connecting" | "online" | "stale" | "unreachable";
+
+/** A state read younger than this proves the Host is answering now. */
+export const HOST_ONLINE_WINDOW_MS = 10_000;
+/** Beyond this, silence stops being jitter and becomes an outage. */
+export const HOST_STALE_WINDOW_MS = 30_000;
+
+/** Derive the verdict from the last answered read. PURE. */
+export function deriveHostStatus(
+  lastAnsweredAtMs: number | null,
+  nowMs: number,
+): HostLinkStatus {
+  if (lastAnsweredAtMs == null) return "connecting";
+  const age = nowMs - lastAnsweredAtMs;
+  if (age < HOST_ONLINE_WINDOW_MS) return "online";
+  if (age < HOST_STALE_WINDOW_MS) return "stale";
+  return "unreachable";
+}

--- a/apps/redskilled-mobile/src/domain/ticket-dispatch.ts
+++ b/apps/redskilled-mobile/src/domain/ticket-dispatch.ts
@@ -1,7 +1,10 @@
+import type { HostLinkStatus } from "./host-status";
+
 export interface PairedHost {
   readonly id: string;
   readonly name: string;
-  readonly status: "online" | "offline";
+  /** Derived from the last answered state read, never from the pairing record. */
+  readonly status: HostLinkStatus;
 }
 
 export interface TicketDispatchRequest {
@@ -32,11 +35,30 @@ export interface TicketDispatchGateway {
 export interface MobileWorker {
   readonly workerId: string;
   readonly repository: string;
-  readonly ticket?: number;
+  readonly ticket?: number | string;
   readonly startedAt: string;
+  /** The phase the Host's project published; `null` when it published none. */
+  readonly phase?: string | null;
+  /** Age of the last published heartbeat at the snapshot instant. */
+  readonly heartbeatAgeMs?: number | null;
+  /** A dispatch receipt awaiting its first state read; reconciled, never kept. */
+  readonly pending?: boolean;
+}
+
+/** One state read: the Worker rows plus the host facts they are dated by. */
+export interface MobileHostSnapshot {
+  readonly workers: readonly MobileWorker[];
+  readonly daemonVersion: string | null;
+  readonly generatedAt: string | null;
+  /** The Host's own staleness verdict; `null` when the answer carried none. */
+  readonly staleness: {
+    readonly stale: boolean;
+    readonly ageMs: number | null;
+    readonly reason: string;
+  } | null;
 }
 
 export interface MobileOperatorGateway extends TicketDispatchGateway {
-  state(): Promise<readonly MobileWorker[]>;
+  state(): Promise<MobileHostSnapshot>;
   stop(workerId: string): Promise<boolean>;
 }

--- a/apps/redskilled-mobile/src/domain/worker-reconcile.ts
+++ b/apps/redskilled-mobile/src/domain/worker-reconcile.ts
@@ -1,0 +1,30 @@
+import type { MobileWorker } from "./ticket-dispatch";
+
+/**
+ * How long a dispatch receipt may stand in for a Worker the Host has not yet
+ * listed. Beyond this the receipt stops being "in flight" and keeping the row
+ * would be the app inventing a Worker the Host denies having.
+ */
+export const PENDING_DISPATCH_GRACE_MS = 30_000;
+
+/**
+ * Fold a dispatch's pending rows into the Host's own list. PURE.
+ *
+ * The Host's answer always wins: a pending row survives only while the Host
+ * has not listed it AND its receipt is younger than the grace window. The
+ * moment the Host lists the Worker, the published row (with its phase and
+ * heartbeat) replaces the receipt.
+ */
+export function reconcilePendingWorkers(
+  published: readonly MobileWorker[],
+  pending: readonly MobileWorker[],
+  nowMs: number,
+): readonly MobileWorker[] {
+  const listed = new Set(published.map((worker) => worker.workerId));
+  const inFlight = pending.filter((worker) =>
+    worker.pending === true &&
+    !listed.has(worker.workerId) &&
+    nowMs - Date.parse(worker.startedAt) < PENDING_DISPATCH_GRACE_MS,
+  );
+  return [...inFlight, ...published];
+}

--- a/apps/redskilled-mobile/src/transport/preview-dispatch-gateway.ts
+++ b/apps/redskilled-mobile/src/transport/preview-dispatch-gateway.ts
@@ -1,32 +1,64 @@
 import { parseGitHubIssueUrl } from "../domain/issue-url";
 import type {
-  TicketDispatchGateway,
+  MobileHostSnapshot,
+  MobileOperatorGateway,
   TicketDispatchReceipt,
   TicketDispatchRequest,
 } from "../domain/ticket-dispatch";
 
 export function createPreviewDispatchGateway(
   isDevelopment = __DEV__,
-): TicketDispatchGateway {
+): MobileOperatorGateway {
+  const refuse = (): never => {
+    throw new Error("Remote link is not configured yet");
+  };
+  const dispatched: Array<{ workerId: string; repository: string; ticket: number; startedAt: string }> = [];
   return {
     async dispatch(
       request: TicketDispatchRequest,
     ): Promise<TicketDispatchReceipt> {
-      if (!isDevelopment) {
-        throw new Error("Remote link is not configured yet");
-      }
+      if (!isDevelopment) refuse();
 
       const issue = parseGitHubIssueUrl(request.issueUrl);
       await new Promise((resolve) => setTimeout(resolve, 450));
 
-      return {
-        version: 1,
+      const receipt = {
+        version: 1 as const,
         hostId: request.hostId,
         repository: `${issue.owner}/${issue.repository}`,
         ticket: issue.ticket,
         workerId: `preview:W${issue.ticket}`,
         sessionId: `preview-session-${issue.ticket}`,
       };
+      dispatched.unshift({
+        workerId: receipt.workerId,
+        repository: receipt.repository,
+        ticket: receipt.ticket,
+        startedAt: new Date().toISOString(),
+      });
+      return receipt;
+    },
+    // The preview serves the same v2-shaped snapshot the remote gateway maps,
+    // so the app's honest-status path is exercised in development instead of
+    // being replaced by a second, simpler fiction.
+    async state(): Promise<MobileHostSnapshot> {
+      if (!isDevelopment) refuse();
+      return {
+        workers: dispatched.map((worker) => ({
+          ...worker,
+          phase: "coding",
+          heartbeatAgeMs: 3_000,
+        })),
+        daemonVersion: "preview",
+        generatedAt: new Date().toISOString(),
+        staleness: { stale: false, ageMs: 3_000, reason: "preview snapshot" },
+      };
+    },
+    async stop(workerId: string): Promise<boolean> {
+      if (!isDevelopment) refuse();
+      const index = dispatched.findIndex((worker) => worker.workerId === workerId);
+      if (index >= 0) dispatched.splice(index, 1);
+      return index >= 0;
     },
   };
 }

--- a/apps/redskilled-mobile/src/transport/remote-operator-gateway.ts
+++ b/apps/redskilled-mobile/src/transport/remote-operator-gateway.ts
@@ -1,11 +1,51 @@
 import { createRedskilledMobileLinkClient } from "@reddb-io/red-skills-link-protocol/mobile-client";
-import type { RedskilledLinkPairedHost } from "@reddb-io/red-skills-link-protocol/protocol";
+import type {
+  RedskilledLinkOperationAnswer,
+  RedskilledLinkPairedHost,
+} from "@reddb-io/red-skills-link-protocol/protocol";
 
 import type {
+  MobileHostSnapshot,
   MobileOperatorGateway,
   TicketDispatchReceipt,
   TicketDispatchRequest,
 } from "../domain/ticket-dispatch";
+
+/**
+ * Map one state answer onto the app's snapshot. PURE, exported for its test.
+ *
+ * The v2 extras are read when present and rendered as absent when not — a Host
+ * still serving the v1 shape yields rows with `null` extras and a `null`
+ * staleness block, never a thrown-away frame: the app's honesty about THAT
+ * host is "it told us nothing", not "it is broken".
+ */
+export function snapshotFromStateAnswer(
+  answer: RedskilledLinkOperationAnswer,
+): MobileHostSnapshot {
+  if (!("workers" in answer) || !Array.isArray(answer.workers)) {
+    throw new Error("Host returned an invalid Worker state");
+  }
+  const host = "host" in answer ? answer.host : null;
+  return {
+    workers: answer.workers.map((worker) => ({
+      workerId: worker.worker_id,
+      repository: worker.repository ?? worker.project_label,
+      ticket: worker.ticket ?? undefined,
+      startedAt: worker.started_at,
+      phase: worker.phase ?? null,
+      heartbeatAgeMs: worker.heartbeat_age_ms ?? null,
+    })),
+    daemonVersion: host?.daemon_version ?? answer.daemon_version ?? null,
+    generatedAt: host?.generated_at ?? null,
+    staleness: host?.staleness == null
+      ? null
+      : {
+        stale: host.staleness.stale,
+        ageMs: host.staleness.age_ms,
+        reason: host.staleness.reason,
+      },
+  };
+}
 
 export function createRemoteOperatorGateway(
   host: RedskilledLinkPairedHost,
@@ -27,15 +67,7 @@ export function createRemoteOperatorGateway(
       };
     },
     async state() {
-      const answer = await client.state();
-      if (!("workers" in answer) || !Array.isArray(answer.workers)) {
-        throw new Error("Host returned an invalid Worker state");
-      }
-      return answer.workers.map((worker) => ({
-        workerId: worker.worker_id,
-        repository: worker.project_label,
-        startedAt: worker.started_at,
-      }));
+      return snapshotFromStateAnswer(await client.state());
     },
     async stop(workerId) {
       const answer = await client.stop(workerId);

--- a/apps/redskilled-mobile/src/ui/copy.ts
+++ b/apps/redskilled-mobile/src/ui/copy.ts
@@ -22,8 +22,14 @@ export const copy = {
     invitationLabel: "Host pairing invitation",
     invitationPlaceholder: "Paste the pairing invitation",
     pairAction: "PAIR HOST",
-    paired: "PAIRED",
     pairedDescription: "Encrypted link · paired device",
+    status: {
+      connecting: "CONNECTING",
+      online: "ONLINE",
+      stale: "STALE",
+      unreachable: "UNREACHABLE",
+    } as const,
+    daemonVersion: (version: string) => `daemon v${version}`,
   },
   dispatch: {
     section: "DISPATCH",
@@ -42,11 +48,14 @@ export const copy = {
     emptyDescription:
       "A dispatched Worker will appear here with its repository and Ticket.",
     running: "RUNNING",
+    pending: "DISPATCHING",
+    heartbeat: (seconds: number) => `HB ${seconds}S AGO`,
     stop: "STOP",
   },
   errors: {
     pairing: "The Host refused this pairing invitation.",
     dispatch: "The Host refused this Ticket dispatch.",
     stop: "The Host refused to stop this Worker.",
+    state: (detail: string) => `The Host did not answer the last state read: ${detail}`,
   },
 } as const;

--- a/apps/redskilled-mobile/tests/host-status.test.ts
+++ b/apps/redskilled-mobile/tests/host-status.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveHostStatus,
+  HOST_ONLINE_WINDOW_MS,
+  HOST_STALE_WINDOW_MS,
+} from "../src/domain/host-status";
+
+describe("the host link status derives from the last answered read", () => {
+  const now = 1_000_000;
+
+  it("says connecting before any read has answered, never online", () => {
+    expect(deriveHostStatus(null, now)).toBe("connecting");
+  });
+
+  it("a fresh answer is online", () => {
+    expect(deriveHostStatus(now - 1_000, now)).toBe("online");
+    expect(deriveHostStatus(now - (HOST_ONLINE_WINDOW_MS - 1), now)).toBe("online");
+  });
+
+  it("an aging answer is stale", () => {
+    expect(deriveHostStatus(now - HOST_ONLINE_WINDOW_MS, now)).toBe("stale");
+    expect(deriveHostStatus(now - (HOST_STALE_WINDOW_MS - 1), now)).toBe("stale");
+  });
+
+  it("silence past the stale window is an outage, not a quiet host", () => {
+    expect(deriveHostStatus(now - HOST_STALE_WINDOW_MS, now)).toBe("unreachable");
+  });
+});

--- a/apps/redskilled-mobile/tests/preview-dispatch-gateway.test.ts
+++ b/apps/redskilled-mobile/tests/preview-dispatch-gateway.test.ts
@@ -21,6 +21,26 @@ describe("preview dispatch gateway", () => {
     });
   });
 
+  it("serves the dispatched Worker back through the same v2-shaped snapshot", async () => {
+    const gateway = createPreviewDispatchGateway(true);
+    await gateway.dispatch({
+      hostId: "host-1",
+      issueUrl: "https://github.com/reddb-io/red-skills/issues/42",
+    });
+
+    const snapshot = await gateway.state();
+    expect(snapshot.workers).toHaveLength(1);
+    expect(snapshot.workers[0]).toMatchObject({
+      workerId: "preview:W42",
+      phase: "coding",
+      heartbeatAgeMs: 3_000,
+    });
+    expect(snapshot.staleness).toEqual({ stale: false, ageMs: 3_000, reason: "preview snapshot" });
+
+    await expect(gateway.stop("preview:W42")).resolves.toBe(true);
+    await expect(gateway.state()).resolves.toMatchObject({ workers: [] });
+  });
+
   it("cannot become a production transport", async () => {
     const gateway = createPreviewDispatchGateway(false);
 

--- a/apps/redskilled-mobile/tests/remote-gateway-snapshot.test.ts
+++ b/apps/redskilled-mobile/tests/remote-gateway-snapshot.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { snapshotFromStateAnswer } from "../src/transport/remote-operator-gateway";
+
+describe("the state answer maps onto the app snapshot", () => {
+  it("carries the v2 host block and published Worker facts through", () => {
+    const snapshot = snapshotFromStateAnswer({
+      version: 2,
+      daemon_version: "4.2.0",
+      workers: [{
+        worker_id: "W1",
+        project_label: "reddb-io/red-skills",
+        started_at: "2026-08-23T12:00:00.000Z",
+        phase: "coding",
+        heartbeat_age_ms: 30_000,
+        repository: "reddb-io/red-skills",
+        ticket: "4321",
+      }],
+      host: {
+        daemon_version: "4.2.0",
+        started_at: "2026-08-23T08:00:00.000Z",
+        worker_ceiling: 4,
+        staleness: { stale: false, age_ms: 5_000, threshold_ms: 30_000, reason: "measured 5s ago" },
+        generated_at: "2026-08-23T12:10:00.000Z",
+      },
+    });
+
+    expect(snapshot).toEqual({
+      workers: [{
+        workerId: "W1",
+        repository: "reddb-io/red-skills",
+        ticket: "4321",
+        startedAt: "2026-08-23T12:00:00.000Z",
+        phase: "coding",
+        heartbeatAgeMs: 30_000,
+      }],
+      daemonVersion: "4.2.0",
+      generatedAt: "2026-08-23T12:10:00.000Z",
+      staleness: { stale: false, ageMs: 5_000, reason: "measured 5s ago" },
+    });
+  });
+
+  it("a v1-shaped answer yields null extras — it told us nothing, it is not broken", () => {
+    const snapshot = snapshotFromStateAnswer({
+      version: 2,
+      daemon_version: "4.1.0",
+      workers: [{
+        worker_id: "W1",
+        project_label: "reddb-io/red-skills",
+        started_at: "2026-08-23T12:00:00.000Z",
+      }],
+    } as never);
+
+    expect(snapshot.workers[0]).toEqual({
+      workerId: "W1",
+      repository: "reddb-io/red-skills",
+      ticket: undefined,
+      startedAt: "2026-08-23T12:00:00.000Z",
+      phase: null,
+      heartbeatAgeMs: null,
+    });
+    expect(snapshot.daemonVersion).toBe("4.1.0");
+    expect(snapshot.staleness).toBeNull();
+  });
+
+  it("refuses an answer that is not a Worker state", () => {
+    expect(() => snapshotFromStateAnswer({
+      version: 1,
+      worker_id: "W1",
+      applied: true,
+      detail: "stopped",
+    })).toThrow("invalid Worker state");
+  });
+});

--- a/apps/redskilled-mobile/tests/worker-reconcile.test.ts
+++ b/apps/redskilled-mobile/tests/worker-reconcile.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { PENDING_DISPATCH_GRACE_MS, reconcilePendingWorkers } from "../src/domain/worker-reconcile";
+
+const now = Date.parse("2026-08-23T12:00:30.000Z");
+const receipt = {
+  workerId: "W42",
+  repository: "reddb-io/red-skills",
+  ticket: 42,
+  startedAt: "2026-08-23T12:00:25.000Z",
+  pending: true as const,
+};
+
+describe("pending dispatch rows reconcile against the Host's own list", () => {
+  it("keeps a young receipt the Host has not listed yet", () => {
+    const merged = reconcilePendingWorkers([], [receipt], now);
+    expect(merged).toEqual([receipt]);
+  });
+
+  it("the Host's published row replaces the receipt the moment it appears", () => {
+    const published = {
+      workerId: "W42",
+      repository: "reddb-io/red-skills",
+      ticket: "42",
+      startedAt: "2026-08-23T12:00:26.000Z",
+      phase: "boot",
+      heartbeatAgeMs: 1_000,
+    };
+    const merged = reconcilePendingWorkers([published], [receipt], now);
+    expect(merged).toEqual([published]);
+  });
+
+  it("a receipt past the grace window is dropped, not kept as fiction", () => {
+    const merged = reconcilePendingWorkers([], [receipt], now + PENDING_DISPATCH_GRACE_MS);
+    expect(merged).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Wave 7 slice 2 (w7b) of the E2E-flow repair, on top of the v2 wire (#4398). The card said "online" the moment a Host was PAIRED — a fact about the past presented as a fact about now — and the 3s state poll swallowed every failure, so a dead Host and a healthy one drew the same screen.

- **Status from evidence**: `deriveHostStatus` (pure) reads the last state read that actually answered — `connecting` before the first answer, `online` under 10s, `stale` under 30s, `unreachable` beyond. A failed read records its reason on the card instead of vanishing into a `.catch(() => undefined)`.
- **Pending dispatch rows**: a dispatch receipt draws a `DISPATCHING` row that the Host's own list reconciles away (`reconcilePendingWorkers`, pure — the receipt survives at most 30s unlisted, because keeping it longer is the app inventing a Worker the Host denies having).
- **Real labels**: Worker rows render the published phase and heartbeat age from the v2 snapshot instead of a hardcoded RUNNING; the card names the daemon version.
- **One mapping**: the remote gateway's answer mapping is the exported pure `snapshotFromStateAnswer`; a v1-shaped answer yields null extras — "it told us nothing" is a different fact from "it is broken".
- **Preview parity**: the preview gateway serves the same v2-shaped snapshot (state/stop included), so development exercises the honest path rather than a second fiction.

## Tests

New pure-domain suites `host-status`, `worker-reconcile`, `remote-gateway-snapshot`; preview gateway test extended to the state/stop surface. `apps/redskilled-mobile`: 38/38, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790205369&installation_model_id=20659&pr_number=4399&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4399&signature=7dbe3a07742b7a59b5e04b4c824b7a7a9a02cd6076d9fdc7b864feac865f860a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->