### PR TITLE
feat(link): the pairing registry is operable — devices, revoke

### DIFF
--- a/.changeset/link-device-registry.md
+++ b/.changeset/link-device-registry.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-link": minor
+---
+
+`redskilled-link devices` and `redskilled-link revoke <device-id>`: the pairing registry is operable — list every device that ever paired (revoked kept and marked, secrets never printed) and cut one off the wire; revocation republishes the public status.json device count, and the wire-side lookups refuse the revoked device from that moment.

--- a/apps/redskilled-link/src/cli.ts
+++ b/apps/redskilled-link/src/cli.ts
@@ -32,6 +32,8 @@ export const REDSKILLED_LINK_USAGE = [
   "redskilled-link host [--relay wss://relay.example] [--name HOST]",
   "redskilled-link unit install|remove|status [--state PATH]",
   "redskilled-link status [--state PATH]",
+  "redskilled-link devices [--state PATH]",
+  "redskilled-link revoke <device-id> [--state PATH]",
   "",
 ].join("\n");
 
@@ -72,6 +74,25 @@ export async function runRedskilledLinkCli(argv: readonly string[]): Promise<num
   }
   if (command === "status") {
     return await runStatusCommand(args);
+  }
+  if (command === "devices") {
+    const devices = await stateStore(args).devices();
+    process.stdout.write(renderDeviceRegistry(devices));
+    return 0;
+  }
+  if (command === "revoke") {
+    const deviceId = args.find((argument) => !argument.startsWith("--") && argument !== value(args, "--state"));
+    if (deviceId == null || deviceId === "") {
+      process.stderr.write(`redskilled-link revoke requires a device id — see \`devices\`\n`);
+      return 2;
+    }
+    const revoked = await stateStore(args).revoke(deviceId);
+    if (!revoked) {
+      process.stderr.write(`no live paired device carries the id ${JSON.stringify(deviceId)} — see \`devices\`\n`);
+      return 1;
+    }
+    process.stdout.write(`Device ${deviceId} revoked. It can no longer reach this Host; pair again to restore it.\n`);
+    return 0;
   }
   process.stdout.write(REDSKILLED_LINK_USAGE);
   return 0;
@@ -156,6 +177,24 @@ async function runUnitCommand(args: readonly string[]): Promise<number> {
   }
   process.stderr.write(`redskilled-link unit: unknown operation ${JSON.stringify(operation)}\n${REDSKILLED_LINK_USAGE}`);
   return 2;
