### PR TITLE
fix(wire): every buffer has a ceiling — frames, and the resident update tail

### DIFF
--- a/.changeset/bounded-buffers.md
+++ b/.changeset/bounded-buffers.md
@@ -1,0 +1,7 @@
+---
+"@reddb-io/shared": patch
+"@reddb-io/protocol-acp": patch
+"@reddb-io/redskilled": patch
+---
+
+Every wire buffer has a ceiling, and the resident client sheds its update tail: an unterminated frame past `MAX_WIRE_FRAME_BYTES` (8 MiB) refuses the connection loudly on both the op-socket server and the dual-dialect ACP stream (nothing to resync on past the ceiling — skip-and-log covers only frames WITH a terminator), and the project ACP client's `pendingUpdates` array — which retained the agent's whole output stream for the connection's life, MB/hour in a long-lived MCP resident — is capped at the newest 512 with shed-count bookkeeping so each prompt still slices exactly its own tail. Leak-audit findings: frame buffers + resident client.

--- a/apps/redskilled/src/acp-client.ts
+++ b/apps/redskilled/src/acp-client.ts
@@ -144,9 +144,21 @@ interface LiveProjectAcpConnection {
   readonly socket: Socket;
   readonly sessionId: string;
   readonly pendingUpdates: SessionNotification["update"][];
+  /** Updates shed from the FRONT of `pendingUpdates` by the retention cap. */
+  readonly droppedUpdates: () => number;
   readonly dead: () => boolean;
   readonly close: () => void;
 }
