### PR TITLE
/go: Update apps/redskilled-link/README.md to document the CLI commands that

### DIFF
--- a/.changeset/link-readme-cli-commands.md
+++ b/.changeset/link-readme-cli-commands.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/redskilled-link": patch
+---
+
+Document the 4.3.0 CLI commands in the README: `unit install|remove|status`, the three-authority `status` report, `devices`, and `revoke <device-id>`.

--- a/apps/redskilled-link/README.md
+++ b/apps/redskilled-link/README.md
@@ -35,3 +35,46 @@ WSS is the implemented transport. `--transport wireguard` currently refuses
 with an explicit explanation: embedded Android WireGuard/VPN permission remains
 a future transport, and opening VPN settings on the Host would configure the
 wrong device.
+
+### systemd unit management
+
+The Host companion keeps running after the terminal closes through a systemd
+user unit. Three subcommands manage it:
+
+```bash
+redskilled-link unit install          # install and start the systemd user unit
+redskilled-link unit status           # query systemd and the published status.json
+redskilled-link unit remove           # stop and remove the systemd user unit
+```
+
+### status
+
+A read-only report that probes three authorities in one screen — the host
+daemon (live ACP state), systemd (process liveness), and the published
+`status.json` projection (what the link has actually done). Unreachable
+exits 1 with the reason printed on the report.
+
+```bash
+redskilled-link status
+```
+
+### devices
+
+Lists every device this Host has ever paired. Revoked devices are kept and
+marked so the operator can distinguish a device that vanished from one that
+was cut off. Secrets never print.
+
+```bash
+redskilled-link devices
+```
+
+### revoke
+
+Cuts one paired device off the wire. A device id that is not currently live
+is a loud miss, not a silent success.
+
+```bash
+redskilled-link revoke <device-id>
+```
+
+Pair the device again to restore access.


### PR DESCRIPTION
Refs #4418

Gate green after 1 implementing round.

<!-- redskilled:github-outbox:5542f832-0b1e-4404-8620-4edb6101be34:land:f0db66ac7bff3d4594cbf7c1927cd7efbab5c30c -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/4419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790267380&installation_model_id=20659&pr_number=4419&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F4419&signature=58840efdf97305e91e4644dbfa02a698a9e8bd67320aa82e3065a55819644877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->