### PR TITLE
fix(redskilled): serialize the identity migration and re-key through the journal

### DIFF
--- a/.changeset/identity-migration-serialized.md
+++ b/.changeset/identity-migration-serialized.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The identity migration is serialized and re-keys the session journal through the live journal instance. Two live defects: the boot pass and a first bind's remember ran the same alias concurrently (two rm/rename races over the same directories, two persists of the same control map — the shape of the 2026-08-25 project-control wedge), and the journal re-key rewrote the FILE, which the durable journal's own next append silently undid (observed as "re-keyed 110 sessions" repeating on every boot).

--- a/apps/redskilled/src/acp-control-plane.ts
+++ b/apps/redskilled/src/acp-control-plane.ts
@@ -140,15 +140,23 @@ export async function startRedskillsAcpControlPlane(
   // canonical `github:` identity — once at boot for everything already known,
   // and again the moment a new alias is learned. Idempotent, so a clean pass
   // costs a few stats and reports nothing.
+  const sessionJournal = await createDurableAcpSessionJournal(acpSessionJournalPath(paths.registrationIntentPath));
   const migrationDeps = {
-    registrationIntentPath: paths.registrationIntentPath,
     projectWorkspaceRoot: paths.projectWorkspaceRoot,
     memoryRoot: memoryRootBesideWorkspaces(paths.projectWorkspaceRoot),
     projectControls,
     persistProjectControls,
+    rekeySessions: (from: string, to: string, label: string) => sessionJournal.rekeyProject(from, to, label),
   };
+  // One migration at a time, on one chain. The boot pass and a first bind's
+  // remember once ran the SAME alias concurrently — two rm/rename races over
+  // the same directories and two persists of the same map, which is the shape
+  // of the 2026-08-25 project-control wedge. A chain makes the second pass a
+  // cheap idempotent no-op instead of a race.
+  let migrationTail: Promise<void> = Promise.resolve();
   const migrateAlias = (alias: { slug: string; githubId: string; fullName: string }): void => {
-    void migrateProjectIdentity(alias, migrationDeps)
+    migrationTail = migrationTail
+      .then(() => migrateProjectIdentity(alias, migrationDeps))
       .then((report) => {
         for (const action of report.actions) {
           process.stderr.write(`project identity migration: ${action}\n`);
@@ -179,7 +187,6 @@ export async function startRedskillsAcpControlPlane(
       surface: "connection",
     }),
   };
-  const sessionJournal = await createDurableAcpSessionJournal(acpSessionJournalPath(paths.registrationIntentPath));
   const runTurn = demandTurnRunnerFor(options, sessionJournal);
   const connectionOptions = {
     ...options,

--- a/apps/redskilled/src/acp-session-journal.ts
+++ b/apps/redskilled/src/acp-session-journal.ts
@@ -134,6 +134,14 @@ export interface AcpSessionJournal {
   ): Promise<void>;
   recovery(publicSessionId: string): AcpSessionRecoveryCheckpoint;
   retake(publicSessionId: string, authorizedProjectId: string): AcpRetakeEvidenceProjection | undefined;
+  /**
+   * Re-key every session held under `fromProjectId` onto the canonical
+   * identity, THROUGH this instance. The identity migration once rewrote the
+   * journal FILE instead; this object then persisted its in-memory snapshot
+   * over it, silently undoing the migration on every append — observed live
+   * as "re-keyed 110 journal session(s)" repeating on every boot (2026-08-25).
+   */
+  rekeyProject(fromProjectId: string, toProjectId: string, projectLabel: string): Promise<number>;
 }
 
 export function acpSessionJournalPath(registrationIntentPath: string): string {
@@ -239,6 +247,16 @@ export async function createAcpSessionJournal(
         decision,
         ...(option == null ? {} : { option_id: option.optionId, option_kind: option.kind }),
       });
+    },
+    rekeyProject(fromProjectId, toProjectId, projectLabel) {
+      let touched = 0;
+      for (const [id, record] of sessions) {
+        if (record.project_id !== fromProjectId) continue;
+        touched += 1;
+        sessions.set(id, { ...record, project_id: toProjectId, project_label: projectLabel });
+      }
+      if (touched === 0) return Promise.resolve(0);
+      return persist().then(() => touched);
     },
     recovery(publicSessionId) {
       const held = sessions.get(publicSessionId);

--- a/apps/redskilled/src/project-identity-migration.ts
+++ b/apps/redskilled/src/project-identity-migration.ts
@@ -21,13 +21,10 @@
 //   `<name>.superseded` — documented, recoverable, never silently dropped.
 // - **Session journal**: rows re-keyed to the canonical id, so retake and
 //   recovery stop splitting on the spelling.
-import { readFile, rename, rm, stat, writeFile } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
+import { rename, rm, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-import { decode, encode, type JsonValue } from "@reddb-io/toon";
 import type { ProjectControlState } from "./project-control.js";
-import { acpSessionJournalPath } from "./acp-session-journal.js";
 import { projectDirectoryName } from "./project-workspace.js";
 
 export interface ProjectIdentityAlias {
@@ -37,7 +34,6 @@ export interface ProjectIdentityAlias {
 }
 
 export interface MigrateProjectIdentityDeps {
-  readonly registrationIntentPath: string;
   readonly projectWorkspaceRoot: string;
   /** The `~/.red/memory` parent; absent skips the memory step. */
   readonly memoryRoot?: string;
@@ -49,6 +45,14 @@ export interface MigrateProjectIdentityDeps {
    */
   readonly projectControls: Map<string, ProjectControlState>;
   readonly persistProjectControls: (projects: ReadonlyMap<string, ProjectControlState>) => Promise<void>;
+  /**
+   * Re-keys journal sessions THROUGH the live journal instance. The migration
+   * once rewrote the journal file directly; the durable journal object then
+   * persisted its own in-memory snapshot over that rewrite, undoing it on
+   * every append — the same single-writer rule the control map already
+   * follows, learned twice.
+   */
+  readonly rekeySessions: (fromProjectId: string, toProjectId: string, projectLabel: string) => Promise<number>;
 }
 
 export interface ProjectIdentityMigrationReport {
@@ -120,50 +124,12 @@ export async function migrateProjectIdentity(
     }
   }
 
-  // 4. Session journal: rows follow the surviving identity.
-  const journalPath = acpSessionJournalPath(deps.registrationIntentPath);
-  const rekeyed = await rekeySessionJournal(journalPath, from, to, alias.fullName);
+  // 4. Session journal: rows follow the surviving identity, re-keyed through
+  //    the one live journal object so its next append cannot undo the move.
+  const rekeyed = await deps.rekeySessions(from, to, alias.fullName);
   if (rekeyed > 0) actions.push(`re-keyed ${rekeyed} journal session(s) from ${from} to ${to}`);
 
   return { from, to, actions };
-}
-
-async function rekeySessionJournal(
-  path: string,
-  from: string,
-  to: string,
-  fullName: string,
-): Promise<number> {
-  let raw: string;
-  try {
-    raw = await readFile(path, "utf8");
-  } catch {
-    return 0;
-  }
-  let parsed: unknown;
-  try {
-    parsed = decode(raw.trim());
-  } catch {
-    return 0;
-  }
-  const snapshot = parsed as { version?: unknown; sessions?: unknown };
-  if (snapshot?.version !== 1 || !Array.isArray(snapshot.sessions)) return 0;
-  let touched = 0;
-  const sessions = snapshot.sessions.map((value) => {
-    const record = value as Record<string, unknown> | null;
-    if (record == null || typeof record !== "object" || record.project_id !== from) return value;
-    touched += 1;
-    return { ...record, project_id: to, project_label: fullName };
-  });
-  if (touched === 0) return 0;
-  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
-  try {
-    await writeFile(temporary, `${encode({ ...snapshot, sessions } as unknown as JsonValue)}\n`, { mode: 0o600 });
-    await rename(temporary, path);
-  } finally {
-    await rm(temporary, { force: true });
-  }
-  return touched;
 }
 
 async function exists(path: string): Promise<boolean> {

--- a/apps/redskilled/tests/acp-session-journal-retention.test.ts
+++ b/apps/redskilled/tests/acp-session-journal-retention.test.ts
@@ -111,3 +111,41 @@ describe("the journal applies its own retention", () => {
     expect(reborn.recovery("worked").entries).toHaveLength(1);
   });
 });
+
+describe("re-keying a project through the journal instance", () => {
+  const aliasProject = (projectId: string, projectLabel: string) => ({
+    projectId,
+    projectLabel,
+    workspacePath: "/tmp/workspace",
+  }) as never;
+
+  it("moves every held session and survives the journal's own next persist", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "redskilled-journal-rekey-"));
+    roots.push(dir);
+    const path = join(dir, "redskilled.acp-sessions.toon");
+    const journal = await createAcpSessionJournal(path);
+    await journal.create("s1", aliasProject("remote:reddb-io/red-skills", "reddb-io/red-skills"));
+    await journal.create("s2", aliasProject("github:7", "a/b"));
+
+    await expect(
+      journal.rekeyProject("remote:reddb-io/red-skills", "github:1240684599", "reddb-io/red-skills"),
+    ).resolves.toBe(1);
+    // The next append persists the journal's OWN snapshot — the re-key must
+    // live inside it, or this write silently undoes the migration (observed
+    // live on 2026-08-25 as the re-key repeating on every boot).
+    await journal.prompt("s2", [{ type: "text", text: "hi" }] as never);
+
+    const reloaded = await createAcpSessionJournal(path);
+    // Retake authorizes by project id: the canonical identity now owns s1,
+    // and the retired spelling no longer does.
+    expect(reloaded.retake("s1", "github:1240684599")).toBeDefined();
+    expect(reloaded.retake("s1", "remote:reddb-io/red-skills")).toBeUndefined();
+  });
+
+  it("a project with no sessions answers 0", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "redskilled-journal-rekey-"));
+    roots.push(dir);
+    const journal = await createAcpSessionJournal(join(dir, "j.toon"));
+    await expect(journal.rekeyProject("remote:x/y", "github:1", "x/y")).resolves.toBe(0);
+  });
+});