+}
+
+/**
+ * The registry as an operator reads it: every device this Host ever paired,
+ * the revoked ones kept and MARKED — a device that vanished from the list and
+ * a device that was cut off are different histories. Secrets never print.
+ */
+export function renderDeviceRegistry(
+  devices: readonly { device_id: string; device_name: string; paired_at: string; revoked: boolean }[],
+): string {
+  if (devices.length === 0) {
+    return "No devices have ever paired with this Host. Create an invitation with `invite`.\n";
+  }
+  const lines = devices.map((device) =>
+    `${device.revoked ? "revoked " : "paired  "} ${device.device_id}  ${device.device_name}` +
+      `  since ${device.paired_at}`,
+  );
+  return `${lines.join("\n")}\n`;
 }
 
 function stateStore(args: readonly string[]) {

--- a/apps/redskilled-link/src/state.ts
+++ b/apps/redskilled-link/src/state.ts
@@ -35,6 +35,14 @@ interface LinkState {
   readonly devices: readonly LinkDeviceRecord[];
 }
 
+/** One paired device as an operator may SEE it — the secret never leaves the store. */
+export interface LinkDeviceView {
+  readonly device_id: string;
+  readonly device_name: string;
+  readonly paired_at: string;
+  readonly revoked: boolean;
+}
+
 export interface RedskilledLinkStateStore {
   identity(): Promise<Pick<LinkState, "host_id" | "host_name" | "relay_url">>;
   configure(options: { readonly relayUrl?: string; readonly hostName?: string }): Promise<void>;
@@ -43,6 +51,10 @@ export interface RedskilledLinkStateStore {
   pair(inviteId: string, device: Omit<LinkDeviceRecord, "paired_at" | "revoked" | "nonces">): Promise<void>;
   device(deviceId: string): Promise<LinkDeviceRecord | undefined>;
   acceptNonce(deviceId: string, nonce: string): Promise<LinkDeviceRecord>;
+  /** Every device this Host ever paired, revoked included — secrets omitted. */
+  devices(): Promise<readonly LinkDeviceView[]>;
+  /** Cut one device off the wire. `false` when no live device carries the id. */
+  revoke(deviceId: string): Promise<boolean>;
 }
 
 export function defaultLinkStatePath(homeDir = homedir()): string {
@@ -199,6 +211,28 @@ export function createRedskilledLinkStateStore(options: {
     },
     async device(deviceId) {
       return (await read()).devices.find((device) => device.device_id === deviceId && !device.revoked);
+    },
+    async devices() {
+      return (await read()).devices.map(({ device_id, device_name, paired_at, revoked }) => ({
+        device_id,
+        device_name,
+        paired_at,
+        revoked,
+      }));
+    },
+    async revoke(deviceId) {
+      // Revocation republishes the status projection: the paired-device count
+      // is exactly the number this operation changes.
+      return await mutate((state) => {
+        const live = state.devices.find((entry) => entry.device_id === deviceId && !entry.revoked);
+        if (live == null) return [state, false];
+        return [{
+          ...state,
+          devices: state.devices.map((entry) => entry.device_id === deviceId
+            ? { ...entry, revoked: true }
+            : entry),
+        }, true];
+      }, true);
     },
     async acceptNonce(deviceId, nonce) {
       return await mutate((state) => {

--- a/apps/redskilled-link/tests/device-registry.test.ts
+++ b/apps/redskilled-link/tests/device-registry.test.ts
@@ -1,0 +1,86 @@
+// The pairing registry is operable: an operator can SEE every device that
+// ever paired (revoked kept and marked — vanished and cut-off are different
+// histories) and can revoke one, which the wire-side lookups then refuse.
+// Secrets never leave the store's view.
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { renderDeviceRegistry } from "../src/cli.js";
+import { createRedskilledLinkStateStore, readPublicLinkStatus } from "../src/state.js";
+
+describe("the device registry", () => {
+  let dir: string;
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true });
+  });
+
+  async function storeWithDevice() {
+    dir = await mkdtemp(join(tmpdir(), "link-devices-"));
+    const store = createRedskilledLinkStateStore({
+      path: join(dir, "state.toon"),
+      relayUrl: "wss://relay.example",
+      hostName: "test-host",
+    });
+    const invitation = await store.createInvitation();
+    await store.pair(invitation.invite_id, {
+      device_id: "D1",
+      device_name: "Pixel",
+      secret: "s".repeat(32),
+    });
+    return store;
+  }
+
+  it("lists every paired device without its secret", async () => {
+    const store = await storeWithDevice();
+
+    const devices = await store.devices();
+    expect(devices).toHaveLength(1);
+    expect(devices[0]).toMatchObject({ device_id: "D1", device_name: "Pixel", revoked: false });
+    expect(JSON.stringify(devices)).not.toContain("s".repeat(32));
+  });
+
+  it("revoking cuts the device off the wire, keeps its history, and republishes the count", async () => {
+    const store = await storeWithDevice();
+
+    await expect(store.revoke("D1")).resolves.toBe(true);
+    // The wire-side lookup refuses the revoked device...
+    await expect(store.device("D1")).resolves.toBeUndefined();
+    await expect(store.acceptNonce("D1", "n-1")).rejects.toThrow();
+    // ...the registry keeps it, marked...
+    const devices = await store.devices();
+    expect(devices[0]).toMatchObject({ device_id: "D1", revoked: true });
+    // ...and the published projection counts zero live devices.
+    await expect(readPublicLinkStatus(join(dir, "status.json"))).resolves.toEqual({
+      version: 1,
+      active_paired_device_count: 0,
+    });
+  });
+
+  it("revoking a device that is not live answers false, not success", async () => {
+    const store = await storeWithDevice();
+
+    await expect(store.revoke("D-unknown")).resolves.toBe(false);
+    await expect(store.revoke("D1")).resolves.toBe(true);
+    // A second revocation has nothing live to cut off.
+    await expect(store.revoke("D1")).resolves.toBe(false);
+  });
+});
+
+describe("the registry rendering", () => {
+  it("marks revoked beside paired and prints no secret column", () => {
+    const rendered = renderDeviceRegistry([
+      { device_id: "D1", device_name: "Pixel", paired_at: "2026-08-24T12:00:00.000Z", revoked: false },
+      { device_id: "D2", device_name: "Old phone", paired_at: "2026-08-01T09:00:00.000Z", revoked: true },
+    ]);
+
+    expect(rendered).toContain("paired   D1  Pixel  since 2026-08-24T12:00:00.000Z");
+    expect(rendered).toContain("revoked  D2  Old phone  since 2026-08-01T09:00:00.000Z");
+  });
+
+  it("an empty registry points at the invitation flow instead of drawing a blank", () => {
+    expect(renderDeviceRegistry([])).toContain("Create an invitation with `invite`");
+  });
+});


### PR DESCRIPTION
## What

Continuing the link surface: a Host could pair devices and never **see** or **unpair** them — the registry had records and a `revoked` flag the wire-side lookups already honored, but no operator surface touched either.

- `redskilled-link devices` lists every device that ever paired, revoked kept and **marked** (a device that vanished from the list and a device that was cut off are different histories), through a new store view (`LinkDeviceView`) that omits secrets by construction.
- `redskilled-link revoke <device-id>` flips the flag the lookups honor: `device()` and `acceptNonce` refuse from that moment; the record stays as history; revoking a non-live id answers `false` (exit 1), not success; and the revocation **republishes `status.json`**, since the paired-device count is exactly the number it changes.

## Tests

`apps/redskilled-link/tests/device-registry.test.ts`: list-without-secret, revoke cuts the wire + keeps history + republishes count 0, revoke-non-live answers false, registry rendering (revoked mark, empty-registry pointer to `invite`). Link suite 25/25 after rebase onto #4401; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790210254&installation_model_id=20659&pr_number=4402&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4402&signature=63d9a231d45b7ff02699213f55e0ccd5bb74423f6296991472f6660026ffe895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->