### PR TITLE
fix(link): pay the router's complexity ratchet — extract revoke, cover the router

### DIFF
--- a/.changeset/link-cli-crap.md
+++ b/.changeset/link-cli-crap.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-link": patch
+---
+
+The command router is decomposed (revoke extracted like unit/status before it) and covered end to end by its own routing tests — no behavior change.

--- a/apps/redskilled-link/src/cli.ts
+++ b/apps/redskilled-link/src/cli.ts
@@ -76,23 +76,11 @@ export async function runRedskilledLinkCli(argv: readonly string[]): Promise<num
     return await runStatusCommand(args);
   }
   if (command === "devices") {
-    const devices = await stateStore(args).devices();
-    process.stdout.write(renderDeviceRegistry(devices));
+    process.stdout.write(renderDeviceRegistry(await stateStore(args).devices()));
     return 0;
   }
   if (command === "revoke") {
-    const deviceId = args.find((argument) => !argument.startsWith("--") && argument !== value(args, "--state"));
-    if (deviceId == null || deviceId === "") {
-      process.stderr.write(`redskilled-link revoke requires a device id — see \`devices\`\n`);
-      return 2;
-    }
-    const revoked = await stateStore(args).revoke(deviceId);
-    if (!revoked) {
-      process.stderr.write(`no live paired device carries the id ${JSON.stringify(deviceId)} — see \`devices\`\n`);
-      return 1;
-    }
-    process.stdout.write(`Device ${deviceId} revoked. It can no longer reach this Host; pair again to restore it.\n`);
-    return 0;
+    return await runRevokeCommand(args);
   }
   process.stdout.write(REDSKILLED_LINK_USAGE);
   return 0;
@@ -177,6 +165,21 @@ async function runUnitCommand(args: readonly string[]): Promise<number> {
   }
   process.stderr.write(`redskilled-link unit: unknown operation ${JSON.stringify(operation)}\n${REDSKILLED_LINK_USAGE}`);
   return 2;
+}
+
+/** Cut one paired device off the wire; a non-live id is a loud miss, not success. */
+async function runRevokeCommand(args: readonly string[]): Promise<number> {
+  const deviceId = args.find((argument) => !argument.startsWith("--") && argument !== value(args, "--state"));
+  if (deviceId == null || deviceId === "") {
+    process.stderr.write(`redskilled-link revoke requires a device id — see \`devices\`\n`);
+    return 2;
+  }
+  if (!await stateStore(args).revoke(deviceId)) {
+    process.stderr.write(`no live paired device carries the id ${JSON.stringify(deviceId)} — see \`devices\`\n`);
+    return 1;
+  }
+  process.stdout.write(`Device ${deviceId} revoked. It can no longer reach this Host; pair again to restore it.\n`);
+  return 0;
 }
 
 /**

--- a/apps/redskilled-link/tests/cli-routing.test.ts
+++ b/apps/redskilled-link/tests/cli-routing.test.ts
@@ -1,0 +1,38 @@
+// The router itself, driven end to end: unknown input answers with the usage
+// instead of a guess, and a unit operation the CLI does not know is a loud
+// exit 2 — the shapes an operator hits first when something else is broken.
+import { describe, expect, it, vi } from "vitest";
+
+import { REDSKILLED_LINK_USAGE, runRedskilledLinkCli } from "../src/cli.js";
+
+describe("the redskilled-link command router", () => {
+  it("no command answers with the usage and exits 0", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      await expect(runRedskilledLinkCli([])).resolves.toBe(0);
+      expect(write).toHaveBeenCalledWith(REDSKILLED_LINK_USAGE);
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it("an unknown unit operation exits 2 and repeats the usage", async () => {
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      await expect(runRedskilledLinkCli(["unit", "explode"])).resolves.toBe(2);
+      expect(String(write.mock.calls[0]?.[0])).toContain("unknown operation");
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it("revoke without a device id exits 2 before touching any store", async () => {
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      await expect(runRedskilledLinkCli(["revoke"])).resolves.toBe(2);
+      expect(String(write.mock.calls[0]?.[0])).toContain("requires a device id");
+    } finally {
+      write.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## What

#4401 and #4402 each passed their own cone, but their union pushed `runRedskilledLinkCli` to CRAP 420 (cyclomatic 20, unnamed by any test) on the merged main — which the 4.3.0 Version PR (#4373) then inherited, **blocking the release train**.

Two payments, no behavior change:
- the `revoke` branches move into `runRevokeCommand` (the same shape `runUnitCommand`/`runStatusCommand` already have);
- the router gains its own end-to-end tests (usage on no command, exit 2 on an unknown unit operation, exit 2 on `revoke` without an id), so the function is named by the suite that exercises it.

Complexity-coverage ratchet verified green locally (17/17); link suite green; typecheck clean.

Unblocks #4373 → v4.3.0 → daemon self-upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790248953&installation_model_id=20659&pr_number=4404&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4404&signature=e0e2dbd57636bfc9e2859c5bdfcabd314c3b063824f89997955adad6ef918e06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->