### PR TITLE
fix(redskilled): the outbox and the custodian shed history — bounded retention

### DIFF
--- a/.changeset/outbox-custody-bounded.md
+++ b/.changeset/outbox-custody-bounded.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The GitHub outbox and the merge custodian shed their history: published outbox entries (kept for idempotency replay — request and response body both) are bounded to the newest 500, pending entries never compacted; terminal custody records (receipts, not obligations) are bounded to the newest 100, active records never compacted. Both compactions run on load and on the write path, so a daemon that never restarts stops re-encoding an ever-growing array on every mutation. Leak-audit finding #4.

--- a/apps/redskilled/src/github-custody.ts
+++ b/apps/redskilled/src/github-custody.ts
@@ -124,6 +124,26 @@ export interface CreateGithubCustodianOptions {
  * connection never removes it. The host singleton is therefore the sole live
  * owner while the TOON snapshot lets its replacement recover the obligation.
  */
+/** Terminal custody records kept as receipts; older ones are shed on load and on append. */
+export const GITHUB_CUSTODY_TERMINAL_RETENTION = 100;
+
+/**
+ * Terminal records are history, not obligations: keep the newest few as the
+ * operator's receipts and shed the rest — every custody record ever handed
+ * off was retained for the daemon's life, and every mutation re-encoded the
+ * whole array (leak audit 2026-08-25, finding #4). Active records are never
+ * compacted. PURE.
+ */
+export function compactGithubCustodySnapshot(value: GithubCustodySnapshot): GithubCustodySnapshot {
+  const terminal = value.records.filter((record) => record.state === "terminal");
+  if (terminal.length <= GITHUB_CUSTODY_TERMINAL_RETENTION) return value;
+  const keep = new Set(terminal.slice(-GITHUB_CUSTODY_TERMINAL_RETENTION));
+  return {
+    ...value,
+    records: value.records.filter((record) => record.state !== "terminal" || keep.has(record)),
+  };
+}
+
 export function createGithubCustodian(options: CreateGithubCustodianOptions): GithubCustodian {
   let snapshot: GithubCustodySnapshot | undefined;
   let tail: Promise<unknown> = Promise.resolve();
@@ -141,7 +161,7 @@ export function createGithubCustodian(options: CreateGithubCustodianOptions): Gi
   const load = async (): Promise<GithubCustodySnapshot> => {
     if (snapshot != null) return snapshot;
     try {
-      snapshot = parseSnapshot(decode((await readFile(options.path, "utf8")).trim()));
+      snapshot = compactGithubCustodySnapshot(parseSnapshot(decode((await readFile(options.path, "utf8")).trim())));
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       snapshot = { version: 1, records: [] };
@@ -292,7 +312,7 @@ export function createGithubCustodian(options: CreateGithubCustodianOptions): Gi
           next_action: "observe-forge",
           terminal_outcome: null,
         };
-        snapshot = { version: 1, records: [...current.records, next] };
+        snapshot = compactGithubCustodySnapshot({ version: 1, records: [...current.records, next] });
         await persist(snapshot);
         return next;
       });

--- a/apps/redskilled/src/github-outbox.ts
+++ b/apps/redskilled/src/github-outbox.ts
@@ -47,6 +47,29 @@ export interface GithubOutbox {
  * execution argument, never an outbox field, so a replacement daemon can retry
  * with freshly resolved secret material without ever exposing it to a Worker.
  */
+/**
+ * Published entries the outbox retains for idempotency replay.
+ *
+ * A published entry exists so a REPEATED idempotency key answers the recorded
+ * value instead of re-writing; that protection only matters for recent keys,
+ * and retaining every write the daemon ever made — request and response body
+ * both — grew without bound (leak audit 2026-08-25, finding #4). Pending
+ * entries are never compacted: an unexecuted write is an obligation, not a
+ * memory.
+ */
+export const GITHUB_OUTBOX_PUBLISHED_RETENTION = 500;
+
+/** Shed old published entries, newest kept, pending always kept. PURE. */
+export function compactOutboxSnapshot(value: GithubOutboxSnapshot): GithubOutboxSnapshot {
+  const published = value.entries.filter((entry) => entry.state === "published");
+  if (published.length <= GITHUB_OUTBOX_PUBLISHED_RETENTION) return value;
+  const keep = new Set(published.slice(-GITHUB_OUTBOX_PUBLISHED_RETENTION));
+  return {
+    ...value,
+    entries: value.entries.filter((entry) => entry.state !== "published" || keep.has(entry)),
+  };
+}
+
 export function createGithubOutbox(
   path: string,
   upstream: RedskilledGithubWriteUpstream,
@@ -65,7 +88,7 @@ export function createGithubOutbox(
     if (snapshot != null) return snapshot;
     try {
       const decoded = decode((await readFile(path, "utf8")).trim());
-      snapshot = parseOutboxSnapshot(decoded);
+      snapshot = compactOutboxSnapshot(parseOutboxSnapshot(decoded));
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
       snapshot = { version: 1, entries: [] };
@@ -122,7 +145,12 @@ export function createGithubOutbox(
     entry.value = value ?? null;
     entry.published_at = clock();
     entry.state = "published";
-    await persist(current);
+    // The compaction runs on the WRITE path too, so a daemon that never
+    // restarts still sheds old published entries instead of retaining every
+    // write it ever made (leak audit 2026-08-25, finding #4).
+    const compacted = compactOutboxSnapshot(current);
+    snapshot = compacted;
+    await persist(compacted);
     return outboxAnswer(entry);
   };
 

--- a/apps/redskilled/tests/github-retention.test.ts
+++ b/apps/redskilled/tests/github-retention.test.ts
@@ -1,0 +1,82 @@
+// Leak-audit finding #4 (2026-08-25): the outbox retained every GitHub write
+// the daemon ever made (request and response body both) and the custodian
+// retained every custody record ever handed off — for the process's life,
+// with each mutation re-encoding the whole array. Published entries exist for
+// idempotency REPLAY and terminal records are RECEIPTS: both wants are
+// recent, so both stores now shed their oldest past a retention.
+import { describe, expect, it } from "vitest";
+
+import {
+  compactGithubCustodySnapshot,
+  GITHUB_CUSTODY_TERMINAL_RETENTION,
+} from "../src/github-custody.js";
+import {
+  compactOutboxSnapshot,
+  GITHUB_OUTBOX_PUBLISHED_RETENTION,
+} from "../src/github-outbox.js";
+
+describe("the outbox sheds old published entries and never a pending one", () => {
+  it("keeps the newest published, all pending, and the original order", () => {
+    const published = (index: number, state = "published", key = `k-${index}`) => ({
+      idempotency_key: key,
+      project_id: "github:1",
+      project_label: "a/b",
+      workspace_path: "/w",
+      credential_profile: "personal",
+      write: { kind: "issue-comment" },
+      queued_at: "2026-08-25T00:00:00.000Z",
+      state,
+      value: { echoed: index },
+    }) as never;
+    const pending = published(-1, "pending", "obligation");
+    const entries = [pending, ...Array.from({ length: GITHUB_OUTBOX_PUBLISHED_RETENTION + 40 }, (_u, index) => published(index))];
+
+    const compacted = compactOutboxSnapshot({ version: 1, entries } as never);
+
+    const kept = compacted.entries.map((entry) => (entry as { idempotency_key: string }).idempotency_key);
+    expect(kept).toContain("obligation");
+    expect(kept).not.toContain("k-0");
+    expect(kept).not.toContain("k-39");
+    expect(kept).toContain("k-40");
+    expect(kept).toContain(`k-${GITHUB_OUTBOX_PUBLISHED_RETENTION + 39}`);
+    expect(compacted.entries).toHaveLength(GITHUB_OUTBOX_PUBLISHED_RETENTION + 1);
+  });
+
+  it("a snapshot under the retention passes through untouched", () => {
+    const value = { version: 1, entries: [] } as never;
+    expect(compactOutboxSnapshot(value)).toBe(value);
+  });
+});
+
+describe("the custodian sheds old terminal records and never an active one", () => {
+  it("keeps every active record and the newest terminal receipts", () => {
+    const record = (index: number, state: "active" | "terminal") => ({
+      version: 1,
+      project_id: "github:1",
+      pull_request: index,
+      branch: `red/w/${index}`,
+      project_label: "a/b",
+      workspace_path: "/w",
+      credential_profile: "personal",
+      handed_off_at: "2026-08-25T00:00:00.000Z",
+      state,
+      last_tick_at: null,
+      last_forge_state: "unknown",
+      next_action: "observe-forge",
+      terminal_outcome: state === "terminal" ? "landed" : null,
+    }) as never;
+    const records = [
+      record(1, "active"),
+      ...Array.from({ length: GITHUB_CUSTODY_TERMINAL_RETENTION + 25 }, (_u, index) => record(100 + index, "terminal")),
+      record(2, "active"),
+    ];
+
+    const compacted = compactGithubCustodySnapshot({ version: 1, records } as never);
+
+    const prs = compacted.records.map((held) => (held as { pull_request: number; state: string }));
+    expect(prs.filter((held) => held.state === "active")).toHaveLength(2);
+    expect(prs.filter((held) => held.state === "terminal")).toHaveLength(GITHUB_CUSTODY_TERMINAL_RETENTION);
+    expect(prs.some((held) => held.pull_request === 100)).toBe(false);
+    expect(prs.some((held) => held.pull_request === 100 + GITHUB_CUSTODY_TERMINAL_RETENTION + 24)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Leak-audit finding **#4** (2026-08-25). Two daemon-lifetime in-memory snapshots that only ever grew:

- **GitHub outbox**: every write the daemon ever made — request and response body both — retained forever, because a `published` entry exists for idempotency replay and nothing asked whether the key could still repeat.
- **Merge custodian**: every custody record ever handed off retained forever, with each twice-per-tick mutation re-encoding the whole array — memory growth plus quadratic GC churn.

## Fix

Both wants are recent, so both stores shed their oldest past a retention, on **load and on the write path** (a daemon that never restarts sheds too):

- `compactOutboxSnapshot` — newest **500** published kept; `pending` entries never compacted (an unexecuted write is an obligation, not a memory).
- `compactGithubCustodySnapshot` — newest **100** terminal receipts kept; `active` records never compacted (the tender's working set).

## Tests

`github-retention.test.ts`: order-preserving shed with pending/active always kept, pass-through under retention. Custody suite 6/6; typecheck clean.

Stability batch: #4407 · #4409 · #4410 · #4411 · #4412 · this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790258767&installation_model_id=20659&pr_number=4413&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4413&signature=d0482f95ec713a8a75388b0da2914264d638346466cd6d27c7b405a38d0272d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->