### PR TITLE
feat(mobile): the app holds a fleet — every Host, one screen

### DIFF
--- a/.changeset/mobile-multi-host.md
+++ b/.changeset/mobile-multi-host.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-mobile": minor
+---
+
+The app holds a fleet: the paired-host store becomes a list (v1 single-host record migrates on first read; adding a second Host never forgets the first; corrupt entries lose only themselves), every Host gets its own card judged on its own polling evidence, Worker rows aggregate across Hosts and stay labeled by the machine that owns them (stop routes to that Host), dispatch targets the tapped Host, and hosts can be unpaired from the device.

--- a/apps/redskilled-mobile/App.tsx
+++ b/apps/redskilled-mobile/App.tsx
@@ -6,6 +6,7 @@ import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  Pressable,
   SafeAreaView,
   ScrollView,
   StyleSheet,
@@ -27,11 +28,15 @@ import {
   SectionHeading,
 } from "./src/design-system/components";
 import { colors, density, radii, spacing, type } from "./src/design-system/tokens";
-import { deriveHostStatus } from "./src/domain/host-status";
+import {
+  fleetHostViews,
+  fleetWorkerRows,
+  type FleetWorkerRow,
+  type HostRuntime,
+} from "./src/domain/host-fleet";
 import { parseGitHubIssueUrl } from "./src/domain/issue-url";
-import type { MobileHostSnapshot, MobileWorker, PairedHost } from "./src/domain/ticket-dispatch";
-import { reconcilePendingWorkers } from "./src/domain/worker-reconcile";
-import { loadPairedHost, savePairedHost } from "./src/transport/paired-host-store";
+import type { MobileOperatorGateway } from "./src/domain/ticket-dispatch";
+import { addPairedHost, loadPairedHosts, removePairedHost } from "./src/transport/paired-host-store";
 import { createRemoteOperatorGateway } from "./src/transport/remote-operator-gateway";
 import { copy } from "./src/ui/copy";
 
@@ -40,7 +45,9 @@ export default function App() {
     JetBrainsMono: require("./vendor/design-system/fonts/jetbrains-mono-variable.ttf"),
     SpaceGrotesk: require("./vendor/design-system/fonts/space-grotesk-variable.ttf"),
   });
-  const [pairedHost, setPairedHost] = useState<RedskilledLinkPairedHost | null>(null);
+  const [hosts, setHosts] = useState<readonly RedskilledLinkPairedHost[]>([]);
+  const [activeHostId, setActiveHostId] = useState<string | null>(null);
+  const [addingHost, setAddingHost] = useState(false);
   const [pairingCode, setPairingCode] = useState("");
   const [isPairing, setIsPairing] = useState(false);
   const [scannerOpen, setScannerOpen] = useState(false);