+
+/**
+ * Updates a connection retains between prompts. Only the CURRENT prompt's tail
+ * is ever read back (`prompt()` slices from its own start marker), but the
+ * array grew with every session/update for the connection's whole life — a
+ * long-lived MCP resident accumulated the agent's full output stream, MB/hour
+ * (leak audit 2026-08-25). Past the cap the oldest are shed and counted, so
+ * the start markers stay honest.
+ */
+export const ACP_CLIENT_PENDING_UPDATE_RETENTION = 512;
 
 /** Connect a public adapter to redskilled through ACP and no private daemon wire. */
 export async function connectRedskillsProjectAcp(
@@ -162,6 +174,7 @@ export async function connectRedskillsProjectAcp(
     const endpoint = (await resolveRedskilledClientEndpoint(paths)).paths;
     const socket = await connectEndpoint(endpoint.acpSocketPath);
     const pendingUpdates: SessionNotification["update"][] = [];
+    let droppedUpdates = 0;
     let sessionId = "";
     let dead = false;
     socket.once("close", () => { dead = true; });
@@ -171,6 +184,10 @@ export async function connectRedskillsProjectAcp(
       .onNotification(methods.client.session.update, async ({ params }) => {
         if (params.sessionId !== sessionId) return;
         pendingUpdates.push(params.update);
+        if (pendingUpdates.length > ACP_CLIENT_PENDING_UPDATE_RETENTION) {
+          droppedUpdates += pendingUpdates.length - ACP_CLIENT_PENDING_UPDATE_RETENTION;
+          pendingUpdates.splice(0, pendingUpdates.length - ACP_CLIENT_PENDING_UPDATE_RETENTION);
+        }
         await options.onUpdate?.(params.update);
       });
     if (options.requestPermission != null) {
@@ -193,6 +210,7 @@ export async function connectRedskillsProjectAcp(
       socket,
       sessionId,
       pendingUpdates,
+      droppedUpdates: () => droppedUpdates,
       dead: () => dead,
       close() {
         dead = true;
@@ -261,7 +279,9 @@ export async function connectRedskillsProjectAcp(
     },
     async prompt(text) {
       const held = await ensureLive();
-      const firstUpdate = held.pendingUpdates.length;
+      // Absolute position, so a retention shed between here and the answer
+      // cannot replay another prompt's tail as this one's.
+      const firstUpdate = held.droppedUpdates() + held.pendingUpdates.length;
       const response = await held.connection.agent.request(methods.agent.session.prompt, {
         sessionId: held.sessionId,
         prompt: [{ type: "text", text }],
@@ -269,7 +289,7 @@ export async function connectRedskillsProjectAcp(
       return {
         stopReason: response.stopReason,
         ...projectControlFrom(response._meta),
-        updates: held.pendingUpdates.slice(firstUpdate),
+        updates: held.pendingUpdates.slice(Math.max(0, firstUpdate - held.droppedUpdates())),
       };
     },
     async cancel() {

--- a/apps/redskilled/src/acp-client.ts
+++ b/apps/redskilled/src/acp-client.ts
@@ -160,6 +160,14 @@ interface LiveProjectAcpConnection {
  */
 export const ACP_CLIENT_PENDING_UPDATE_RETENTION = 512;
 
+/** Shed the oldest updates past the retention, in place; answers how many. PURE mutation. */
+export function shedPendingUpdates(pendingUpdates: SessionNotification["update"][]): number {
+  const excess = pendingUpdates.length - ACP_CLIENT_PENDING_UPDATE_RETENTION;
+  if (excess <= 0) return 0;
+  pendingUpdates.splice(0, excess);
+  return excess;
+}
+
 /** Connect a public adapter to redskilled through ACP and no private daemon wire. */
 export async function connectRedskillsProjectAcp(
   options: ConnectRedskillsProjectAcpOptions = {},
@@ -184,10 +192,7 @@ export async function connectRedskillsProjectAcp(
       .onNotification(methods.client.session.update, async ({ params }) => {
         if (params.sessionId !== sessionId) return;
         pendingUpdates.push(params.update);
-        if (pendingUpdates.length > ACP_CLIENT_PENDING_UPDATE_RETENTION) {
-          droppedUpdates += pendingUpdates.length - ACP_CLIENT_PENDING_UPDATE_RETENTION;
-          pendingUpdates.splice(0, pendingUpdates.length - ACP_CLIENT_PENDING_UPDATE_RETENTION);
-        }
+        droppedUpdates += shedPendingUpdates(pendingUpdates);
         await options.onUpdate?.(params.update);
       });
     if (options.requestPermission != null) {

--- a/apps/redskilled/tests/acp-dual-dialect-stream.test.ts
+++ b/apps/redskilled/tests/acp-dual-dialect-stream.test.ts
@@ -246,3 +246,23 @@ describe("parity with the SDK's ndJsonStream (ADR 0170)", () => {
     expect(cancelled).toEqual(new Error("session over"));
   });
 });
+
+describe("an unterminated frame past the byte ceiling refuses the connection", () => {
+  it("errors loudly instead of buffering the peer's bytes forever", async () => {
+    const { readable: inputReadable, writable: inputWritable } = new TransformStream<Uint8Array, Uint8Array>();
+    const output = new WritableStream<Uint8Array>({ write: () => undefined });
+    const stream = dualDialectStream(output, inputReadable);
+    const reader = stream.readable.getReader();
+    const writer = inputWritable.getWriter();
+
+    // A TOON-sniffed frame (no leading '{' or '[') that never sends its blank
+    // line: 9 MiB of un-terminated bytes, in 1 MiB chunks.
+    const chunk = new TextEncoder().encode("k: " + "x".repeat(1_048_576 - 4) + " ");
+    const feed = (async () => {
+      for (let i = 0; i < 9; i += 1) await writer.write(chunk);
+    })();
+
+    await expect(reader.read()).rejects.toThrow(/exceeded .* without a terminator/);
+    await feed.catch(() => undefined);
+  });
+});

--- a/apps/redskilled/tests/acp-dual-dialect-stream.test.ts
+++ b/apps/redskilled/tests/acp-dual-dialect-stream.test.ts
@@ -6,6 +6,11 @@
 // connection completes a real request/response round trip when one end of the
 // wire is writing TOON-RPC. The resident-wire framing itself is proven in
 // `packages/shared/resident-wire.test.ts`; nothing here respells it.
+import {
+  ACP_CLIENT_PENDING_UPDATE_RETENTION,
+  connectRedskillsProjectAcp,
+  shedPendingUpdates,
+} from "../src/acp-client.js";
 import { describe, expect, it } from "vitest";
 import { dualDialectStream } from "@reddb-io/protocol-acp";
 
@@ -264,5 +269,23 @@ describe("an unterminated frame past the byte ceiling refuses the connection", (
 
     await expect(reader.read()).rejects.toThrow(/exceeded .* without a terminator/);
     await feed.catch(() => undefined);
+  });
+});
+
+describe("the resident client's update retention", () => {
+  it("shedPendingUpdates drops only the excess, oldest first, and counts it", () => {
+    const updates = Array.from(
+      { length: ACP_CLIENT_PENDING_UPDATE_RETENTION + 7 },
+      (_unused, index) => ({ sessionUpdate: "agent_message_chunk", index }),
+    ) as never[];
+
+    expect(shedPendingUpdates(updates)).toBe(7);
+    expect(updates).toHaveLength(ACP_CLIENT_PENDING_UPDATE_RETENTION);
+    expect((updates[0] as { index: number }).index).toBe(7);
+    expect(shedPendingUpdates(updates)).toBe(0);
+  });
+
+  it("connectRedskillsProjectAcp is the one exported entrance this retention guards", () => {
+    expect(typeof connectRedskillsProjectAcp).toBe("function");
   });
 });

--- a/packages/protocol-acp/dual-dialect-stream.ts
+++ b/packages/protocol-acp/dual-dialect-stream.ts
@@ -55,6 +55,16 @@ type WireMessage = Record<string, unknown>;
  * A drop-in for `ndJsonStream(output, input)` that reads both dialects and
  * answers in the one the peer last proved.
  */
+/**
+ * Skip-and-log covers a malformed frame WITH a terminator; an unterminated
+ * frame past the ceiling has nothing to resync on, so the connection is
+ * refused loudly instead of buffering the peer's bytes without bound (leak
+ * audit 2026-08-25).
+ */
+function assertFrameWithinCeiling(buffer: string): void {
+  if (buffer.length > MAX_WIRE_FRAME_BYTES) throw new WireFrameOverflowError(buffer.length);
+}
+
 export function dualDialectStream(
   output: WritableStream<Uint8Array>,
   input: ReadableStream<Uint8Array>,
@@ -128,11 +138,7 @@ export function dualDialectStream(
           for (;;) {
             const taken = takeWireFrame(buffer);
             if (taken === null) {
-              // Skip-and-log covers a malformed frame WITH a terminator; an
-              // unterminated frame past the ceiling has nothing to resync on,
-              // so the connection is refused loudly instead of buffering the
-              // peer's bytes without bound (leak audit 2026-08-25).
-              if (buffer.length > MAX_WIRE_FRAME_BYTES) throw new WireFrameOverflowError(buffer.length);
+              assertFrameWithinCeiling(buffer);
               break;
             }
             buffer = taken.rest;

--- a/packages/protocol-acp/dual-dialect-stream.ts
+++ b/packages/protocol-acp/dual-dialect-stream.ts
@@ -36,6 +36,8 @@ import {
   takeWireFrame,
   decodeWireFrameStrict,
   type ResidentWireDialect,
+  MAX_WIRE_FRAME_BYTES,
+  WireFrameOverflowError,
 } from "@reddb-io/shared/resident-wire.js";
 
 /** The envelope markers, spelled once: JSON-RPC 2.0 on JSON, TOON-RPC 1.0 on TOON. */
@@ -125,7 +127,14 @@ export function dualDialectStream(
           buffer += textDecoder.decode(value, { stream: true });
           for (;;) {
             const taken = takeWireFrame(buffer);
-            if (taken === null) break;
+            if (taken === null) {
+              // Skip-and-log covers a malformed frame WITH a terminator; an
+              // unterminated frame past the ceiling has nothing to resync on,
+              // so the connection is refused loudly instead of buffering the
+              // peer's bytes without bound (leak audit 2026-08-25).
+              if (buffer.length > MAX_WIRE_FRAME_BYTES) throw new WireFrameOverflowError(buffer.length);
+              break;
+            }
             buffer = taken.rest;
             decodeAndEnqueue(controller, taken.frame, taken.dialect);
           }

--- a/packages/shared/resident-core.ts
+++ b/packages/shared/resident-core.ts
@@ -30,6 +30,8 @@ import {
   rememberJsonOnlyPeer,
   residentWireDialectFor,
   takeWireFrame,
+  MAX_WIRE_FRAME_BYTES,
+  WireFrameOverflowError,
   type ResidentWireDialect,
 } from "./resident-wire.js";
 
@@ -143,7 +145,12 @@ export function serveWireSocket<TRequest>(
   socket.on("data", (chunk: string) => {
     buffer += chunk;
     const framed = takeWireFrame(buffer);
-    if (!framed) return;
+    if (!framed) {
+      // No delimiter to resync on past the ceiling: refuse the connection
+      // instead of holding its bytes for as long as the peer stays quiet.
+      if (buffer.length > MAX_WIRE_FRAME_BYTES) socket.destroy(new WireFrameOverflowError(buffer.length));
+      return;
+    }
     buffer = framed.rest;
     socket.pause();
     const respond = (response: unknown): void => {

--- a/packages/shared/resident-wire.ts
+++ b/packages/shared/resident-wire.ts
@@ -86,6 +86,27 @@ export function sniffWireDialect(text: string): ResidentWireDialect {
  * Leading blank lines are dropped rather than treated as an empty frame, so a
  * peer that terminates generously cannot wedge the next message.
  */
+/**
+ * The most bytes one unterminated frame may buffer before the connection is
+ * judged unrecoverable. A frame is delimited by a newline (JSON) or a blank
+ * line (TOON); a peer that opens a frame and never terminates it grew the
+ * reader's buffer without bound (leak audit 2026-08-25) — and past this point
+ * there is no delimiter to resync on, so the honest answer is to refuse the
+ * connection loudly rather than hold its bytes forever.
+ */
+export const MAX_WIRE_FRAME_BYTES = 8 * 1024 * 1024;
+
+/** Thrown by readers when a peer exceeds {@link MAX_WIRE_FRAME_BYTES}. */
+export class WireFrameOverflowError extends Error {
+  constructor(heldBytes: number) {
+    super(
+      `wire frame exceeded ${MAX_WIRE_FRAME_BYTES} bytes without a terminator ` +
+        `(${heldBytes} held) — the connection cannot resync and is refused`,
+    );
+    this.name = "WireFrameOverflowError";
+  }
+}
+
 export function takeWireFrame(buffer: string): ResidentWireFrame | null {
   let start = 0;
   while (buffer[start] === "\n" || buffer[start] === "\r") start += 1;


### PR DESCRIPTION
## What

The last two findings of the 2026-08-25 leak audit.

**No frame buffer had a byte bound.** A peer that opens a frame and never sends its terminator (`\n` for JSON, blank line for TOON) grew the reader's buffer for as long as it stayed quiet — on the op-socket server (`serveWireSocket`) and the dual-dialect ACP stream alike. Past the ceiling there is no delimiter left to resync on, so both readers now refuse the connection with a loud `WireFrameOverflowError` at `MAX_WIRE_FRAME_BYTES` (8 MiB). Deliberately distinct from the skip-and-log lane, which covers only malformed frames that **did** terminate — ADR 0170's parity rules are untouched for every framed byte.

**The resident client retained the agent's whole output stream.** `pendingUpdates` in the project ACP client grew with every `session/update` for the connection's life — MB/hour inside the long-lived MCP resident, the worst per-hour rate in the audit. Only the current prompt's tail is ever read back, so the array is capped at the newest **512** with a shed counter (`ACP_CLIENT_PENDING_UPDATE_RETENTION`), and `prompt()` keeps its slice markers in absolute positions — a shed mid-prompt can never replay another prompt's tail as this one's.

## Tests

`acp-dual-dialect-stream.test.ts`: 9 MiB unterminated TOON-sniffed feed → loud refusal (14/14). `resident-wire` suite green. Typecheck clean across shared, protocol-acp, redskilled.

Stability batch complete: #4407 · #4409 · #4410 · #4411 · #4412 · #4413 · this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790258985&installation_model_id=20659&pr_number=4414&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4414&signature=5cc30a000e9d1beb0f20bcd204d43de6e1c88b2ee5605c9e67c9a13c572feee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->