### PR TITLE
feat(redskilled): the daemon protects the machine from itself

### DIFF
--- a/.changeset/daemon-survives-itself.md
+++ b/.changeset/daemon-survives-itself.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": minor
+---
+
+The daemon protects the machine from itself: a self-guard in the binary probes the daemon's own op socket with a client's ping (two minutes of sustained misses = deliberate exit 70 — a wedged-but-alive process that `Restart=always` never fires for now self-heals) and watches its own RSS (past 1.5GiB = deliberate exit 71 — shedding a multi-day leak is one restart, losing the machine is an outage). The unit template additionally declares `MemoryHigh=1G` / `MemoryMax=2G` so even a guard-dead daemon cannot take the host down; host drop-ins still override.

--- a/apps/redskilled/src/cli.ts
+++ b/apps/redskilled/src/cli.ts
@@ -76,6 +76,7 @@ import {
   type RedskilledUnitIO,
 } from "./supervision.js";
 import { awaitRedskilledTakeoverCommit, isRedskilledSupervised } from "./self-replace.js";
+import { createRedskilledSelfGuard } from "./daemon/self-guard.js";
 import { startGithubCustodyTender } from "./github-custody-tender.js";
 import { stabilizeRunningRedskilledEntry } from "./stable-bundle.js";
 import { runRedskillsAcpAdapter } from "./acp-control-plane.js";
@@ -634,6 +635,23 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
     // a client's handoff/status call, so every restart parked active records on
     // `repair-custodian` until someone happened to ask. Wired here in the CLI —
     // the lifecycle file is baseline-pinned — and stopped with the daemon.
+    // The daemon protects the machine from itself (2026-08-25, twice in one
+    // day): a wedged-but-alive process no Restart= ever fires for, and a
+    // multi-day leak that takes the HOST down before any generous unit
+    // ceiling takes the daemon down. Both verdicts end in a deliberate exit —
+    // the supervisor restarts a fresh generation in about a second. Wired
+    // here in the CLI because the lifecycle file is baseline-pinned.
+    const selfGuard = createRedskilledSelfGuard({
+      socketPath: paths.socketPath,
+      onFatal: (verdict) => {
+        process.stderr.write(`${verdict.detail}\n`);
+        void daemon.stop({ reason: "requested", note: verdict.detail }).catch(() => undefined);
+        // The stop path flushes and releases; if it wedges too, the hard exit
+        // is the whole point of the guard.
+        setTimeout(() => process.exit(verdict.exitCode), 5_000).unref();
+      },
+    });
+    selfGuard.arm();
     const custodyTender = startGithubCustodyTender({
       custodyPath: join(redskilledHomeDir(homedir()), "state", "github", "custody.toon"),
       registration: githubGateway,
@@ -644,6 +662,7 @@ export async function runRedskilledCli(argv: readonly string[]): Promise<number>
       },
     });
     await daemon.closed;
+    selfGuard.stop();
     custodyTender.stop();
     deaths.phase("closed");
     return 0;