@@ -49,50 +56,60 @@ export default function App() {
   const [issueUrl, setIssueUrl] = useState("");
   const [isDispatching, setIsDispatching] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [workers, setWorkers] = useState<readonly MobileWorker[]>([]);
-  const [snapshot, setSnapshot] = useState<MobileHostSnapshot | null>(null);
-  const [lastAnsweredAt, setLastAnsweredAt] = useState<number | null>(null);
-  const [linkFailure, setLinkFailure] = useState<string | null>(null);
-  const gateway = useMemo(
-    () => pairedHost == null ? null : createRemoteOperatorGateway(pairedHost),
-    [pairedHost],
-  );
+  const [runtime, setRuntime] = useState<Readonly<Record<string, HostRuntime>>>({});
+  const [pending, setPending] = useState<readonly FleetWorkerRow[]>([]);
+  const gateways = useMemo(() => {
+    const built = new Map<string, MobileOperatorGateway>();
+    for (const host of hosts) built.set(host.host_id, createRemoteOperatorGateway(host));
+    return built;
+  }, [hosts]);
+  const activeHost = hosts.find((host) => host.host_id === activeHostId) ?? hosts[0] ?? null;
 
   useEffect(() => {
     let active = true;
-    void loadPairedHost().then((host) => {
-      if (active) setPairedHost(host);
+    void loadPairedHosts().then((loaded) => {
+      if (active) setHosts(loaded);
     });
     return () => { active = false; };
   }, []);
 
   useEffect(() => {
-    if (gateway == null) return;
+    if (gateways.size === 0) return;
     let active = true;
-    // Every outcome lands in state: an answered read stamps the instant the
-    // status verdict derives from, and a failed read records WHY instead of
-    // being swallowed — the card then reads stale/unreachable by evidence.
-    const refresh = () => void gateway.state().then((read) => {
-      if (!active) return;
-      setSnapshot(read);
-      setLastAnsweredAt(Date.now());
-      setLinkFailure(null);
-      setWorkers((current) => reconcilePendingWorkers(
-        read.workers,
-        current.filter((worker) => worker.pending === true),
-        Date.now(),
-      ));
-    }).catch((failure: unknown) => {
-      if (!active) return;
-      setLinkFailure(failure instanceof Error ? failure.message : String(failure));
-    });
+    // Each Host is polled on its own and each outcome lands in ITS runtime:
+    // an answered read stamps the instant the status verdict derives from,
+    // and a failed read records WHY instead of being swallowed — one dead
+    // machine reads unreachable on its own card while the rest stay honest.
+    const refresh = () => {
+      for (const [hostId, gateway] of gateways) {
+        void gateway.state().then((snapshot) => {
+          if (!active) return;
+          setRuntime((current) => ({
+            ...current,
+            [hostId]: { snapshot, lastAnsweredAtMs: Date.now(), failure: null },
+          }));
+          setPending((current) => current.filter((row) =>
+            row.hostId !== hostId || !snapshot.workers.some((worker) => worker.workerId === row.workerId)));
+        }).catch((failure: unknown) => {
+          if (!active) return;
+          setRuntime((current) => ({
+            ...current,
+            [hostId]: {
+              snapshot: current[hostId]?.snapshot ?? null,
+              lastAnsweredAtMs: current[hostId]?.lastAnsweredAtMs ?? null,
+              failure: failure instanceof Error ? failure.message : String(failure),
+            },
+          }));
+        });
+      }
+    };
     refresh();
     const timer = setInterval(refresh, 3_000);
     return () => {
       active = false;
       clearInterval(timer);
     };
-  }, [gateway]);
+  }, [gateways]);
 
   const issue = useMemo(() => {
     try {
@@ -102,31 +119,31 @@ export default function App() {
     }
   }, [issueUrl]);
 
-  const hostStatus = deriveHostStatus(lastAnsweredAt, Date.now());
-  const selectedHost: PairedHost | null = pairedHost == null ? null : {
-    id: pairedHost.host_id,
-    name: pairedHost.host_name,
-    status: hostStatus,
-  };
-  const canDispatch = selectedHost != null && issue != null && !isDispatching;
+  const now = Date.now();
+  const hostViews = fleetHostViews(hosts, runtime, now);
+  const workers = fleetWorkerRows(hosts, runtime, pending, now);
+  const canDispatch = activeHost != null && issue != null && !isDispatching;
 
   async function dispatchIssue() {
-    if (selectedHost == null || issue == null || gateway == null) return;
+    const gateway = activeHost == null ? null : gateways.get(activeHost.host_id);
+    if (activeHost == null || issue == null || gateway == null) return;
 
     setIsDispatching(true);
     setError(null);
     try {
       const receipt = await gateway.dispatch({
-        hostId: selectedHost.id,
+        hostId: activeHost.host_id,
         issueUrl: issue.canonicalUrl,
       });
-      setWorkers((current) => [{
+      setPending((current) => [{
         workerId: receipt.workerId,
         repository: receipt.repository,
         ticket: receipt.ticket,
         startedAt: new Date().toISOString(),
         pending: true,
-      }, ...current.filter((worker) => worker.workerId !== receipt.workerId)]);
+        hostId: activeHost.host_id,
+        hostName: activeHost.host_name,
+      }, ...current.filter((row) => row.workerId !== receipt.workerId)]);
       setIssueUrl("");
     } catch {
       setError(copy.errors.dispatch);
@@ -141,14 +158,23 @@ export default function App() {
     setError(null);
     try {
       const host = await pairRedskilledHost(invitation, `Redskilled ${Platform.OS}`);
-      await savePairedHost(host);
-      setPairedHost(host);
+      setHosts(await addPairedHost(host));
+      setActiveHostId(host.host_id);
+      setAddingHost(false);
       setPairingCode("");
     } catch {
       setError(copy.errors.pairing);
     } finally {
       setIsPairing(false);
     }
+  }
+
+  async function unpairHost(hostId: string) {
+    setError(null);
+    setHosts(await removePairedHost(hostId));
+    setRuntime(({ [hostId]: _gone, ...rest }) => rest);
+    setPending((current) => current.filter((row) => row.hostId !== hostId));
+    if (activeHostId === hostId) setActiveHostId(null);
   }
 
   async function scanPairingInvitation({ data }: BarcodeScanningResult) {
@@ -163,12 +189,27 @@ export default function App() {
     }
   }
 
-  async function stopWorker(workerId: string) {
+  async function stopWorker(row: FleetWorkerRow) {
+    const gateway = gateways.get(row.hostId);
     if (gateway == null) return;
     setError(null);
     try {
-      if (await gateway.stop(workerId)) {
-        setWorkers((current) => current.filter((worker) => worker.workerId !== workerId));
+      if (await gateway.stop(row.workerId)) {
+        setPending((current) => current.filter((entry) => entry.workerId !== row.workerId));
+        setRuntime((current) => {
+          const state = current[row.hostId];
+          if (state?.snapshot == null) return current;
+          return {
+            ...current,
+            [row.hostId]: {
+              ...state,
+              snapshot: {
+                ...state.snapshot,
+                workers: state.snapshot.workers.filter((worker) => worker.workerId !== row.workerId),
+              },
+            },
+          };
+        });
       }
     } catch {
       setError(copy.errors.stop);
@@ -210,8 +251,60 @@ export default function App() {
           </View>
 
           <View style={styles.section}>
-            <SectionHeading eyebrow={copy.host.section} />
-            {selectedHost == null ? (
+            <SectionHeading
+              actions={hosts.length === 0 ? undefined : <Pill label={copy.host.count(hosts.length)} />}
+              eyebrow={copy.host.section}
+            />
+            {hostViews.map((view) => (
+              <Pressable
+                accessibilityLabel={copy.host.selectLabel(view.hostName)}
+                key={view.hostId}
+                onPress={() => setActiveHostId(view.hostId)}
+              >
+                <Card
+                  style={[
+                    styles.hostCard,
+                    activeHost?.host_id === view.hostId && styles.hostCardActive,
+                  ]}
+                >
+                  <View style={styles.hostIdentity}>
+                    <View style={styles.hostGlyph}>
+                      <Text style={styles.hostGlyphText}>H</Text>
+                    </View>
+                    <View style={styles.hostText}>
+                      <Text style={styles.hostName}>{view.hostName}</Text>
+                      <Text style={styles.metadata}>
+                        {view.daemonVersion == null
+                          ? copy.host.pairedDescription
+                          : `${copy.host.daemonVersion(view.daemonVersion)} · ${copy.host.workerCount(view.workerCount)}`}
+                      </Text>
+                      {view.failure == null || view.status === "online" ? null : (
+                        <Text style={styles.metadata}>{copy.errors.state(view.failure)}</Text>
+                      )}
+                    </View>
+                  </View>
+                  <View style={styles.hostActions}>
+                    <Pill glyph="◆" label={copy.host.status[view.status]} />
+                    <Button
+                      label={copy.host.unpair}
+                      onPress={() => void unpairHost(view.hostId)}
+                      tone="danger"
+                      variant="ghost"
+                    />
+                  </View>
+                </Card>
+              </Pressable>
+            ))}
+            {hosts.length > 0 && !addingHost ? (
+              <Button
+                label={copy.host.addAnother}
+                onPress={() => {
+                  setAddingHost(true);
+                  setError(null);
+                }}
+                variant="secondary"
+              />
+            ) : (
               <Card>
                 <EmptyState
                   description={copy.host.emptyDescription}
@@ -271,33 +364,22 @@ export default function App() {
                   loading={isPairing}
                   onPress={() => void pairHost(pairingCode)}
                 />
-              </Card>
-            ) : (
-              <Card style={styles.hostCard}>
-                <View style={styles.hostIdentity}>
-                  <View style={styles.hostGlyph}>
-                    <Text style={styles.hostGlyphText}>H</Text>
-                  </View>
-                  <View style={styles.hostText}>
-                    <Text style={styles.hostName}>{selectedHost.name}</Text>
-                    <Text style={styles.metadata}>
-                      {snapshot?.daemonVersion == null
-                        ? copy.host.pairedDescription
-                        : `${copy.host.pairedDescription} · ${copy.host.daemonVersion(snapshot.daemonVersion)}`}
-                    </Text>
-                    {linkFailure == null || hostStatus === "online" ? null : (
-                      <Text style={styles.metadata}>{copy.errors.state(linkFailure)}</Text>
-                    )}
-                  </View>
-                </View>
-                <Pill glyph="◆" label={copy.host.status[selectedHost.status]} />
+                {hosts.length === 0 ? null : (
+                  <Button
+                    label={copy.host.addCancel}
+                    onPress={() => setAddingHost(false)}
+                    variant="ghost"
+                  />
+                )}
               </Card>
             )}
           </View>
 
           <View style={styles.section}>
             <SectionHeading
-              description={copy.dispatch.description}
+              description={activeHost == null
+                ? copy.dispatch.description
+                : copy.dispatch.target(activeHost.host_name)}
               eyebrow={copy.dispatch.section}
               title={copy.dispatch.title}
             />
@@ -358,7 +440,7 @@ export default function App() {
               <Card style={styles.workerList}>
                 {workers.map((worker, index) => (
                   <View
-                    key={worker.workerId}
+                    key={`${worker.hostId}:${worker.workerId}`}
                     style={[styles.workerRow, index > 0 && styles.workerRowBorder]}
                   >
                     <View style={styles.workerGlyph}>
@@ -368,7 +450,9 @@ export default function App() {
                       <Text numberOfLines={1} style={styles.workerTitle}>
                         {worker.repository}{worker.ticket == null ? "" : ` #${worker.ticket}`}
                       </Text>
-                      <Text numberOfLines={1} style={styles.workerId}>{worker.workerId}</Text>
+                      <Text numberOfLines={1} style={styles.workerId}>
+                        {worker.hostName} · {worker.workerId}
+                      </Text>
                       <Text style={styles.runningText}>
                         {worker.pending === true
                           ? copy.workers.pending
@@ -382,7 +466,7 @@ export default function App() {
                     </View>
                     <Button
                       label={copy.workers.stop}
-                      onPress={() => void stopWorker(worker.workerId)}
+                      onPress={() => void stopWorker(worker)}
                       tone="danger"
                       variant="ghost"
                     />
@@ -465,6 +549,8 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
   },
+  hostCardActive: { borderColor: colors.primary },
+  hostActions: { alignItems: "flex-end", gap: density.gapSm },
   hostIdentity: { alignItems: "center", flex: 1, flexDirection: "row", gap: density.gapLg },
   hostGlyph: {
     alignItems: "center",

--- a/apps/redskilled-mobile/src/domain/host-fleet.ts
+++ b/apps/redskilled-mobile/src/domain/host-fleet.ts
@@ -1,0 +1,81 @@
+/**
+ * host-fleet — the cross-host view, derived from per-host evidence.
+ *
+ * Each paired Host is polled on its own; this module folds those independent
+ * outcomes into the one screen the operator asked the Remote link for: every
+ * machine's verdict, and every Worker anywhere, each row still naming the
+ * Host it belongs to — because a stop must be routed to the machine that owns
+ * the Worker, and a row that lost its Host is a button that cannot act.
+ */
+import { deriveHostStatus, type HostLinkStatus } from "./host-status";
+import type { MobileHostSnapshot, MobileWorker } from "./ticket-dispatch";
+import { reconcilePendingWorkers } from "./worker-reconcile";
+
+/** What one Host's polling has established so far. */
+export interface HostRuntime {
+  readonly snapshot: MobileHostSnapshot | null;
+  readonly lastAnsweredAtMs: number | null;
+  readonly failure: string | null;
+}
+
+export interface FleetHostView {
+  readonly hostId: string;
+  readonly hostName: string;
+  readonly status: HostLinkStatus;
+  readonly daemonVersion: string | null;
+  readonly workerCount: number;
+  readonly failure: string | null;
+}
+
+export interface FleetWorkerRow extends MobileWorker {
+  readonly hostId: string;
+  readonly hostName: string;
+}
+
+const EMPTY_RUNTIME: HostRuntime = { snapshot: null, lastAnsweredAtMs: null, failure: null };
+
+/** One card per paired Host, each judged only on its own evidence. PURE. */
+export function fleetHostViews(
+  hosts: readonly { host_id: string; host_name: string }[],
+  runtime: Readonly<Record<string, HostRuntime>>,
+  nowMs: number,
+): readonly FleetHostView[] {
+  return hosts.map((host) => {
+    const state = runtime[host.host_id] ?? EMPTY_RUNTIME;
+    return {
+      hostId: host.host_id,
+      hostName: host.host_name,
+      status: deriveHostStatus(state.lastAnsweredAtMs, nowMs),
+      daemonVersion: state.snapshot?.daemonVersion ?? null,
+      workerCount: state.snapshot?.workers.length ?? 0,
+      failure: state.failure,
+    };
+  });
+}
+
+/**
+ * Every Worker anywhere, host-labelled, pending receipts reconciled per Host.
+ * A Host that never answered contributes nothing — absence of rows, not
+ * invented idleness; its outage is on its own card. PURE.
+ */
+export function fleetWorkerRows(
+  hosts: readonly { host_id: string; host_name: string }[],
+  runtime: Readonly<Record<string, HostRuntime>>,
+  pending: readonly FleetWorkerRow[],
+  nowMs: number,
+): readonly FleetWorkerRow[] {
+  return hosts.flatMap((host) => {
+    const state = runtime[host.host_id] ?? EMPTY_RUNTIME;
+    const label = (worker: MobileWorker): FleetWorkerRow => ({
+      ...worker,
+      hostId: host.host_id,
+      hostName: host.host_name,
+    });
+    const own = pending.filter((row) => row.hostId === host.host_id);
+    if (state.snapshot == null) {
+      // No answer yet: the dispatch receipts are the only evidence there is.
+      return reconcilePendingWorkers([], own, nowMs).map(label);
+    }
+    return reconcilePendingWorkers(state.snapshot.workers, own, nowMs).map(label);
+  });
+}

--- a/apps/redskilled-mobile/src/transport/paired-host-store.ts
+++ b/apps/redskilled-mobile/src/transport/paired-host-store.ts
@@ -1,25 +1,103 @@
-import * as SecureStore from "expo-secure-store";
+/**
+ * paired-host-store — every Host this device has paired, in the secure store.
+ *
+ * v2 is a LIST: the whole point of the Remote link is seeing all of an
+ * operator's machines, and a store that could hold one Host made "add a
+ * second" silently forget the first. The value is the base64url paired-host
+ * records joined by newlines — no serialization format of our own, just the
+ * codec the pairing already speaks, one per line. A v1 single record migrates
+ * into the list on first read and the legacy key is retired.
+ *
+ * The KV boundary is injectable so the store's behavior (round-trip,
+ * migration, removal, corrupt-entry policy) is asserted by tests that never
+ * touch a device keychain.
+ */
 import {
   decodePairedHost,
   encodePairedHost,
 } from "@reddb-io/red-skills-link-protocol/crypto";
 import type { RedskilledLinkPairedHost } from "@reddb-io/red-skills-link-protocol/protocol";
 
-const PAIRED_HOST_KEY = "redskilled-link.paired-host.v1";
+const PAIRED_HOSTS_KEY = "redskilled-link.paired-hosts.v2";
+const LEGACY_PAIRED_HOST_KEY = "redskilled-link.paired-host.v1";
 
-export async function loadPairedHost(): Promise<RedskilledLinkPairedHost | null> {
-  const encoded = await SecureStore.getItemAsync(PAIRED_HOST_KEY);
-  if (encoded == null) return null;
-  try {
-    return decodePairedHost(encoded);
-  } catch {
-    await SecureStore.deleteItemAsync(PAIRED_HOST_KEY);
-    return null;
-  }
+export interface PairedHostKV {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+  delete(key: string): Promise<void>;
 }
 
-export async function savePairedHost(host: RedskilledLinkPairedHost): Promise<void> {
-  await SecureStore.setItemAsync(PAIRED_HOST_KEY, encodePairedHost(host), {
-    keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
-  });
+// Imported lazily so the store's LOGIC loads without the native module: the
+// tests inject their own KV, and expo-secure-store's untranspiled source is
+// only resolvable inside the Expo bundler.
+const secureStore = () => import("expo-secure-store");
+
+const secureStoreKV: PairedHostKV = {
+  get: async (key) => (await secureStore()).getItemAsync(key),
+  set: async (key, value) => {
+    const store = await secureStore();
+    await store.setItemAsync(key, value, {
+      keychainAccessible: store.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    });
+  },
+  delete: async (key) => (await secureStore()).deleteItemAsync(key),
+};
+
+/** Every paired Host, oldest first. A corrupt line is dropped, not fatal. */
+export async function loadPairedHosts(
+  kv: PairedHostKV = secureStoreKV,
+): Promise<readonly RedskilledLinkPairedHost[]> {
+  const encoded = await kv.get(PAIRED_HOSTS_KEY);
+  if (encoded != null) return decodeLines(encoded);
+
+  // One-time migration: a device paired before the list existed keeps its Host.
+  const legacy = await kv.get(LEGACY_PAIRED_HOST_KEY);
+  if (legacy == null) return [];
+  const migrated = decodeLines(legacy);
+  await persist(kv, migrated);
+  await kv.delete(LEGACY_PAIRED_HOST_KEY);
+  return migrated;
+}
+
+/** Add or replace one Host (matched by `host_id`) and return the new list. */
+export async function addPairedHost(
+  host: RedskilledLinkPairedHost,
+  kv: PairedHostKV = secureStoreKV,
+): Promise<readonly RedskilledLinkPairedHost[]> {
+  const current = await loadPairedHosts(kv);
+  const next = [...current.filter((entry) => entry.host_id !== host.host_id), host];
+  await persist(kv, next);
+  return next;
+}
+
+/** Forget one Host on this device. The Host's own registry is not touched. */
+export async function removePairedHost(
+  hostId: string,
+  kv: PairedHostKV = secureStoreKV,
+): Promise<readonly RedskilledLinkPairedHost[]> {
+  const current = await loadPairedHosts(kv);
+  const next = current.filter((entry) => entry.host_id !== hostId);
+  await persist(kv, next);
+  return next;
+}
+
+async function persist(kv: PairedHostKV, hosts: readonly RedskilledLinkPairedHost[]): Promise<void> {
+  if (hosts.length === 0) {
+    await kv.delete(PAIRED_HOSTS_KEY);
+    return;
+  }
+  await kv.set(PAIRED_HOSTS_KEY, hosts.map(encodePairedHost).join("\n"));
+}
+
+function decodeLines(encoded: string): RedskilledLinkPairedHost[] {
+  const hosts: RedskilledLinkPairedHost[] = [];
+  for (const line of encoded.split("\n")) {
+    if (line.trim() === "") continue;
+    try {
+      hosts.push(decodePairedHost(line));
+    } catch {
+      // A corrupt entry loses that entry, never the whole fleet.
+    }
+  }
+  return hosts;
 }

--- a/apps/redskilled-mobile/src/ui/copy.ts
+++ b/apps/redskilled-mobile/src/ui/copy.ts
@@ -22,6 +22,12 @@ export const copy = {
     invitationLabel: "Host pairing invitation",
     invitationPlaceholder: "Paste the pairing invitation",
     pairAction: "PAIR HOST",
+    addAnother: "ADD ANOTHER HOST",
+    addCancel: "CANCEL",
+    unpair: "UNPAIR",
+    count: (count: number) => `${count} HOST${count === 1 ? "" : "S"}`,
+    selectLabel: (name: string) => `Select ${name} as the dispatch target`,
+    workerCount: (count: number) => `${count} Worker${count === 1 ? "" : "s"}`,
     pairedDescription: "Encrypted link · paired device",
     status: {
       connecting: "CONNECTING",
@@ -39,6 +45,7 @@ export const copy = {
     issueLabel: "GitHub Issue URL",
     issuePlaceholder: "https://github.com/owner/repo/issues/123",
     invalidIssue: "Enter a URL like https://github.com/owner/repo/issues/123",
+    target: (hostName: string) => `Dispatches to ${hostName}. Tap another Host card to change the target.`,
     action: "DISPATCH WORKER",
   },
   workers: {

--- a/apps/redskilled-mobile/tests/host-fleet.test.ts
+++ b/apps/redskilled-mobile/tests/host-fleet.test.ts
@@ -1,0 +1,82 @@
+// The cross-host view: every card judged on its own evidence, every Worker
+// row still naming the Host that owns it, pending receipts reconciled per
+// Host — one dead machine reads unreachable on its own card while the rest
+// stay honest.
+import { describe, expect, it } from "vitest";
+
+import { fleetHostViews, fleetWorkerRows, type HostRuntime } from "../src/domain/host-fleet";
+import type { MobileWorker } from "../src/domain/ticket-dispatch";
+
+const now = Date.parse("2026-08-24T12:00:30.000Z");
+const hosts = [
+  { host_id: "h1", host_name: "laptop" },
+  { host_id: "h2", host_name: "desktop" },
+];
+
+function answered(workers: readonly MobileWorker[]): HostRuntime {
+  return {
+    snapshot: { workers, daemonVersion: "4.2.6", generatedAt: null, staleness: null },
+    lastAnsweredAtMs: now - 1_000,
+    failure: null,
+  };
+}
+
+describe("the fleet view", () => {
+  it("judges each Host on its own evidence — one outage never colors the rest", () => {
+    const views = fleetHostViews(hosts, {
+      h1: answered([]),
+      h2: { snapshot: null, lastAnsweredAtMs: now - 60_000, failure: "relay refused" },
+    }, now);
+
+    expect(views[0]).toMatchObject({ hostId: "h1", status: "online", daemonVersion: "4.2.6" });
+    expect(views[1]).toMatchObject({ hostId: "h2", status: "unreachable", failure: "relay refused" });
+  });
+
+  it("a Host never polled reads connecting, not online", () => {
+    const views = fleetHostViews(hosts, {}, now);
+    expect(views.map((view) => view.status)).toEqual(["connecting", "connecting"]);
+  });
+
+  it("labels every Worker row with its owning Host and reconciles pending per Host", () => {
+    const published = {
+      workerId: "W1",
+      repository: "reddb-io/red-skills",
+      startedAt: "2026-08-24T12:00:00.000Z",
+      phase: "coding",
+      heartbeatAgeMs: 3_000,
+    };
+    const pendingRow = {
+      workerId: "W9",
+      repository: "acme/widgets",
+      startedAt: "2026-08-24T12:00:25.000Z",
+      pending: true as const,
+      hostId: "h2",
+      hostName: "desktop",
+    };
+
+    const rows = fleetWorkerRows(hosts, { h1: answered([published]) }, [pendingRow], now);
+
+    expect(rows).toHaveLength(2);
+    expect(rows.find((row) => row.workerId === "W1")).toMatchObject({ hostId: "h1", hostName: "laptop" });
+    // h2 never answered: its dispatch receipt is the only evidence there is.
+    expect(rows.find((row) => row.workerId === "W9")).toMatchObject({ hostId: "h2", pending: true });
+  });
+
+  it("the Host's answer retires its own pending receipt and no other Host's", () => {
+    const receiptOnH1 = {
+      workerId: "W1",
+      repository: "reddb-io/red-skills",
+      startedAt: "2026-08-24T12:00:25.000Z",
+      pending: true as const,
+      hostId: "h1",
+      hostName: "laptop",
+    };
+    const published = { workerId: "W1", repository: "reddb-io/red-skills", startedAt: "2026-08-24T12:00:26.000Z" };
+
+    const rows = fleetWorkerRows(hosts, { h1: answered([published]) }, [receiptOnH1], now);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ workerId: "W1", hostId: "h1" });
+    expect(rows[0]?.pending).toBeUndefined();
+  });
+});

--- a/apps/redskilled-mobile/tests/paired-host-store.test.ts
+++ b/apps/redskilled-mobile/tests/paired-host-store.test.ts
@@ -1,0 +1,89 @@
+// The store holds a FLEET: adding a second Host must never forget the first,
+// a v1 single-host record migrates on first read, and a corrupt entry loses
+// that entry — never the whole fleet.
+import { describe, expect, it } from "vitest";
+import { encodePairedHost } from "@reddb-io/red-skills-link-protocol/crypto";
+import type { RedskilledLinkPairedHost } from "@reddb-io/red-skills-link-protocol/protocol";
+
+import {
+  addPairedHost,
+  loadPairedHosts,
+  removePairedHost,
+  type PairedHostKV,
+} from "../src/transport/paired-host-store";
+
+function host(id: string, name: string): RedskilledLinkPairedHost {
+  return {
+    version: 1,
+    relay_url: "wss://relay.example",
+    host_id: id,
+    host_name: name,
+    device_id: `device-for-${id}`,
+    device_secret: "c2VjcmV0LXNlY3JldC1zZWNyZXQtc2VjcmV0ISE",
+  };
+}
+
+function memoryKV(initial: Record<string, string> = {}): PairedHostKV & { data: Map<string, string> } {
+  const data = new Map(Object.entries(initial));
+  return {
+    data,
+    get: async (key) => data.get(key) ?? null,
+    set: async (key, value) => { data.set(key, value); },
+    delete: async (key) => { data.delete(key); },
+  };
+}
+
+describe("the paired-host store holds a fleet", () => {
+  it("adding a second Host keeps the first", async () => {
+    const kv = memoryKV();
+    await addPairedHost(host("h1", "laptop"), kv);
+    const after = await addPairedHost(host("h2", "desktop"), kv);
+
+    expect(after.map((entry) => entry.host_id)).toEqual(["h1", "h2"]);
+    await expect(loadPairedHosts(kv)).resolves.toHaveLength(2);
+  });
+
+  it("re-pairing the same Host replaces its record instead of duplicating it", async () => {
+    const kv = memoryKV();
+    await addPairedHost(host("h1", "laptop"), kv);
+    const after = await addPairedHost({ ...host("h1", "laptop"), device_id: "device-2" }, kv);
+
+    expect(after).toHaveLength(1);
+    expect(after[0]?.device_id).toBe("device-2");
+  });
+
+  it("migrates the v1 single-host record into the list and retires the legacy key", async () => {
+    const kv = memoryKV({
+      "redskilled-link.paired-host.v1": encodePairedHost(host("h-legacy", "old-laptop")),
+    });
+
+    const loaded = await loadPairedHosts(kv);
+    expect(loaded.map((entry) => entry.host_id)).toEqual(["h-legacy"]);
+    expect(kv.data.has("redskilled-link.paired-host.v1")).toBe(false);
+    expect(kv.data.has("redskilled-link.paired-hosts.v2")).toBe(true);
+  });
+
+  it("removing a Host forgets only that Host, and an empty fleet clears the key", async () => {
+    const kv = memoryKV();
+    await addPairedHost(host("h1", "laptop"), kv);
+    await addPairedHost(host("h2", "desktop"), kv);
+
+    const afterOne = await removePairedHost("h1", kv);
+    expect(afterOne.map((entry) => entry.host_id)).toEqual(["h2"]);
+
+    await removePairedHost("h2", kv);
+    expect(kv.data.has("redskilled-link.paired-hosts.v2")).toBe(false);
+  });
+
+  it("a corrupt entry loses that entry, never the fleet", async () => {
+    const kv = memoryKV();
+    await addPairedHost(host("h1", "laptop"), kv);
+    kv.data.set(
+      "redskilled-link.paired-hosts.v2",
+      `${kv.data.get("redskilled-link.paired-hosts.v2")}\nnot-a-record`,
+    );
+
+    const loaded = await loadPairedHosts(kv);
+    expect(loaded.map((entry) => entry.host_id)).toEqual(["h1"]);
+  });
+});


### PR DESCRIPTION
## What

The Remote link exists so an operator sees **all** their machines (the original E2E vision, items 5–6), but the app's store held exactly one Host — pairing a second silently forgot the first.

- **Fleet store**: `paired-host-store` becomes a list (v2 key, records joined by newlines using the pairing codec — no serialization of our own). The v1 single-host record migrates on first read and the legacy key is retired; a corrupt entry loses that entry, never the fleet; re-pairing a Host replaces its record. The KV boundary is injectable so store behavior is tested without a device keychain, and `expo-secure-store` is imported lazily (its untranspiled source only resolves inside the Expo bundler).
- **Independent verdicts**: each Host is polled on its own and judged on its own evidence (`host-fleet.ts`, pure `fleetHostViews`/`fleetWorkerRows`) — one dead machine reads `UNREACHABLE` on its own card, with its reason, while the rest stay honest.
- **Cross-host Workers**: rows aggregate across Hosts and keep naming the machine that owns them (a stop must be routed there); pending dispatch receipts reconcile against their **own** Host's answer only.
- **Dispatch target**: tapping a Host card makes it the dispatch target, and the dispatch section says so; `UNPAIR` forgets a Host on this device without touching the Host's own registry (that side is `redskilled-link revoke`, #4402).

## Tests

`paired-host-store.test.ts` (keep-first, replace-on-repair, v1 migration + legacy-key retirement, remove-one/clear-key, corrupt-entry policy) and `host-fleet.test.ts` (per-host verdicts, connecting-before-evidence, host-labeled aggregation, per-host pending reconciliation). Mobile suite 47/47 after rebase; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790210822&installation_model_id=20659&pr_number=4403&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4403&signature=4820dade22239c34fe479e3223f479e6b28df824824465e0f3f89714943bb098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->