### PR TITLE
fix(redskilled): the go brief carries its own acceptance criteria

### DIFF
--- a/.changeset/go-brief-carries-criteria.md
+++ b/.changeset/go-brief-carries-criteria.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled": patch
+---
+
+The go brief carries its own acceptance criteria: the brief contract's structural door refuses a handoff with no acceptance-criteria section before any claim (#4296), which parked the first live 4.4.0 `/go` dispatch as `blocked:spec`. An ad-hoc demand IS its own criterion — the minted Ticket body and the turn handoff now state the demand and the shared gate as the criteria section, so the structural door passes without inventing checkboxes the dispatcher never wrote.

--- a/apps/redskilled/src/acp-connection-methods.ts
+++ b/apps/redskilled/src/acp-connection-methods.ts
@@ -19,6 +19,7 @@ import type { DemandTurnRequest, DemandTurnResult } from "./acp-demand-turn.js";
 import { mintHostWorkerId } from "./worker-launch.js";
 import {
   createAcpGithubGoTicketTracker,
+  goAcceptanceCriteria,
   goDispatchMethodDomain,
   GO_DISPATCH_LANE,
   type GoDispatchBrief,
@@ -243,7 +244,11 @@ export function goTurnAdmit(deps: ConnectionMethodDeps): GoAdmit {
         title: brief.title,
         labels: [GO_DISPATCH_LANE],
         base,
-        handoff: brief.demand,
+        // The demand plus its own criteria section: the brief contract's
+        // structural door refuses a handoff with no acceptance criteria at
+        // all, before any claim (#4296) — the first live 4.4.0 dispatch
+        // parked exactly there.
+        handoff: `${brief.demand}\n\n${goAcceptanceCriteria(brief.demand).join("\n")}`,
         worker_id: workerId,
       },
       onBorn: (bornWorkerId) => {

--- a/apps/redskilled/src/acp-go-dispatch.ts
+++ b/apps/redskilled/src/acp-go-dispatch.ts
@@ -103,6 +103,8 @@ export function buildGoTicket(demand: string): GoTicketSpec {
       "",
       text,
       "",
+      ...goAcceptanceCriteria(text),
+      "",
       "---",
       "",
       `🤖 Disposable dispatch Ticket, minted by \`${REDSKILLS_ACP_METHODS.goDispatch}\` into the`,
@@ -111,6 +113,25 @@ export function buildGoTicket(demand: string): GoTicketSpec {
     ].join("\n"),
     labels: [GO_DISPATCH_LANE],
   };
+}
+
+/**
+ * The acceptance-criteria section every go brief must carry (#4296's
+ * structural door): a brief with no criteria at all is refused at the wire
+ * before any claim, which is exactly what parked the first live 4.4.0
+ * dispatch as `blocked:spec`. An ad-hoc demand IS its own criterion — the
+ * dispatcher stated exactly what done means, in the demand — so the section
+ * states that and the gate, rather than inventing checkboxes the dispatcher
+ * never wrote. PURE.
+ */
+export function goAcceptanceCriteria(demand: string): readonly string[] {
+  const headline = (demand.split("\n", 1)[0] ?? "").trim();
+  return [
+    "## Acceptance criteria",
+    "",
+    `- The stated demand is satisfied: ${headline.slice(0, 160) || "as written above"}.`,
+    "- The change ships through the shared gate on its own branch and PR.",
+  ];
 }
 
 /**

--- a/apps/redskilled/tests/acp-go-dispatch.test.ts
+++ b/apps/redskilled/tests/acp-go-dispatch.test.ts
@@ -6,9 +6,11 @@ import {
   goDispatchParams,
 } from "@reddb-io/protocol-acp";
 
+import { briefContractStructuralRefusal } from "@reddb-io/shared/brief-contract.js";
 import {
   bindAcpGoDispatch,
   buildGoTicket,
+  goAcceptanceCriteria,
   goDispatchMethodDomain,
   GO_DISPATCH_LANE,
   type GoTicketSpec,
@@ -127,5 +129,19 @@ describe("_redskills/go_dispatch", () => {
 
     expect(domain.domain).toBe("go");
     expect(domain.bindings.map((binding) => binding.method)).toEqual([REDSKILLS_ACP_METHODS.goDispatch]);
+  });
+});
+
+describe("the go brief carries its own acceptance criteria", () => {
+  it("the Ticket body and the criteria section both state the demand and the gate", () => {
+    const spec = buildGoTicket("document the link commands\nwith the existing README tone");
+    expect(spec.body).toContain("## Acceptance criteria");
+    expect(spec.body).toContain("- The stated demand is satisfied: document the link commands.");
+    expect(spec.body).toContain("shared gate");
+  });
+
+  it("the criteria section passes the brief contract's structural door", () => {
+    const handoff = `implement the thing\n\n${goAcceptanceCriteria("implement the thing").join("\n")}`;
+    expect(briefContractStructuralRefusal(handoff)).toBeNull();
   });
 });

--- a/apps/redskilled/tests/acp-go-turn-admit.test.ts
+++ b/apps/redskilled/tests/acp-go-turn-admit.test.ts
@@ -57,9 +57,14 @@ describe("go_dispatch admits by running the turn", () => {
         title: "/go: document the link commands",
         labels: ["lane:go"],
         base: "main",
-        handoff: "document the link commands",
       },
     });
+    // The handoff carries the demand AND its own acceptance-criteria section,
+    // because the brief contract's structural door refuses a handoff with no
+    // criteria at all before any claim (#4296).
+    const handoff = (requests[0]?.ticket as { handoff: string }).handoff;
+    expect(handoff).toContain("document the link commands");
+    expect(handoff).toContain("## Acceptance criteria");
   });
 
   it("a turn that dies before admission rejects the dispatch, loudly", async () => {

--- a/apps/redskilled/tests/acp-go-turn-admit.test.ts
+++ b/apps/redskilled/tests/acp-go-turn-admit.test.ts
@@ -62,7 +62,7 @@ describe("go_dispatch admits by running the turn", () => {
     // The handoff carries the demand AND its own acceptance-criteria section,
     // because the brief contract's structural door refuses a handoff with no
     // criteria at all before any claim (#4296).
-    const handoff = (requests[0]?.ticket as { handoff: string }).handoff;
+    const handoff = (requests[0]!.ticket as { handoff: string }).handoff;
     expect(handoff).toContain("document the link commands");
     expect(handoff).toContain("## Acceptance criteria");
   });


### PR DESCRIPTION
## What

The first live `/go` on 4.4.0 proved the whole chain in one minute — claim, judgment, **park with a comment, labels, clean exit** (#4415) — and the judgment was:

> `brief contract refused: missing acceptance-criteria section`

Correct behavior from the structural door (#4296 refuses a brief with no criteria at all, before any claim); wrong brief from the dispatcher: `go_dispatch` handed the demand text raw.

An ad-hoc demand **is** its own criterion — the dispatcher stated exactly what done means. `goAcceptanceCriteria(demand)` derives the section from it (the stated demand satisfied; shipped through the shared gate on its own branch and PR), the minted Ticket body carries it for the human who finds the Ticket later, and the turn handoff carries it for the wire door.

## Tests

The composed handoff is linted against the **real** `briefContractStructuralRefusal` (null = passes), so the dispatcher and the door can never drift apart silently again; Ticket-body section pinned; turn-admit handoff expectation updated. 11/11; typecheck clean.

After merge: re-run the live proof (`worker_dispatch` → worker → PR) and `/retake 4415`-style requeue is unnecessary — reddb-io/redskilled#12 stays parked as the door's honest receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4MhtBgSJrB8P6nzcHUysu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790264971&installation_model_id=20659&pr_number=4416&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4416&signature=ff1139f563cefd2ef7d626235988f284b1b2c8eeaea70d17f87f36b35ccd7b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->