### PR TITLE
feat(link): redskilled-link status asks the host's redskilled, probe-only

### DIFF
--- a/.changeset/link-status-report.md
+++ b/.changeset/link-status-report.md
@@ -1,0 +1,6 @@
+---
+"@reddb-io/redskilled-link": minor
+"@reddb-io/redskilled": patch
+---
+
+`redskilled-link status`: one report from three quoted authorities — the host's redskilled asked over the operator ACP surface in the new probe-only mode (`ensure: false` on the operator client: a status read never provisions the daemon it reports on), systemd's words for the Host companion unit, and the published `status.json`. Absences carry their reason; workers render with published phase, ticket and heartbeat age from the v2 answer.

--- a/.red/contracts/toon-json-file-io-allowlist.json
+++ b/.red/contracts/toon-json-file-io-allowlist.json
@@ -172,6 +172,11 @@
       "reason": "The public link status.json is read by non-TOON surfaces (mobile app, shell probes) as ecosystem JSON by design."
     },
     {
+      "id": "apps/redskilled-link/src/state.ts#json-parse-file-read#6c120e4f2849",
+      "classification": "external",
+      "reason": "readPublicLinkStatus reads back the same deliberately-JSON public status.json the write site above publishes for non-TOON surfaces."
+    },
+    {
       "id": "apps/release/src/cli.ts#json-parse-file-read#06f60309d571",
       "classification": "external",
       "reason": "npm package.json manifests are an external JSON format the release engine must read as-is"

--- a/apps/redskilled-link/src/cli.ts
+++ b/apps/redskilled-link/src/cli.ts
@@ -16,6 +16,7 @@ import {
   defaultLinkStatusPath,
   readPublicLinkStatus,
 } from "./state.js";
+import { renderLinkStatusReport } from "./status-report.js";
 import {
   currentRedskilledLinkEntry,
   installRedskilledLinkUnit,
@@ -30,6 +31,7 @@ export const REDSKILLED_LINK_USAGE = [
   "redskilled-link invite [--relay wss://relay.example] [--name HOST] [--qr]",
   "redskilled-link host [--relay wss://relay.example] [--name HOST]",
   "redskilled-link unit install|remove|status [--state PATH]",
+  "redskilled-link status [--state PATH]",
   "",
 ].join("\n");
 
@@ -67,6 +69,28 @@ export async function runRedskilledLinkCli(argv: readonly string[]): Promise<num
   }
   if (command === "unit") {
     return await runUnitCommand(args);
+  }
+  if (command === "status") {
+    // Probe-only on purpose: this report answers about the daemon that IS
+    // there; ensuring one would change the machine to describe it.
+    const daemon = await createRedskillsOperatorAcpClient(undefined, { ensure: false })
+      .state()
+      .then((state) => ({ reachable: true as const, state }))
+      .catch((error: unknown) => ({
+        reachable: false as const,
+        reason: error instanceof Error ? error.message : String(error),
+      }));
+    const statePath = value(args, "--state");
+    const publishedPath = statePath == null
+      ? defaultLinkStatusPath()
+      : join(dirname(statePath), "status.json");
+    process.stdout.write(renderLinkStatusReport({
+      daemon,
+      unit: readRedskilledLinkUnitStatus(),
+      published: await readPublicLinkStatus(publishedPath),
+      publishedPath,
+    }));
+    return daemon.reachable ? 0 : 1;
   }
   process.stdout.write(REDSKILLED_LINK_USAGE);
   return 0;

--- a/apps/redskilled-link/src/cli.ts
+++ b/apps/redskilled-link/src/cli.ts
@@ -71,29 +71,37 @@ export async function runRedskilledLinkCli(argv: readonly string[]): Promise<num
     return await runUnitCommand(args);
   }
   if (command === "status") {
-    // Probe-only on purpose: this report answers about the daemon that IS
-    // there; ensuring one would change the machine to describe it.
-    const daemon = await createRedskillsOperatorAcpClient(undefined, { ensure: false })
-      .state()
-      .then((state) => ({ reachable: true as const, state }))
-      .catch((error: unknown) => ({
-        reachable: false as const,
-        reason: error instanceof Error ? error.message : String(error),
-      }));
-    const statePath = value(args, "--state");
-    const publishedPath = statePath == null
-      ? defaultLinkStatusPath()
-      : join(dirname(statePath), "status.json");
-    process.stdout.write(renderLinkStatusReport({
-      daemon,
-      unit: readRedskilledLinkUnitStatus(),
-      published: await readPublicLinkStatus(publishedPath),
-      publishedPath,
-    }));
-    return daemon.reachable ? 0 : 1;
+    return await runStatusCommand(args);
   }
   process.stdout.write(REDSKILLED_LINK_USAGE);
   return 0;
