### PR TITLE
feat(link): the Host companion unit is operable — install, remove, status

### DIFF
--- a/.changeset/link-host-supervision.md
+++ b/.changeset/link-host-supervision.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-link": minor
+---
+
+`redskilled-link unit install|remove|status`: the Host companion's systemd unit is now operable outside onboarding — remove disables, deletes and reloads; status answers from both authorities (systemd's own words for the process, and the published `status.json` projection for what the link has done), and the projection finally has a reader (`readPublicLinkStatus`).

--- a/apps/redskilled-link/src/cli.ts
+++ b/apps/redskilled-link/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { createRedskillsOperatorAcpClient } from "@reddb-io/redskilled/acp-operator-client";
@@ -9,13 +10,26 @@ import { runRedskilledLinkHost } from "./host.js";
 import { runRedskilledLinkOnboarding } from "./onboarding.js";
 import { showInvitationQr } from "./qr-terminal.js";
 import { startRedskilledRelay } from "./relay.js";
-import { createRedskilledLinkStateStore } from "./state.js";
+import {
+  createRedskilledLinkStateStore,
+  defaultLinkStatePath,
+  defaultLinkStatusPath,
+  readPublicLinkStatus,
+} from "./state.js";
+import {
+  currentRedskilledLinkEntry,
+  installRedskilledLinkUnit,
+  planRedskilledLinkUnit,
+  readRedskilledLinkUnitStatus,
+  removeRedskilledLinkUnit,
+} from "./supervision.js";
 
 export const REDSKILLED_LINK_USAGE = [
   "redskilled-link onboard [--relay wss://relay.example] [--name HOST]",
   "redskilled-link relay [--host 127.0.0.1] [--port 8787]",
   "redskilled-link invite [--relay wss://relay.example] [--name HOST] [--qr]",
   "redskilled-link host [--relay wss://relay.example] [--name HOST]",
+  "redskilled-link unit install|remove|status [--state PATH]",
   "",
 ].join("\n");
 
@@ -51,8 +65,65 @@ export async function runRedskilledLinkCli(argv: readonly string[]): Promise<num
     await runRedskilledLinkHost({ state: store, operator: createRedskillsOperatorAcpClient() });
     return 0;
   }
+  if (command === "unit") {
+    return await runUnitCommand(args);
+  }
   process.stdout.write(REDSKILLED_LINK_USAGE);
   return 0;