--- a/apps/redskilled/src/daemon/self-guard.ts
+++ b/apps/redskilled/src/daemon/self-guard.ts
@@ -1,0 +1,138 @@
+/**
+ * self-guard — the daemon protects the machine from ITSELF.
+ *
+ * Two failure shapes motivated this, both observed live:
+ *
+ * 1. **The wedge.** A daemon can deadlock a subsystem while the process stays
+ *    alive — `Restart=always` never fires, systemd reads "active (running)",
+ *    and every client hangs until a human restarts it (seen 2026-08-25: the
+ *    project-control path wedged after a first-bind identity migration while
+ *    the read ops kept answering). The guard probes the daemon's OWN op
+ *    socket with the same `ping` a client sends; a sustained miss streak is
+ *    answered with a deliberate exit, and the supervisor brings back a fresh
+ *    generation in about a second.
+ *
+ * 2. **The leak.** A daemon that grows for days takes the MACHINE down before
+ *    any generous unit ceiling takes the daemon down (a host running only the
+ *    daemon died after ~4 days, 2026-08-25). The guard reads its own RSS on
+ *    the same cadence; past the ceiling it exits deliberately — shedding the
+ *    leak is one restart, losing the machine is an outage.
+ *
+ * The guard lives in the daemon BINARY, not only in the unit template, so
+ * every host inherits it by riding the release train — a machine with an old
+ * unit file is protected the moment its daemon self-upgrades. Exits are loud:
+ * one stderr line with the verdict (the journal keeps it), and a distinct
+ * exit code per shape.
+ */
+import { randomUUID } from "node:crypto";
+import { sendRedskilledRequest } from "../protocol.js";
+
+export const REDSKILLED_SELF_GUARD_INTERVAL_MS = 15_000;
+export const REDSKILLED_SELF_GUARD_PING_TIMEOUT_MS = 2_000;
+/** 8 misses x 15s = two minutes of a daemon no client can reach. */
+export const REDSKILLED_SELF_GUARD_MISS_LIMIT = 8;
+/** Observed healthy peak is ~450MiB; 1.5GiB is leak territory, not load. */
+export const REDSKILLED_SELF_GUARD_RSS_LIMIT_BYTES = 1_610_612_736;
+
+export const REDSKILLED_SELF_GUARD_EXIT_UNRESPONSIVE = 70;
+export const REDSKILLED_SELF_GUARD_EXIT_RSS = 71;
+
+export interface RedskilledSelfGuardVerdict {
+  readonly kind: "unresponsive" | "rss-ceiling";
+  readonly exitCode: number;
+  readonly detail: string;
+}
+
+export interface RedskilledSelfGuardOptions {
+  readonly socketPath: string;
+  /** Answers like a client or throws; injectable for tests. */
+  readonly probe?: () => Promise<void>;
+  /** This process's resident set in bytes; injectable for tests. */
+  readonly rss?: () => number;
+  readonly intervalMs?: number;
+  readonly missLimit?: number;
+  readonly rssLimitBytes?: number;
+  /** Called at most once; the caller owns the actual exit. */
+  readonly onFatal: (verdict: RedskilledSelfGuardVerdict) => void;
+}
+
+export interface RedskilledSelfGuard {
+  arm(): void;
+  stop(): void;
+  /** Test seam: run one evaluation immediately. */
+  tick(): Promise<void>;
+}
+
+export function createRedskilledSelfGuard(options: RedskilledSelfGuardOptions): RedskilledSelfGuard {
+  const intervalMs = options.intervalMs ?? REDSKILLED_SELF_GUARD_INTERVAL_MS;
+  const missLimit = Math.max(1, options.missLimit ?? REDSKILLED_SELF_GUARD_MISS_LIMIT);
+  const rssLimit = options.rssLimitBytes ?? REDSKILLED_SELF_GUARD_RSS_LIMIT_BYTES;
+  const rss = options.rss ?? (() => process.memoryUsage.rss());
+  const probe = options.probe ?? (async () => {
+    const response = await sendRedskilledRequest(
+      { socketPath: options.socketPath, timeoutMs: REDSKILLED_SELF_GUARD_PING_TIMEOUT_MS },
+      { id: randomUUID(), op: "ping", self: true },
+    );
+    if (!response.ok) throw new Error(response.error);
+  });
+
+  let timer: NodeJS.Timeout | undefined;
+  let stopped = false;
+  let fatal = false;
+  let misses = 0;
+
+  const fail = (verdict: RedskilledSelfGuardVerdict): void => {
+    if (fatal) return;
+    fatal = true;
+    stopped = true;
+    if (timer != null) clearInterval(timer);
+    options.onFatal(verdict);
+  };
+
+  async function tick(): Promise<void> {
+    if (stopped) return;
+    const held = rss();
+    if (held > rssLimit) {
+      fail({
+        kind: "rss-ceiling",
+        exitCode: REDSKILLED_SELF_GUARD_EXIT_RSS,
+        detail:
+          `redskilled self-guard: resident set ${Math.round(held / 1_048_576)}MiB exceeds the ` +
+          `${Math.round(rssLimit / 1_048_576)}MiB ceiling — exiting deliberately so the supervisor ` +
+          "restarts a fresh generation instead of the machine paying for the leak",
+      });
+      return;
+    }
+    try {
+      await probe();
+      misses = 0;
+    } catch (error) {
+      misses += 1;
+      if (misses >= missLimit) {
+        fail({
+          kind: "unresponsive",
+          exitCode: REDSKILLED_SELF_GUARD_EXIT_UNRESPONSIVE,
+          detail:
+            `redskilled self-guard: ${misses} consecutive self-pings failed (last: ${
+              error instanceof Error ? error.message : String(error)
+            }) — the process is alive but no client can reach it, exiting deliberately so the ` +
+            "supervisor restarts a generation that answers",
+        });
+      }
+    }
+  }
+
+  return {
+    arm() {
+      if (stopped || timer != null) return;
+      timer = setInterval(() => void tick(), intervalMs);
+      timer.unref();
+    },
+    stop() {
+      stopped = true;
+      if (timer != null) clearInterval(timer);
+      timer = undefined;
+    },
+    tick,
+  };
+}