+}
+
+/**
+ * One screen from three quoted authorities: the host daemon, systemd, and the
+ * published status.json. Probe-only on purpose — this report answers about
+ * the daemon that IS there; ensuring one would change the machine to
+ * describe it. Unreachable exits 1 with the reason on the report.
+ */
+async function runStatusCommand(args: readonly string[]): Promise<number> {
+  const daemon = await createRedskillsOperatorAcpClient(undefined, { ensure: false })
+    .state()
+    .then((state) => ({ reachable: true as const, state }))
+    .catch((error: unknown) => ({
+      reachable: false as const,
+      reason: error instanceof Error ? error.message : String(error),
+    }));
+  const statePath = value(args, "--state");
+  const publishedPath = statePath == null
+    ? defaultLinkStatusPath()
+    : join(dirname(statePath), "status.json");
+  process.stdout.write(renderLinkStatusReport({
+    daemon,
+    unit: readRedskilledLinkUnitStatus(),
+    published: await readPublicLinkStatus(publishedPath),
+    publishedPath,
+  }));
+  return daemon.reachable ? 0 : 1;
 }
 
 /**

--- a/apps/redskilled-link/src/status-report.ts
+++ b/apps/redskilled-link/src/status-report.ts
@@ -1,0 +1,70 @@
+/**
+ * status-report — one screen answering "is the whole link chain alive".
+ *
+ * Three authorities, each quoted rather than merged: the HOST's redskilled
+ * (asked over the operator ACP surface, probe-only — a status read must never
+ * provision the daemon it reports on), systemd for the Host companion unit,
+ * and the published `status.json` for what the link has done. An absence in
+ * any of the three is stated with its reason, never blended into a calm line.
+ */
+import type { RedskillsOperatorAcpClient } from "@reddb-io/redskilled/acp-operator-client";
+
+import type { RedskilledLinkPublicStatus } from "./state.js";
+import type { RedskilledLinkUnitStatus } from "./supervision.js";
+
+/** The v2 operator answer, named through the client that serves it so this
+ * app keeps exactly one dependency edge onto the daemon. */
+type MobileOperatorStateAnswer = Awaited<ReturnType<RedskillsOperatorAcpClient["state"]>>;
+
+export interface LinkStatusReportInput {
+  readonly daemon:
+    | { readonly reachable: true; readonly state: MobileOperatorStateAnswer }
+    | { readonly reachable: false; readonly reason: string };
+  readonly unit: RedskilledLinkUnitStatus;
+  readonly published: RedskilledLinkPublicStatus | null;
+  readonly publishedPath: string;
+}
+
+/** Render the report. PURE — every fact arrives as an argument. */
+export function renderLinkStatusReport(input: LinkStatusReportInput): string {
+  const lines: string[] = [];
+
+  if (!input.daemon.reachable) {
+    lines.push(`Host daemon: unreachable — ${input.daemon.reason}`);
+  } else {
+    const state = input.daemon.state;
+    const staleness = state.host.staleness;
+    const freshness = staleness == null
+      ? "freshness unmeasured"
+      : staleness.stale
+        ? `STALE (${staleness.reason})`
+        : staleness.reason;
+    lines.push(
+      `Host daemon: v${state.host.daemon_version} · ${state.workers.length} Worker(s)` +
+        ` · ceiling ${state.host.worker_ceiling ?? "∞"} · ${freshness}`,
+    );
+    for (const worker of state.workers) {
+      const heartbeat = worker.heartbeat_age_ms == null
+        ? "no heartbeat published"
+        : `hb ${Math.round(worker.heartbeat_age_ms / 1000)}s ago`;
+      lines.push(
+        `  ${worker.worker_id} ${worker.repository ?? worker.project_label}` +
+          `${worker.ticket == null ? "" : ` #${worker.ticket}`}` +
+          ` ${worker.phase ?? "unpublished"} (${heartbeat})`,
+      );
+    }
+  }
+
+  lines.push(
+    `Link unit: ${input.unit.active ?? "unknown (systemd did not answer)"}` +
+      ` (${input.unit.enabled ?? "enablement unknown"})`,
+  );
+
+  lines.push(
+    input.published == null
+      ? `Paired devices: none published at ${input.publishedPath} (the companion has not written a status yet)`
+      : `Paired devices: ${input.published.active_paired_device_count}`,
+  );
+
+  return `${lines.join("\n")}\n`;
+}