--- a/apps/redskilled/tests/project-identity-migration.test.ts
+++ b/apps/redskilled/tests/project-identity-migration.test.ts
@@ -3,18 +3,16 @@
 // the other), two memory roots, and journal sessions split across both. The
 // durable cache stops new twins; this migration repairs the history — and
 // these tests pin its merge rules and its idempotence.
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { decode, encode, type JsonValue } from "@reddb-io/toon";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
   memoryRootBesideWorkspaces,
   migrateProjectIdentity,
 } from "../src/project-identity-migration.js";
-import { acpSessionJournalPath } from "../src/acp-session-journal.js";
 import { projectDirectoryName } from "../src/project-workspace.js";
 import type { ProjectControlState } from "../src/project-control.js";
 
@@ -31,21 +29,29 @@ const TO = "github:1240684599";
 async function host() {
   const root = await mkdtemp(join(tmpdir(), "redskilled-identity-migration-"));
   roots.push(root);
-  const registrationIntentPath = join(root, ".red", "redskilled", "redskilled.registrations.toon");
   const projectWorkspaceRoot = join(root, ".red", "redskilled", "projects");
   await mkdir(projectWorkspaceRoot, { recursive: true });
   const persisted: unknown[] = [];
+  const rekeys: { from: string; to: string; label: string }[] = [];
   const projectControls = new Map<string, ProjectControlState>();
   return {
     root,
     persisted,
+    rekeys,
     deps: {
-      registrationIntentPath,
       projectWorkspaceRoot,
       memoryRoot: memoryRootBesideWorkspaces(projectWorkspaceRoot),
       projectControls,
       persistProjectControls: async (projects: ReadonlyMap<string, ProjectControlState>) => {
         persisted.push(new Map(projects));
+      },
+      // Journal re-keying goes THROUGH the live journal instance (the file
+      // rewrite was silently undone by the journal's own next append); the
+      // migration only reports what the instance answered.
+      // The default host holds no journal sessions; the re-key test overrides.
+      rekeySessions: async (from: string, to: string, label: string) => {
+        rekeys.push({ from, to, label });
+        return 0;
       },
     },
   };
@@ -102,25 +108,18 @@ describe("migrating a remote: project onto its github: identity", () => {
     expect(existsSync(`${fromMemory}.superseded`)).toBe(true);
   });
 
-  it("re-keys journal sessions to the canonical identity", async () => {
-    const { deps } = await host();
-    const journalPath = acpSessionJournalPath(deps.registrationIntentPath);
-    await mkdir(join(deps.registrationIntentPath, ".."), { recursive: true });
-    await writeFile(journalPath, `${encode({
-      version: 1,
-      sessions: [
-        { public_session_id: "s1", project_id: FROM, project_label: "reddb-io/red-skills", workspace_path: "/x", entries: [], session_evidence: [] },
-        { public_session_id: "s2", project_id: "github:7", project_label: "a/b", workspace_path: "/y", entries: [], session_evidence: [] },
-      ],
-    } as unknown as JsonValue)}\n`);
+  it("re-keys journal sessions through the live journal instance, never the file", async () => {
+    const { deps, rekeys } = await host();
 
-    const report = await migrateProjectIdentity(ALIAS, deps);
+    const report = await migrateProjectIdentity(ALIAS, {
+      ...deps,
+      rekeySessions: async (from, to, label) => {
+        rekeys.push({ from, to, label });
+        return 1;
+      },
+    });
 
-    const rewritten = decode((await readFile(journalPath, "utf8")).trim()) as {
-      sessions: { public_session_id: string; project_id: string }[];
-    };
-    expect(rewritten.sessions.find((s) => s.public_session_id === "s1")?.project_id).toBe(TO);
-    expect(rewritten.sessions.find((s) => s.public_session_id === "s2")?.project_id).toBe("github:7");
+    expect(rekeys).toEqual([{ from: FROM, to: TO, label: ALIAS.fullName }]);
     expect(report.actions).toEqual([expect.stringContaining("re-keyed 1 journal session")]);
   });
 


### PR DESCRIPTION
## What

Root-cause fixes for the two defects the first 4.3.0 boot exposed live:

1. **Concurrent migrations of the same alias.** The boot pass (`identityStore.all()`) and the first bind's `remember` both fired `migrateProjectIdentity` for the same alias at the same instant (journal: bind 12:34:29Z, migration 12:34:34Z) — two `rm`/`rename` races over the same workspace directories and two persists of the same live control map. That is the shape of the project-control wedge that hung every drive, registration and `worker_stop` until a human restart. Migrations now run **one at a time on one promise chain**; a second pass over an alias is a cheap idempotent no-op.

2. **The journal re-key was silently undone.** The migration rewrote the journal FILE while the durable journal object held its boot-loaded in-memory snapshot; the journal's next append persisted that snapshot whole, undoing the move — observed live as `re-keyed 110 journal session(s)` repeating on every boot. The journal gains `rekeyProject(from, to, label)` and the migration goes **through the live instance** (the same single-writer rule the control map already followed). The pinned test appends after the re-key and proves the move survives the journal's own persist.

The wedge shape itself is additionally covered by the self-guard (#4407): two minutes of an unreachable daemon now ends in a deliberate exit and a fresh generation.

## Tests

`acp-session-journal-retention.test.ts`: rekey moves the row, survives the next append (reload + `retake` authorization flips to the canonical id), zero-session rekey answers 0. `project-identity-migration.test.ts`: re-key routed through the injected instance hook, action reporting, idempotence — all green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790256946&installation_model_id=20659&pr_number=4409&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4409&signature=0e80d21346b5e1a8a605559e7075776ebae9aa8828764e82f6fac946bb7e8349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->