--- a/apps/redskilled/src/supervision.ts
+++ b/apps/redskilled/src/supervision.ts
@@ -145,6 +145,14 @@ function renderUnit(command: string, args: readonly string[], paths: RedskilledP
     "[Service]",
     "Type=simple",
     "LimitCORE=0",
+    // The daemon's own budget, distinct from any Worker's: a leak that grows
+    // for days must take THIS unit down (Restart= brings back a fresh
+    // generation) before it takes the machine down. Healthy peak is ~450MiB;
+    // a host that genuinely needs more overrides with a drop-in, which beats
+    // these lines by systemd's own precedence.
+    "MemoryHigh=1G",
+    "MemoryMax=2G",
+    "MemorySwapMax=512M",
     `ExecStart=${[command, ...args].map(quoteUnitWord).join(" ")}`,
     // The whole reason the unit exists: a daemon that dies comes back without a
     // client having to want work first.

--- a/apps/redskilled/tests/self-guard.test.ts
+++ b/apps/redskilled/tests/self-guard.test.ts
@@ -1,0 +1,91 @@
+// The daemon protects the machine from itself. Two live failures drove this:
+// a wedged-but-alive process (2026-08-25, project-control deadlock) that
+// Restart=always never fires for, and a multi-day leak that killed a host
+// before any generous unit ceiling killed the daemon. Both end in ONE loud
+// deliberate exit; the supervisor owns the comeback.
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createRedskilledSelfGuard,
+  REDSKILLED_SELF_GUARD_EXIT_RSS,
+  REDSKILLED_SELF_GUARD_EXIT_UNRESPONSIVE,
+} from "../src/daemon/self-guard.js";
+
+describe("the redskilled self-guard", () => {
+  it("a healthy daemon never trips either verdict", async () => {
+    const onFatal = vi.fn();
+    const guard = createRedskilledSelfGuard({
+      socketPath: "/nowhere",
+      probe: async () => undefined,
+      rss: () => 400 * 1_048_576,
+      missLimit: 2,
+      onFatal,
+    });
+
+    for (let i = 0; i < 10; i += 1) await guard.tick();
+    expect(onFatal).not.toHaveBeenCalled();
+  });
+
+  it("sustained ping misses end in one unresponsive exit — a wedge is not health", async () => {
+    const onFatal = vi.fn();
+    const guard = createRedskilledSelfGuard({
+      socketPath: "/nowhere",
+      probe: async () => { throw new Error("op socket did not answer"); },
+      rss: () => 100 * 1_048_576,
+      missLimit: 3,
+      onFatal,
+    });
+
+    await guard.tick();
+    await guard.tick();
+    expect(onFatal).not.toHaveBeenCalled();
+    await guard.tick();
+    await guard.tick();
+
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    const verdict = onFatal.mock.calls[0]?.[0];
+    expect(verdict).toMatchObject({ kind: "unresponsive", exitCode: REDSKILLED_SELF_GUARD_EXIT_UNRESPONSIVE });
+    expect(verdict.detail).toContain("3 consecutive self-pings failed");
+  });
+
+  it("a recovering daemon resets the miss streak — jitter is not a wedge", async () => {
+    const onFatal = vi.fn();
+    let fail = true;
+    const guard = createRedskilledSelfGuard({
+      socketPath: "/nowhere",
+      probe: async () => { if (fail) throw new Error("busy"); },
+      rss: () => 100 * 1_048_576,
+      missLimit: 3,
+      onFatal,
+    });
+
+    await guard.tick();
+    await guard.tick();
+    fail = false;
+    await guard.tick();
+    fail = true;
+    await guard.tick();
+    await guard.tick();
+
+    expect(onFatal).not.toHaveBeenCalled();
+  });
+
+  it("an RSS past the ceiling exits deliberately — shedding a leak beats losing the machine", async () => {
+    const onFatal = vi.fn();
+    const guard = createRedskilledSelfGuard({
+      socketPath: "/nowhere",
+      probe: async () => undefined,
+      rss: () => 2_000 * 1_048_576,
+      rssLimitBytes: 1_536 * 1_048_576,
+      onFatal,
+    });
+
+    await guard.tick();
+    await guard.tick();
+
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    const verdict = onFatal.mock.calls[0]?.[0];
+    expect(verdict).toMatchObject({ kind: "rss-ceiling", exitCode: REDSKILLED_SELF_GUARD_EXIT_RSS });
+    expect(verdict.detail).toContain("2000MiB");
+  });
+});