--- a/apps/redskilled-link/tests/status-report.test.ts
+++ b/apps/redskilled-link/tests/status-report.test.ts
@@ -1,0 +1,96 @@
+// One screen, three authorities, absences stated: the report quotes the HOST's
+// redskilled (probe-only), systemd's words for the companion unit, and the
+// published status.json — and an absence in any of the three carries its
+// reason instead of blending into a calm line.
+import { describe, expect, it } from "vitest";
+
+import { renderLinkStatusReport } from "../src/status-report.js";
+import { REDSKILLED_LINK_UNIT_NAME } from "../src/supervision.js";
+
+const unit = { unitName: REDSKILLED_LINK_UNIT_NAME, active: "active", enabled: "enabled" } as const;
+
+describe("the link status report", () => {
+  it("quotes the daemon's v2 answer: version, workers with phase and heartbeat, freshness", () => {
+    const report = renderLinkStatusReport({
+      daemon: {
+        reachable: true,
+        state: {
+          version: 2,
+          daemon_version: "4.2.6",
+          workers: [{
+            worker_id: "W1",
+            project_label: "reddb-io/red-skills",
+            started_at: "2026-08-24T12:00:00.000Z",
+            phase: "coding",
+            heartbeat_age_ms: 3_000,
+            repository: "reddb-io/red-skills",
+            ticket: "4321",
+          }],
+          host: {
+            daemon_version: "4.2.6",
+            started_at: "2026-08-24T08:00:00.000Z",
+            worker_ceiling: 4,
+            staleness: { stale: false, age_ms: 5_000, threshold_ms: 30_000, reason: "measured 5s ago" },
+            generated_at: "2026-08-24T12:00:05.000Z",
+          },
+        },
+      },
+      unit,
+      published: { version: 1, active_paired_device_count: 2 },
+      publishedPath: "/home/x/.red/redskilled/link/status.json",
+    });
+
+    expect(report).toContain("Host daemon: v4.2.6 · 1 Worker(s) · ceiling 4 · measured 5s ago");
+    expect(report).toContain("W1 reddb-io/red-skills #4321 coding (hb 3s ago)");
+    expect(report).toContain("Link unit: active (enabled)");
+    expect(report).toContain("Paired devices: 2");
+  });
+
+  it("an unreachable daemon is an outage with its reason, never a calm blank", () => {
+    const report = renderLinkStatusReport({
+      daemon: { reachable: false, reason: "connect ENOENT /run/redskilled/acp.sock" },
+      unit: { unitName: REDSKILLED_LINK_UNIT_NAME, active: null, enabled: null },
+      published: null,
+      publishedPath: "/home/x/.red/redskilled/link/status.json",
+    });
+
+    expect(report).toContain("Host daemon: unreachable — connect ENOENT");
+    expect(report).toContain("unknown (systemd did not answer)");
+    expect(report).toContain("none published at /home/x/.red/redskilled/link/status.json");
+  });
+
+  it("a worker the project never published renders unpublished, not invented", () => {
+    const report = renderLinkStatusReport({
+      daemon: {
+        reachable: true,
+        state: {
+          version: 2,
+          daemon_version: "4.2.6",
+          workers: [{
+            worker_id: "W2",
+            project_label: "acme/widgets",
+            started_at: "2026-08-24T12:00:00.000Z",
+            phase: null,
+            heartbeat_age_ms: null,
+            repository: null,
+            ticket: null,
+          }],
+          host: {
+            daemon_version: "4.2.6",
+            started_at: "2026-08-24T08:00:00.000Z",
+            worker_ceiling: null,
+            staleness: null,
+            generated_at: "2026-08-24T12:00:05.000Z",
+          },
+        },
+      },
+      unit,
+      published: { version: 1, active_paired_device_count: 0 },
+      publishedPath: "/x/status.json",
+    });
+
+    expect(report).toContain("ceiling ∞ · freshness unmeasured");
+    expect(report).toContain("W2 acme/widgets unpublished (no heartbeat published)");
+    expect(report).toContain("Paired devices: 0");
+  });
+});