+}
+
+/**
+ * Supervise the Host companion the way the daemon supervises itself: a
+ * systemd user unit with an absolute ExecStart and Restart=always. `status`
+ * answers from BOTH authorities — systemd for the process, and the public
+ * `status.json` projection the state store publishes for what the link has
+ * actually done — because a running unit with zero paired devices and a dead
+ * unit with three are different outages.
+ */
+async function runUnitCommand(args: readonly string[]): Promise<number> {
+  const [operation = "status"] = args;
+  if (operation === "install") {
+    const statePath = value(args, "--state") ?? defaultLinkStatePath();
+    const unit = await installRedskilledLinkUnit(planRedskilledLinkUnit({
+      entry: currentRedskilledLinkEntry(),
+      statePath,
+    }));
+    if (!unit.installed) {
+      process.stderr.write(`redskilled-link unit: ${unit.detail ?? "systemd refused the install"}\n`);
+      return 1;
+    }
+    process.stdout.write(`Host companion installed and started: ${unit.unitPath}\n`);
+    return 0;
+  }
+  if (operation === "remove") {
+    const removal = await removeRedskilledLinkUnit();
+    if (!removal.removed) {
+      process.stderr.write(`redskilled-link unit: ${removal.detail ?? "systemd refused the removal"}\n`);
+      return 1;
+    }
+    process.stdout.write(`Host companion removed: ${removal.unitPath}\n`);
+    return 0;
+  }
+  if (operation === "status") {
+    const unit = readRedskilledLinkUnitStatus();
+    const statePath = value(args, "--state");
+    const statusPath = statePath == null
+      ? defaultLinkStatusPath()
+      : join(dirname(statePath), "status.json");
+    const published = await readPublicLinkStatus(statusPath);
+    process.stdout.write([
+      `Unit: ${unit.unitName}`,
+      `Active: ${unit.active ?? "unknown (systemd did not answer)"}`,
+      `Enabled: ${unit.enabled ?? "unknown (systemd did not answer)"}`,
+      published == null
+        ? `Published status: none at ${statusPath} (the companion has not written one yet)`
+        : `Paired devices: ${published.active_paired_device_count}`,
+      "",
+    ].join("\n"));
+    return 0;
+  }
+  process.stderr.write(`redskilled-link unit: unknown operation ${JSON.stringify(operation)}\n${REDSKILLED_LINK_USAGE}`);
+  return 2;
 }
 
 function stateStore(args: readonly string[]) {

--- a/apps/redskilled-link/src/state.ts
+++ b/apps/redskilled-link/src/state.ts
@@ -53,6 +53,34 @@ export function defaultLinkStatusPath(homeDir = homedir()): string {
   return join(redskilledHomeDir(homeDir), "link", "status.json");
 }
 
+/**
+ * Read the public status projection the state store publishes beside itself.
+ *
+ * `null` is "nothing has been published here", stated rather than guessed —
+ * the file appears on the first state mutation, so a fresh install reads null
+ * until the Host companion has actually done something.
+ */
+export async function readPublicLinkStatus(
+  path = defaultLinkStatusPath(),
+): Promise<RedskilledLinkPublicStatus | null> {
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  try {
+    const value = JSON.parse(text) as unknown;
+    if (value == null || typeof value !== "object" || Array.isArray(value)) return null;
+    const status = value as Record<string, unknown>;
+    if (status.version !== 1 || typeof status.active_paired_device_count !== "number") return null;
+    return { version: 1, active_paired_device_count: status.active_paired_device_count };
+  } catch {
+    return null;
+  }
+}
+
 export function createRedskilledLinkStateStore(options: {
   readonly path?: string;
   readonly statusPath?: string;

--- a/apps/redskilled-link/src/supervision.ts
+++ b/apps/redskilled-link/src/supervision.ts
@@ -7,7 +7,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 
@@ -147,6 +147,67 @@ export async function installRedskilledLinkUnit(
   const restart = run(["systemctl", "--user", "restart", plan.unitName]);
   if (restart.status !== 0) return failed(plan, restart, "systemd did not start the Host companion");
   return { unitPath: plan.unitPath, installed: true };
+}
+
+export interface RedskilledLinkUnitRemoval {
+  readonly unitPath: string;
+  readonly removed: boolean;
+  readonly detail?: string;
+}
+
+/**
+ * Take the Host companion back out: stop it, disable it, delete the unit.
+ *
+ * A best-effort inverse of install — a machine where the unit was never
+ * installed answers `removed: true`, because the state the operator asked for
+ * (no companion) already holds.
+ */
+export async function removeRedskilledLinkUnit(
+  io: RedskilledLinkUnitIO & { readonly unlink?: (path: string) => Promise<void> } = {},
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<RedskilledLinkUnitRemoval> {
+  const run = io.run ?? defaultRun;
+  const unlink = io.unlink ?? (async (target: string) => { await rm(target, { force: true }); });
+  const unitPath = redskilledLinkUnitPath(env);
+  const disable = run(["systemctl", "--user", "disable", "--now", REDSKILLED_LINK_UNIT_NAME]);
+  await unlink(unitPath);
+  const reload = run(["systemctl", "--user", "daemon-reload"]);
+  if (reload.status !== 0) {
+    return {
+      unitPath,
+      removed: false,
+      detail: (reload.stderr ?? reload.stdout ?? "").trim() || "systemd user manager did not reload",
+    };
+  }
+  return {
+    unitPath,
+    removed: true,
+    ...(disable.status === 0 ? {} : { detail: "the unit was not enabled; the file is gone either way" }),
+  };
+}
+
+export interface RedskilledLinkUnitStatus {
+  readonly unitName: typeof REDSKILLED_LINK_UNIT_NAME;
+  /** systemd's own words: "active", "inactive", "failed" — or null when unaskable. */
+  readonly active: string | null;
+  readonly enabled: string | null;
+}
+
+/** Ask systemd, and only systemd, whether the companion runs. */
+export function readRedskilledLinkUnitStatus(
+  io: RedskilledLinkUnitIO = {},
+): RedskilledLinkUnitStatus {
+  const run = io.run ?? defaultRun;
+  const answer = (argv: readonly string[]): string | null => {
+    const result = run(argv);
+    const word = (result.stdout ?? "").trim();
+    return word === "" ? null : word;
+  };
+  return {
+    unitName: REDSKILLED_LINK_UNIT_NAME,
+    active: answer(["systemctl", "--user", "is-active", REDSKILLED_LINK_UNIT_NAME]),
+    enabled: answer(["systemctl", "--user", "is-enabled", REDSKILLED_LINK_UNIT_NAME]),
+  };
 }
 
 function failed(

--- a/apps/redskilled-link/tests/link-e2e.test.ts
+++ b/apps/redskilled-link/tests/link-e2e.test.ts
@@ -71,7 +71,18 @@ describe("app <> relay <> Host <> redskilled", () => {
       paired,
       WebSocket as unknown as LinkWebSocketConstructor,
     );
-    await expect(app.state()).resolves.toEqual({ version: 1, daemon_version: "4.2.0", workers: [] });
+    await expect(app.state()).resolves.toEqual({
+      version: 2,
+      daemon_version: "4.2.0",
+      workers: [],
+      host: {
+        daemon_version: "4.2.0",
+        started_at: "2026-08-23T08:00:00.000Z",
+        worker_ceiling: 4,
+        staleness: null,
+        generated_at: "2026-08-23T12:10:00.000Z",
+      },
+    });
     await expect(app.dispatch("https://github.com/reddb-io/red-skills/issues/42")).resolves.toEqual({
       version: 1,
       repository: "reddb-io/red-skills",

--- a/apps/redskilled-link/tests/unit-supervision.test.ts
+++ b/apps/redskilled-link/tests/unit-supervision.test.ts
@@ -1,0 +1,91 @@
+// The Host companion's whole lifecycle is operable without onboard: install
+// exists there, but remove and status did not exist anywhere — a unit an
+// operator could create and never take back or ask about. And the public
+// status.json the state store publishes had NO reader (#4365 noted it), which
+// made it a dead surface: these tests pin the reader and the systemd answers.
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readPublicLinkStatus } from "../src/state.js";
+import {
+  readRedskilledLinkUnitStatus,
+  removeRedskilledLinkUnit,
+  REDSKILLED_LINK_UNIT_NAME,
+} from "../src/supervision.js";
+
+describe("the Host companion unit answers remove and status", () => {
+  it("remove disables, deletes the unit file and reloads — in that order", async () => {
+    const calls: string[][] = [];
+    const unlinked: string[] = [];
+    const removal = await removeRedskilledLinkUnit({
+      run: (argv) => { calls.push([...argv]); return { status: 0, stdout: "", stderr: "" }; },
+      unlink: async (path) => { unlinked.push(path); },
+    }, { XDG_CONFIG_HOME: "/tmp/xdg" });
+
+    expect(removal.removed).toBe(true);
+    expect(unlinked).toEqual([join("/tmp/xdg", "systemd", "user", REDSKILLED_LINK_UNIT_NAME)]);
+    expect(calls).toEqual([
+      ["systemctl", "--user", "disable", "--now", REDSKILLED_LINK_UNIT_NAME],
+      ["systemctl", "--user", "daemon-reload"],
+    ]);
+  });
+
+  it("removing a never-installed unit is success — the asked-for state already holds", async () => {
+    const removal = await removeRedskilledLinkUnit({
+      run: (argv) => argv.includes("disable")
+        ? { status: 1, stdout: "", stderr: "not enabled" }
+        : { status: 0, stdout: "", stderr: "" },
+      unlink: async () => undefined,
+    }, { XDG_CONFIG_HOME: "/tmp/xdg" });
+
+    expect(removal.removed).toBe(true);
+    expect(removal.detail).toContain("either way");
+  });
+
+  it("status repeats systemd's own words and says when systemd did not answer", () => {
+    const answered = readRedskilledLinkUnitStatus({
+      run: (argv) => ({ status: 0, stdout: argv.includes("is-active") ? "active\n" : "enabled\n", stderr: "" }),
+    });
+    expect(answered).toEqual({ unitName: REDSKILLED_LINK_UNIT_NAME, active: "active", enabled: "enabled" });
+
+    const silent = readRedskilledLinkUnitStatus({
+      run: () => ({ status: 1, stdout: "", stderr: "" }),
+    });
+    expect(silent.active).toBeNull();
+    expect(silent.enabled).toBeNull();
+  });
+});
+
+describe("the published status.json finally has a reader", () => {
+  let dir: string;
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  it("reads the projection the state store publishes", async () => {
+    dir = await mkdtemp(join(tmpdir(), "link-status-"));
+    const path = join(dir, "status.json");
+    await writeFile(path, `${JSON.stringify({ version: 1, active_paired_device_count: 2 })}\n`);
+
+    await expect(readPublicLinkStatus(path)).resolves.toEqual({
+      version: 1,
+      active_paired_device_count: 2,
+    });
+  });
+
+  it("absence and garbage both read as null — nothing published, stated not guessed", async () => {
+    dir = await mkdtemp(join(tmpdir(), "link-status-"));
+    await expect(readPublicLinkStatus(join(dir, "status.json"))).resolves.toBeNull();
+
+    const garbage = join(dir, "garbage.json");
+    await writeFile(garbage, "not json");
+    await expect(readPublicLinkStatus(garbage)).resolves.toBeNull();
+
+    const wrongShape = join(dir, "wrong.json");
+    await writeFile(wrongShape, JSON.stringify({ version: 9 }));
+    await expect(readPublicLinkStatus(wrongShape)).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Wave 7 slice 3 (w7c) — the final slice of the E2E-flow repair plan. Onboarding could install the Host companion's systemd unit, but nothing could take it back out or ask about it, and the public `status.json` projection the state store publishes (#4365) had **no reader** — a dead surface.

`redskilled-link unit install|remove|status`:

- **install** reuses the onboarding plan (absolute ExecStart, `Restart=always`, stable-bundle copy) as a standalone operation;
- **remove** disables, deletes the unit file and reloads — in that order; removing a never-installed unit is success, because the state the operator asked for (no companion) already holds;
- **status** answers from BOTH authorities: systemd's own words for the process (repeated verbatim; `null` stated when systemd does not answer) and the new `readPublicLinkStatus` for what the link has actually done — because a running unit with zero paired devices and a dead unit with three are different outages.

Also re-pins the link e2e `state()` assertion to the v2 answer shape — #4398 updated the fixture but not the assertion, and this suite is not in the PR gate, so the drift surfaced here.

## Tests

`apps/redskilled-link/tests/unit-supervision.test.ts` (remove ordering, idempotent remove, status verbatim/null, status.json reader: present / absent / garbage / wrong shape). Link suite 20/20, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790205569&installation_model_id=20659&pr_number=4400&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4400&signature=ca9ce33ddb914a300840f63645d343e3d060b2997a860cdc7432714a68221ff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->