--- a/apps/redskilled/tests/self-supervision.test.ts
+++ b/apps/redskilled/tests/self-supervision.test.ts
@@ -174,6 +174,10 @@ describe("the user unit that supervises the daemon", () => {
     // The whole reason the unit exists.
     expect(plan.text).toContain("Restart=always");
     expect(plan.text).toContain("LimitCORE=0");
+    // The daemon's own budget: a multi-day leak takes THIS unit down (and
+    // Restart= brings back a fresh generation) before it takes the machine.
+    expect(plan.text).toContain("MemoryHigh=1G");
+    expect(plan.text).toContain("MemoryMax=2G");
     expect(plan.text).toContain("StartLimitIntervalSec=60");
     expect(plan.text).toContain("StartLimitBurst=5");
     expect(plan.text).toContain(`Environment="${REDSKILLED_SUPERVISED_ENV}=1"`);


### PR DESCRIPTION
## What

Two live failures in one day:

1. **The leak** — a machine running only the daemon for ~4 days died of apparent memory exhaustion. Its unit ceiling (10G/14G drop-in) is effectively "the whole machine": the HOST pays for the leak before systemd ever takes the daemon down.
2. **The wedge** — this host's daemon deadlocked its project-control path after the first-bind identity migration while staying `active (running)`. `Restart=always` never fires for a process that is alive but unreachable; only a human restart cleared it.

**Self-guard in the binary** (`daemon/self-guard.ts`, armed in the CLI serve path — lifecycle stays pinned): every 15s it probes the daemon's own op socket with the same `ping` a client sends (8 sustained misses ≈ 2 minutes = deliberate **exit 70**) and reads its own RSS (past **1.5GiB** = deliberate **exit 71**). One loud stderr line for the journal, the flushing stop path attempted, hard exit if that wedges too — the supervisor owns the comeback in ~1s. Living in the binary means **every host inherits it via the release train**, old unit files included.

**Unit template**: `MemoryHigh=1G` / `MemoryMax=2G` / `MemorySwapMax=512M` (healthy peak observed ~450MiB), so even a guard-dead daemon cannot take the host down. Host drop-ins beat these lines by systemd's own precedence.

## Tests

`tests/self-guard.test.ts`: healthy never trips; sustained misses → one unresponsive verdict; recovery resets the streak (jitter ≠ wedge); RSS breach → one rss-ceiling verdict. `self-supervision.test.ts` pins the template ceilings. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790256175&installation_model_id=20659&pr_number=4407&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4407&signature=2498c4081cd7c241f845c1e3eb66f3686cfa6964f9e2744fb7c8366b7116f1fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->