--- a/apps/redskilled/src/acp-operator-client.ts
+++ b/apps/redskilled/src/acp-operator-client.ts
@@ -21,11 +21,22 @@ export interface RedskillsOperatorAcpClient {
   stop(workerId: string): Promise<MobileWorkerStopAnswer>;
 }
 
+export interface RedskillsOperatorAcpClientOptions {
+  /**
+   * `false` = probe only: answer from the daemon that IS there, or fail —
+   * never provision or start one. A status read that births the thing it
+   * reports on cannot tell an idle machine from the machine it just changed.
+   * Default `true`, the behavior every existing caller (dispatch, host) wants.
+   */
+  readonly ensure?: boolean;
+}
+
 export function createRedskillsOperatorAcpClient(
   paths: RedskilledPaths = resolveRedskilledPaths(),
+  options: RedskillsOperatorAcpClientOptions = {},
 ): RedskillsOperatorAcpClient {
   const request = async <Answer>(method: string, params: object): Promise<Answer> => {
-    await ensureRedskilledDaemon(paths);
+    if (options.ensure !== false) await ensureRedskilledDaemon(paths);
     const endpoint = (await resolveRedskilledClientEndpoint(paths)).paths;
     const socket = await connectEndpoint(endpoint.acpSocketPath);
     const connection = client({ name: "redskilled-link" }).connect(socketStream(socket));


### PR DESCRIPTION
## What

Next phase of the link/mobile surface (post waves 0–7): the status report the operator was assembling by hand. `redskilled-link status` is one screen quoting three authorities without blending them:

- **the HOST's redskilled**, asked over the operator ACP surface: daemon version, worker count, ceiling (`∞` stated, never unknown), the host's own staleness verdict, and per-Worker `phase` / `ticket` / heartbeat age from the v2 answer (#4398);
- **systemd**, verbatim, for the Host companion unit;
- **the published `status.json`** (reader from #4400) for paired devices.

The operator client (`apps/redskilled/src/acp-operator-client.ts`) gains a **probe-only mode** (`ensure: false`): a status read must never provision the daemon it reports on — an unreachable daemon is an honest answer with its reason, and the command exits 1 on it. Default unchanged (`ensure: true`) for dispatch/host.

## Tests

`apps/redskilled-link/tests/status-report.test.ts` pins the pure renderer: full v2 answer, unreachable-with-reason + null systemd + unpublished status, and a worker the project never published (`unpublished`, `no heartbeat published`, `ceiling ∞`, `freshness unmeasured`). Link suite 23/23; typecheck clean on both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790208060&installation_model_id=20659&pr_number=4401&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4401&signature=12c04bf3b26b962e7aa5ef32563ddcff470f3086d64fc071c6b8b9b853b03bec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->